### PR TITLE
fix: add case-insensitive redirects for coin detail pages

### DIFF
--- a/functions/coins/[[symbol]].js
+++ b/functions/coins/[[symbol]].js
@@ -1,0 +1,15 @@
+// Cloudflare Pages Function: Case-insensitive redirect for /coins/*
+// Redirects /coins/BTCUSDT/ -> /coins/btcusdt/ (301 permanent)
+export async function onRequest(context) {
+  const url = new URL(context.request.url);
+  const path = url.pathname;
+  const lower = path.toLowerCase();
+  
+  // If path contains uppercase, redirect to lowercase
+  if (path !== lower) {
+    return Response.redirect(url.origin + lower, 301);
+  }
+  
+  // Pass through to static file
+  return context.next();
+}


### PR DESCRIPTION
## Summary
- Add Cloudflare Functions middleware to handle case-insensitive redirects for coin detail pages
- Redirects  →  (301 permanent)
- Handles all 550 coins automatically with pattern matching
- No static build changes needed

## Problem
- PRUVIQ generates static pages with lowercase symbols: 
- External links with uppercase symbols result in 404: 

## Solution
- Use Cloudflare Pages Functions at 
- Intercepts requests to  before static file lookup
- Compares path to lowercase version, redirects if different
- Passes through to static file if already lowercase

## Test plan
- [ ] Deploy to Cloudflare Pages preview
- [ ] Test  → redirects to  (301)
- [ ] Test  → loads normally (200)
- [ ] Test  → loads normally (200)
- [ ] Test  → redirects to  (301)
- [ ] Verify SEO: 301 redirects preserve link equity

Generated with [Claude Code](https://claude.com/claude-code)