### PR TITLE
fix: redirect chain trailing slash

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -3,14 +3,14 @@
 # 검증: bash scripts/qa-redirects.sh
 # 참고: 코인 대소문자 리다이렉트는 _worker.js에서 처리 (Cloudflare 100개 제한)
 
-/builder /simulate 301
-/builder/* /simulate 301
+/builder /simulate/ 301
+/builder/* /simulate/ 301
 
 # /performance page exists — no redirect needed
 
 /sitemap.xml /sitemap-index.xml 301
 
 # KO equivalents
-/ko/builder /ko/simulate 301
-/ko/builder/* /ko/simulate 301
+/ko/builder /ko/simulate/ 301
+/ko/builder/* /ko/simulate/ 301
 # /ko/performance page exists — no redirect needed


### PR DESCRIPTION
## Summary
- Fix 4 Google Search Console redirect errors
- `/builder` → `/simulate/` (was `/simulate`, causing 307 chain)
- `/ko/builder` → `/ko/simulate/` (same issue)

## Evidence
GSC shows 4 "리디렉션 오류" pages. Root cause: redirect targets missing trailing slash → Astro adds 307 → double redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)