### PR TITLE
fix(images): add OG image conversion + prefer WebP/AVIF

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
       "devDependencies": {
         "@axe-core/playwright": "^4.11.1",
         "@playwright/test": "^1.50.0",
-        "axe-core": "^4.10.0"
+        "axe-core": "^4.10.0",
+        "sharp": "^0.34.5"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -472,6 +473,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
       "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -898,8 +900,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
       "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -911,6 +913,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -933,6 +936,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -955,6 +959,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -971,6 +976,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -987,6 +993,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1003,6 +1010,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1019,6 +1027,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1035,6 +1044,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1051,6 +1061,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1067,6 +1078,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1083,6 +1095,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1099,6 +1112,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1115,6 +1129,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1137,6 +1152,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1159,6 +1175,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1181,6 +1198,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1203,6 +1221,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1225,6 +1244,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1247,6 +1267,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1269,6 +1290,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1291,6 +1313,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1310,6 +1333,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1329,6 +1353,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1348,6 +1373,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5557,9 +5583,9 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -5874,6 +5900,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD",
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.3.0",
   "scripts": {
     "dev": "astro dev",
+    "convert-og-image": "node scripts/convert-og-image.js",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
@@ -23,6 +24,7 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.11.1",
     "@playwright/test": "^1.50.0",
-    "axe-core": "^4.10.0"
+    "axe-core": "^4.10.0",
+    "sharp": "^0.34.5"
   }
 }

--- a/scripts/convert-og-image.js
+++ b/scripts/convert-og-image.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+import sharp from 'sharp';
+import fs from 'fs';
+import path from 'path';
+
+const input = path.resolve(process.cwd(), 'public', 'og-image.png');
+const outWebp = path.resolve(process.cwd(), 'public', 'og-image.webp');
+const outAvif = path.resolve(process.cwd(), 'public', 'og-image.avif');
+
+(async () => {
+  try {
+    if (!fs.existsSync(input)) {
+      console.error('Input file not found:', input);
+      process.exit(2);
+    }
+    console.log('Converting', input);
+    await sharp(input).resize(1200, 630).webp({ quality: 80 }).toFile(outWebp);
+    await sharp(input).resize(1200, 630).avif({ quality: 50 }).toFile(outAvif);
+    console.log('Generated:', outWebp, outAvif);
+  } catch (e) {
+    console.error('Error converting images:', e);
+    process.exit(1);
+  }
+})();

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -20,7 +20,7 @@ const basePath = getBasePath(Astro.url.pathname);
 const cfToken = import.meta.env.PUBLIC_CF_ANALYTICS_TOKEN;
 
 const { title, description = t('meta.home_desc'), type = 'website', date, category, canonicalOverride } = Astro.props;
-const ogImage = new URL(Astro.props.ogImage || '/og-image.png', Astro.site || 'https://pruviq.com').href;
+const ogImage = new URL(Astro.props.ogImage || '/og-image.webp', Astro.site || 'https://pruviq.com').href;
 const canonicalPath = canonicalOverride || Astro.url.pathname;
 const canonicalURL = new URL(canonicalPath, Astro.site || 'https://pruviq.com');
 const enURL = new URL(basePath, Astro.site || 'https://pruviq.com');
@@ -87,6 +87,7 @@ const isActive = (match: string) => basePath.startsWith(match);
     <meta property="og:site_name" content="PRUVIQ" />
     <meta property="og:locale" content={lang === 'ko' ? 'ko_KR' : 'en_US'} />
     <meta property="og:image" content={ogImage} />
+    <meta property="og:image" content={new URL(Astro.props.ogImage || '/og-image.png', Astro.site || 'https://pruviq.com').href} />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <!-- Twitter -->


### PR DESCRIPTION
Summary:\n\n- Add scripts/convert-og-image.js (node + sharp) to generate public/og-image.webp and public/og-image.avif\n- Add npm script "convert-og-image" to run the converter\n- Prefer /og-image.webp as the primary OG image in src/layouts/Layout.astro and keep /og-image.png as fallback\n\nNotes:\n- Conversion could not be executed inside this environment because sharp could not be loaded on darwin-arm64 (native prebuilt binary issue). I added the conversion script and the devDependency so a maintainer or CI with correct binary support can run  to produce the generated assets.\n- If you prefer, run locally:  then commit the generated files (, ).\n\nFixes #132