### PR TITLE
docs(api): warn /simulate/compare may time out (#111)

### DIFF
--- a/src/pages/api.astro
+++ b/src/pages/api.astro
@@ -202,6 +202,10 @@ const API_BASE = 'https://api.pruviq.com';
   "top_n": 50
 }`}</code></pre>
           </details>
+          <div class="mt-3 p-3 rounded bg-[--color-bg-subtle] border border-[--color-border] text-sm text-[--color-text-muted]">
+            <strong class="font-mono text-xs text-[--color-accent]">Note:</strong>
+            <span class="ml-2">The <code class="font-mono">/simulate/compare</code> endpoint can be long-running for large <code class="font-mono">top_n</code> values or wide date ranges and may return a 524 Gateway Timeout on some hosting platforms. To reduce the chance of timeouts, use a smaller <code class="font-mono">top_n</code>, narrow the date range, or run multiple smaller comparison jobs. A robust server-side fix requires backend changes (async job queue or caching).</span>
+          </div>
         </div>
 
       </div>

--- a/src/pages/ko/api.astro
+++ b/src/pages/ko/api.astro
@@ -202,6 +202,10 @@ const API_BASE = 'https://api.pruviq.com';
   "top_n": 50
 }`}</code></pre>
           </details>
+          <div class="mt-3 p-3 rounded bg-[--color-bg-subtle] border border-[--color-border] text-sm text-[--color-text-muted]">
+            <strong class="font-mono text-xs text-[--color-accent]">참고:</strong>
+            <span class="ml-2"><code class="font-mono">/simulate/compare</code> 엔드포인트는 <code class="font-mono">top_n</code> 값이 크거나 기간이 넓을 경우 실행 시간이 길어져 일부 호스팅 환경에서 524 Gateway Timeout 응답을 반환할 수 있습니다. 타임아웃 가능성을 줄이려면 <code class="font-mono">top_n</code>을 줄이거나 기간을 좁히거나 여러 개의 작은 비교 작업으로 분할해 실행하세요. 근본적인 해결은 백엔드 변경(비동기 작업 큐 또는 캐싱)이 필요합니다.</span>
+          </div>
         </div>
 
       </div>


### PR DESCRIPTION
Add a short warning to the API docs for /simulate/compare explaining that large top_n or wide date ranges can be long-running and may trigger 524 Gateway Timeout on some hosting platforms. Suggest mitigations: reduce top_n, narrow date range, or split into multiple smaller comparisons.\n\nThis is a documentation-only change to surface the known limitation described in issue #111.\n\nRefs: #111