### PR TITLE
fix(8): improve muted text contrast for accessibility

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -25,7 +25,7 @@
   --color-accent: #3b82f6;
   --color-accent-dim: #2563eb;
   --color-text: #e5e5e5;
-  --color-text-muted: #888888;
+  --color-text-muted: #cfcfcf;
   --color-red: #ef4444;
   --color-yellow: #ffaa00;
   --color-up: #10b981;


### PR DESCRIPTION
Raise --color-text-muted to improve contrast against dark background and reduce WCAG violations for text small size. See issue #8.