### PR TITLE
fix(demo): use full date format for demo data_range (#117)

### DIFF
--- a/backend/scripts/generate_demo_data.py
+++ b/backend/scripts/generate_demo_data.py
@@ -186,8 +186,8 @@ def main():
         print("ERROR: No coins loaded.")
         sys.exit(1)
 
-    first_date = coins[0][1]["timestamp"].min().strftime("%Y-%m")
-    last_date = coins[0][1]["timestamp"].max().strftime("%Y-%m")
+    first_date = coins[0][1]["timestamp"].min().strftime("%Y-%m-%d")
+    last_date = coins[0][1]["timestamp"].max().strftime("%Y-%m-%d")
     data_range = f"{first_date} ~ {last_date}"
 
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Generate demo data with full YYYY-MM-DD date strings for  to match the live API output and avoid inconsistency when demo results are shown in the UI. This fixes issue #117 (date_range display mismatch).\n\nRefs: #117