### PR TITLE
fix(perf): defer Cloudflare Insights beacon via idle-load to reduce network dependency (fixes #46)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -400,7 +400,7 @@ const isActive = (match: string) => basePath.startsWith(match);
       });
     </script>
     {cfToken && (
-      <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon={`{"token":"${cfToken}"}`}></script>
+      <script type="module" src="/scripts/cf-beacon-loader.js" defer></script>
     )}
   </body>
 </html>

--- a/src/scripts/cf-beacon-loader.js
+++ b/src/scripts/cf-beacon-loader.js
@@ -1,0 +1,31 @@
+// Load Cloudflare Insights beacon after page is idle or loaded to avoid blocking critical path
+(function () {
+  try {
+    const token = (window?.PRUVIQ?.cfToken) || (new URLSearchParams(window.location.search).get('cf_token')) || null;
+    // If token is provided via data attribute on body (SSR), prefer that
+    const tokenFromDom = document?.querySelector('meta[name="cf-beacon-token"]')?.getAttribute('content');
+    const cfToken = tokenFromDom || token || (window && window.__CF_BEACON_TOKEN__);
+
+    function insertBeacon() {
+      if (!cfToken) return;
+      const s = document.createElement('script');
+      s.src = 'https://static.cloudflareinsights.com/beacon.min.js';
+      s.defer = true;
+      s.setAttribute('data-cf-beacon', JSON.stringify({ token: cfToken }));
+      document.head.appendChild(s);
+    }
+
+    if ('requestIdleCallback' in window) {
+      requestIdleCallback(function () {
+        insertBeacon();
+      }, { timeout: 3000 });
+    } else {
+      window.addEventListener('load', insertBeacon, { once: true, passive: true });
+      // Fallback: after 3s
+      setTimeout(insertBeacon, 3000);
+    }
+  } catch (e) {
+    // silently fail — analytics non-critical
+    console.error && console.debug && console.debug('cf-beacon-loader error', e);
+  }
+})();


### PR DESCRIPTION
Summary:\n- Defer loading of Cloudflare Insights beacon until the browser is idle or after window.load to remove it from the critical network dependency tree. This reduces potential impact on LCP and main-thread work.\n\nChanges:\n- Added src/scripts/cf-beacon-loader.js which loads the external beacon asynchronously using requestIdleCallback or onload fallback.\n- Replaced direct <script src="https://static.cloudflareinsights.com/beacon.min.js"> with a deferred module loader in src/layouts/Layout.astro.\n\nWhy:\n- The analytics beacon is non-critical for initial render. Loading it during idle time reduces competition for network and main-thread resources on first paint.\n\nTesting:\n- Built site locally (npm run build) and verified no build errors.\n\nFixes: https://github.com/poong92/pruviq/issues/46