### PR TITLE
fix: lazy-load Cloudflare beacon loader to reduce main-thread work

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -334,7 +334,30 @@ const isActive = (match: string) => basePath.startsWith(match);
 
     <script type="module" src="/scripts/layout-client.js" defer></script>
     {cfToken && (
-      <script type="module" src="/scripts/cf-beacon-loader.js" defer></script>
+      <>
+        <script>
+          /* Lazy-load Cloudflare beacon loader during idle or after load to reduce main-thread work */
+          (function() {
+            function loadCF() {
+              try {
+                var s = document.createElement('script');
+                s.type = 'module';
+                s.src = '/scripts/cf-beacon-loader.js';
+                s.defer = true;
+                document.body.appendChild(s);
+              } catch (e) { /* ignore */ }
+            }
+            if (typeof window !== 'undefined') {
+              if ('requestIdleCallback' in window) {
+                requestIdleCallback(loadCF, { timeout: 2000 });
+              } else {
+                window.addEventListener('load', loadCF);
+                setTimeout(loadCF, 2000);
+              }
+            }
+          })();
+        </script>
+      </>
     )}
   </body>
 </html>


### PR DESCRIPTION
Fixes #40 — lazy-loads Cloudflare beacon loader during idle/load to reduce main-thread work and defer non-critical third-party script execution. This is a safe, low-risk change that should improve Lighthouse Main-Thread time by loading the beacon after initial load.\n\nBuild: verified locally (npm run build).