### PR TITLE
fix(coins): support base slugs in getStaticPaths

### DIFF
--- a/src/pages/coins/[symbol].astro
+++ b/src/pages/coins/[symbol].astro
@@ -6,10 +6,17 @@ import { useTranslations } from '../../i18n/index';
 const t = useTranslations('en');
 
 export async function getStaticPaths() {
-  return COIN_SYMBOLS.map(s => ({
-    params: { symbol: s.toLowerCase() },
-    props: { symbolUpper: s },
-  }));
+  return COIN_SYMBOLS.flatMap(s => {
+    const slug = s.toLowerCase();
+    const entries = [
+      { params: { symbol: slug }, props: { symbolUpper: s } },
+    ];
+    if (slug.endsWith('usdt')) {
+      const base = slug.slice(0, -4);
+      if (base) entries.push({ params: { symbol: base }, props: { symbolUpper: s } });
+    }
+    return entries;
+  });
 }
 
 const { symbol } = Astro.params;

--- a/src/pages/ko/coins/[symbol].astro
+++ b/src/pages/ko/coins/[symbol].astro
@@ -3,10 +3,17 @@ import Layout from '../../../layouts/Layout.astro';
 import { COIN_SYMBOLS } from '../../../data/coin-symbols';
 
 export async function getStaticPaths() {
-  return COIN_SYMBOLS.map(s => ({
-    params: { symbol: s.toLowerCase() },
-    props: { symbolUpper: s },
-  }));
+  return COIN_SYMBOLS.flatMap(s => {
+    const slug = s.toLowerCase();
+    const entries = [
+      { params: { symbol: slug }, props: { symbolUpper: s } },
+    ];
+    if (slug.endsWith('usdt')) {
+      const base = slug.slice(0, -4);
+      if (base) entries.push({ params: { symbol: base }, props: { symbolUpper: s } });
+    }
+    return entries;
+  });
 }
 
 const { symbol } = Astro.params;


### PR DESCRIPTION
## Summary
- /coins/btc now works alongside /coins/btcusdt (both route to same page)
- Applied to both en and ko locales
- Build passes: 2438 pages (up from ~1290)

## Changes
- `getStaticPaths()` uses `flatMap` to generate both `btcusdt` and `btc` slugs
- Safe guard: only generates base slug when symbol ends with `usdt` and base is non-empty

## Test plan
- [x] `npm run build` passes (2438 pages)
- [x] Code review: clean, no security issues

Generated by OpenClaw Bot (GPT-5-mini)
Reviewed by JEPO