### PR TITLE
feat: add review feedback loop for OpenClaw → JEPO cycle

### DIFF
--- a/.github/OPENCLAW_LESSONS.md
+++ b/.github/OPENCLAW_LESSONS.md
@@ -1,0 +1,85 @@
+# OpenClaw Lessons Learned
+
+> 이 파일은 JEPO 코드 리뷰에서 발견된 패턴과 교훈을 기록합니다.
+> PR을 생성하기 전에 반드시 이 파일을 읽고 동일한 실수를 반복하지 마세요.
+
+---
+
+## 필수 체크리스트 (PR 생성 전)
+
+- [ ] **git 브랜치 전환 시 데이터 보존**: checkout 전에 생성된 파일을 tmpdir에 백업
+- [ ] **동시 실행 보호**: 크론/스케줄 스크립트에는 반드시 `flock` 락 추가
+- [ ] **trap EXIT**: 쉘 스크립트에서 브랜치 전환 시 `trap 'git checkout main' EXIT` 필수
+- [ ] **빌드 검증 의미 확인**: 검증 대상이 실제 변경된 데이터인지 확인
+- [ ] **`|| true` 남용 금지**: 실패를 무시하면 후속 단계가 잘못된 상태에서 실행됨
+- [ ] **backend/ 경로 주의**: automerge가 `backend/` 경로 변경을 차단함 — 반드시 수동 리뷰 필요
+
+---
+
+## 리뷰 이력
+
+### 2026-03-03 — PR #154: fix(static-refresh): push generated static data to dedicated 'generated-data' branch
+
+**문제점**:
+1. `git checkout --orphan` + `git rm -rf .`이 방금 생성된 `public/data/*`를 삭제 → 빈 커밋
+2. `git checkout main` 복귀 후 빌드 검증이 기존 데이터로 실행 → 검증 무의미
+3. `flock` 없이 4시간 크론 실행 → 동시 실행 충돌 가능
+4. `trap` 없음 → 중간 실패 시 잘못된 브랜치에 남겨짐
+
+**올바른 패턴**:
+```bash
+# 1. 데이터 생성 후 백업
+TMPDIR=$(mktemp -d)
+cp -r public/data "$TMPDIR/"
+
+# 2. 브랜치 전환
+trap 'git checkout main 2>/dev/null || exit 1' EXIT
+git checkout $BRANCH
+
+# 3. 백업 복원
+cp -r "$TMPDIR/data" public/
+rm -rf "$TMPDIR"
+
+# 4. 커밋 & 푸시
+git add -f public/data
+git commit -m "chore: update snapshot"
+git push --force origin $BRANCH
+```
+
+**핵심 교훈**: git 브랜치 전환은 워킹 트리를 변경한다. 생성된 파일을 보존하려면 반드시 전환 전에 백업하라.
+
+---
+
+## 패턴별 가이드
+
+### 쉘 스크립트 안전 패턴
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# 동시 실행 방지
+exec 9>/tmp/script-name.lock
+flock -n 9 || { echo "Already running"; exit 0; }
+
+# 중단 시 복구
+trap 'cleanup_function' EXIT
+
+# 메인 로직
+```
+
+### git 브랜치 전환 시 데이터 보존
+```bash
+# 절대 하지 말 것:
+git checkout other-branch  # 워킹 트리의 uncommitted 변경이 사라짐!
+
+# 올바른 방법:
+TMPDIR=$(mktemp -d)
+cp -r important-files "$TMPDIR/"
+git checkout other-branch
+cp -r "$TMPDIR/important-files" ./
+rm -rf "$TMPDIR"
+```
+
+### 검증 시점
+- 빌드 검증은 실제 변경된 데이터가 포함된 상태에서 실행
+- `git checkout main` 후에는 main의 기존 데이터가 복원됨 → 새 데이터 검증이 아님

--- a/.github/workflows/review-feedback-loop.yml
+++ b/.github/workflows/review-feedback-loop.yml
@@ -1,0 +1,192 @@
+name: "Review Feedback Loop"
+
+# When JEPO posts a "Needs Changes" review, close the bad PR
+# and update the original issue with fix instructions for OpenClaw.
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: feedback-loop
+  cancel-in-progress: false
+
+jobs:
+  process-needs-changes:
+    name: Process JEPO Review Feedback
+    runs-on: ubuntu-latest
+    # Only trigger on PR comments (not issue comments) that contain JEPO review
+    if: |
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, 'JEPO Code Review') &&
+      contains(github.event.comment.body, 'Needs Changes')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract review and create feedback
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.issue.number;
+            const reviewBody = context.payload.comment.body;
+
+            core.info(`Processing JEPO review on PR #${prNumber}`);
+
+            // --- 1. Get PR details ---
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const prTitle = pr.data.title;
+            const prBody = pr.data.body || '';
+            const prBranch = pr.data.head.ref;
+
+            // --- 2. Find linked issue from PR body (e.g. "Closes: #153") ---
+            const issueMatch = prBody.match(/(?:closes|fixes|resolves):?\s*#(\d+)/i);
+            const linkedIssue = issueMatch ? parseInt(issueMatch[1]) : null;
+            core.info(`Linked issue: ${linkedIssue ? '#' + linkedIssue : 'none'}`);
+
+            // --- 3. Parse review into sections ---
+            // Extract everything between "Needs Changes" and "Suggestions" or end
+            const criticalMatch = reviewBody.match(/### 치명적[^]*?(?=###\s|---\s*$)/gs);
+            const sections = reviewBody.split(/### /).filter(s => s.trim()).map(s => '### ' + s);
+
+            // Build structured fix instructions
+            let fixInstructions = `## JEPO Review Feedback (PR #${prNumber})\n\n`;
+            fixInstructions += `**원본 PR**: #${prNumber} — ${prTitle}\n`;
+            fixInstructions += `**리뷰 결과**: Needs Changes\n`;
+            fixInstructions += `**날짜**: ${new Date().toISOString().split('T')[0]}\n\n`;
+            fixInstructions += `---\n\n`;
+            fixInstructions += `## 수정 필수 사항\n\n`;
+
+            // Extract actionable items from the review
+            const actionItems = [];
+
+            if (reviewBody.includes('데이터 소실') || reviewBody.includes('data loss')) {
+              actionItems.push('- [ ] 브랜치 전환 전 생성된 파일을 임시 디렉토리에 백업 후 복원');
+            }
+            if (reviewBody.includes('빌드 검증 무의미') || reviewBody.includes('build verification')) {
+              actionItems.push('- [ ] 빌드 검증이 새 데이터를 포함하도록 수정');
+            }
+            if (reviewBody.includes('동시 실행') || reviewBody.includes('concurrent') || reviewBody.includes('flock')) {
+              actionItems.push('- [ ] flock 또는 락 파일로 동시 실행 보호 추가');
+            }
+            if (reviewBody.includes('trap') || reviewBody.includes('복구 누락')) {
+              actionItems.push('- [ ] trap EXIT로 중단 시 자동 복구 추가');
+            }
+            if (reviewBody.includes('worktree')) {
+              actionItems.push('- [ ] git worktree 활용을 검토하여 브랜치 전환 제거');
+            }
+
+            // If no specific items were matched, extract generic ones
+            if (actionItems.length === 0) {
+              actionItems.push('- [ ] JEPO 리뷰에서 지적된 모든 항목 수정 (아래 원문 참조)');
+            }
+
+            fixInstructions += actionItems.join('\n') + '\n\n';
+            fixInstructions += `## 참고: OPENCLAW_LESSONS.md\n\n`;
+            fixInstructions += `\`.github/OPENCLAW_LESSONS.md\`를 반드시 읽고, 동일한 패턴의 실수를 반복하지 마세요.\n\n`;
+            fixInstructions += `## JEPO 원문 리뷰\n\n`;
+            fixInstructions += `<details>\n<summary>전체 리뷰 보기</summary>\n\n`;
+            fixInstructions += reviewBody + '\n';
+            fixInstructions += `</details>\n`;
+
+            // --- 4. Update linked issue or create new one ---
+            if (linkedIssue) {
+              // Add fix instructions as comment on the original issue
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: linkedIssue,
+                body: fixInstructions,
+              });
+
+              // Add 'fix-requested' label to the issue
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: linkedIssue,
+                  labels: ['fix-requested'],
+                });
+              } catch (e) {
+                core.warning(`Failed to add label: ${e.message}`);
+              }
+
+              core.info(`Posted fix instructions on issue #${linkedIssue}`);
+            } else {
+              // No linked issue — create a new one
+              const newIssue = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `Fix: ${prTitle}`,
+                body: fixInstructions,
+                labels: ['fix-requested', 'P1-high'],
+              });
+              core.info(`Created fix issue #${newIssue.data.number}`);
+            }
+
+            // --- 5. Close the buggy PR with explanation ---
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: [
+                `## PR Closed by Review Feedback Loop`,
+                ``,
+                `JEPO 리뷰에서 **Needs Changes**가 감지되어 이 PR을 닫습니다.`,
+                ``,
+                linkedIssue
+                  ? `수정 지침이 원본 이슈 #${linkedIssue}에 추가되었습니다. OpenClaw가 수정된 PR을 새로 생성할 예정입니다.`
+                  : `수정 지침이 포함된 새 이슈가 생성되었습니다.`,
+                ``,
+                `---`,
+                `_Automated by Review Feedback Loop_`,
+              ].join('\n'),
+            });
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              state: 'closed',
+            });
+
+            core.info(`Closed PR #${prNumber}`);
+
+            // --- 6. Update lessons learned ---
+            // Read current lessons file
+            const fs = require('fs');
+            const lessonsPath = '.github/OPENCLAW_LESSONS.md';
+            let lessons = '';
+            try {
+              const content = await github.rest.repos.getContent({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                path: lessonsPath,
+                ref: 'main',
+              });
+              lessons = Buffer.from(content.data.content, 'base64').toString();
+            } catch (e) {
+              lessons = '# OpenClaw Lessons Learned\n\n';
+            }
+
+            // Append new lesson (avoid duplicates by checking if PR is already mentioned)
+            if (!lessons.includes(`PR #${prNumber}`)) {
+              const newLesson = [
+                `\n### ${new Date().toISOString().split('T')[0]} — PR #${prNumber}: ${prTitle}`,
+                ``,
+                `**문제**: ${actionItems.map(i => i.replace('- [ ] ', '')).join(', ')}`,
+                `**교훈**: ${actionItems.length > 0 ? actionItems[0].replace('- [ ] ', '') : 'JEPO 리뷰 참조'}`,
+                ``,
+              ].join('\n');
+
+              // We don't commit directly here — the lessons file is managed
+              // via the OPENCLAW_LESSONS.md in the repo. Log for now.
+              core.info(`New lesson to add:\n${newLesson}`);
+            }


### PR DESCRIPTION
## Summary
- **review-feedback-loop.yml**: JEPO가 "Needs Changes" 리뷰를 남기면 자동으로:
  1. 원본 이슈에 구조화된 수정 지침 추가
  2. `fix-requested` 라벨 부여
  3. 버그가 있는 PR 닫기
  4. OpenClaw가 이슈를 재픽업하여 더 나은 PR 생성

- **OPENCLAW_LESSONS.md**: 과거 리뷰에서 발견된 패턴과 교훈 기록
  - 필수 체크리스트 (PR 생성 전)
  - 리뷰 이력 (PR #154 데이터 소실 버그)
  - 쉘 스크립트 안전 패턴 가이드

## 완성된 파이프라인
```
OpenClaw → Issue → PR → JEPO Review
  → Approve → Auto-merge → Deploy → Verify
  → Needs Changes → Close PR → Fix Instructions on Issue → OpenClaw 재시도
```

## Test plan
- [x] `fix-requested` 라벨 생성 완료
- [x] PR #154 → 이슈 #153에 수정 지침 추가 (수동 테스트)
- [x] PR #154 닫기 완료
- [ ] CI checks pass (validate, E2E, accessibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)