### PR TITLE
fix(ui): disconnect ResizeObserver on unmount to prevent memory leak

### DIFF
--- a/src/components/CoinChart.tsx
+++ b/src/components/CoinChart.tsx
@@ -181,6 +181,8 @@ export default function CoinChart({ symbol, lang = 'en' }: { symbol: string; lan
     for (const bar of ohlcv) map.set(bar.t, bar);
     ohlcvMapRef.current = map;
 
+    let ro: ResizeObserver | null = null;
+
     import('lightweight-charts').then(({ createChart, CandlestickSeries, LineSeries, HistogramSeries }) => {
       if (disposed || !chartContainerRef.current) return;
 
@@ -265,7 +267,6 @@ export default function CoinChart({ symbol, lang = 'en' }: { symbol: string; lan
       chartRef.current = chart;
       chart.timeScale().fitContent();
 
-      let ro: ResizeObserver | null = null;
       if (chartContainerRef.current) {
         ro = new ResizeObserver(entries => {
           for (const entry of entries) chart.applyOptions({ width: entry.contentRect.width, height: entry.contentRect.height });

--- a/src/components/PerformanceDashboard.tsx
+++ b/src/components/PerformanceDashboard.tsx
@@ -177,6 +177,8 @@ export default function PerformanceDashboard({ lang = 'en' }: { lang?: 'en' | 'k
       .filter(d => d.trades > 0 || d.cum_pnl !== 0)
       .map(d => ({ time: d.date, value: parseFloat(d.cum_pnl.toFixed(2)) }));
 
+    let ro: ResizeObserver | null = null;
+
     import('lightweight-charts').then(({ createChart, AreaSeries }) => {
       if (disposed || !chartContainerRef.current) return;
 
@@ -233,7 +235,6 @@ export default function PerformanceDashboard({ lang = 'en' }: { lang?: 'en' | 'k
       chart.timeScale().fitContent();
       chartRef.current = chart;
 
-      let ro: ResizeObserver | null = null;
       if (chartContainerRef.current) {
         ro = new ResizeObserver(entries => {
           for (const entry of entries) chart.applyOptions({ width: entry.contentRect.width });


### PR DESCRIPTION
Fixes pruviq/pruviq#171\n\nDeclare ResizeObserver in outer effect scope and disconnect it in the effect cleanup for CoinChart and PerformanceDashboard to avoid leaking observers when components unmount. Local build tested.