### PR TITLE
feat: i18n disclaimer + dynamic Run CTA

### DIFF
--- a/src/components/BuilderPanel.tsx
+++ b/src/components/BuilderPanel.tsx
@@ -318,7 +318,7 @@ export default function BuilderPanel(props: Props) {
               </span>
             ) : props.conditions.length === 0 ? (
               <span class="text-xs">{t.addCondition}</span>
-            ) : t.run}
+            ) : props.coinsLoaded > 0 ? t.runWithCoins?.replace('{n}', String(props.coinsLoaded)) || t.run : t.run}
           </button>
         </div>
       </div>

--- a/src/components/SimulatorPage.tsx
+++ b/src/components/SimulatorPage.tsx
@@ -33,6 +33,7 @@ const L = {
     preset: 'Presets',
     indicators: 'Indicators',
     run: 'Run Backtest',
+    runWithCoins: 'Simulate on {n} Coins',
     running: 'Running...',
     results: 'Results',
     noResults: 'Run a backtest to see results.',
@@ -57,6 +58,7 @@ const L = {
     loading: 'Loading...',
     error: 'Error',
     apiDown: 'API unavailable. Using demo mode.',
+    disclaimer: 'Past performance does not guarantee future results. Simulations include estimated fees (0.04%) and slippage (0.02%). This is not financial advice.',
     mobile: { chart: 'Chart', config: 'Settings', results: 'Results' },
     quickStart: 'New to backtesting?',
     quickStartDesc: 'Try our proven BB Squeeze SHORT strategy — pre-loaded and ready to run.',
@@ -80,6 +82,7 @@ const L = {
     preset: '프리셋',
     indicators: '지표',
     run: '백테스트 실행',
+    runWithCoins: '{n}개 코인 시뮬레이션',
     running: '실행 중...',
     results: '결과',
     noResults: '백테스트를 실행하면 결과가 표시됩니다.',
@@ -104,6 +107,7 @@ const L = {
     loading: '로딩 중...',
     error: '에러',
     apiDown: 'API 연결 불가. 데모 모드로 전환합니다.',
+    disclaimer: '과거 성과가 미래 수익을 보장하지 않습니다. 시뮬레이션에는 예상 수수료(0.04%)와 슬리피지(0.02%)가 포함됩니다. 이것은 투자 조언이 아닙니다.',
     mobile: { chart: '차트', config: '설정', results: '결과' },
     quickStart: '백테스팅이 처음이신가요?',
     quickStartDesc: '검증된 BB Squeeze SHORT 전략을 바로 실행해보세요.',
@@ -499,8 +503,7 @@ export default function SimulatorPage({ lang = 'en' }: Props) {
       {/* Disclaimer */}
       <div class="mt-6 mb-8 text-center">
         <p class="text-[--color-text-muted] text-[10px] max-w-lg mx-auto">
-          Past performance does not guarantee future results. Simulations include estimated fees (0.04%) and slippage (0.02%).
-          This is not financial advice.
+          {t.disclaimer}
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add i18n disclaimer text (EN/KO) replacing hardcoded English string
- Add `runWithCoins` i18n key: shows coin count in Run button (e.g. "Simulate on 535 Coins" / "535개 코인 시뮬레이션")
- Improves conversion by showing specific value proposition in the CTA

## Changes
- `SimulatorPage.tsx`: Added `disclaimer`, `runWithCoins` keys to both EN/KO translation objects
- `BuilderPanel.tsx`: Run button now shows coin count when available

## Test plan
- [ ] /simulate — verify Run button shows "Simulate on 535 Coins"
- [ ] /ko/simulate — verify "535개 코인 시뮬레이션"
- [ ] Verify disclaimer shows in correct language per page
- [ ] Verify fallback to generic "Run Backtest" when coins not loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)