### PR TITLE
feat: Day 1 UX overhaul — onboarding, CTA, validation

### DIFF
--- a/src/components/BuilderPanel.tsx
+++ b/src/components/BuilderPanel.tsx
@@ -306,16 +306,18 @@ export default function BuilderPanel(props: Props) {
           )}
           <button
             onClick={props.onRun}
-            disabled={props.isRunning}
+            disabled={props.isRunning || props.conditions.length === 0}
             class={`w-full py-2.5 rounded-lg font-mono text-sm font-bold transition-colors
-              ${props.isRunning ? 'cursor-wait' : 'hover:opacity-90'}`}
-            style={props.isRunning ? runDisabledStyle : runStyle}
+              ${props.isRunning || props.conditions.length === 0 ? 'cursor-not-allowed' : 'hover:opacity-90'}`}
+            style={props.isRunning || props.conditions.length === 0 ? runDisabledStyle : runStyle}
           >
             {props.isRunning ? (
               <span class="flex items-center justify-center gap-2">
                 <span class="spinner" />
                 {props.progressLabels[props.progressStep] || t.running}
               </span>
+            ) : props.conditions.length === 0 ? (
+              <span class="text-xs">{t.addCondition}</span>
             ) : t.run}
           </button>
         </div>

--- a/src/components/PresetBar.tsx
+++ b/src/components/PresetBar.tsx
@@ -17,8 +17,8 @@ export default function PresetBar({ presets, activePreset, onSelectPreset, label
   if (presets.length === 0) return null;
 
   return (
-    <div class="px-3 py-2 border-b border-[--color-border]">
-      <div class="text-[10px] font-mono text-[--color-text-muted] uppercase mb-1.5">{label}</div>
+    <div class="px-3 py-2 border-b border-[--color-border]" style={{ background: `linear-gradient(135deg, ${COLORS.accentBg}, transparent)` }}>
+      <div class="text-[10px] font-mono uppercase mb-1.5" style={{ color: COLORS.accent }}>{label}</div>
       <div class="flex flex-wrap gap-1">
         <button
           onClick={() => onSelectPreset(null)}

--- a/src/components/SimulatorPage.tsx
+++ b/src/components/SimulatorPage.tsx
@@ -58,6 +58,10 @@ const L = {
     error: 'Error',
     apiDown: 'API unavailable. Using demo mode.',
     mobile: { chart: 'Chart', config: 'Settings', results: 'Results' },
+    quickStart: 'New to backtesting?',
+    quickStartDesc: 'Try our proven BB Squeeze SHORT strategy — pre-loaded and ready to run.',
+    quickStartCta: 'Run BB Squeeze SHORT',
+    quickStartDismiss: 'I\'ll build my own',
   },
   ko: {
     title: '전략 시뮬레이터',
@@ -101,6 +105,10 @@ const L = {
     error: '에러',
     apiDown: 'API 연결 불가. 데모 모드로 전환합니다.',
     mobile: { chart: '차트', config: '설정', results: '결과' },
+    quickStart: '백테스팅이 처음이신가요?',
+    quickStartDesc: '검증된 BB Squeeze SHORT 전략을 바로 실행해보세요.',
+    quickStartCta: 'BB Squeeze SHORT 실행',
+    quickStartDismiss: '직접 만들기',
   },
 };
 
@@ -167,6 +175,9 @@ export default function SimulatorPage({ lang = 'en' }: Props) {
 
   // Mobile tab
   const [mobileTab, setMobileTab] = useState<'chart' | 'config' | 'results'>('config');
+
+  // Quick Start banner
+  const [showQuickStart, setShowQuickStart] = useState(true);
 
   const resultsRef = useRef<HTMLDivElement>(null);
 
@@ -393,6 +404,32 @@ export default function SimulatorPage({ lang = 'en' }: Props) {
           </button>
         ))}
       </div>
+
+      {/* Quick Start Banner */}
+      {showQuickStart && !result && (
+        <div class="mb-3 border rounded-lg p-4 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3"
+          style={{ borderColor: COLORS.accent, background: `linear-gradient(135deg, ${COLORS.accentBg}, transparent)` }}>
+          <div>
+            <p class="font-mono text-sm font-bold" style={{ color: COLORS.accent }}>{t.quickStart}</p>
+            <p class="text-[--color-text-muted] text-xs mt-0.5">{t.quickStartDesc}</p>
+          </div>
+          <div class="flex gap-2 flex-shrink-0">
+            <button
+              onClick={() => { loadPreset('bb-squeeze-short'); setShowQuickStart(false); runBacktest(); }}
+              class="px-4 py-2 rounded font-mono text-xs font-bold transition-colors hover:opacity-90"
+              style={{ background: COLORS.accent, color: '#fff', boxShadow: `0 0 12px ${COLORS.accentGlow}` }}
+            >
+              {t.quickStartCta} &rarr;
+            </button>
+            <button
+              onClick={() => setShowQuickStart(false)}
+              class="px-3 py-2 rounded font-mono text-[10px] text-[--color-text-muted] border border-[--color-border] hover:text-[--color-text] transition-colors"
+            >
+              {t.quickStartDismiss}
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* Main split layout */}
       <div class="flex flex-col md:flex-row gap-3">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,9 +34,9 @@ const lastUpdated = new Date().toLocaleDateString('en-US');
              class="btn-primary bg-[--color-accent] text-[--color-bg] px-8 py-3 rounded font-semibold text-center hover:bg-[--color-accent-dim] min-h-[44px] text-lg">
             {t('hero.cta_primary')} &rarr;
           </a>
-          <a href="/simulate"
+          <a href="/strategies"
              class="border border-[--color-border] text-[--color-text] px-8 py-3 rounded font-semibold text-center hover:border-[--color-accent] hover:text-[--color-accent] transition-colors min-h-[44px] text-lg">
-            {t('hero.cta_builder')}
+            {t('hero.cta1')}
           </a>
         </div>
 


### PR DESCRIPTION
## Summary\n- **Quick Start banner**: First-time visitors see a welcoming banner with \"Run BB Squeeze SHORT\" one-click CTA (EN/KO i18n)\n- **Homepage Hero CTA fix**: EN second button was duplicate `/simulate` — now goes to `/strategies` (\"Explore Strategies\")\n- **Run button validation**: Disabled when no entry conditions are set, shows \"+ Add Condition\" prompt\n- **Preset highlight**: PresetBar gets accent gradient background to draw attention\n\n## Impact\n- 4 files changed, +46/-7 lines\n- Build: 2446 pages, 0 errors\n- No breaking changes\n\n## Test plan\n- [ ] `/simulate` — Quick Start banner visible, clicking \"Run BB Squeeze SHORT\" runs backtest\n- [ ] `/simulate` — Dismissing banner hides it permanently in session\n- [ ] `/simulate` — Custom mode with 0 conditions: Run button disabled\n- [ ] `/` (EN) — Hero CTAs: \"Try Live Demo\" → /simulate, \"Explore Strategies\" → /strategies\n- [ ] `/ko/` — Hero CTAs already correct (no change)\n- [ ] PresetBar has accent gradient background\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"