### PR TITLE
chore: repo migration + remove personal trading data

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -41,7 +41,7 @@ P3: SEO meta 태그 누락 페이지 보완
 Phase: 프로덕션 안정화
 시작일: 2026-02-14
 상태: P0/P1/MEDIUM 전부 해결 + 전체 검증 PASS
-GitHub: poong92/pruviq
+GitHub: pruviq/pruviq
 배포: Cloudflare Pages (pruviq.com)
 백엔드: api.pruviq.com (Mac Mini, FastAPI)
 빌드: 1,257 pages (0 errors)
@@ -281,7 +281,7 @@ autotrader 서버 (DO): 절대 건드리지 않음
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│  Mac Mini에 같은 레포(poong92/pruviq)가 2곳에 clone 됨     │
+│  Mac Mini에 같은 레포(pruviq/pruviq)가 2곳에 clone 됨     │
 │                                                             │
 │  jepo (/Users/jepo/pruviq)                                 │
 │    - API 서버 (uvicorn --workers 1)                        │

--- a/.claude/agents/deployment-ops.md
+++ b/.claude/agents/deployment-ops.md
@@ -95,7 +95,7 @@ PRUVIQ 웹사이트 및 API 인프라의 24/7 운영, 자동화 파이프라인 
     ssh jepo@172.30.1.16 "cd ~/pruviq && git branch"
 
 [ ] Cloudflare 마지막 빌드 성공
-    gh run list -R poong92/pruviq | head -1
+    gh run list -R pruviq/pruviq | head -1
 
 [ ] CoinGecko 매칭: 231/500 이상
     curl -s https://api.pruviq.com/coins | jq '.coins | length'

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# 모든 변경에 @poong92 리뷰 필수 (보안: automerge 공급망 보호)
-* @poong92
+# 모든 변경에 @pruviq 리뷰 필수 (보안: automerge 공급망 보호)
+* @pruviq

--- a/.github/workflows/post-deploy-pipeline.yml
+++ b/.github/workflows/post-deploy-pipeline.yml
@@ -116,7 +116,7 @@ jobs:
           Remaining: ${REMAINING} issues
           ---
           Check this issue and create a PR:
-          https://github.com/poong92/pruviq/issues/${ISSUE_NUM}"
+          https://github.com/pruviq/pruviq/issues/${ISSUE_NUM}"
           MSG=$(echo "$MSG" | sed 's/^          //g')
           curl -sf -X POST "https://api.telegram.org/bot${TOKEN}/sendMessage" \
             -d chat_id="${CHAT_ID}" -d text="${MSG}" || echo "Telegram send failed"

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -220,7 +220,7 @@ Every claim needs evidence:
 - [ ] SEO: meta tags optimization
 - [ ] i18n: complete learn page translations
 - [ ] Mobile: touch targets 44px minimum
-- [x] Trust: add more trust signals — small footer trust badges PR created (#138 - https://github.com/poong92/pruviq/pull/138) (build verified locally)
+- [x] Trust: add more trust signals — small footer trust badges PR created (#138 - https://github.com/pruviq/pruviq/pull/138) (build verified locally)
 - [P0] Cloudflare Workers preview builds failing for PRs #136 and #135 — blocked; requires Cloudflare dashboard access (issue #137) (labelled P0-critical)
 - [P1] Convert public/og-image.png to WebP/AVIF and update OG references — issue #132 (labelled P1-high); PR #136 exists but is blocked by Cloudflare preview failures
 - [P1] BRAVE_API_KEY provisioning for issue #21 — requires adding secret to repository/CI (issue #21)

--- a/SOUL.md
+++ b/SOUL.md
@@ -62,7 +62,7 @@ Full-stack developer maintaining and improving pruviq.com:
 
 - **Site URL:** https://pruviq.com (EN) / https://pruviq.com/ko/ (KO)
 - **API URL:** https://api.pruviq.com
-- **Repo:** /Users/openclaw/pruviq/ (git: poong92/pruviq)
+- **Repo:** /Users/openclaw/pruviq/ (git: pruviq/pruviq)
 - **Key APIs:**
   - /market — market dashboard data
   - /news — crypto news

--- a/backend/scripts/deploy_macmini.sh
+++ b/backend/scripts/deploy_macmini.sh
@@ -22,7 +22,7 @@ if [ -d "$REPO_DIR" ]; then
     cd "$REPO_DIR" && git pull
 else
     echo "Cloning repo..."
-    git clone https://github.com/poong92/pruviq.git "$REPO_DIR"
+    git clone https://github.com/pruviq/pruviq.git "$REPO_DIR"
     cd "$REPO_DIR"
 fi
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -122,7 +122,7 @@
 │  │  - 결과 분석                 - Ollama AI 요약                    │     │
 │  │                              - API 서버 (FastAPI)                │     │
 │  │                                                                    │     │
-│  │  GitHub (poong92/pruviq)     Cloudflare Pages (웹 대시보드)      │     │
+│  │  GitHub (pruviq/pruviq)     Cloudflare Pages (웹 대시보드)      │     │
 │  │  - 코드 관리                 - 정적 프론트엔드                    │     │
 │  │  - CI/CD                     - API 프록시                         │     │
 │  └────────────────────────────────────────────────────────────────────┘     │
@@ -973,7 +973,7 @@ httpx>=0.27.0            # 비동기 HTTP 클라이언트
                         │ git push
                         ▼
 ┌─────────────────────────────────────────────────────────┐
-│  GitHub (poong92/pruviq)                                │
+│  GitHub (pruviq/pruviq)                                │
 │                                                         │
 │  역할:                                                  │
 │  - 소스 코드 관리                                       │

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -11,7 +11,7 @@
 
 ```
                         ┌──────────────────────────────────────────┐
-                        │              GitHub (poong92)             │
+                        │              GitHub (pruviq)             │
                         │  ┌──────────────┐  ┌──────────────────┐  │
                         │  │  autotrader   │  │     pruviq       │  │
                         │  │  (private)    │  │    (private)     │  │
@@ -680,7 +680,7 @@ Phase 3 (스케일):
 
 | 항목 | autotrader | PRUVIQ | 공유 |
 |------|-----------|--------|------|
-| GitHub Repo | poong92/autotrader | poong92/pruviq | X |
+| GitHub Repo | pruviq/autotrader | pruviq/pruviq | X |
 | 실행 서버 | DO 서버 | Mac Mini | X |
 | Python venv | .venv-at | .venv-pv | X |
 | Binance API Key | 거래 권한 | 읽기 전용 | X (별도 키) |

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -218,7 +218,7 @@ git push                 git pull               Docker
 
 ## 11. 즉시 실행 (이번 주)
 
-1. **GitHub repo 생성** — poong92/pruviq
+1. **GitHub repo 생성** — pruviq/pruviq
 2. **Parquet 저장소** — downloader.py → Parquet 출력으로 전환
 3. **Binance 현물 전체 다운로드** — 거래량 상위 300개
 4. **BB Squeeze 검증** — QA 5종 테스트 통과

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -28,10 +28,10 @@ export const en = {
   'hero.stat4': 'Backtested Trades',
   'hero.stat5': 'Data Points Processed',
   'hero.stat6': 'No Credit Card',
-  'hero.live_trades': '1,650+ Live Trades',
-  'hero.live_wr': '54.6% Win Rate',
-  'hero.live_days': '48 Days Verified',
-  'hero.live_capital': '$3,000 Real Capital',
+  'hero.tool_coins': '549+ Coins Tested',
+  'hero.tool_strategies': '88+ Strategies Backtested',
+  'hero.tool_data': '2+ Years Historical Data',
+  'hero.tool_free': '100% Free, No Signup',
 
   // Problem
   'problem.tag': 'THE PROBLEM',
@@ -574,7 +574,7 @@ export const en = {
   'trust.badge_open_desc': 'All strategy code public on GitHub. Verify it yourself.',
   'trust.stat_trades': 'Trades Backtested',
   'trust.stat_datapoints': 'Data Points Processed',
-  'trust.stat_live_days': 'Days Live Trading Published',
+  'trust.stat_live_days': 'Coins Backtested',
   'trust.stat_strategies': 'Strategies Tested (4 Failed)',
 
   // TradingView comparison page

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -30,10 +30,10 @@ export const ko: Record<TranslationKey, string> = {
   'hero.stat4': '백테스트 거래 수',
   'hero.stat5': '처리된 데이터 포인트',
   'hero.stat6': '신용카드 불필요',
-  'hero.live_trades': '1,650+ 실거래',
-  'hero.live_wr': '승률 54.6%',
-  'hero.live_days': '48일 검증',
-  'hero.live_capital': '실제 자본 $3,000',
+  'hero.tool_coins': '549+ 코인 테스트',
+  'hero.tool_strategies': '88+ 전략 백테스트',
+  'hero.tool_data': '2년+ 과거 데이터',
+  'hero.tool_free': '100% 무료, 가입 불필요',
 
   // Problem
   'problem.tag': '문제점',
@@ -576,7 +576,7 @@ export const ko: Record<TranslationKey, string> = {
   'trust.badge_open_desc': '모든 전략 코드를 GitHub에 공개. 직접 확인하세요.',
   'trust.stat_trades': '백테스트 거래 수',
   'trust.stat_datapoints': '처리된 데이터 포인트',
-  'trust.stat_live_days': '실거래 결과 공개 일수',
+  'trust.stat_live_days': '백테스트 코인 수',
   'trust.stat_strategies': '테스트된 전략 (4개 실패)',
 
   // TradingView comparison page

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -114,7 +114,7 @@ const isActive = (match: string) => basePath.startsWith(match);
           ? '무료 크립토 전략 백테스팅 플랫폼. 549개 이상 코인에서 2년 이상의 실제 시장 데이터로 트레이딩 전략을 만들고 테스트하세요.'
           : 'Free crypto strategy backtesting platform. Build and test trading strategies on 549+ coins with 2+ years of real market data.',
         "founder": { "@type": "Organization", "name": "PRUVIQ Team" },
-        "sameAs": ["https://t.me/PRUVIQ", "https://github.com/poong92/pruviq"],
+        "sameAs": ["https://t.me/PRUVIQ", "https://github.com/pruviq/pruviq"],
         "knowsAbout": lang === 'ko'
           ? ['암호화폐 트레이딩', '백테스팅', '알고리즘 트레이딩', '퀀트 금융']
           : ['cryptocurrency trading', 'backtesting', 'algorithmic trading', 'quantitative finance']
@@ -173,10 +173,10 @@ const isActive = (match: string) => basePath.startsWith(match);
           },
           {
             "@type": "Question",
-            "name": "PRUVIQ에 실거래 검증이 있나요?",
+            "name": "PRUVIQ의 전략은 어떻게 검증되나요?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "네. BB Squeeze SHORT 전략이 $3,000 자본의 실제 바이낸스 선물 계좌에서 운영되고 있습니다. 손실을 포함한 모든 거래가 공개됩니다. 실거래 성과 페이지에서 38일 이상의 검증된 트레이딩 데이터와 전체 버전 히스토리를 확인할 수 있습니다."
+              "text": "PRUVIQ는 549개 이상의 코인에서 2년 이상의 과거 데이터로 모든 전략을 백테스트합니다. 수수료, 슬리피지, 펀딩비를 포함한 현실적인 시뮬레이션으로 검증하며, 실패한 전략도 모두 공개합니다."
             }
           }
         ] : [
@@ -214,10 +214,10 @@ const isActive = (match: string) => basePath.startsWith(match);
           },
           {
             "@type": "Question",
-            "name": "Does PRUVIQ have real trading verification?",
+            "name": "How does PRUVIQ verify strategies?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Yes. One strategy (BB Squeeze SHORT) runs on a real Binance Futures account with $3,000 capital. Every trade is published publicly, including losses. The live performance page shows 38+ days of verified trading data with full version history."
+              "text": "PRUVIQ backtests all strategies on 549+ coins with 2+ years of historical data. Every simulation includes realistic fees, slippage, and funding costs. Failed strategies are published alongside successful ones for full transparency."
             }
           }
         ]
@@ -350,7 +350,7 @@ const isActive = (match: string) => basePath.startsWith(match);
                 <a href={compareTvPath} class="text-[--color-text-muted] hover:text-[--color-text] transition-colors">{t('footer.compare')}</a>
                 <a href="https://t.me/PRUVIQ" target="_blank" rel="noopener noreferrer" class="text-[--color-text-muted] hover:text-[--color-text] transition-colors">{t('footer.telegram')}</a>
                 <a href="https://x.com/pruviq_com" target="_blank" rel="noopener noreferrer" class="text-[--color-text-muted] hover:text-[--color-text] transition-colors">Twitter / X</a>
-                <a href="https://github.com/poong92/pruviq" target="_blank" rel="noopener noreferrer" class="text-[--color-text-muted] hover:text-[--color-text] transition-colors">GitHub</a>
+                <a href="https://github.com/pruviq/pruviq" target="_blank" rel="noopener noreferrer" class="text-[--color-text-muted] hover:text-[--color-text] transition-colors">GitHub</a>
               </div>
             </div>
             <div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -27,12 +27,12 @@ const lastUpdated = new Date().toLocaleDateString('en-US');
         <p class="text-lg md:text-xl text-[--color-text-muted] mb-4 max-w-2xl">
           {t('hero.desc')}
         </p>
-        <!-- Live Trading Proof Bar -->
+        <!-- Tool Stats Bar -->
         <div class="flex flex-wrap gap-3 mb-4 font-mono text-sm">
-          <span class="px-3 py-1.5 rounded bg-green-500/10 text-green-400 border border-green-500/20">{t('hero.live_trades')}</span>
-          <span class="px-3 py-1.5 rounded bg-[--color-accent]/10 text-[--color-accent] border border-[--color-accent]/20">{t('hero.live_wr')}</span>
-          <span class="px-3 py-1.5 rounded bg-[--color-accent]/10 text-[--color-accent] border border-[--color-accent]/20">{t('hero.live_days')}</span>
-          <span class="px-3 py-1.5 rounded bg-[--color-accent]/10 text-[--color-accent] border border-[--color-accent]/20">{t('hero.live_capital')}</span>
+          <span class="px-3 py-1.5 rounded bg-green-500/10 text-green-400 border border-green-500/20">{t('hero.tool_coins')}</span>
+          <span class="px-3 py-1.5 rounded bg-[--color-accent]/10 text-[--color-accent] border border-[--color-accent]/20">{t('hero.tool_strategies')}</span>
+          <span class="px-3 py-1.5 rounded bg-[--color-accent]/10 text-[--color-accent] border border-[--color-accent]/20">{t('hero.tool_data')}</span>
+          <span class="px-3 py-1.5 rounded bg-[--color-accent]/10 text-[--color-accent] border border-[--color-accent]/20">{t('hero.tool_free')}</span>
         </div>
 
         <p class="text-sm text-[--color-text-muted] mb-8 max-w-2xl opacity-70">

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -26,12 +26,12 @@ const verifiedCount = allStrategies.filter(s => s.data.status === 'verified').le
         <p class="text-lg md:text-xl text-[--color-text-muted] mb-4 max-w-2xl">
           {t('hero.desc')}
         </p>
-        <!-- 라이브 트레이딩 실적 바 -->
+        <!-- 도구 스탯 바 -->
         <div class="flex flex-wrap gap-3 mb-4 font-mono text-sm">
-          <span class="px-3 py-1.5 rounded bg-green-500/10 text-green-400 border border-green-500/20">{t('hero.live_trades')}</span>
-          <span class="px-3 py-1.5 rounded bg-[--color-accent]/10 text-[--color-accent] border border-[--color-accent]/20">{t('hero.live_wr')}</span>
-          <span class="px-3 py-1.5 rounded bg-[--color-accent]/10 text-[--color-accent] border border-[--color-accent]/20">{t('hero.live_days')}</span>
-          <span class="px-3 py-1.5 rounded bg-[--color-accent]/10 text-[--color-accent] border border-[--color-accent]/20">{t('hero.live_capital')}</span>
+          <span class="px-3 py-1.5 rounded bg-green-500/10 text-green-400 border border-green-500/20">{t('hero.tool_coins')}</span>
+          <span class="px-3 py-1.5 rounded bg-[--color-accent]/10 text-[--color-accent] border border-[--color-accent]/20">{t('hero.tool_strategies')}</span>
+          <span class="px-3 py-1.5 rounded bg-[--color-accent]/10 text-[--color-accent] border border-[--color-accent]/20">{t('hero.tool_data')}</span>
+          <span class="px-3 py-1.5 rounded bg-[--color-accent]/10 text-[--color-accent] border border-[--color-accent]/20">{t('hero.tool_free')}</span>
         </div>
 
         <p class="text-sm text-[--color-text-muted] mb-8 max-w-2xl opacity-70">


### PR DESCRIPTION
## Summary
- Migrate all GitHub references from `poong92/pruviq` to `pruviq/pruviq`
- Remove personal live trading data from hero badges ($3K capital, 48 days, win rate)
- Replace with tool-focused stats (549+ coins, 88+ strategies, 2+ years data)
- Update JSON-LD FAQ to focus on backtesting tool verification
- Update CODEOWNERS, deploy scripts, docs

## Files Changed (15)
- `src/i18n/en.ts` + `ko.ts` — hero badges: personal → tool stats
- `src/layouts/Layout.astro` — sameAs, footer link, JSON-LD FAQ
- `src/pages/index.astro` + `ko/index.astro` — hero section
- `.claude/CLAUDE.md`, `.github/CODEOWNERS`, docs, deploy scripts

## Test plan
- [x] `npm run build` — 2,446 pages, 0 errors
- [ ] Verify EN homepage hero badges show tool stats
- [ ] Verify KO homepage hero badges show tool stats
- [ ] Verify footer GitHub link points to pruviq/pruviq