### PR TITLE
feat(repro): UI PoC for reproducible package (ReproBadge)

### DIFF
--- a/src/components/ReproBadge.tsx
+++ b/src/components/ReproBadge.tsx
@@ -1,0 +1,66 @@
+import { useState, useEffect } from 'preact/hooks';
+
+interface ReproMeta {
+  data_version?: string;
+  engine_version?: string;
+  result_hash?: string;
+  package_url?: string;
+  created?: string;
+}
+
+interface Props {
+  strategy: string;
+  lang?: 'en' | 'ko';
+}
+
+export default function ReproBadge({ strategy, lang = 'en' }: Props) {
+  const [meta, setMeta] = useState<ReproMeta | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    const url = `/data/reproducible/${strategy}.json`;
+    fetch(url)
+      .then((res) => {
+        if (!res.ok) throw new Error('no-repro-data');
+        return res.json();
+      })
+      .then((json: ReproMeta) => {
+        if (!mounted) return;
+        setMeta(json);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (!mounted) return;
+        setLoading(false);
+        setError('not found');
+      });
+    return () => { mounted = false; };
+  }, [strategy]);
+
+  if (loading) return null;
+  if (!meta) return null; // no reproducible package available
+
+  const label = lang === 'ko' ? '재현 가능 패키지' : 'Reproducible Package';
+
+  return (
+    <div class="mt-3 mb-3 flex items-center gap-3">
+      <div class="px-2 py-1 rounded border border-[--color-border] bg-[--color-bg-card] text-sm flex items-center gap-3">
+        <span class="font-mono text-xs text-[--color-accent] border border-[--color-accent] px-2 py-0.5 rounded">VERIFIED</span>
+        <div class="text-sm text-[--color-text-muted]">
+          <div class="font-semibold text-[--color-text]">{label}</div>
+          <div class="text-[--color-text-muted] text-[12px]">Data v{meta.data_version || 'N/A'} • Engine {meta.engine_version || 'N/A'}</div>
+        </div>
+      </div>
+
+      <div class="ml-auto flex items-center gap-3">
+        {meta.package_url ? (
+          <a href={meta.package_url} class="inline-block border border-[--color-border] text-[--color-text] px-3 py-2 rounded font-mono text-sm hover:border-[--color-accent]" target="_blank" rel="noopener">{lang === 'ko' ? '패키지 다운로드' : 'Download package'}</a>
+        ) : (
+          <a href={`/data/reproducible/${strategy}.zip`} class="inline-block border border-[--color-border] text-[--color-text] px-3 py-2 rounded font-mono text-sm hover:border-[--color-accent]" target="_blank" rel="noopener">{lang === 'ko' ? '패키지 다운로드' : 'Download package'}</a>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/strategies/[id].astro
+++ b/src/pages/strategies/[id].astro
@@ -2,6 +2,7 @@
 import { getCollection, render } from 'astro:content';
 import Layout from '../../layouts/Layout.astro';
 import StrategyDemo from '../../components/StrategyDemo';
+import ReproBadge from '../../components/ReproBadge';
 import { useTranslations } from '../../i18n/index';
 
 const t = useTranslations('en');
@@ -61,6 +62,8 @@ const statusLabels: Record<string, string> = {
         <h1 class="text-3xl md:text-4xl font-bold mt-2 mb-4">{strategy.data.name}</h1>
         <p class="text-[--color-text-muted]">{strategy.data.description}</p>
       </div>
+
+      <ReproBadge client:visible strategy={strategy.id} />
 
       {(strategy.data.winRate || strategy.data.profitFactor || strategy.data.totalPnl || strategy.data.maxDrawdown) && (
         <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 font-mono text-sm border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] mb-8">


### PR DESCRIPTION
Adds a lightweight client-side ReproBadge component that fetches /data/reproducible/<strategy>.json at runtime and, when present, shows a 'Reproducible Package' badge + download link. This is a front-end PoC only — the reproducible package files and metadata must be added under public/data/reproducible/<strategy>.json and <strategy>.zip (or package_url in JSON).\n\nWhat I changed:\n- src/components/ReproBadge.tsx — new client component (fetches JSON and renders badge/download link)\n- src/pages/strategies/[id].astro — imports and displays ReproBadge on strategy pages\n\nNotes / Next steps:\n- Add reproducible metadata + zip packages to public/data/reproducible/ (backend or CI should generate these).\n- Consider server-side inclusion for SEO (e.g., include metadata at build time if packages are known at build).\n- Add QA checklist: verify file exists, sign package, publish to storage (S3/Cloudflare) and update JSON with package_url.\n\nBuild: npm run build succeeded locally (1284 pages built).