### PR TITLE
fix: move client scripts inside Layout to fix broken interactive pages

### DIFF
--- a/src/pages/coins/[symbol].astro
+++ b/src/pages/coins/[symbol].astro
@@ -150,23 +150,23 @@ const canonicalOverride = symbol.endsWith('usdt') ? undefined : `/coins/${symbol
       </div>
     </div>
   </section>
+
+  <script>
+    import { h, render } from 'preact';
+    import CoinChart from '../../components/CoinChart';
+    import ErrorBoundary from '../../components/ErrorBoundary';
+    import ExchangeCTA from '../../components/ExchangeCTA';
+
+    const mount = document.getElementById('coin-mount');
+    if (mount) {
+      const symbol = mount.dataset.symbol;
+      render(h(ErrorBoundary, { name: 'Coin Chart' }, h(CoinChart, { symbol, lang: 'en' })), mount);
+    }
+
+    const ctaMount = document.getElementById('exchange-cta-mount');
+    if (ctaMount) {
+      const coin = ctaMount.dataset.coin;
+      render(h(ExchangeCTA, { mode: 'card', lang: 'en', coin }), ctaMount);
+    }
+  </script>
 </Layout>
-
-<script>
-  import { h, render } from 'preact';
-  import CoinChart from '../../components/CoinChart';
-  import ErrorBoundary from '../../components/ErrorBoundary';
-  import ExchangeCTA from '../../components/ExchangeCTA';
-
-  const mount = document.getElementById('coin-mount');
-  if (mount) {
-    const symbol = mount.dataset.symbol;
-    render(h(ErrorBoundary, { name: 'Coin Chart' }, h(CoinChart, { symbol, lang: 'en' })), mount);
-  }
-
-  const ctaMount = document.getElementById('exchange-cta-mount');
-  if (ctaMount) {
-    const coin = ctaMount.dataset.coin;
-    render(h(ExchangeCTA, { mode: 'card', lang: 'en', coin }), ctaMount);
-  }
-</script>

--- a/src/pages/coins/index.astro
+++ b/src/pages/coins/index.astro
@@ -28,15 +28,15 @@ const t = useTranslations('en');
       </div>
     </div>
   </section>
+
+  <script>
+    import { h, render } from 'preact';
+    import CoinListTable from '../../components/CoinListTable';
+    import ErrorBoundary from '../../components/ErrorBoundary';
+
+    const mount = document.getElementById('coins-mount');
+    if (mount) {
+      render(h(ErrorBoundary, { name: 'Coin List' }, h(CoinListTable, { lang: 'en' })), mount);
+    }
+  </script>
 </Layout>
-
-<script>
-  import { h, render } from 'preact';
-  import CoinListTable from '../../components/CoinListTable';
-  import ErrorBoundary from '../../components/ErrorBoundary';
-
-  const mount = document.getElementById('coins-mount');
-  if (mount) {
-    render(h(ErrorBoundary, { name: 'Coin List' }, h(CoinListTable, { lang: 'en' })), mount);
-  }
-</script>

--- a/src/pages/ko/blog/[id].astro
+++ b/src/pages/ko/blog/[id].astro
@@ -95,16 +95,16 @@ const categoryLabels: Record<string, string> = {
       </div>
     </div>
   </article>
-</Layout>
 
-<script define:vars={{ postId: post.id }}>
-  try {
-    const KEY = 'pruviq_learn_read';
-    const raw = localStorage.getItem(KEY);
-    const read = raw ? JSON.parse(raw) : [];
-    if (!read.includes(postId)) {
-      read.push(postId);
-      localStorage.setItem(KEY, JSON.stringify(read));
-    }
-  } catch {}
-</script>
+  <script define:vars={{ postId: post.id }}>
+    try {
+      const KEY = 'pruviq_learn_read';
+      const raw = localStorage.getItem(KEY);
+      const read = raw ? JSON.parse(raw) : [];
+      if (!read.includes(postId)) {
+        read.push(postId);
+        localStorage.setItem(KEY, JSON.stringify(read));
+      }
+    } catch {}
+  </script>
+</Layout>

--- a/src/pages/ko/coins/[symbol].astro
+++ b/src/pages/ko/coins/[symbol].astro
@@ -147,23 +147,23 @@ const canonicalOverride = symbol.endsWith('usdt') ? undefined : `/ko/coins/${sym
       </div>
     </div>
   </section>
+
+  <script>
+    import { h, render } from 'preact';
+    import CoinChart from '../../../components/CoinChart';
+    import ErrorBoundary from '../../../components/ErrorBoundary';
+    import ExchangeCTA from '../../../components/ExchangeCTA';
+
+    const mount = document.getElementById('coin-mount');
+    if (mount) {
+      const symbol = mount.dataset.symbol;
+      render(h(ErrorBoundary, { name: 'Coin Chart' }, h(CoinChart, { symbol, lang: 'ko' })), mount);
+    }
+
+    const ctaMount = document.getElementById('exchange-cta-mount');
+    if (ctaMount) {
+      const coin = ctaMount.dataset.coin;
+      render(h(ExchangeCTA, { mode: 'card', lang: 'ko', coin }), ctaMount);
+    }
+  </script>
 </Layout>
-
-<script>
-  import { h, render } from 'preact';
-  import CoinChart from '../../../components/CoinChart';
-  import ErrorBoundary from '../../../components/ErrorBoundary';
-  import ExchangeCTA from '../../../components/ExchangeCTA';
-
-  const mount = document.getElementById('coin-mount');
-  if (mount) {
-    const symbol = mount.dataset.symbol;
-    render(h(ErrorBoundary, { name: 'Coin Chart' }, h(CoinChart, { symbol, lang: 'ko' })), mount);
-  }
-
-  const ctaMount = document.getElementById('exchange-cta-mount');
-  if (ctaMount) {
-    const coin = ctaMount.dataset.coin;
-    render(h(ExchangeCTA, { mode: 'card', lang: 'ko', coin }), ctaMount);
-  }
-</script>

--- a/src/pages/ko/coins/index.astro
+++ b/src/pages/ko/coins/index.astro
@@ -28,15 +28,15 @@ const t = useTranslations('ko');
       </div>
     </div>
   </section>
+
+  <script>
+    import { h, render } from 'preact';
+    import CoinListTable from '../../../components/CoinListTable';
+    import ErrorBoundary from '../../../components/ErrorBoundary';
+
+    const mount = document.getElementById('coins-mount');
+    if (mount) {
+      render(h(ErrorBoundary, { name: 'Coin List' }, h(CoinListTable, { lang: 'ko' })), mount);
+    }
+  </script>
 </Layout>
-
-<script>
-  import { h, render } from 'preact';
-  import CoinListTable from '../../../components/CoinListTable';
-  import ErrorBoundary from '../../../components/ErrorBoundary';
-
-  const mount = document.getElementById('coins-mount');
-  if (mount) {
-    render(h(ErrorBoundary, { name: 'Coin List' }, h(CoinListTable, { lang: 'ko' })), mount);
-  }
-</script>

--- a/src/pages/ko/market/index.astro
+++ b/src/pages/ko/market/index.astro
@@ -30,15 +30,15 @@ const t = useTranslations('ko');
       </div>
     </div>
   </section>
+
+  <script>
+    import { h, render } from 'preact';
+    import MarketDashboard from '../../../components/MarketDashboard';
+    import ErrorBoundary from '../../../components/ErrorBoundary';
+
+    const mount = document.getElementById('market-mount');
+    if (mount) {
+      render(h(ErrorBoundary, { name: 'Market Dashboard' }, h(MarketDashboard, { lang: 'ko' })), mount);
+    }
+  </script>
 </Layout>
-
-<script>
-  import { h, render } from 'preact';
-  import MarketDashboard from '../../../components/MarketDashboard';
-  import ErrorBoundary from '../../../components/ErrorBoundary';
-
-  const mount = document.getElementById('market-mount');
-  if (mount) {
-    render(h(ErrorBoundary, { name: 'Market Dashboard' }, h(MarketDashboard, { lang: 'ko' })), mount);
-  }
-</script>

--- a/src/pages/ko/simulate/index.astro
+++ b/src/pages/ko/simulate/index.astro
@@ -81,15 +81,15 @@ const t = useTranslations('ko');
       </div>
     </div>
   </section>
+
+  <script>
+    import { h, render } from 'preact';
+    import SimulatorPage from '../../../components/SimulatorPage';
+    import ErrorBoundary from '../../../components/ErrorBoundary';
+
+    const mount = document.getElementById('simulator-mount');
+    if (mount) {
+      render(h(ErrorBoundary, { name: 'Simulator' }, h(SimulatorPage, { lang: 'ko' })), mount);
+    }
+  </script>
 </Layout>
-
-<script>
-  import { h, render } from 'preact';
-  import SimulatorPage from '../../../components/SimulatorPage';
-  import ErrorBoundary from '../../../components/ErrorBoundary';
-
-  const mount = document.getElementById('simulator-mount');
-  if (mount) {
-    render(h(ErrorBoundary, { name: 'Simulator' }, h(SimulatorPage, { lang: 'ko' })), mount);
-  }
-</script>

--- a/src/pages/ko/strategies/[id].astro
+++ b/src/pages/ko/strategies/[id].astro
@@ -199,15 +199,15 @@ const statusLabels: Record<string, string> = {
       </div>
     </div>
   </article>
+
+  <script>
+    import { h, render } from 'preact';
+    import ExchangeCTA from '../../../components/ExchangeCTA';
+
+    const mount = document.getElementById('exchange-cta-mount');
+    if (mount) {
+      const strategy = mount.dataset.strategy;
+      render(h(ExchangeCTA, { mode: 'card', lang: 'ko', strategy }), mount);
+    }
+  </script>
 </Layout>
-
-<script>
-  import { h, render } from 'preact';
-  import ExchangeCTA from '../../../components/ExchangeCTA';
-
-  const mount = document.getElementById('exchange-cta-mount');
-  if (mount) {
-    const strategy = mount.dataset.strategy;
-    render(h(ExchangeCTA, { mode: 'card', lang: 'ko', strategy }), mount);
-  }
-</script>

--- a/src/pages/ko/strategies/compare.astro
+++ b/src/pages/ko/strategies/compare.astro
@@ -22,15 +22,15 @@ const t = useTranslations('ko');
       </div>
     </div>
   </section>
+
+  <script>
+    import { h, render } from 'preact';
+    import StrategyComparison from '../../../components/StrategyComparison';
+    import ErrorBoundary from '../../../components/ErrorBoundary';
+
+    const mount = document.getElementById('compare-mount');
+    if (mount) {
+      render(h(ErrorBoundary, { name: 'Strategy Comparison' }, h(StrategyComparison, { lang: 'ko' })), mount);
+    }
+  </script>
 </Layout>
-
-<script>
-  import { h, render } from 'preact';
-  import StrategyComparison from '../../../components/StrategyComparison';
-  import ErrorBoundary from '../../../components/ErrorBoundary';
-
-  const mount = document.getElementById('compare-mount');
-  if (mount) {
-    render(h(ErrorBoundary, { name: 'Strategy Comparison' }, h(StrategyComparison, { lang: 'ko' })), mount);
-  }
-</script>

--- a/src/pages/market/index.astro
+++ b/src/pages/market/index.astro
@@ -30,15 +30,15 @@ const t = useTranslations('en');
       </div>
     </div>
   </section>
+
+  <script>
+    import { h, render } from 'preact';
+    import MarketDashboard from '../../components/MarketDashboard';
+    import ErrorBoundary from '../../components/ErrorBoundary';
+
+    const mount = document.getElementById('market-mount');
+    if (mount) {
+      render(h(ErrorBoundary, { name: 'Market Dashboard' }, h(MarketDashboard, { lang: 'en' })), mount);
+    }
+  </script>
 </Layout>
-
-<script>
-  import { h, render } from 'preact';
-  import MarketDashboard from '../../components/MarketDashboard';
-  import ErrorBoundary from '../../components/ErrorBoundary';
-
-  const mount = document.getElementById('market-mount');
-  if (mount) {
-    render(h(ErrorBoundary, { name: 'Market Dashboard' }, h(MarketDashboard, { lang: 'en' })), mount);
-  }
-</script>

--- a/src/pages/simulate/index.astro
+++ b/src/pages/simulate/index.astro
@@ -81,15 +81,15 @@ const t = useTranslations('en');
       </div>
     </div>
   </section>
+
+  <script>
+    import { h, render } from 'preact';
+    import SimulatorPage from '../../components/SimulatorPage';
+    import ErrorBoundary from '../../components/ErrorBoundary';
+
+    const mount = document.getElementById('simulator-mount');
+    if (mount) {
+      render(h(ErrorBoundary, { name: 'Simulator' }, h(SimulatorPage, { lang: 'en' })), mount);
+    }
+  </script>
 </Layout>
-
-<script>
-  import { h, render } from 'preact';
-  import SimulatorPage from '../../components/SimulatorPage';
-  import ErrorBoundary from '../../components/ErrorBoundary';
-
-  const mount = document.getElementById('simulator-mount');
-  if (mount) {
-    render(h(ErrorBoundary, { name: 'Simulator' }, h(SimulatorPage, { lang: 'en' })), mount);
-  }
-</script>

--- a/src/pages/strategies/[id].astro
+++ b/src/pages/strategies/[id].astro
@@ -180,15 +180,15 @@ const statusLabels: Record<string, string> = {
       </div>
     </div>
   </article>
+
+  <script>
+    import { h, render } from 'preact';
+    import ExchangeCTA from '../../components/ExchangeCTA';
+
+    const mount = document.getElementById('exchange-cta-mount');
+    if (mount) {
+      const strategy = mount.dataset.strategy;
+      render(h(ExchangeCTA, { mode: 'card', lang: 'en', strategy }), mount);
+    }
+  </script>
 </Layout>
-
-<script>
-  import { h, render } from 'preact';
-  import ExchangeCTA from '../../components/ExchangeCTA';
-
-  const mount = document.getElementById('exchange-cta-mount');
-  if (mount) {
-    const strategy = mount.dataset.strategy;
-    render(h(ExchangeCTA, { mode: 'card', lang: 'en', strategy }), mount);
-  }
-</script>

--- a/src/pages/strategies/compare.astro
+++ b/src/pages/strategies/compare.astro
@@ -22,15 +22,15 @@ const t = useTranslations('en');
       </div>
     </div>
   </section>
+
+  <script>
+    import { h, render } from 'preact';
+    import StrategyComparison from '../../components/StrategyComparison';
+    import ErrorBoundary from '../../components/ErrorBoundary';
+
+    const mount = document.getElementById('compare-mount');
+    if (mount) {
+      render(h(ErrorBoundary, { name: 'Strategy Comparison' }, h(StrategyComparison, { lang: 'en' })), mount);
+    }
+  </script>
 </Layout>
-
-<script>
-  import { h, render } from 'preact';
-  import StrategyComparison from '../../components/StrategyComparison';
-  import ErrorBoundary from '../../components/ErrorBoundary';
-
-  const mount = document.getElementById('compare-mount');
-  if (mount) {
-    render(h(ErrorBoundary, { name: 'Strategy Comparison' }, h(StrategyComparison, { lang: 'en' })), mount);
-  }
-</script>


### PR DESCRIPTION
## Summary

- **Root cause**: All 13 pages with Preact client-side components had `<script>` tags placed after `</Layout>` in Astro source, causing them to render **after `</html>`** in the build output
- **Impact**: Cloudflare Workers strips content after `</html>`, breaking Simulator, Market, Coins, Strategies, and Blog pages — all show "Loading..." skeleton indefinitely
- **Fix**: Moved all `<script>` blocks inside `<Layout>` component slot for proper HTML placement

## Pages Fixed (13)
- `/simulate` (EN/KO) — **Simulator completely broken**
- `/market` (EN/KO)
- `/coins` + `/coins/[symbol]` (EN/KO)
- `/strategies/[id]` + `/strategies/compare` (EN/KO)
- `/ko/blog/[id]`

## Verification
- `npm run build` succeeds (2,446 pages)
- Script tags now render before `</html>` in all 13 pages
- API `/backtest` endpoint confirmed working independently

## Test Plan
- [ ] Visit /simulate — verify simulator loads (not stuck on "Loading...")
- [ ] Run a backtest with default BB Squeeze preset
- [ ] Visit /market — verify market data loads
- [ ] Visit /coins — verify coin list loads
- [ ] Visit /ko/simulate — verify Korean version works