### PR TITLE
chore(data): update performance.json to 1625 trades (47 days)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,5 @@ backend/src/__pycache__/
 *.pyo
 data/
 !src/data/
-\!public/data/
+!public/data/
 test-results/

--- a/public/data/performance.json
+++ b/public/data/performance.json
@@ -1,782 +1,301 @@
 {
-  "generated": "2026-02-18T02:54:59Z",
-  "strategy": "BB Squeeze SHORT v1.7.0",
+  "generated": "2026-02-27T09:57:50Z",
+  "strategy": "BB Squeeze SHORT",
   "period": {
     "from": "2026-01-12",
-    "to": "2026-02-18"
+    "to": "2026-02-27"
   },
   "summary": {
-    "total_trades": 1317,
-    "win_rate": 54.59,
+    "total_trades": 1625,
+    "win_rate": 54.46,
     "profit_factor": 1.01,
-    "total_pnl": 9.72,
-    "starting_balance": 3102.0,
-    "current_balance": 3111.72,
-    "max_drawdown_pct": 12.97,
-    "avg_trade_pnl": 0.01,
-    "best_day_pnl": 415.43,
-    "worst_day_pnl": -334.15,
-    "tp_count": 464,
-    "sl_count": 341,
-    "timeout_count": 208,
-    "other_count": 304
+    "total_pnl": 21.22,
+    "starting_balance": 3102,
+    "current_balance": 3123.22,
+    "max_drawdown_pct": 13.0
   },
   "daily": [
     {
       "date": "2026-01-12",
       "pnl": 0.0,
       "trades": 0,
-      "cum_pnl": 0.0,
-      "wins": 0,
-      "losses": 0
+      "cum_pnl": 0.0
     },
     {
       "date": "2026-01-13",
       "pnl": 10.56,
       "trades": 5,
-      "cum_pnl": 10.56,
-      "wins": 5,
-      "losses": 0
+      "cum_pnl": 10.56
     },
     {
       "date": "2026-01-14",
       "pnl": -334.15,
       "trades": 129,
-      "cum_pnl": -323.59,
-      "wins": 38,
-      "losses": 91
+      "cum_pnl": -323.59
     },
     {
       "date": "2026-01-15",
       "pnl": 4.19,
       "trades": 6,
-      "cum_pnl": -319.39,
-      "wins": 5,
-      "losses": 1
+      "cum_pnl": -319.39
     },
     {
       "date": "2026-01-16",
       "pnl": 9.71,
       "trades": 5,
-      "cum_pnl": -309.68,
-      "wins": 5,
-      "losses": 0
+      "cum_pnl": -309.68
     },
     {
       "date": "2026-01-17",
       "pnl": -1.25,
       "trades": 7,
-      "cum_pnl": -310.93,
-      "wins": 4,
-      "losses": 3
+      "cum_pnl": -310.93
     },
     {
       "date": "2026-01-18",
       "pnl": -10.55,
       "trades": 4,
-      "cum_pnl": -321.48,
-      "wins": 1,
-      "losses": 3
+      "cum_pnl": -321.48
     },
     {
       "date": "2026-01-19",
       "pnl": -8.77,
       "trades": 15,
-      "cum_pnl": -330.25,
-      "wins": 9,
-      "losses": 6
+      "cum_pnl": -330.25
     },
     {
       "date": "2026-01-20",
       "pnl": -6.8,
       "trades": 8,
-      "cum_pnl": -337.06,
-      "wins": 3,
-      "losses": 5
+      "cum_pnl": -337.06
     },
     {
       "date": "2026-01-21",
       "pnl": 1.92,
       "trades": 24,
-      "cum_pnl": -335.14,
-      "wins": 7,
-      "losses": 17
+      "cum_pnl": -335.14
     },
     {
       "date": "2026-01-22",
       "pnl": -55.22,
       "trades": 73,
-      "cum_pnl": -390.36,
-      "wins": 26,
-      "losses": 47
+      "cum_pnl": -390.36
     },
     {
       "date": "2026-01-23",
       "pnl": -2.31,
       "trades": 5,
-      "cum_pnl": -392.67,
-      "wins": 1,
-      "losses": 4
+      "cum_pnl": -392.67
     },
     {
       "date": "2026-01-24",
       "pnl": 0.0,
       "trades": 0,
-      "cum_pnl": -392.67,
-      "wins": 0,
-      "losses": 0
+      "cum_pnl": -392.67
     },
     {
       "date": "2026-01-25",
       "pnl": -0.43,
       "trades": 3,
-      "cum_pnl": -393.1,
-      "wins": 0,
-      "losses": 3
+      "cum_pnl": -393.1
     },
     {
       "date": "2026-01-26",
       "pnl": 43.05,
       "trades": 35,
-      "cum_pnl": -350.05,
-      "wins": 23,
-      "losses": 12
+      "cum_pnl": -350.05
     },
     {
       "date": "2026-01-27",
       "pnl": -10.35,
       "trades": 26,
-      "cum_pnl": -360.4,
-      "wins": 13,
-      "losses": 13
+      "cum_pnl": -360.4
     },
     {
       "date": "2026-01-28",
       "pnl": -25.14,
       "trades": 75,
-      "cum_pnl": -385.54,
-      "wins": 26,
-      "losses": 49
+      "cum_pnl": -385.54
     },
     {
       "date": "2026-01-29",
       "pnl": 5.14,
       "trades": 46,
-      "cum_pnl": -380.4,
-      "wins": 26,
-      "losses": 20
+      "cum_pnl": -380.4
     },
     {
       "date": "2026-01-30",
       "pnl": 0.46,
       "trades": 31,
-      "cum_pnl": -379.95,
-      "wins": 18,
-      "losses": 13
+      "cum_pnl": -379.95
     },
     {
       "date": "2026-01-31",
       "pnl": 25.13,
       "trades": 105,
-      "cum_pnl": -354.82,
-      "wins": 69,
-      "losses": 36
+      "cum_pnl": -354.82
     },
     {
       "date": "2026-02-01",
       "pnl": 271.18,
       "trades": 132,
-      "cum_pnl": -83.63,
-      "wins": 120,
-      "losses": 12
+      "cum_pnl": -83.63
     },
     {
       "date": "2026-02-02",
       "pnl": 37.79,
       "trades": 27,
-      "cum_pnl": -45.84,
-      "wins": 18,
-      "losses": 9
+      "cum_pnl": -45.84
     },
     {
       "date": "2026-02-03",
       "pnl": -8.41,
       "trades": 28,
-      "cum_pnl": -54.25,
-      "wins": 12,
-      "losses": 16
+      "cum_pnl": -54.25
     },
     {
       "date": "2026-02-04",
       "pnl": -197.88,
       "trades": 110,
-      "cum_pnl": -252.13,
-      "wins": 19,
-      "losses": 91
+      "cum_pnl": -252.13
     },
     {
       "date": "2026-02-05",
       "pnl": 30.55,
       "trades": 62,
-      "cum_pnl": -221.59,
-      "wins": 38,
-      "losses": 24
+      "cum_pnl": -221.59
     },
     {
       "date": "2026-02-06",
       "pnl": 415.43,
       "trades": 163,
-      "cum_pnl": 193.84,
-      "wins": 158,
-      "losses": 5
+      "cum_pnl": 193.84
     },
     {
       "date": "2026-02-07",
       "pnl": -1.11,
       "trades": 2,
-      "cum_pnl": 192.73,
-      "wins": 1,
-      "losses": 1
+      "cum_pnl": 192.73
     },
     {
       "date": "2026-02-08",
       "pnl": -4.86,
       "trades": 6,
-      "cum_pnl": 187.87,
-      "wins": 2,
-      "losses": 4
+      "cum_pnl": 187.87
     },
     {
       "date": "2026-02-09",
       "pnl": 10.44,
       "trades": 8,
-      "cum_pnl": 198.31,
-      "wins": 6,
-      "losses": 2
+      "cum_pnl": 198.31
     },
     {
       "date": "2026-02-10",
       "pnl": -4.38,
       "trades": 10,
-      "cum_pnl": 193.93,
-      "wins": 5,
-      "losses": 5
+      "cum_pnl": 193.93
     },
     {
       "date": "2026-02-11",
       "pnl": 16.42,
       "trades": 24,
-      "cum_pnl": 210.35,
-      "wins": 14,
-      "losses": 10
+      "cum_pnl": 210.35
     },
     {
       "date": "2026-02-12",
       "pnl": -88.78,
       "trades": 28,
-      "cum_pnl": 121.57,
-      "wins": 6,
-      "losses": 22
+      "cum_pnl": 121.57
     },
     {
       "date": "2026-02-13",
       "pnl": -103.5,
       "trades": 74,
-      "cum_pnl": 18.08,
-      "wins": 20,
-      "losses": 54
+      "cum_pnl": 18.08
     },
     {
       "date": "2026-02-14",
       "pnl": -6.94,
       "trades": 8,
-      "cum_pnl": 11.14,
-      "wins": 4,
-      "losses": 4
+      "cum_pnl": 11.14
     },
     {
       "date": "2026-02-15",
       "pnl": -14.23,
       "trades": 10,
-      "cum_pnl": -3.09,
-      "wins": 3,
-      "losses": 7
+      "cum_pnl": -3.09
     },
     {
       "date": "2026-02-16",
       "pnl": -0.73,
       "trades": 5,
-      "cum_pnl": -3.82,
-      "wins": 2,
-      "losses": 3
+      "cum_pnl": -3.82
     },
     {
       "date": "2026-02-17",
       "pnl": 5.67,
       "trades": 14,
-      "cum_pnl": 1.85,
-      "wins": 9,
-      "losses": 5
+      "cum_pnl": 1.85
     },
     {
       "date": "2026-02-18",
+      "pnl": -3.64,
+      "trades": 13,
+      "cum_pnl": -1.79
+    },
+    {
+      "date": "2026-02-19",
+      "pnl": 34.61,
+      "trades": 34,
+      "cum_pnl": 32.82
+    },
+    {
+      "date": "2026-02-20",
+      "pnl": 51.91,
+      "trades": 43,
+      "cum_pnl": 84.73
+    },
+    {
+      "date": "2026-02-21",
+      "pnl": -167.6,
+      "trades": 63,
+      "cum_pnl": -82.88
+    },
+    {
+      "date": "2026-02-22",
+      "pnl": -6.89,
+      "trades": 39,
+      "cum_pnl": -89.76
+    },
+    {
+      "date": "2026-02-23",
+      "pnl": 93.39,
+      "trades": 28,
+      "cum_pnl": 3.63
+    },
+    {
+      "date": "2026-02-24",
+      "pnl": 39.46,
+      "trades": 24,
+      "cum_pnl": 43.09
+    },
+    {
+      "date": "2026-02-25",
+      "pnl": 10.02,
+      "trades": 44,
+      "cum_pnl": 53.11
+    },
+    {
+      "date": "2026-02-26",
+      "pnl": -39.76,
+      "trades": 16,
+      "cum_pnl": 13.35
+    },
+    {
+      "date": "2026-02-27",
       "pnl": 7.87,
-      "trades": 4,
-      "cum_pnl": 9.72,
-      "wins": 3,
-      "losses": 1
-    }
-  ],
-  "recent_trades": [
-    {
-      "symbol": "RIVERUSDT",
-      "entry_price": 10.7418929,
-      "exit_price": 9.877714330357144,
-      "pnl_pct": 8.04,
-      "pnl_usd": 4.84,
-      "reason": "TP",
-      "closed_at": "2026-02-18T05:22:42.299012"
-    },
-    {
-      "symbol": "USUSDT",
-      "entry_price": 0.0036034,
-      "exit_price": 0.0039849182242206235,
-      "pnl_pct": -10.59,
-      "pnl_usd": -6.36,
-      "reason": "SL",
-      "closed_at": "2026-02-18T02:48:51.964124"
-    },
-    {
-      "symbol": "IRYSUSDT",
-      "entry_price": 0.03147,
-      "exit_price": 0.02896,
-      "pnl_pct": 7.98,
-      "pnl_usd": 4.79,
-      "reason": "TP",
-      "closed_at": "2026-02-18T01:48:04.311985"
-    },
-    {
-      "symbol": "TRUTHUSDT",
-      "entry_price": 0.011971,
-      "exit_price": 0.011049000000000002,
-      "pnl_pct": 7.7,
-      "pnl_usd": 4.61,
-      "reason": "TP",
-      "closed_at": "2026-02-18T00:41:54.322651"
-    },
-    {
-      "symbol": "USUSDT",
-      "entry_price": 0.004108,
-      "exit_price": 0.0037869999999999996,
-      "pnl_pct": 7.81,
-      "pnl_usd": 4.69,
-      "reason": "TP",
-      "closed_at": "2026-02-17T23:46:13.789981"
-    },
-    {
-      "symbol": "MYXUSDT",
-      "entry_price": 1.568,
-      "exit_price": 1.4500000000000002,
-      "pnl_pct": 7.53,
-      "pnl_usd": 4.37,
-      "reason": "TP",
-      "closed_at": "2026-02-17T23:30:18.799792"
-    },
-    {
-      "symbol": "XVGUSDT",
-      "entry_price": 0.0060786,
-      "exit_price": 0.006006,
-      "pnl_pct": 1.11,
-      "pnl_usd": 0.67,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-17T23:02:34.166061"
-    },
-    {
-      "symbol": "SYSUSDT",
-      "entry_price": 0.01363,
-      "exit_price": 0.01358,
-      "pnl_pct": 0.29,
-      "pnl_usd": 0.17,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-17T23:02:22.387556"
-    },
-    {
-      "symbol": "SOPHUSDT",
-      "entry_price": 0.0096996,
-      "exit_price": 0.009864,
-      "pnl_pct": -1.77,
-      "pnl_usd": -1.06,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-17T23:02:17.085658"
-    },
-    {
-      "symbol": "CHRUSDT",
-      "entry_price": 0.0255,
-      "exit_price": 0.0251,
-      "pnl_pct": 1.49,
-      "pnl_usd": 0.89,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-17T23:01:28.779258"
-    },
-    {
-      "symbol": "MANTAUSDT",
-      "entry_price": 0.07684781,
-      "exit_price": 0.07962,
-      "pnl_pct": -3.69,
-      "pnl_usd": -2.21,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-17T22:02:10.956706"
-    },
-    {
-      "symbol": "LPTUSDT",
-      "entry_price": 2.44,
-      "exit_price": 2.461,
-      "pnl_pct": -0.94,
-      "pnl_usd": -0.56,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-17T22:01:25.465080"
-    },
-    {
-      "symbol": "BUSDT",
-      "entry_price": 0.143,
-      "exit_price": 0.1407,
-      "pnl_pct": 1.53,
-      "pnl_usd": 0.91,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-17T22:00:58.266557"
-    },
-    {
-      "symbol": "LQTYUSDT",
-      "entry_price": 0.2708,
-      "exit_price": 0.2695,
-      "pnl_pct": 0.4,
-      "pnl_usd": 0.24,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-17T20:01:45.362547"
-    },
-    {
-      "symbol": "MYXUSDT",
-      "entry_price": 1.73,
-      "exit_price": 1.5879999999999999,
-      "pnl_pct": 8.21,
-      "pnl_usd": 4.83,
-      "reason": "TP",
-      "closed_at": "2026-02-17T16:18:57.628255"
-    },
-    {
-      "symbol": "IRYSUSDT",
-      "entry_price": 0.03409,
-      "exit_price": 0.031450000000000006,
-      "pnl_pct": 7.74,
-      "pnl_usd": 4.64,
-      "reason": "TP",
-      "closed_at": "2026-02-17T14:56:14.227021"
-    },
-    {
-      "symbol": "RAYSOLUSDT",
-      "entry_price": 0.60576061,
-      "exit_price": 0.666300003939394,
-      "pnl_pct": -9.99,
-      "pnl_usd": -5.99,
-      "reason": "SL",
-      "closed_at": "2026-02-17T09:03:04.776513"
-    },
-    {
-      "symbol": "AWEUSDT",
-      "entry_price": 0.0879189,
-      "exit_price": 0.09657998504398826,
-      "pnl_pct": -9.85,
-      "pnl_usd": -5.91,
-      "reason": "SL",
-      "closed_at": "2026-02-17T02:41:14.930963"
-    },
-    {
-      "symbol": "DOLOUSDT",
-      "entry_price": 0.0345884,
-      "exit_price": 0.03816995889145496,
-      "pnl_pct": -10.35,
-      "pnl_usd": -6.2,
-      "reason": "SL",
-      "closed_at": "2026-02-16T20:08:28.870964"
-    },
-    {
-      "symbol": "EDUUSDT",
-      "entry_price": 0.1256,
-      "exit_price": 0.1324,
-      "pnl_pct": -5.49,
-      "pnl_usd": -3.29,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-16T14:01:55.449249"
-    },
-    {
-      "symbol": "PLAYUSDT",
-      "entry_price": 0.0278,
-      "exit_price": 0.02565,
-      "pnl_pct": 7.73,
-      "pnl_usd": 4.62,
-      "reason": "TP",
-      "closed_at": "2026-02-16T13:23:25.676071"
-    },
-    {
-      "symbol": "RIFUSDT",
-      "entry_price": 0.03214,
-      "exit_price": 0.029670000000000002,
-      "pnl_pct": 7.69,
-      "pnl_usd": 4.61,
-      "reason": "TP",
-      "closed_at": "2026-02-16T08:10:20.474595"
-    },
-    {
-      "symbol": "HEMIUSDT",
-      "entry_price": 0.01003,
-      "exit_price": 0.0101,
-      "pnl_pct": -0.78,
-      "pnl_usd": -0.47,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-16T01:01:46.612298"
-    },
-    {
-      "symbol": "PLAYUSDT",
-      "entry_price": 0.03323,
-      "exit_price": 0.030520000000000002,
-      "pnl_pct": 8.16,
-      "pnl_usd": 4.9,
-      "reason": "TP",
-      "closed_at": "2026-02-15T21:39:02.965661"
-    },
-    {
-      "symbol": "POWERUSDT",
-      "entry_price": 0.2190354,
-      "exit_price": 0.20191305578754576,
-      "pnl_pct": 7.82,
-      "pnl_usd": 4.67,
-      "reason": "TP",
-      "closed_at": "2026-02-15T19:30:01.132819"
-    },
-    {
-      "symbol": "1000CHEEMSUSDT",
-      "entry_price": 0.0005032,
-      "exit_price": 0.0005538856240506861,
-      "pnl_pct": -10.07,
-      "pnl_usd": -6.04,
-      "reason": "SL",
-      "closed_at": "2026-02-15T16:04:28.965828"
-    },
-    {
-      "symbol": "ENJUSDT",
-      "entry_price": 0.02038,
-      "exit_price": 0.02242,
-      "pnl_pct": -10.01,
-      "pnl_usd": -6.0,
-      "reason": "SL",
-      "closed_at": "2026-02-15T03:30:38.559054"
-    },
-    {
-      "symbol": "JSTUSDT",
-      "entry_price": 0.03977,
-      "exit_price": 0.041545,
-      "pnl_pct": -4.54,
-      "pnl_usd": -2.72,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-15T03:01:33.236343"
-    },
-    {
-      "symbol": "SCRTUSDT",
-      "entry_price": 0.0896,
-      "exit_price": 0.0958,
-      "pnl_pct": -7.0,
-      "pnl_usd": -4.19,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-15T02:01:29.377592"
-    },
-    {
-      "symbol": "LQTYUSDT",
-      "entry_price": 0.2677,
-      "exit_price": 0.2798,
-      "pnl_pct": -4.6,
-      "pnl_usd": -2.76,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-15T02:01:08.962872"
-    },
-    {
-      "symbol": "DUSDT",
-      "entry_price": 0.00881,
-      "exit_price": 0.00908,
-      "pnl_pct": -3.14,
-      "pnl_usd": -1.88,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-15T02:00:49.133574"
-    },
-    {
-      "symbol": "RIVERUSDT",
-      "entry_price": 13.903,
-      "exit_price": 13.034651162790698,
-      "pnl_pct": 6.25,
-      "pnl_usd": 3.73,
-      "reason": "TP",
-      "closed_at": "2026-02-15T01:07:07.765936"
-    },
-    {
-      "symbol": "APTUSDT",
-      "entry_price": 0.9129,
-      "exit_price": 0.9721,
-      "pnl_pct": -6.56,
-      "pnl_usd": -3.94,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-15T01:01:41.422989"
-    },
-    {
-      "symbol": "BUSDT",
-      "entry_price": 0.1476,
-      "exit_price": 0.145,
-      "pnl_pct": 1.68,
-      "pnl_usd": 1.01,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-14T22:01:07.953934"
-    },
-    {
-      "symbol": "B2USDT",
-      "entry_price": 0.6699,
-      "exit_price": 0.7382000000000001,
-      "pnl_pct": -10.2,
-      "pnl_usd": -6.08,
-      "reason": "SL",
-      "closed_at": "2026-02-14T21:10:27.723740"
-    },
-    {
-      "symbol": "PLAYUSDT",
-      "entry_price": 0.04103,
-      "exit_price": 0.03851557152635181,
-      "pnl_pct": 6.13,
-      "pnl_usd": 3.67,
-      "reason": "TP",
-      "closed_at": "2026-02-14T18:18:36.821506"
-    },
-    {
-      "symbol": "QNTUSDT",
-      "entry_price": 67.51,
-      "exit_price": 74.22,
-      "pnl_pct": -9.94,
-      "pnl_usd": -5.37,
-      "reason": "SL",
-      "closed_at": "2026-02-14T17:56:28.152601"
-    },
-    {
-      "symbol": "XPINUSDT",
-      "entry_price": 0.001617,
-      "exit_price": 0.001521,
-      "pnl_pct": 5.94,
-      "pnl_usd": 3.56,
-      "reason": "TP",
-      "closed_at": "2026-02-14T04:30:26.938506"
-    },
-    {
-      "symbol": "EULUSDT",
-      "entry_price": 0.782,
-      "exit_price": 0.8590000000000001,
-      "pnl_pct": -9.85,
-      "pnl_usd": -5.91,
-      "reason": "SL",
-      "closed_at": "2026-02-14T02:25:28.894872"
-    },
-    {
-      "symbol": "HEMIUSDT",
-      "entry_price": 0.01071,
-      "exit_price": 0.010150000000000001,
-      "pnl_pct": 5.23,
-      "pnl_usd": 3.13,
-      "reason": "TP",
-      "closed_at": "2026-02-14T00:25:27.534651"
-    },
-    {
-      "symbol": "CHRUSDT",
-      "entry_price": 0.0262,
-      "exit_price": 0.0266,
-      "pnl_pct": -1.61,
-      "pnl_usd": -0.96,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-14T00:00:45.492577"
-    },
-    {
-      "symbol": "RLSUSDT",
-      "entry_price": 0.004677,
-      "exit_price": 0.005150999999999999,
-      "pnl_pct": -10.13,
-      "pnl_usd": -6.08,
-      "reason": "SL",
-      "closed_at": "2026-02-13T21:08:14.706628"
-    },
-    {
-      "symbol": "IOTXUSDT",
-      "entry_price": 0.00533,
-      "exit_price": 0.00537,
-      "pnl_pct": -0.83,
-      "pnl_usd": -0.5,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-13T20:40:57.418118"
-    },
-    {
-      "symbol": "POWRUSDT",
-      "entry_price": 0.06307,
-      "exit_price": 0.06509,
-      "pnl_pct": -3.28,
-      "pnl_usd": -1.97,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-13T18:02:08.351099"
-    },
-    {
-      "symbol": "BNTUSDT",
-      "entry_price": 0.2760696,
-      "exit_price": 0.2781,
-      "pnl_pct": -0.82,
-      "pnl_usd": -0.49,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-13T18:01:26.449642"
-    },
-    {
-      "symbol": "FORMUSDT",
-      "entry_price": 0.1973,
-      "exit_price": 0.2055,
-      "pnl_pct": -4.24,
-      "pnl_usd": -2.54,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-13T16:02:12.877996"
-    },
-    {
-      "symbol": "FLUXUSDT",
-      "entry_price": 0.0685,
-      "exit_price": 0.0692,
-      "pnl_pct": -1.1,
-      "pnl_usd": -0.66,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-13T16:02:10.871016"
-    },
-    {
-      "symbol": "FIOUSDT",
-      "entry_price": 0.00855,
-      "exit_price": 0.00893,
-      "pnl_pct": -4.52,
-      "pnl_usd": -2.71,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-13T16:02:09.017731"
-    },
-    {
-      "symbol": "ENAUSDT",
-      "entry_price": 0.1114,
-      "exit_price": 0.1151,
-      "pnl_pct": -3.4,
-      "pnl_usd": -2.04,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-13T16:02:04.408686"
-    },
-    {
-      "symbol": "DOGSUSDT",
-      "entry_price": 2.68e-05,
-      "exit_price": 2.85e-05,
-      "pnl_pct": -6.42,
-      "pnl_usd": -3.85,
-      "reason": "TIMEOUT",
-      "closed_at": "2026-02-13T16:02:00.654254"
+      "trades": 8,
+      "cum_pnl": 21.22
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Fix `.gitignore`: escaped `\!` prevented `public/data/` from being tracked
- Update `performance.json`: 1317→1625 trades, period through 2026-02-27
- Metrics: WR 54.46%, PF 1.01, PnL $21.22, MDD 13.0%

## Changes
- `.gitignore`: `\!public/data/` → `!public/data/` (fix negation)
- `public/data/performance.json`: fresh data from server (47 days)

## Impact
LiveStats widget on homepage will show current data instead of stale 2/18 data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)