### PR TITLE
fix(simulator): enlarge builder panel for readability

### DIFF
--- a/src/components/BuilderPanel.tsx
+++ b/src/components/BuilderPanel.tsx
@@ -66,11 +66,11 @@ export default function BuilderPanel(props: Props) {
   return (
     <div class="border border-[--color-border] rounded-lg bg-[--color-bg-card] overflow-hidden flex flex-col" style={{ height: '640px' }}>
       {/* Panel header */}
-      <div class="px-3 py-2 border-b border-[--color-border] flex-shrink-0">
+      <div class="px-4 py-2.5 border-b border-[--color-border] flex-shrink-0">
         <div class="flex items-center justify-between">
-          <span class="font-mono text-xs text-[--color-accent] tracking-wider">STRATEGY BUILDER</span>
+          <span class="font-mono text-sm text-[--color-accent] tracking-wider font-bold">STRATEGY BUILDER</span>
           {props.coinsLoaded > 0 && (
-            <span class="text-[--color-text-muted] text-[10px] font-mono">{props.coinsLoaded} coins</span>
+            <span class="text-[--color-text-muted] text-xs font-mono">{props.coinsLoaded} coins</span>
           )}
         </div>
       </div>
@@ -86,9 +86,9 @@ export default function BuilderPanel(props: Props) {
         />
 
         {/* Indicators */}
-        <div class="px-3 py-1.5 border-b border-[--color-border]">
-          <div class="text-[10px] font-mono text-[--color-text-muted] uppercase mb-1">{t.indicators}</div>
-          <div class="flex flex-wrap gap-1">
+        <div class="px-4 py-2.5 border-b border-[--color-border]">
+          <div class="text-xs font-mono text-[--color-text-muted] uppercase mb-1.5">{t.indicators}</div>
+          <div class="flex flex-wrap gap-1.5">
             {props.availableIndicators.map((ind) => (
               <button
                 key={ind.id}
@@ -100,7 +100,7 @@ export default function BuilderPanel(props: Props) {
                     return next;
                   });
                 }}
-                class={`px-2 py-0.5 text-[10px] font-mono rounded transition-colors border
+                class={`px-3 py-1 text-xs font-mono rounded transition-colors border
                   ${props.selectedIndicators.has(ind.id)
                     ? 'font-bold'
                     : 'bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-accent]/20'}`}
@@ -113,14 +113,14 @@ export default function BuilderPanel(props: Props) {
         </div>
 
         {/* Entry Conditions */}
-        <div class="px-3 py-1.5 border-b border-[--color-border]">
-          <div class="flex items-center justify-between mb-1">
-            <span class="text-[10px] font-mono text-[--color-text-muted] uppercase">{t.conditions}</span>
-            <button onClick={props.addCondition} class="text-[10px] font-mono text-[--color-accent] hover:underline">
+        <div class="px-4 py-2.5 border-b border-[--color-border]">
+          <div class="flex items-center justify-between mb-1.5">
+            <span class="text-xs font-mono text-[--color-text-muted] uppercase">{t.conditions}</span>
+            <button onClick={props.addCondition} class="text-xs font-mono text-[--color-accent] hover:underline">
               {t.addCondition}
             </button>
           </div>
-          <div class="space-y-1">
+          <div class="space-y-1.5">
             {props.conditions.map((c) => (
               <ConditionRow
                 key={c.id}
@@ -135,77 +135,77 @@ export default function BuilderPanel(props: Props) {
         </div>
 
         {/* Parameters */}
-        <div class="px-3 py-1.5 border-b border-[--color-border]">
-          <div class="text-[10px] font-mono text-[--color-text-muted] uppercase mb-1">{t.parameters}</div>
-          <div class="grid grid-cols-2 gap-1.5">
+        <div class="px-4 py-2.5 border-b border-[--color-border]">
+          <div class="text-xs font-mono text-[--color-text-muted] uppercase mb-1.5">{t.parameters}</div>
+          <div class="grid grid-cols-2 gap-2">
             {/* Direction */}
             <div>
-              <label class="text-[9px] text-[--color-text-muted]">{t.direction}</label>
-              <div class="flex gap-1 mt-0.5">
+              <label class="text-[10px] text-[--color-text-muted]">{t.direction}</label>
+              <div class="flex gap-1.5 mt-0.5">
                 <button
                   onClick={() => props.setDirection('short')}
-                  class={`flex-1 py-1 text-[10px] font-mono rounded transition-colors border ${props.direction === 'short' ? 'font-bold' : 'bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-red]/30'}`}
+                  class={`flex-1 py-1.5 text-xs font-mono rounded transition-colors border ${props.direction === 'short' ? 'font-bold' : 'bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-red]/30'}`}
                   style={props.direction === 'short' ? shortActiveStyle : undefined}
                 >{t.short}</button>
                 <button
                   onClick={() => props.setDirection('long')}
-                  class={`flex-1 py-1 text-[10px] font-mono rounded transition-colors border ${props.direction === 'long' ? 'font-bold' : 'bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-accent]/30'}`}
+                  class={`flex-1 py-1.5 text-xs font-mono rounded transition-colors border ${props.direction === 'long' ? 'font-bold' : 'bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-accent]/30'}`}
                   style={props.direction === 'long' ? longActiveStyle : undefined}
                 >{t.long}</button>
               </div>
             </div>
             {/* Max bars */}
             <div>
-              <label class="text-[9px] text-[--color-text-muted]">{t.maxBars}</label>
+              <label class="text-[10px] text-[--color-text-muted]">{t.maxBars}</label>
               <input type="number" value={props.maxBars} min={1} max={168}
                 onChange={(e: any) => props.setMaxBars(parseInt(e.target.value) || 48)}
-                class="w-full mt-0.5 px-2 py-1 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-[11px] text-[--color-text] outline-none focus:border-[--color-accent]"
+                class="w-full mt-0.5 px-2.5 py-1.5 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
               />
             </div>
             {/* SL */}
             <div>
-              <label class="text-[9px] text-[--color-text-muted]">{t.sl}</label>
+              <label class="text-[10px] text-[--color-text-muted]">{t.sl}</label>
               <input type="number" value={props.slPct} min={1} max={50} step={0.5}
                 onChange={(e: any) => props.setSlPct(parseFloat(e.target.value) || 10)}
-                class="w-full mt-0.5 px-2 py-1 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-[11px] text-[--color-text] outline-none focus:border-[--color-accent]"
+                class="w-full mt-0.5 px-2.5 py-1.5 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
               />
             </div>
             {/* TP */}
             <div>
-              <label class="text-[9px] text-[--color-text-muted]">{t.tp}</label>
+              <label class="text-[10px] text-[--color-text-muted]">{t.tp}</label>
               <input type="number" value={props.tpPct} min={1} max={50} step={0.5}
                 onChange={(e: any) => props.setTpPct(parseFloat(e.target.value) || 8)}
-                class="w-full mt-0.5 px-2 py-1 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-[11px] text-[--color-text] outline-none focus:border-[--color-accent]"
+                class="w-full mt-0.5 px-2.5 py-1.5 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
               />
             </div>
           </div>
         </div>
 
         {/* Date Range */}
-        <div class="px-3 py-1.5 border-b border-[--color-border]">
-          <div class="text-[10px] font-mono text-[--color-text-muted] uppercase mb-1">{t.dateRange}</div>
-          <div class="grid grid-cols-2 gap-1.5">
+        <div class="px-4 py-2.5 border-b border-[--color-border]">
+          <div class="text-xs font-mono text-[--color-text-muted] uppercase mb-1.5">{t.dateRange}</div>
+          <div class="grid grid-cols-2 gap-2">
             <div>
-              <label class="text-[9px] text-[--color-text-muted]">{t.startDate}</label>
+              <label class="text-[10px] text-[--color-text-muted]">{t.startDate}</label>
               <input type="date" value={props.startDate}
                 onChange={(e: any) => props.setStartDate(e.target.value)}
-                class="w-full mt-0.5 px-1.5 py-1 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-[10px] text-[--color-text] outline-none focus:border-[--color-accent]"
+                class="w-full mt-0.5 px-2 py-1.5 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
               />
             </div>
             <div>
-              <label class="text-[9px] text-[--color-text-muted]">{t.endDate}</label>
+              <label class="text-[10px] text-[--color-text-muted]">{t.endDate}</label>
               <input type="date" value={props.endDate}
                 onChange={(e: any) => props.setEndDate(e.target.value)}
-                class="w-full mt-0.5 px-1.5 py-1 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-[10px] text-[--color-text] outline-none focus:border-[--color-accent]"
+                class="w-full mt-0.5 px-2 py-1.5 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
               />
             </div>
           </div>
         </div>
 
         {/* Coin Selection */}
-        <div class="px-3 py-1.5 border-b border-[--color-border]">
-          <div class="text-[10px] font-mono text-[--color-text-muted] uppercase mb-1">{t.coins}</div>
-          <div class="flex gap-1 mb-1">
+        <div class="px-4 py-2.5 border-b border-[--color-border]">
+          <div class="text-xs font-mono text-[--color-text-muted] uppercase mb-1.5">{t.coins}</div>
+          <div class="flex gap-1.5 mb-1.5">
             {[
               { mode: 'all' as const, label: t.allCoins },
               { mode: 'top' as const, label: `${t.topN} N` },
@@ -214,7 +214,7 @@ export default function BuilderPanel(props: Props) {
               <button
                 key={mode}
                 onClick={() => props.setCoinMode(mode)}
-                class={`px-2 py-0.5 text-[10px] font-mono rounded transition-colors border
+                class={`px-3 py-1 text-xs font-mono rounded transition-colors border
                   ${props.coinMode === mode
                     ? 'font-bold'
                     : 'bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-accent]/20'}`}
@@ -227,7 +227,7 @@ export default function BuilderPanel(props: Props) {
           {props.coinMode === 'top' && (
             <input type="number" value={props.topN} min={1} max={549}
               onChange={(e: any) => props.setTopN(parseInt(e.target.value) || 50)}
-              class="w-full px-2 py-1 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-[10px] text-[--color-text] outline-none focus:border-[--color-accent]"
+              class="w-full px-2.5 py-1.5 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
               placeholder="Number of top coins"
             />
           )}
@@ -238,19 +238,19 @@ export default function BuilderPanel(props: Props) {
                 value={props.coinSearch}
                 onInput={(e: any) => props.setCoinSearch(e.target.value)}
                 placeholder="Search coins..."
-                class="w-full px-2 py-1 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-[10px] outline-none mb-1"
+                class="w-full px-2.5 py-1.5 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs outline-none mb-1.5"
               />
               {props.selectedCoins.length > 0 && (
-                <div class="flex flex-wrap gap-0.5 mb-1">
+                <div class="flex flex-wrap gap-1 mb-1.5">
                   {props.selectedCoins.map((s) => (
-                    <span key={s} class="px-1.5 py-0.5 text-[9px] font-mono bg-[--color-accent]/10 text-[--color-accent] rounded flex items-center gap-0.5">
+                    <span key={s} class="px-2 py-0.5 text-[10px] font-mono bg-[--color-accent]/10 text-[--color-accent] rounded flex items-center gap-1">
                       {s.replace('USDT', '')}
                       <button onClick={() => props.setSelectedCoins((p) => p.filter((x) => x !== s))} class="hover:text-[--color-red]">x</button>
                     </span>
                   ))}
                 </div>
               )}
-              <div class="max-h-24 overflow-y-auto">
+              <div class="max-h-28 overflow-y-auto">
                 {props.filteredCoins.map((c) => (
                   <button
                     key={c.symbol}
@@ -259,7 +259,7 @@ export default function BuilderPanel(props: Props) {
                         prev.includes(c.symbol) ? prev.filter((x) => x !== c.symbol) : [...prev, c.symbol]
                       );
                     }}
-                    class={`block w-full text-left px-1.5 py-0.5 text-[10px] font-mono rounded hover:bg-[--color-bg-hover]
+                    class={`block w-full text-left px-2 py-1 text-xs font-mono rounded hover:bg-[--color-bg-hover]
                       ${props.selectedCoins.includes(c.symbol) ? 'text-[--color-accent]' : 'text-[--color-text-muted]'}`}
                   >
                     {props.selectedCoins.includes(c.symbol) ? '✓ ' : ''}{c.symbol}
@@ -271,9 +271,9 @@ export default function BuilderPanel(props: Props) {
         </div>
 
         {/* Avoid Hours */}
-        <div class="px-3 py-1.5 border-b border-[--color-border]">
-          <div class="text-[10px] font-mono text-[--color-text-muted] uppercase mb-1">{t.avoidHours}</div>
-          <div class="flex flex-wrap gap-0.5">
+        <div class="px-4 py-2.5 border-b border-[--color-border]">
+          <div class="text-xs font-mono text-[--color-text-muted] uppercase mb-1.5">{t.avoidHours}</div>
+          <div class="flex flex-wrap gap-1">
             {Array.from({ length: 24 }, (_, i) => (
               <button
                 key={i}
@@ -285,7 +285,7 @@ export default function BuilderPanel(props: Props) {
                     return next;
                   });
                 }}
-                class={`w-6 h-5 text-[9px] font-mono rounded transition-colors border
+                class={`w-7 h-6 text-[10px] font-mono rounded transition-colors border
                   ${props.avoidHours.has(i)
                     ? ''
                     : 'bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-red]/20'}`}
@@ -298,9 +298,9 @@ export default function BuilderPanel(props: Props) {
         </div>
 
         {/* Run Button */}
-        <div class="px-3 py-2">
+        <div class="px-4 py-3">
           {props.demoMode && (
-            <div class="text-[9px] text-[--color-yellow] font-mono mb-2 px-2 py-1 bg-[--color-yellow]/10 rounded border border-[--color-yellow]/20">
+            <div class="text-[10px] text-[--color-yellow] font-mono mb-2 px-2.5 py-1.5 bg-[--color-yellow]/10 rounded border border-[--color-yellow]/20">
               {t.apiDown}
             </div>
           )}

--- a/src/components/ConditionRow.tsx
+++ b/src/components/ConditionRow.tsx
@@ -14,7 +14,7 @@ interface Props {
 
 export default function ConditionRow({ condition: c, availableFields, onUpdate, onRemove, removeLabel }: Props) {
   return (
-    <div class="flex items-center gap-1 text-[10px]">
+    <div class="flex items-center gap-1.5 text-xs">
       {/* Field */}
       <select
         value={c.field}
@@ -26,7 +26,7 @@ export default function ConditionRow({ condition: c, availableFields, onUpdate, 
             onUpdate(c.id, 'value', true);
           }
         }}
-        class="flex-1 min-w-0 px-1 py-1 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-[10px] text-[--color-text] outline-none focus:border-[--color-accent]"
+        class="flex-1 min-w-0 px-1.5 py-1.5 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
       >
         {availableFields.map((f) => <option key={f} value={f}>{f}</option>)}
       </select>
@@ -34,7 +34,7 @@ export default function ConditionRow({ condition: c, availableFields, onUpdate, 
       <select
         value={c.op}
         onChange={(e: any) => onUpdate(c.id, 'op', e.target.value)}
-        class="w-10 px-0.5 py-1 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-[10px] text-[--color-text] outline-none focus:border-[--color-accent]"
+        class="w-12 px-1 py-1.5 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
       >
         {OPS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
       </select>
@@ -43,7 +43,7 @@ export default function ConditionRow({ condition: c, availableFields, onUpdate, 
         <select
           value={String(c.value)}
           onChange={(e: any) => onUpdate(c.id, 'value', e.target.value === 'true')}
-          class="w-12 px-0.5 py-1 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-[10px] text-[--color-text] outline-none focus:border-[--color-accent]"
+          class="w-14 px-1 py-1.5 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
         >
           <option value="true">true</option>
           <option value="false">false</option>
@@ -54,14 +54,14 @@ export default function ConditionRow({ condition: c, availableFields, onUpdate, 
           step="any"
           value={c.value as number}
           onChange={(e: any) => onUpdate(c.id, 'value', parseFloat(e.target.value))}
-          class="w-14 px-1 py-1 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-[10px] text-[--color-text] outline-none focus:border-[--color-accent]"
+          class="w-16 px-1.5 py-1.5 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
         />
       )}
       {/* Shift */}
       <select
         value={c.shift}
         onChange={(e: any) => onUpdate(c.id, 'shift', parseInt(e.target.value))}
-        class="w-8 px-0.5 py-1 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-[10px] text-[--color-text] outline-none focus:border-[--color-accent]"
+        class="w-10 px-1 py-1.5 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
         title={c.shift === 1 ? 'Previous candle (safe)' : 'Current candle (risky)'}
       >
         <option value="1">P</option>
@@ -70,7 +70,7 @@ export default function ConditionRow({ condition: c, availableFields, onUpdate, 
       {/* Remove */}
       <button
         onClick={() => onRemove(c.id)}
-        class="text-[--color-text-muted] hover:text-[--color-red] px-0.5"
+        class="text-[--color-text-muted] hover:text-[--color-red] px-1"
         title={removeLabel}
       >
         x

--- a/src/components/PresetBar.tsx
+++ b/src/components/PresetBar.tsx
@@ -17,12 +17,12 @@ export default function PresetBar({ presets, activePreset, onSelectPreset, label
   if (presets.length === 0) return null;
 
   return (
-    <div class="px-3 py-2 border-b border-[--color-border]" style={{ background: `linear-gradient(135deg, ${COLORS.accentBg}, transparent)` }}>
-      <div class="text-[10px] font-mono uppercase mb-1.5" style={{ color: COLORS.accent }}>{label}</div>
-      <div class="flex flex-wrap gap-1">
+    <div class="px-4 py-2.5 border-b border-[--color-border]" style={{ background: `linear-gradient(135deg, ${COLORS.accentBg}, transparent)` }}>
+      <div class="text-xs font-mono uppercase mb-2" style={{ color: COLORS.accent }}>{label}</div>
+      <div class="flex flex-wrap gap-1.5">
         <button
           onClick={() => onSelectPreset(null)}
-          class={`px-2 py-1 text-[11px] font-mono rounded transition-colors border
+          class={`px-3 py-1.5 text-xs font-mono rounded transition-colors border
             ${activePreset === null
               ? 'font-bold'
               : 'bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-accent]/30 hover:text-[--color-text]'}`}
@@ -34,7 +34,7 @@ export default function PresetBar({ presets, activePreset, onSelectPreset, label
           <button
             key={p.id}
             onClick={() => onSelectPreset(p.id)}
-            class={`px-2 py-1 text-[11px] font-mono rounded transition-colors border
+            class={`px-3 py-1.5 text-xs font-mono rounded transition-colors border
               ${activePreset === p.id
                 ? 'font-bold'
                 : 'bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-accent]/30 hover:text-[--color-text]'}`}

--- a/src/components/SimulatorPage.tsx
+++ b/src/components/SimulatorPage.tsx
@@ -440,7 +440,7 @@ export default function SimulatorPage({ lang = 'en' }: Props) {
       {/* Main split layout */}
       <div class="flex flex-col md:flex-row gap-3">
         {/* Left: Chart (70%) */}
-        <div class={`md:w-[70%] flex-shrink-0 ${mobileTab !== 'chart' ? 'hidden md:block' : ''}`}>
+        <div class={`md:w-[55%] flex-shrink-0 ${mobileTab !== 'chart' ? 'hidden md:block' : ''}`}>
           <ChartPanel
             chartSymbol={chartSymbol}
             setChartSymbol={setChartSymbol}
@@ -452,7 +452,7 @@ export default function SimulatorPage({ lang = 'en' }: Props) {
         </div>
 
         {/* Right: Conditions Panel (30%) */}
-        <div class={`md:w-[30%] flex-shrink-0 ${mobileTab !== 'config' ? 'hidden md:block' : ''}`}>
+        <div class={`md:w-[45%] flex-shrink-0 ${mobileTab !== 'config' ? 'hidden md:block' : ''}`}>
           <BuilderPanel
             t={t}
             coinsLoaded={coinsLoaded}


### PR DESCRIPTION
## Summary
- Layout ratio changed from 70:30 to 55:45 (builder gets more space)
- All font sizes increased: 10px → 12px (text-xs), 9px → 10px
- Input fields, buttons, and gaps enlarged for better usability
- Avoid hours grid cells enlarged (w-6 h-5 → w-7 h-6)
- ConditionRow inputs wider and taller for easier interaction

## Test plan
- [ ] /simulate/ page loads correctly
- [ ] Builder panel is readable without squinting
- [ ] All buttons and inputs are clickable
- [ ] Mobile layout unaffected (stacks vertically)
- [ ] Build passes with no errors