### PR TITLE
fix(images): prefer AVIF/WebP for OG image (fixes #132)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,6 +2,8 @@
 import '../styles/global.css'
 import { getLangFromUrl, useTranslations, getAlternatePath, getBasePath } from '../i18n/index';
 import Breadcrumbs from '../components/Breadcrumbs.astro';
+import fs from 'fs';
+import path from 'path';
 
 interface Props {
   title: string;
@@ -20,7 +22,21 @@ const basePath = getBasePath(Astro.url.pathname);
 const cfToken = import.meta.env.PUBLIC_CF_ANALYTICS_TOKEN;
 
 const { title, description = t('meta.home_desc'), type = 'website', date, category, canonicalOverride } = Astro.props;
-const ogImage = new URL(Astro.props.ogImage || '/og-image.png', Astro.site || 'https://pruviq.com').href;
+// Prefer AVIF/WebP if available in public/; fallback to PNG
+const publicDir = new URL('../../public', import.meta.url).pathname;
+let defaultOg = '/og-image.png';
+try {
+  const candidates = ['og-image.avif', 'og-image.webp', 'og-image.png'];
+  for (const f of candidates) {
+    if (fs.existsSync(path.join(publicDir, f))) {
+      defaultOg = '/' + f;
+      break;
+    }
+  }
+} catch (e) {
+  // ignore filesystem errors and fall back to PNG
+}
+const ogImage = new URL(Astro.props.ogImage || defaultOg, Astro.site || 'https://pruviq.com').href;
 const canonicalPath = canonicalOverride || Astro.url.pathname;
 const canonicalURL = new URL(canonicalPath, Astro.site || 'https://pruviq.com');
 const enURL = new URL(basePath, Astro.site || 'https://pruviq.com');


### PR DESCRIPTION
This change updates Layout.astro to prefer AVIF/WebP OG images when present in public/. If no AVIF/WebP file exists, it falls back to the existing PNG. This allows the site to serve optimized formats when binaries (sharp/cwebp) are used offline or in CI to generate them, without breaking builds.

What I changed:
- src/layouts/Layout.astro: runtime check for public/og-image.avif -> .webp -> .png (choose first existing) and use that as og:image/twitter:image.

Why:
- Improves performance by preferring modern image formats where available (issue #132).

Notes:
- I did NOT add image conversion tooling here (sharp) to avoid native build issues in CI. The next step is to generate and commit public/og-image.webp and public/og-image.avif using a machine that supports image conversion (or add a small conversion step to CI).