### PR TITLE
feat: dashboard spot unification + 30s live prices

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -1036,6 +1036,30 @@ MARKET_REFRESH_INTERVAL = 900  # seconds — background fetch every 15min (match
 _market_cache: Optional[dict] = None
 _news_cache: Optional[dict] = None
 
+# --- Binance Spot live ticker (30s TTL) + Futures fallback ---
+BINANCE_SPOT_URL = "https://api.binance.com/api/v3/ticker/24hr"
+BINANCE_FUTURES_URL = "https://fapi.binance.com/fapi/v1/ticker/24hr"
+_live_spot_cache: Optional[dict] = None
+_live_spot_ts: float = 0.0
+_live_spot_lock = asyncio.Lock()
+
+# Spot symbol → internal (futures-style) symbol mapping for 1000x coins
+SPOT_TO_INTERNAL = {
+    "SHIBUSDT": "1000SHIBUSDT", "PEPEUSDT": "1000PEPEUSDT",
+    "FLOKIUSDT": "1000FLOKIUSDT", "BONKUSDT": "1000BONKUSDT",
+    "SATSUSDT": "1000SATSUSDT", "RATSUSDT": "1000RATSUSDT",
+    "LUNCUSDT": "1000LUNCUSDT", "XECUSDT": "1000XECUSDT",
+    "CATUSDT": "1000CATUSDT", "WHYUSDT": "1000WHYUSDT",
+    "CHEEMSUSDT": "1000CHEEMSUSDT",
+    "MOGUSDT": "1000000MOGUSDT", "BOBUSDT": "1000000BOBUSDT",
+    "BABYDOGEUSDT": "1MBABYDOGEUSDT",
+}
+SPOT_MULTIPLIER: Dict[str, int] = {k: 1000 for k in [
+    "SHIBUSDT", "PEPEUSDT", "FLOKIUSDT", "BONKUSDT", "SATSUSDT",
+    "RATSUSDT", "LUNCUSDT", "XECUSDT", "CATUSDT", "WHYUSDT", "CHEEMSUSDT",
+]}
+SPOT_MULTIPLIER.update({"MOGUSDT": 1_000_000, "BOBUSDT": 1_000_000, "BABYDOGEUSDT": 1_000_000})
+
 
 def _fetch_fear_greed() -> dict:
     """Fetch Fear & Greed Index from Alternative.me."""
@@ -1296,6 +1320,92 @@ async def get_market():
     data = await asyncio.to_thread(_build_market_overview)
     _market_cache = data
     return MarketOverview(**data)
+
+
+def _fetch_spot_tickers() -> list:
+    """Fetch all USDT tickers from Binance Spot API. Weight 40 per call."""
+    try:
+        resp = http_requests.get(BINANCE_SPOT_URL, timeout=10)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as e:
+        logger.warning(f"Binance Spot fetch: {e}")
+        return []
+
+
+def _fetch_futures_tickers() -> list:
+    """Fetch Futures tickers for Spot-missing coins. Weight 40 per call."""
+    try:
+        resp = http_requests.get(BINANCE_FUTURES_URL, timeout=10)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as e:
+        logger.warning(f"Binance Futures fallback fetch: {e}")
+        return []
+
+
+def _build_live_coins(spot_tickers: list, futures_tickers: list) -> list:
+    """Build coins list from Spot (primary) + Futures (fallback for gaps)."""
+    coins = []
+    seen_symbols: set = set()
+    # 1. Spot tickers (primary)
+    for t in spot_tickers:
+        sym = t.get("symbol", "")
+        if not sym.endswith("USDT"):
+            continue
+        mul = SPOT_MULTIPLIER.get(sym, 1)
+        display_sym = SPOT_TO_INTERNAL.get(sym, sym)
+        coins.append({
+            "symbol": display_sym,
+            "price": float(t.get("lastPrice", 0)) * mul,
+            "change_24h": round(float(t.get("priceChangePercent", 0)), 2),
+            "volume_24h": round(float(t.get("quoteVolume", 0)), 2),
+        })
+        seen_symbols.add(display_sym)
+    # 2. Futures fallback (only for symbols not covered by Spot)
+    for t in futures_tickers:
+        sym = t.get("symbol", "")
+        if not sym.endswith("USDT") or sym in seen_symbols:
+            continue
+        coins.append({
+            "symbol": sym,
+            "price": float(t.get("lastPrice", 0)),
+            "change_24h": round(float(t.get("priceChangePercent", 0)), 2),
+            "volume_24h": round(float(t.get("quoteVolume", 0)), 2),
+        })
+        seen_symbols.add(sym)
+    return coins
+
+
+@app.get("/market/live")
+async def market_live():
+    """Real-time Binance prices (30s TTL cache).
+    Spot (primary) + Futures (fallback for Spot-missing coins).
+    Weight: 40 (Spot) + 40 (Futures) = 80/refresh × 2/min = 160 (6000 limit = 2.7%).
+    """
+    global _live_spot_cache, _live_spot_ts
+    if _live_spot_cache and time.time() - _live_spot_ts < 30:
+        return _live_spot_cache
+    async with _live_spot_lock:
+        # Double-check after acquiring lock (prevents thundering herd)
+        if _live_spot_cache and time.time() - _live_spot_ts < 30:
+            return _live_spot_cache
+        spot, futures = await asyncio.gather(
+            asyncio.to_thread(_fetch_spot_tickers),
+            asyncio.to_thread(_fetch_futures_tickers),
+        )
+        if not spot and not futures:
+            if _live_spot_cache:
+                return _live_spot_cache
+            raise HTTPException(503, "Binance unavailable")
+        coins = _build_live_coins(spot or [], futures or [])
+        result = {
+            "coins": coins,
+            "source": "binance_spot+futures",
+            "generated": datetime.now(timezone.utc).isoformat(),
+        }
+        _live_spot_cache, _live_spot_ts = result, time.time()
+        return result
 
 
 @app.get("/news", response_model=NewsResponse)

--- a/backend/scripts/refresh_static.py
+++ b/backend/scripts/refresh_static.py
@@ -46,8 +46,28 @@ OUTPUT_DIR = REPO_DIR / "public" / "data"
 COIN_SYMBOLS_TS = REPO_DIR / "src" / "data" / "coin-symbols.ts"
 COIN_METADATA = OUTPUT_DIR / "coin-metadata.json"  # fallback names/logos when CoinGecko is down
 
-# Binance Futures API (PRIMARY — unlimited, no key needed)
-BINANCE_TICKER_URL = "https://fapi.binance.com/fapi/v1/ticker/24hr"
+# Binance Spot API (PRIMARY — unlimited, no key needed)
+# Changed from Futures (fapi) to Spot (api) for dashboard consistency
+BINANCE_SPOT_TICKER_URL = "https://api.binance.com/api/v3/ticker/24hr"
+# Futures fallback for coins not listed on Spot (e.g. KASUSDT, TRUMPUSDT, 1000RATSUSDT...)
+BINANCE_FUTURES_TICKER_URL = "https://fapi.binance.com/fapi/v1/ticker/24hr"
+
+# Spot symbol → internal (futures-style) symbol mapping for 1000x coins
+SPOT_TO_INTERNAL = {
+    "SHIBUSDT": "1000SHIBUSDT", "PEPEUSDT": "1000PEPEUSDT",
+    "FLOKIUSDT": "1000FLOKIUSDT", "BONKUSDT": "1000BONKUSDT",
+    "SATSUSDT": "1000SATSUSDT", "RATSUSDT": "1000RATSUSDT",
+    "LUNCUSDT": "1000LUNCUSDT", "XECUSDT": "1000XECUSDT",
+    "CATUSDT": "1000CATUSDT", "WHYUSDT": "1000WHYUSDT",
+    "CHEEMSUSDT": "1000CHEEMSUSDT",
+    "MOGUSDT": "1000000MOGUSDT", "BOBUSDT": "1000000BOBUSDT",
+    "BABYDOGEUSDT": "1MBABYDOGEUSDT",
+}
+SPOT_MULTIPLIER: dict[str, int] = {k: 1000 for k in [
+    "SHIBUSDT", "PEPEUSDT", "FLOKIUSDT", "BONKUSDT", "SATSUSDT",
+    "RATSUSDT", "LUNCUSDT", "XECUSDT", "CATUSDT", "WHYUSDT", "CHEEMSUSDT",
+]}
+SPOT_MULTIPLIER.update({"MOGUSDT": 1_000_000, "BOBUSDT": 1_000_000, "BABYDOGEUSDT": 1_000_000})
 
 # CoinGecko Free API (SECONDARY — logos, market cap, sparklines)
 CG_BASE = "https://api.coingecko.com/api/v3"
@@ -102,15 +122,52 @@ def load_coin_symbols() -> list[str]:
 
 
 def fetch_binance_tickers() -> list[dict]:
-    """Fetch all USDT futures tickers from Binance (1 API call, unlimited)."""
-    print("  Fetching Binance Futures tickers...")
-    data = fetch_json(BINANCE_TICKER_URL)
+    """Fetch USDT tickers: Spot (primary) + Futures fallback for Spot-missing coins.
+
+    Applies SPOT_TO_INTERNAL reverse mapping so that Spot symbols (SHIBUSDT)
+    become internal symbols (1000SHIBUSDT) with price × multiplier.
+    Futures-only coins (KASUSDT, TRUMPUSDT, etc.) are fetched via Futures API
+    to avoid price=0 gaps. Total weight: 40 (Spot) + 40 (Futures) = 80.
+    """
+    print("  Fetching Binance Spot tickers...")
+    data = fetch_json(BINANCE_SPOT_TICKER_URL)
     if not data or not isinstance(data, list):
-        print("  ERROR: Binance ticker API failed")
+        print("  ERROR: Binance Spot ticker API failed")
         return []
-    # Filter USDT pairs only
-    usdt_tickers = [t for t in data if t.get("symbol", "").endswith("USDT")]
-    print(f"  Got {len(usdt_tickers)} USDT tickers from Binance")
+    # Filter USDT pairs, remap 1000x symbols
+    usdt_tickers = []
+    spot_internal_symbols: set[str] = set()
+    for t in data:
+        sym = t.get("symbol", "")
+        if not sym.endswith("USDT"):
+            continue
+        mul = SPOT_MULTIPLIER.get(sym, 1)
+        mapped_sym = SPOT_TO_INTERNAL.get(sym, sym)
+        ticker = dict(t)
+        ticker["symbol"] = mapped_sym
+        # NOTE: Only lastPrice needs multiplier. priceChangePercent is %, quoteVolume is USDT.
+        if mul != 1:
+            ticker["lastPrice"] = str(float(t.get("lastPrice", 0)) * mul)
+        usdt_tickers.append(ticker)
+        spot_internal_symbols.add(mapped_sym)
+    print(f"  Got {len(usdt_tickers)} USDT tickers from Binance Spot")
+
+    # Futures fallback: fill gaps for Futures-only symbols
+    our_symbols = load_coin_symbols()
+    if our_symbols:
+        missing = set(our_symbols) - spot_internal_symbols
+        if missing:
+            print(f"  {len(missing)} symbols missing from Spot, fetching Futures fallback...")
+            futures_data = fetch_json(BINANCE_FUTURES_TICKER_URL)
+            if futures_data and isinstance(futures_data, list):
+                added = 0
+                for t in futures_data:
+                    sym = t.get("symbol", "")
+                    if sym in missing:
+                        usdt_tickers.append(t)
+                        added += 1
+                print(f"  Added {added}/{len(missing)} from Futures fallback")
+
     return usdt_tickers
 
 

--- a/src/components/MarketDashboard.tsx
+++ b/src/components/MarketDashboard.tsx
@@ -1,6 +1,9 @@
-import { useState, useEffect, useRef } from 'preact/hooks';
+import { useState, useEffect } from 'preact/hooks';
 import { changeColor, timeAgo } from '../utils/format';
-import { STATIC_DATA, fetchWithFallback, API_BASE_URL } from '../config/api';
+import { useMarketLive } from '../hooks/useMarketLive';
+import { useMarketOverview } from '../hooks/useMarketOverview';
+import { useNews } from '../hooks/useNews';
+import { useMacro } from '../hooks/useMacro';
 
 const labels = {
   en: {
@@ -18,7 +21,7 @@ const labels = {
     newsLoading: 'Loading news...',
     newsError: 'Failed to load news.',
     updated: 'Updated',
-    disclaimer: 'Market data is for informational purposes only. Not financial advice. Data refreshed every 15 min.',
+    disclaimer: 'Market data is for informational purposes only. Not financial advice. Prices update every 30s. Market data refreshed every 5 min.',
     readMore: 'Read more',
     searchNews: 'Search news...',
     allSources: 'All',
@@ -54,7 +57,7 @@ const labels = {
     newsLoading: '뉴스 로딩 중...',
     newsError: '뉴스 로딩 실패.',
     updated: '업데이트',
-    disclaimer: '시장 데이터는 정보 제공 목적으로만 제공됩니다. 투자 조언이 아닙니다. 15분마다 자동 갱신.',
+    disclaimer: '시장 데이터는 정보 제공 목적으로만 제공됩니다. 투자 조언이 아닙니다. 가격 30초 갱신. 시장 데이터 5분 갱신.',
     readMore: '자세히 보기',
     searchNews: '뉴스 검색...',
     allSources: '전체',
@@ -75,42 +78,6 @@ const labels = {
     showMoreNews: '더 보기',
     showLessNews: '접기',
   },
-};
-
-type NewsItem = { title: string; link: string; source: string; category?: string; published: string; summary: string };
-
-type MarketData = {
-  btc_price: number;
-  btc_change_24h: number;
-  eth_price: number;
-  eth_change_24h: number;
-  fear_greed_index: number;
-  fear_greed_label: string;
-  total_market_cap_b: number;
-  btc_dominance: number;
-  total_volume_24h_b: number;
-  generated: string;
-};
-
-type NewsData = {
-  items: NewsItem[];
-  generated: string;
-};
-
-type MacroIndicator = {
-  id: string;
-  name: string;
-  value: number;
-  change: number | null;
-  previous?: number | null;
-  unit: string;
-  updated: string;
-  source: string;
-};
-
-type MacroData = {
-  indicators: MacroIndicator[];
-  generated: string;
 };
 
 /* --- Skeleton Components --- */
@@ -185,7 +152,6 @@ function ExpandButton({ expanded, onClick, expandLabel, collapseLabel }: { expan
 
 const CRYPTO_SOURCES = ['CoinDesk', 'CoinTelegraph', 'Decrypt', 'Bitcoin Magazine'];
 const MACRO_SOURCES = ['Bloomberg', 'CNBC Economy', 'MarketWatch'];
-const REFRESH_MS = 300_000; // 5 min (static data refreshed every 15 min)
 
 // Fear & Greed gauge scale labels
 const FG_SCALE = [
@@ -201,87 +167,40 @@ function getFGSegment(value: number) {
 
 export default function MarketDashboard({ lang = 'en' }: { lang?: 'en' | 'ko' }) {
   const l = labels[lang] || labels.en;
-  const [market, setMarket] = useState<MarketData | null>(null);
-  const [news, setNews] = useState<NewsData | null>(null);
-  const [macro, setMacro] = useState<MacroData | null>(null);
-  const [marketErr, setMarketErr] = useState(false);
-  const [newsErr, setNewsErr] = useState(false);
-  const [macroErr, setMacroErr] = useState(false);
+
+  // 4 independent hooks — each polls at its own interval
+  const { btcPrice, btcChange, ethPrice, ethChange, flash, generated, error: liveErr, retry: retryLive } = useMarketLive();
+  const { market, error: marketErr, retry: retryMarket } = useMarketOverview();
+  const { news, error: newsErr, retry: retryNews } = useNews();
+  const { macro, error: macroErr } = useMacro();
+
   const [searchQuery, setSearchQuery] = useState('');
   const [sourceFilter, setSourceFilter] = useState('');
   const [newsTab, setNewsTab] = useState<'crypto' | 'macro'>('crypto');
-  const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
-  const [refreshAgo, setRefreshAgo] = useState('');
-
-  // Expansion states
   const [newsExpanded, setNewsExpanded] = useState(false);
 
-  // Price flash tracking
-  const prevBtc = useRef<number>(0);
-  const prevEth = useRef<number>(0);
-  const [btcFlash, setBtcFlash] = useState('');
-  const [ethFlash, setEthFlash] = useState('');
-
-  const fetchMarket = () => {
-    fetchWithFallback('/market', STATIC_DATA.market)
-      .then((d: MarketData) => {
-        // Price flash detection
-        if (prevBtc.current && d.btc_price !== prevBtc.current) {
-          setBtcFlash(d.btc_price > prevBtc.current ? 'flash-up' : 'flash-down');
-          setTimeout(() => setBtcFlash(''), 600);
-        }
-        if (prevEth.current && d.eth_price !== prevEth.current) {
-          setEthFlash(d.eth_price > prevEth.current ? 'flash-up' : 'flash-down');
-          setTimeout(() => setEthFlash(''), 600);
-        }
-        prevBtc.current = d.btc_price;
-        prevEth.current = d.eth_price;
-        setMarket(d);
-        setMarketErr(false);
-        setLastRefresh(new Date());
-      })
-      .catch(() => setMarketErr(true));
-  };
-
-  const fetchNews = () => {
-    fetchWithFallback('/news', STATIC_DATA.news)
-      .then(d => { setNews(d); setNewsErr(false); })
-      .catch(() => setNewsErr(true));
-  };
-
-  const fetchMacro = () => {
-    fetchWithFallback('/macro', STATIC_DATA.macro)
-      .then((d: MacroData) => { setMacro(d); setMacroErr(false); })
-      .catch(() => setMacroErr(true));
-  };
-
+  // Live "updated X ago" counter (based on live price generated timestamp)
+  const [refreshAgo, setRefreshAgo] = useState('');
   useEffect(() => {
-    fetchMarket();
-    fetchNews();
-    fetchMacro();
-    const interval = setInterval(() => { fetchMarket(); fetchNews(); }, REFRESH_MS);
-    // Macro refreshes less frequently (FRED data updates daily)
-    const macroInterval = setInterval(fetchMacro, 30 * 60 * 1000);
-    return () => { clearInterval(interval); clearInterval(macroInterval); };
-  }, []);
-
-  // Live "updated X ago" counter
-  useEffect(() => {
+    if (!generated) return;
+    const genTime = new Date(generated).getTime();
     const tick = () => {
-      if (!lastRefresh) return;
-      const sec = Math.floor((Date.now() - lastRefresh.getTime()) / 1000);
+      const sec = Math.max(0, Math.floor((Date.now() - genTime) / 1000));
       if (sec < 60) setRefreshAgo(`${sec}s`);
       else setRefreshAgo(`${Math.floor(sec / 60)}m`);
     };
     tick();
     const id = setInterval(tick, 10_000);
     return () => clearInterval(id);
-  }, [lastRefresh]);
+  }, [generated]);
+
+  // Determine if we have enough data to render (either live prices or market overview)
+  const hasData = btcPrice > 0 || market;
+  const hasError = liveErr && marketErr;
 
   const activeNewsSources = newsTab === 'crypto' ? CRYPTO_SOURCES : MACRO_SOURCES;
 
   const filteredNews = news?.items.filter(item => {
-    // Tab filter: use category if available, otherwise match by source name
     const itemCat = item.category || (MACRO_SOURCES.includes(item.source) ? 'macro' : 'crypto');
     if (itemCat !== newsTab) return false;
     if (sourceFilter && item.source !== sourceFilter) return false;
@@ -292,7 +211,13 @@ export default function MarketDashboard({ lang = 'en' }: { lang?: 'en' | 'ko' })
     return true;
   }) ?? [];
 
-  // Display helpers: show dash (—) when certain market values are 0 or missing
+  // Use live prices (30s) with fallback to market overview (5min)
+  const displayBtcPrice = btcPrice || market?.btc_price || 0;
+  const displayBtcChange = btcPrice ? btcChange : (market?.btc_change_24h ?? 0);
+  const displayEthPrice = ethPrice || market?.eth_price || 0;
+  const displayEthChange = ethPrice ? ethChange : (market?.eth_change_24h ?? 0);
+
+  // Display helpers
   const totalMcapDisplay = market && market.total_market_cap_b ? `$${market.total_market_cap_b.toFixed(0)}B` : '—';
   const btcDomDisplay = market && market.btc_dominance ? `${market.btc_dominance}%` : '—';
   const volume24hDisplay = market && market.total_volume_24h_b ? `$${market.total_volume_24h_b.toFixed(0)}B` : '—';
@@ -304,7 +229,7 @@ export default function MarketDashboard({ lang = 'en' }: { lang?: 'en' | 'ko' })
   return (
     <div class="max-w-[1100px] mx-auto">
       {/* Loading skeleton */}
-      {!market && !marketErr && (
+      {!hasData && !hasError && (
         <div>
           <SkeletonPriceBar />
           <div class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
@@ -313,11 +238,11 @@ export default function MarketDashboard({ lang = 'en' }: { lang?: 'en' | 'ko' })
         </div>
       )}
 
-      {marketErr && (
+      {hasError && (
         <div class="text-center py-10">
           <p class="font-mono text-sm text-[--color-red] mb-3">{l.error}</p>
           <button
-            onClick={() => { setMarketErr(false); fetchMarket(); }}
+            onClick={() => { retryLive(); retryMarket(); }}
             class="px-4 py-2 rounded-lg border border-[--color-border] bg-[--color-bg-card] text-[--color-text] font-mono text-sm cursor-pointer hover:border-[--color-accent] transition-colors min-h-[44px]"
           >
             {lang === 'ko' ? '다시 시도' : 'Retry'}
@@ -325,71 +250,75 @@ export default function MarketDashboard({ lang = 'en' }: { lang?: 'en' | 'ko' })
         </div>
       )}
 
-      {market && (
+      {hasData && (
         <div class="fade-in">
-          {/* BTC + ETH Price Bar */}
+          {/* BTC + ETH Price Bar — 30s live refresh */}
           <div class="flex gap-4 flex-wrap mb-4">
-            <div class={`flex items-center gap-3 border border-[--color-border] rounded-lg py-3 px-5 bg-[--color-bg-card] flex-1 min-w-[200px] ${btcFlash}`}>
+            <div class={`flex items-center gap-3 border border-[--color-border] rounded-lg py-3 px-5 bg-[--color-bg-card] flex-1 min-w-[200px] ${flash.btc}`}>
               <span class="text-sm font-semibold text-[--color-btc]">BTC</span>
               <span class="text-xl font-bold font-mono text-[--color-text]">
-                ${market.btc_price.toLocaleString('en-US', { maximumFractionDigits: 0 })}
+                ${displayBtcPrice.toLocaleString('en-US', { maximumFractionDigits: 0 })}
               </span>
-              <span class="text-sm font-semibold font-mono" style={{ color: changeColor(market.btc_change_24h) }}>
-                {market.btc_change_24h > 0 ? '+' : ''}{market.btc_change_24h.toFixed(2)}%
+              <span class="text-sm font-semibold font-mono" style={{ color: changeColor(displayBtcChange) }}>
+                {displayBtcChange > 0 ? '+' : ''}{displayBtcChange.toFixed(2)}%
               </span>
             </div>
-            <div class={`flex items-center gap-3 border border-[--color-border] rounded-lg py-3 px-5 bg-[--color-bg-card] flex-1 min-w-[200px] ${ethFlash}`}>
+            <div class={`flex items-center gap-3 border border-[--color-border] rounded-lg py-3 px-5 bg-[--color-bg-card] flex-1 min-w-[200px] ${flash.eth}`}>
               <span class="text-sm font-semibold text-[--color-eth]">ETH</span>
               <span class="text-xl font-bold font-mono text-[--color-text]">
-                ${market.eth_price.toLocaleString('en-US', { maximumFractionDigits: 0 })}
+                ${displayEthPrice.toLocaleString('en-US', { maximumFractionDigits: 0 })}
               </span>
-              <span class="text-sm font-semibold font-mono" style={{ color: changeColor(market.eth_change_24h) }}>
-                {market.eth_change_24h > 0 ? '+' : ''}{market.eth_change_24h.toFixed(2)}%
+              <span class="text-sm font-semibold font-mono" style={{ color: changeColor(displayEthChange) }}>
+                {displayEthChange > 0 ? '+' : ''}{displayEthChange.toFixed(2)}%
               </span>
             </div>
           </div>
 
-          {/* Stat Cards */}
+          {/* Stat Cards — 5min market overview refresh */}
           <div class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
             {/* Fear & Greed with enhanced gauge */}
-            <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover" style={{ backgroundColor: `${fgSegment.color}10` }}>
-              <div class="text-[11px] text-[--color-text-muted] uppercase tracking-wider mb-1.5">{l.fearGreed}</div>
-              <div class="flex items-baseline gap-1.5">
-                <span class="text-2xl font-bold font-mono" style={{ color: fgSegment.color }}>{market.fear_greed_index}</span>
-                <span class="text-sm font-mono text-[--color-text-muted]">/ 100</span>
-              </div>
-
-              {/* Gauge bar */}
-              <div class="mt-3 mb-2">
-                <div class="w-full bg-[--color-bg-hover] rounded-full overflow-hidden" style={{ height: '8px' }} role="img" aria-label={`Fear and Greed gauge ${market.fear_greed_index} out of 100`}>
-                  <div
-                    style={{
-                      width: `${fgPct}%`,
-                      backgroundColor: fgSegment.color,
-                      height: '8px',
-                    }}
-                    class="rounded-full transition-all duration-500"
-                  />
+            {market ? (
+              <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover" style={{ backgroundColor: `${fgSegment.color}10` }}>
+                <div class="text-[11px] text-[--color-text-muted] uppercase tracking-wider mb-1.5">{l.fearGreed}</div>
+                <div class="flex items-baseline gap-1.5">
+                  <span class="text-2xl font-bold font-mono" style={{ color: fgSegment.color }}>{market.fear_greed_index}</span>
+                  <span class="text-sm font-mono text-[--color-text-muted]">/ 100</span>
                 </div>
-                {/* Scale markers */}
-                <div class="flex justify-between mt-1">
-                  <span class="text-[9px] text-[--color-text-muted] font-mono">0</span>
-                  <span class="text-[9px] text-[--color-text-muted] font-mono">25</span>
-                  <span class="text-[9px] text-[--color-text-muted] font-mono">50</span>
-                  <span class="text-[9px] text-[--color-text-muted] font-mono">75</span>
-                  <span class="text-[9px] text-[--color-text-muted] font-mono">100</span>
-                </div>
-              </div>
 
-              <div class="text-xs font-semibold" style={{ color: fgSegment.color }}>{market.fear_greed_label}</div>
-            </div>
+                {/* Gauge bar */}
+                <div class="mt-3 mb-2">
+                  <div class="w-full bg-[--color-bg-hover] rounded-full overflow-hidden" style={{ height: '8px' }} role="img" aria-label={`Fear and Greed gauge ${market.fear_greed_index} out of 100`}>
+                    <div
+                      style={{
+                        width: `${fgPct}%`,
+                        backgroundColor: fgSegment.color,
+                        height: '8px',
+                      }}
+                      class="rounded-full transition-all duration-500"
+                    />
+                  </div>
+                  {/* Scale markers */}
+                  <div class="flex justify-between mt-1">
+                    <span class="text-[9px] text-[--color-text-muted] font-mono">0</span>
+                    <span class="text-[9px] text-[--color-text-muted] font-mono">25</span>
+                    <span class="text-[9px] text-[--color-text-muted] font-mono">50</span>
+                    <span class="text-[9px] text-[--color-text-muted] font-mono">75</span>
+                    <span class="text-[9px] text-[--color-text-muted] font-mono">100</span>
+                  </div>
+                </div>
+
+                <div class="text-xs font-semibold" style={{ color: fgSegment.color }}>{market.fear_greed_label}</div>
+              </div>
+            ) : (
+              <SkeletonCard />
+            )}
 
             <StatCard label={l.totalMcap} value={totalMcapDisplay} />
             <StatCard label={l.btcDom} value={btcDomDisplay} />
             <StatCard label={l.volume24h} value={volume24hDisplay} />
           </div>
 
-          {/* Macro Economic Indicators */}
+          {/* Macro Economic Indicators — 30min refresh */}
           <div class="border border-[--color-border] rounded-lg bg-[--color-bg-card] overflow-hidden mb-6">
             <div class="px-4 py-3 border-b border-[--color-border] flex items-center justify-between">
               <span class="text-xs font-semibold text-[--color-text-muted] uppercase tracking-wider">
@@ -418,7 +347,6 @@ export default function MarketDashboard({ lang = 'en' }: { lang?: 'en' | 'ko' })
                   const delta = ind.change ?? (ind.previous != null ? ind.value - ind.previous : null);
                   const deltaColor = delta != null ? (delta >= 0 ? 'text-[--color-up]' : 'text-[--color-down]') : '';
                   const arrow = delta != null ? (delta >= 0 ? '\u25B2' : '\u25BC') : '';
-                  // Format large numbers (S&P, Nasdaq, Gold)
                   const fmtValue = ind.value >= 1000
                     ? ind.value.toLocaleString('en-US', { maximumFractionDigits: 2 })
                     : ind.value.toFixed(2);
@@ -466,7 +394,7 @@ export default function MarketDashboard({ lang = 'en' }: { lang?: 'en' | 'ko' })
             </div>
           </div>
 
-          {/* News Feed */}
+          {/* News Feed — 5min refresh */}
           <div class="border border-[--color-border] rounded-lg bg-[--color-bg-card] overflow-hidden mb-6">
             <div class="px-4 py-3 border-b border-[--color-border] flex flex-wrap items-center gap-2.5">
               <span class="text-xs font-semibold text-[--color-text-muted] uppercase tracking-wider mr-auto">
@@ -526,7 +454,7 @@ export default function MarketDashboard({ lang = 'en' }: { lang?: 'en' | 'ko' })
               <div class="text-center py-8">
                 <p class="font-mono text-sm text-[--color-red] mb-3">{l.newsError}</p>
                 <button
-                  onClick={() => { setNewsErr(false); fetchNews(); }}
+                  onClick={retryNews}
                   class="px-4 py-2 rounded-lg border border-[--color-border] bg-[--color-bg-card] text-[--color-text] font-mono text-sm cursor-pointer hover:border-[--color-accent] transition-colors min-h-[44px]"
                 >
                   {lang === 'ko' ? '다시 시도' : 'Retry'}
@@ -593,7 +521,7 @@ export default function MarketDashboard({ lang = 'en' }: { lang?: 'en' | 'ko' })
           </div>
 
           {/* Last Updated + Disclaimer */}
-          {lastRefresh && (
+          {generated && (
             <p class="text-[11px] text-[--color-text-muted] text-center mt-4 font-mono">
               {l.lastUpdated}: {refreshAgo} {l.ago}
             </p>

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -39,3 +39,22 @@ export async function fetchWithFallback(apiPath: string, staticPath: string): Pr
     }
   }
 }
+
+// API-first fetch: try live API first (real-time), fall back to static
+export async function fetchLiveFirst(apiPath: string, staticPath: string): Promise<any> {
+  try {
+    const res = await fetch(`${API_BASE_URL}${apiPath}`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    if (!res.ok) throw new Error(`API ${res.status}`);
+    return await res.json();
+  } catch {
+    try {
+      const res = await fetch(staticPath);
+      if (!res.ok) throw new Error(`Static ${res.status}`);
+      return await res.json();
+    } catch {
+      throw new Error(`Data unavailable: ${apiPath} (static: ${staticPath})`);
+    }
+  }
+}

--- a/src/hooks/useMacro.ts
+++ b/src/hooks/useMacro.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect } from 'preact/hooks';
+import { STATIC_DATA, fetchWithFallback } from '../config/api';
+
+type MacroIndicator = {
+  id: string;
+  name: string;
+  value: number;
+  change: number | null;
+  previous?: number | null;
+  unit: string;
+  updated: string;
+  source: string;
+};
+
+type MacroData = {
+  indicators: MacroIndicator[];
+  generated: string;
+};
+
+const POLL_MS = 1_800_000; // 30 minutes
+
+export function useMacro() {
+  const [macro, setMacro] = useState<MacroData | null>(null);
+  const [error, setError] = useState(false);
+
+  const fetchMacro = () => {
+    fetchWithFallback('/macro', STATIC_DATA.macro)
+      .then((d: MacroData) => { setMacro(d); setError(false); })
+      .catch(() => setError(true));
+  };
+
+  useEffect(() => {
+    fetchMacro();
+    const id = setInterval(fetchMacro, POLL_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  return { macro, error, retry: fetchMacro };
+}

--- a/src/hooks/useMarketLive.ts
+++ b/src/hooks/useMarketLive.ts
@@ -1,0 +1,82 @@
+import { useState, useEffect, useRef } from 'preact/hooks';
+import { fetchLiveFirst } from '../config/api';
+
+type LiveCoin = {
+  symbol: string;
+  price: number;
+  change_24h: number;
+  volume_24h: number;
+};
+
+type LiveData = {
+  coins: LiveCoin[];
+  source?: string;
+  generated: string;
+};
+
+const POLL_MS = 30_000; // 30 seconds
+
+export function useMarketLive() {
+  const [btcPrice, setBtcPrice] = useState(0);
+  const [btcChange, setBtcChange] = useState(0);
+  const [ethPrice, setEthPrice] = useState(0);
+  const [ethChange, setEthChange] = useState(0);
+  const [generated, setGenerated] = useState('');
+  const [flash, setFlash] = useState<{ btc: string; eth: string }>({ btc: '', eth: '' });
+  const [error, setError] = useState(false);
+
+  const prevBtc = useRef(0);
+  const prevEth = useRef(0);
+  const flashTimers = useRef<number[]>([]);
+
+  const fetchLive = () => {
+    // NOTE: coins-stats.json has a superset schema (name, image, sparkline_7d, etc.)
+    // but shares the fields we use: symbol, price, change_24h, generated.
+    fetchLiveFirst('/market/live', '/data/coins-stats.json')
+      .then((data: LiveData) => {
+        const coins = data.coins || [];
+        const btc = coins.find(c => c.symbol === 'BTCUSDT');
+        const eth = coins.find(c => c.symbol === 'ETHUSDT');
+
+        const newBtcPrice = btc?.price ?? 0;
+        const newEthPrice = eth?.price ?? 0;
+
+        // Flash detection
+        if (prevBtc.current && newBtcPrice !== prevBtc.current) {
+          const dir = newBtcPrice > prevBtc.current ? 'flash-up' : 'flash-down';
+          setFlash(f => ({ ...f, btc: dir }));
+          const tid = window.setTimeout(() => setFlash(f => ({ ...f, btc: '' })), 600);
+          flashTimers.current.push(tid);
+        }
+        if (prevEth.current && newEthPrice !== prevEth.current) {
+          const dir = newEthPrice > prevEth.current ? 'flash-up' : 'flash-down';
+          setFlash(f => ({ ...f, eth: dir }));
+          const tid = window.setTimeout(() => setFlash(f => ({ ...f, eth: '' })), 600);
+          flashTimers.current.push(tid);
+        }
+
+        prevBtc.current = newBtcPrice;
+        prevEth.current = newEthPrice;
+
+        setBtcPrice(newBtcPrice);
+        setBtcChange(btc?.change_24h ?? 0);
+        setEthPrice(newEthPrice);
+        setEthChange(eth?.change_24h ?? 0);
+        setGenerated(data.generated || '');
+        setError(false);
+      })
+      .catch(() => setError(true));
+  };
+
+  useEffect(() => {
+    fetchLive();
+    const id = setInterval(fetchLive, POLL_MS);
+    return () => {
+      clearInterval(id);
+      flashTimers.current.forEach(t => clearTimeout(t));
+      flashTimers.current = [];
+    };
+  }, []);
+
+  return { btcPrice, btcChange, ethPrice, ethChange, flash, generated, error, retry: fetchLive };
+}

--- a/src/hooks/useMarketOverview.ts
+++ b/src/hooks/useMarketOverview.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect } from 'preact/hooks';
+import { STATIC_DATA, fetchWithFallback } from '../config/api';
+
+type MarketData = {
+  btc_price: number;
+  btc_change_24h: number;
+  eth_price: number;
+  eth_change_24h: number;
+  fear_greed_index: number;
+  fear_greed_label: string;
+  total_market_cap_b: number;
+  btc_dominance: number;
+  total_volume_24h_b: number;
+  top_gainers?: any[];
+  top_losers?: any[];
+  generated: string;
+};
+
+const POLL_MS = 300_000; // 5 minutes
+
+export function useMarketOverview() {
+  const [market, setMarket] = useState<MarketData | null>(null);
+  const [error, setError] = useState(false);
+
+  const fetchMarket = () => {
+    fetchWithFallback('/market', STATIC_DATA.market)
+      .then((d: MarketData) => { setMarket(d); setError(false); })
+      .catch(() => setError(true));
+  };
+
+  useEffect(() => {
+    fetchMarket();
+    const id = setInterval(fetchMarket, POLL_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  return { market, error, retry: fetchMarket };
+}

--- a/src/hooks/useNews.ts
+++ b/src/hooks/useNews.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect } from 'preact/hooks';
+import { STATIC_DATA, fetchWithFallback } from '../config/api';
+
+type NewsItem = {
+  title: string;
+  link: string;
+  source: string;
+  category?: string;
+  published: string;
+  summary: string;
+};
+
+type NewsData = {
+  items: NewsItem[];
+  generated: string;
+};
+
+const POLL_MS = 300_000; // 5 minutes
+
+export function useNews() {
+  const [news, setNews] = useState<NewsData | null>(null);
+  const [error, setError] = useState(false);
+
+  const fetchNews = () => {
+    fetchWithFallback('/news', STATIC_DATA.news)
+      .then((d: NewsData) => { setNews(d); setError(false); })
+      .catch(() => setError(true));
+  };
+
+  useEffect(() => {
+    fetchNews();
+    const id = setInterval(fetchNews, POLL_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  return { news, error, retry: fetchNews };
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -110,6 +110,10 @@ body {
 .flash-up { animation: flash-green 0.6s ease-out; }
 .flash-down { animation: flash-red 0.6s ease-out; }
 
+/* Data pulse — subtle blink on live data refresh */
+@keyframes data-pulse { 0%{opacity:1} 50%{opacity:.7} 100%{opacity:1} }
+.data-pulse { animation: data-pulse 0.4s ease-in-out; }
+
 /* Keyboard focus styles (WCAG AA) */
 :focus-visible {
   outline: 2px solid var(--color-accent);


### PR DESCRIPTION
## Summary
- Add `/market/live` endpoint (Binance Spot primary + Futures fallback, 30s TTL, asyncio.Lock)
- Switch `refresh_static.py` from Futures-only to Spot+Futures hybrid
- Create 4 independent polling hooks: `useMarketLive` (30s), `useMarketOverview` (5min), `useNews` (5min), `useMacro` (30min)
- Refactor `MarketDashboard.tsx` from 607-line monolith to 4-hook composition
- Add `fetchLiveFirst()` API-first fetch utility and `data-pulse` CSS animation

## Key metrics
- **Symbol coverage**: 574/574 = 100% (409 Spot + 165 Futures fallback)
- **Price refresh**: 5min → **30s** (10x faster)
- **Rate limit usage**: 160 weight/min (6000 limit = 2.7%)
- **Build**: 2446 pages, clean pass

## Changed files (9)
| File | Change |
|------|--------|
| `backend/api/main.py` | `/market/live` endpoint + Spot+Futures hybrid + asyncio.Lock |
| `backend/scripts/refresh_static.py` | fapi→api (Spot primary) + Futures fallback |
| `src/config/api.ts` | `fetchLiveFirst()` |
| `src/hooks/useMarketLive.ts` | **NEW** — 30s price polling |
| `src/hooks/useMarketOverview.ts` | **NEW** — 5min market overview |
| `src/hooks/useNews.ts` | **NEW** — 5min news |
| `src/hooks/useMacro.ts` | **NEW** — 30min macro |
| `src/components/MarketDashboard.tsx` | 4-hook refactor + disclaimer update |
| `src/styles/global.css` | data-pulse animation |

## What's NOT changed
Simulator, backtest, data_manager.py, coin-symbols.ts, OHLCV endpoints

## Test plan
- [x] Python syntax check (main.py, refresh_static.py)
- [x] Frontend build (2446 pages, clean)
- [x] Binance API field compatibility (Spot/Futures identical)
- [x] Symbol coverage dry-run (574/574 = 100%)
- [x] Side-effect scan (all consumers verified)
- [x] Import chain verification (2 pages, 4 hooks, ErrorBoundary)
- [ ] Post-deploy: `curl /market/live` → 500+ coins
- [ ] Post-deploy: Browser Network tab 30s polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)