### PR TITLE
fix: auto-switch to results tab on mobile

### DIFF
--- a/src/components/SimulatorPage.tsx
+++ b/src/components/SimulatorPage.tsx
@@ -269,6 +269,7 @@ export default function SimulatorPage({ lang = 'en' }: Props) {
         const demoData = await fetch('/data/demo-backtest-result.json').then((r) => r.json());
         setResult({ ...demoData, _isDemo: true });
         setResultTab('summary');
+        setMobileTab('results');
       } catch { setError('Demo data load failed'); }
       finally { setIsRunning(false); }
       return;
@@ -323,6 +324,7 @@ export default function SimulatorPage({ lang = 'en' }: Props) {
       const data: BacktestResult = await res.json();
       setResult(data);
       setResultTab('summary');
+      setMobileTab('results');
       setTimeout(() => resultsRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' }), 200);
     } catch (e: any) {
       setError(e.message || 'Backtest failed');


### PR DESCRIPTION
## Summary
- Auto-switch mobile view to Results tab after backtest completes
- Applies to both live API and demo mode backtests
- Prevents mobile users from staying on Settings tab and missing results

## Test plan
- [ ] Mobile: run backtest → auto-switches to Results tab
- [ ] Desktop: unchanged behavior (scroll to results)
- [ ] Demo mode: same auto-switch behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)