### PR TITLE
chore(ci): add Research PoC workflow (Brave Search, runs only when BRAVE_API_KEY present)

### DIFF
--- a/.github/workflows/research-poc.yml
+++ b/.github/workflows/research-poc.yml
@@ -1,0 +1,37 @@
+name: Research PoC (Brave Search)
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  run-research-poc:
+    if: ${{ secrets.BRAVE_API_KEY != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      BRAVE_API_KEY: ${{ secrets.BRAVE_API_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests feedparser
+
+      - name: Run research PoC
+        run: |
+          mkdir -p reports
+          python scripts/research_agent.py --out reports/agent-research-${{ github.run_number }}.md --topics "Auto-GPT,LangChain,agent evaluation"
+
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: research-report
+          path: reports/agent-research-${{ github.run_number }}.md


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs the research PoC script when the BRAVE_API_KEY secret is present. The workflow is manual (workflow_dispatch) and guarded with  so it is a safe no-op when the secret is not configured.

This change does NOT provision the BRAVE_API_KEY secret. To enable automated runs, add BRAVE_API_KEY as a repository secret (Settings → Secrets & variables → Actions) with the Brave API key.

Relates to: #21
