### PR TITLE
chore(generated-data): add workflow + docs to publish generated static data to dedicated branch

### DIFF
--- a/.github/workflows/static-refresh-to-branch.yml
+++ b/.github/workflows/static-refresh-to-branch.yml
@@ -1,0 +1,52 @@
+name: Update generated-data branch
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  snapshot-generated-data:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create or update generated-data branch
+        run: |
+          set -euo pipefail
+          git config user.name "autofix-bot"
+          git config user.email "autofix@example.com"
+          BRANCH=generated-data
+          # Create orphan branch if missing, otherwise checkout
+          if git show-ref --verify --quiet refs/heads/$BRANCH; then
+            git checkout $BRANCH
+          else
+            git checkout --orphan $BRANCH
+            git rm -rf . || true
+          fi
+
+          # Ensure public/data exists
+          if [ ! -d public/data ]; then
+            echo "No public/data directory found — nothing to commit" >&2
+            exit 0
+          fi
+
+          # Copy public/data contents into repo workspace root (already present)
+          git add -A public/data
+
+          if git diff --cached --quiet; then
+            echo "No changes to public/data — nothing to commit"
+            exit 0
+          fi
+
+          git commit -m "chore: update generated static data snapshot"
+
+          # Push branch
+          git push --set-upstream origin $BRANCH --force
+
+      - name: Done
+        run: echo "generated-data branch updated"

--- a/docs/generated-data.md
+++ b/docs/generated-data.md
@@ -1,0 +1,18 @@
+# Generated static data
+
+This repository contains generated JSON snapshots under `public/data/*.json` created by the static refresh pipeline. These files are useful for serving a snapshot of market and coin data, but they frequently cause merge conflicts when the static refresh runs and updates the files on main.
+
+Recommended approach (implemented by this PR):
+
+1. Keep a dedicated branch `generated-data` where the refresh pipeline publishes generated snapshots. This repository includes a convenience GitHub Actions workflow `.github/workflows/static-refresh-to-branch.yml` which can be triggered manually (or by a CI job) to capture the current `public/data` directory into the `generated-data` branch.
+
+2. The static refresh pipeline (external scheduler) should push generated files to the `generated-data` branch and open a PR to `main` when updates are desired. This centralizes generated-data changes and reduces direct, frequent modifications to `main` which cause merge conflicts.
+
+3. Long-term options (choose one):
+   - Move generated files entirely to a separate storage (S3 or CDN) and fetch at build/serve time.
+   - Write generated files to a build-time cache (e.g., `.cache/`) and add them to `.gitignore`.
+   - Use a merge policy or bot to always accept `generated-data` branch into `main` via PRs.
+
+Notes:
+- This change is intentionally non-invasive: it does not remove tracked files from `main` to avoid breaking any build that expects shipped data. It provides an automation path to reduce direct commits to `main` from scheduled refreshes.
+- Next step (ops): update the external static refresh job to push to `generated-data` and open a PR when significant changes occur.


### PR DESCRIPTION
This PR adds a small GitHub Actions workflow and documentation to publish the repository's generated static data (public/data) into a dedicated branch (`generated-data`).

Why: scheduled static refreshes frequently update public/data JSON files and cause merge conflicts when they land on main. This provides a straightforward automation path: the refresh pipeline can push generated snapshots to the `generated-data` branch and open PRs to main when updates are desired.

Files added:
- .github/workflows/static-refresh-to-branch.yml
- docs/generated-data.md

Fixes: #128
