### PR TITLE
feat: chart trade markers + R:R ratio

### DIFF
--- a/src/components/ChartPanel.tsx
+++ b/src/components/ChartPanel.tsx
@@ -2,7 +2,7 @@
  * ChartPanel.tsx - Chart display with symbol switching
  */
 import { useEffect, useRef } from 'preact/hooks';
-import type { OhlcvBar } from './simulator-types';
+import type { OhlcvBar, TradeItem } from './simulator-types';
 import { getCssVar, COLORS } from './simulator-types';
 
 interface Props {
@@ -11,9 +11,10 @@ interface Props {
   chartData: OhlcvBar[];
   chartLoading: boolean;
   loadingText: string;
+  trades?: TradeItem[];
 }
 
-export default function ChartPanel({ chartSymbol, setChartSymbol, chartData, chartLoading, loadingText }: Props) {
+export default function ChartPanel({ chartSymbol, setChartSymbol, chartData, chartLoading, loadingText, trades }: Props) {
   const chartContainerRef = useRef<HTMLDivElement>(null);
   const chartInstanceRef = useRef<any>(null);
 
@@ -102,6 +103,36 @@ export default function ChartPanel({ chartSymbol, setChartSymbol, chartData, cha
         color: b.c >= b.o ? COLORS.greenFill : COLORS.redFill,
       })));
 
+      // Trade entry/exit markers
+      if (trades && trades.length > 0) {
+        const symbolTrades = trades.filter((t) => t.symbol === chartSymbol);
+        if (symbolTrades.length > 0) {
+          const markers = symbolTrades.flatMap((t) => {
+            const entryTs = Math.floor(new Date(t.entry_time).getTime() / 1000);
+            const exitTs = Math.floor(new Date(t.exit_time).getTime() / 1000);
+            const isShort = t.direction === 'short';
+            const isWin = t.pnl_pct > 0;
+            return [
+              {
+                time: entryTs as any,
+                position: isShort ? 'aboveBar' as const : 'belowBar' as const,
+                color: COLORS.accent,
+                shape: isShort ? 'arrowDown' as const : 'arrowUp' as const,
+                text: isShort ? 'S' : 'L',
+              },
+              {
+                time: exitTs as any,
+                position: isShort ? 'belowBar' as const : 'aboveBar' as const,
+                color: isWin ? COLORS.green : COLORS.red,
+                shape: 'circle' as const,
+                text: `${t.pnl_pct > 0 ? '+' : ''}${t.pnl_pct.toFixed(1)}%`,
+              },
+            ];
+          }).sort((a, b) => (a.time as number) - (b.time as number));
+          candleSeries.setMarkers(markers);
+        }
+      }
+
       chart.timeScale().fitContent();
       chartInstanceRef.current = chart;
 
@@ -121,7 +152,7 @@ export default function ChartPanel({ chartSymbol, setChartSymbol, chartData, cha
         chartInstanceRef.current = null;
       }
     };
-  }, [chartData]);
+  }, [chartData, trades]);
 
   return (
     <div class="border border-[--color-border] rounded-lg bg-[--color-bg-card] overflow-hidden">

--- a/src/components/ResultsCard.tsx
+++ b/src/components/ResultsCard.tsx
@@ -101,7 +101,7 @@ export default function ResultsCard({ data, isDefault, lang = 'en', isDemo = fal
       </div>
 
       {(data.avg_win_pct !== undefined || data.avg_loss_pct !== undefined) && (
-        <div class="grid grid-cols-3 gap-2 mb-3">
+        <div class="grid grid-cols-4 gap-2 mb-3">
           <MetricBox
             label={t.avgWin}
             value={`+${(data.avg_win_pct ?? 0).toFixed(2)}%`}
@@ -111,6 +111,11 @@ export default function ResultsCard({ data, isDefault, lang = 'en', isDemo = fal
             label={t.avgLoss}
             value={`${(data.avg_loss_pct ?? 0).toFixed(2)}%`}
             color="var(--color-red)"
+          />
+          <MetricBox
+            label={t.rr}
+            value={data.avg_loss_pct && data.avg_loss_pct !== 0 ? `1:${(Math.abs(data.avg_win_pct ?? 0) / Math.abs(data.avg_loss_pct)).toFixed(2)}` : 'N/A'}
+            color={((data.avg_win_pct ?? 0) / Math.abs(data.avg_loss_pct ?? 1)) >= 1 ? 'var(--color-accent)' : 'var(--color-text-muted)'}
           />
           <MetricBox
             label={t.maxConsec}

--- a/src/components/SimulatorPage.tsx
+++ b/src/components/SimulatorPage.tsx
@@ -441,6 +441,7 @@ export default function SimulatorPage({ lang = 'en' }: Props) {
             chartData={chartData}
             chartLoading={chartLoading}
             loadingText={t.loading}
+            trades={result?.trades}
           />
         </div>
 


### PR DESCRIPTION
## Summary\n- **Chart trade markers**: After running a backtest, entry/exit points are shown on the chart as markers\n  - Entry: blue arrow (S for short, L for long)\n  - Exit: green circle (win) or red circle (loss) with PnL %\n  - Only shows trades for the currently displayed symbol\n- **R:R ratio**: Added Risk:Reward ratio to ResultsCard, calculated from avg_win/avg_loss\n- **4-column layout**: Secondary metrics now show Avg Win, Avg Loss, R:R, Max Consec Losses\n\n## Technical\n- ChartPanel: new optional `trades` prop, lightweight-charts `setMarkers()` API\n- ResultsCard: dynamic R:R calculation with color coding (blue if >= 1:1)\n- 3 files changed, +41/-4 lines\n\n## Test plan\n- [ ] Run backtest on BB Squeeze SHORT → markers appear on BTCUSDT chart\n- [ ] Switch to ETHUSDT → markers update to ETH trades only\n- [ ] R:R ratio shows correctly in summary tab\n- [ ] 4-column layout renders correctly on mobile\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"