### PR TITLE
feat: simulator UX education — look-ahead warning, break-even WR, UTC labels

### DIFF
--- a/src/components/BuilderPanel.tsx
+++ b/src/components/BuilderPanel.tsx
@@ -62,6 +62,7 @@ const runDisabledStyle = { background: COLORS.disabled, color: COLORS.disabledTe
 
 export default function BuilderPanel(props: Props) {
   const { t } = props;
+  const hasLookAhead = props.conditions.some((c) => c.shift === 0);
 
   return (
     <div class="border border-[--color-border] rounded-lg bg-[--color-bg-card] overflow-hidden flex flex-col h-auto md:h-[640px]">
@@ -132,6 +133,14 @@ export default function BuilderPanel(props: Props) {
               />
             ))}
           </div>
+          {/* Look-ahead bias warning */}
+          {hasLookAhead && (
+            <div class="mt-2 px-2.5 py-1.5 rounded bg-[--color-yellow]/10 border border-[--color-yellow]/20">
+              <span class="text-[10px] font-mono text-[--color-yellow]">
+                {t.lookAheadWarn || 'C = current candle (incomplete in live). P = previous candle (confirmed). Using C may cause look-ahead bias.'}
+              </span>
+            </div>
+          )}
         </div>
 
         {/* Parameters */}

--- a/src/components/ConditionRow.tsx
+++ b/src/components/ConditionRow.tsx
@@ -61,8 +61,12 @@ export default function ConditionRow({ condition: c, availableFields, onUpdate, 
       <select
         value={c.shift}
         onChange={(e: any) => onUpdate(c.id, 'shift', parseInt(e.target.value))}
-        class="w-10 px-1 py-1.5 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
-        title={c.shift === 1 ? 'Previous candle (safe)' : 'Current candle (risky)'}
+        class={`w-10 px-1 py-1.5 bg-[--color-bg-tooltip] border rounded font-mono text-xs outline-none focus:border-[--color-accent] ${
+          c.shift === 0
+            ? 'border-[--color-yellow] text-[--color-yellow]'
+            : 'border-[--color-border] text-[--color-text]'
+        }`}
+        title={c.shift === 1 ? 'Previous candle (safe)' : 'Current candle — look-ahead bias risk in live trading'}
       >
         <option value="1">P</option>
         <option value="0">C</option>

--- a/src/components/OOSValidation.tsx
+++ b/src/components/OOSValidation.tsx
@@ -262,6 +262,7 @@ export default function OOSValidation({ lang = 'en', strategy = 'bb-squeeze', di
                 [t(lang, 'oos.win_rate', 'Win Rate'), `${fmt(result.oos.is_metrics.win_rate)}%`, `${fmt(result.oos.oos_metrics.win_rate)}%`],
                 [t(lang, 'oos.return', 'Return'), `${fmt(result.oos.is_metrics.total_return)}%`, `${fmt(result.oos.oos_metrics.total_return)}%`],
                 [t(lang, 'oos.pf', 'Profit Factor'), fmt(result.oos.is_metrics.profit_factor), fmt(result.oos.oos_metrics.profit_factor)],
+                [t(lang, 'oos.mdd', 'Max Drawdown'), `${fmt(result.oos.is_metrics.max_dd)}%`, `${fmt(result.oos.oos_metrics.max_dd)}%`],
               ].map(([label, isVal, oosVal]) => (
                 <div class="flex justify-between items-center text-sm">
                   <span class="text-[var(--color-text-muted)]">{label}</span>

--- a/src/components/ResultsCard.tsx
+++ b/src/components/ResultsCard.tsx
@@ -41,6 +41,8 @@ const labels = {
     calmar: 'Calmar',
     riskMetrics: 'Risk-Adjusted',
     demoNote: 'DEMO · Pre-computed results for BB Squeeze SHORT',
+    breakeven: 'Break-even WR',
+    margin: 'Margin',
   },
   ko: {
     live: '현재 라이브 설정',
@@ -58,6 +60,8 @@ const labels = {
     calmar: '칼마',
     riskMetrics: '리스크 조정',
     demoNote: 'DEMO · BB Squeeze SHORT 사전 계산 결과',
+    breakeven: '손익분기 승률',
+    margin: '여유',
   },
 };
 
@@ -81,6 +85,13 @@ export default function ResultsCard({ data, isDefault, lang = 'en', isDemo = fal
   const pfColor = profitFactorColor(data.profit_factor);
   const retColor = signColor(data.total_return_pct);
 
+  // Break-even win rate: |avgLoss| / (|avgWin| + |avgLoss|)
+  const avgWin = Math.abs(data.avg_win_pct ?? 0);
+  const avgLoss = Math.abs(data.avg_loss_pct ?? 0);
+  const hasBreakeven = data.avg_win_pct !== undefined && data.avg_loss_pct !== undefined && avgLoss > 0 && avgWin > 0;
+  const breakevenWR = hasBreakeven ? (avgLoss / (avgWin + avgLoss)) * 100 : 0;
+  const wrMargin = data.win_rate - breakevenWR;
+
   return (
     <div>
       {isDefault && (
@@ -99,6 +110,16 @@ export default function ResultsCard({ data, isDefault, lang = 'en', isDemo = fal
         <MetricBox label={t.totalReturn} value={`${data.total_return_pct > 0 ? '+' : ''}${data.total_return_pct}%`} color={retColor} />
         <MetricBox label={t.maxDD} value={`${data.max_drawdown_pct}%`} color="var(--color-red)" />
       </div>
+
+      {/* Break-even win rate */}
+      {hasBreakeven && (
+        <div class="flex gap-3 text-[10px] font-mono text-[--color-text-muted] mb-3 px-1">
+          <span>{t.breakeven}: {breakevenWR.toFixed(1)}%</span>
+          <span style={{ color: wrMargin > 0 ? 'var(--color-accent)' : 'var(--color-red)' }}>
+            {t.margin}: {wrMargin > 0 ? '+' : ''}{wrMargin.toFixed(1)}%p
+          </span>
+        </div>
+      )}
 
       {(data.avg_win_pct !== undefined || data.avg_loss_pct !== undefined) && (
         <div class="grid grid-cols-2 md:grid-cols-4 gap-2 mb-3">

--- a/src/components/ResultsPanel.tsx
+++ b/src/components/ResultsPanel.tsx
@@ -234,6 +234,11 @@ export default function ResultsPanel({ t, result, error, resultTab, setResultTab
               {result && result.max_drawdown_pct !== undefined && (
                 <div class="mt-2 font-mono text-xs text-[--color-text-muted]">
                   Max Drawdown: <span style={{ color: COLORS.red }}>{result.max_drawdown_pct.toFixed(1)}%</span>
+                  {result.max_drawdown_pct > 100 && (
+                    <span class="ml-1.5 text-[10px] opacity-70">
+                      ({lang === 'ko' ? '누적 % — 개별 코인 합산' : 'cumulative % — sum of per-coin trades'})
+                    </span>
+                  )}
                 </div>
               )}
             </div>

--- a/src/components/SimulatorPage.tsx
+++ b/src/components/SimulatorPage.tsx
@@ -49,7 +49,7 @@ const L = {
     prev: 'Prev',
     curr: 'Curr',
     remove: 'Remove',
-    avoidHours: 'Avoid Hours',
+    avoidHours: 'Avoid Hours (UTC)',
     short: 'SHORT',
     long: 'LONG',
     symbol: 'Symbol',
@@ -58,12 +58,13 @@ const L = {
     loading: 'Loading...',
     error: 'Error',
     apiDown: 'API unavailable. Using demo mode.',
-    disclaimer: 'Past performance does not guarantee future results. Simulations include estimated fees (0.04%) and slippage (0.02%). This is not financial advice.',
+    disclaimer: 'Past performance does not guarantee future results. Simulations include estimated fees (0.04%) and slippage (0.02%). Each coin is tested independently (no cross-coin position limits). This is not financial advice.',
     mobile: { chart: 'Chart', config: 'Settings', results: 'Results' },
     quickStart: 'New to backtesting?',
     quickStartDesc: 'Try our proven BB Squeeze SHORT strategy — pre-loaded and ready to run.',
     quickStartCta: 'Run BB Squeeze SHORT',
     quickStartDismiss: 'I\'ll build my own',
+    lookAheadWarn: 'C = current candle (incomplete in live). P = previous candle (confirmed). Using C may cause look-ahead bias.',
   },
   ko: {
     title: '전략 시뮬레이터',
@@ -98,7 +99,7 @@ const L = {
     prev: '이전',
     curr: '현재',
     remove: '삭제',
-    avoidHours: '제외 시간',
+    avoidHours: '제외 시간 (UTC)',
     short: 'SHORT',
     long: 'LONG',
     symbol: '심볼',
@@ -107,12 +108,13 @@ const L = {
     loading: '로딩 중...',
     error: '에러',
     apiDown: 'API 연결 불가. 데모 모드로 전환합니다.',
-    disclaimer: '과거 성과가 미래 수익을 보장하지 않습니다. 시뮬레이션에는 예상 수수료(0.04%)와 슬리피지(0.02%)가 포함됩니다. 이것은 투자 조언이 아닙니다.',
+    disclaimer: '과거 성과가 미래 수익을 보장하지 않습니다. 시뮬레이션에는 예상 수수료(0.04%)와 슬리피지(0.02%)가 포함됩니다. 각 코인은 독립 시뮬레이션됩니다(동시 포지션 제한 없음). 이것은 투자 조언이 아닙니다.',
     mobile: { chart: '차트', config: '설정', results: '결과' },
     quickStart: '백테스팅이 처음이신가요?',
     quickStartDesc: '검증된 BB Squeeze SHORT 전략을 바로 실행해보세요.',
     quickStartCta: 'BB Squeeze SHORT 실행',
     quickStartDismiss: '직접 만들기',
+    lookAheadWarn: 'C = 현재 캔들(실거래에서 미완성). P = 이전 캔들(확정됨). C 사용 시 look-ahead bias 위험이 있습니다.',
   },
 };
 
@@ -504,7 +506,7 @@ export default function SimulatorPage({ lang = 'en' }: Props) {
 
       {/* Disclaimer */}
       <div class="mt-6 mb-8 text-center">
-        <p class="text-[--color-text-muted] text-[10px] max-w-lg mx-auto">
+        <p class="text-[--color-text-muted] text-[11px] max-w-lg mx-auto">
           {t.disclaimer}
         </p>
       </div>


### PR DESCRIPTION
## Summary
- **ConditionRow**: Yellow highlight when shift=C (look-ahead bias risk)
- **BuilderPanel**: Warning banner when any condition uses current candle
- **SimulatorPage**: Avoid Hours labeled (UTC), look-ahead i18n, independent trial note
- **ResultsCard**: Break-even WR + margin display below main metrics
- **ResultsPanel**: MDD >100% explanatory note (cumulative per-coin sum)
- **OOSValidation**: Missing MDD row added in mobile view
- **Disclaimer**: Font 10px to 11px, independent trial explanation (en/ko)

## Test plan
- Build passes (verified: 2446 pages, 2.42s)
- /simulate/ and /ko/simulate/ load correctly
- Shift C shows yellow highlight + warning banner
- Break-even WR shows in results
- Avoid Hours shows (UTC) label
- MDD >100% shows explanatory note

Generated with Claude Code