### PR TITLE
feat: enrich /coins/stats with CoinGecko metadata

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -73,6 +73,8 @@ indicator_cache = IndicatorCache()
 sim_cache: OrderedDict = OrderedDict()
 rate_limits: Dict[str, list] = {}
 coin_stats_cache: Optional[dict] = None
+_cg_metadata: Dict[str, dict] = {}
+_cg_ts: float = 0.0
 
 
 REFRESH_INTERVAL = 3600  # seconds (1 hour)
@@ -102,6 +104,7 @@ def _refresh_data():
             indicator_cache.build_multi(data_manager, all_strategies)
             strategy = BBSqueezeStrategy(avoid_hours=AVOID_HOURS)
             global coin_stats_cache
+            _load_coingecko_metadata()
             coin_stats_cache = _build_coin_stats(strategy)
             logger.info(f"Reload complete: {indicator_cache.count} coins")
         else:
@@ -169,6 +172,7 @@ async def lifespan(app: FastAPI):
         print("Pre-computing coin stats...")
         strategy = BBSqueezeStrategy(avoid_hours=AVOID_HOURS)
         global coin_stats_cache
+        _load_coingecko_metadata()
         coin_stats_cache = _build_coin_stats(strategy)
         print(f"Coin stats cached for {len(coin_stats_cache['coins'])} coins")
 
@@ -648,6 +652,39 @@ def _ts_to_unix(ts) -> int:
     return int(pd.Timestamp(str(ts)).timestamp())
 
 
+def _load_coingecko_metadata():
+    """Load CoinGecko metadata from static coins-stats.json for enrichment."""
+    global _cg_metadata, _cg_ts
+    cg_path = Path(__file__).parent.parent.parent / "public" / "data" / "coins-stats.json"
+    try:
+        if not cg_path.exists():
+            logger.warning("CoinGecko metadata file not found")
+            return
+        mtime = cg_path.stat().st_mtime
+        if mtime == _cg_ts:
+            return  # no change
+        with open(cg_path) as f:
+            raw = json.load(f)
+        meta = {}
+        for coin in raw.get("coins", []):
+            sym = coin.get("symbol", "")
+            if sym:
+                meta[sym] = {
+                    "name": coin.get("name"),
+                    "image": coin.get("image"),
+                    "change_1h": coin.get("change_1h"),
+                    "change_7d": coin.get("change_7d"),
+                    "market_cap": coin.get("market_cap"),
+                    "market_cap_rank": coin.get("market_cap_rank"),
+                    "sparkline_7d": coin.get("sparkline_7d"),
+                }
+        _cg_metadata = meta
+        _cg_ts = mtime
+        logger.info(f"CoinGecko metadata loaded: {len(meta)} coins")
+    except Exception as e:
+        logger.warning(f"CoinGecko metadata load failed: {e}")
+
+
 def _build_coin_stats(strategy) -> dict:
     """Pre-compute stats for all coins."""
     cost_model = CostModel.futures()
@@ -674,6 +711,7 @@ def _build_coin_stats(strategy) -> dict:
         change_24h = round(((last_close - close_24h_ago) / close_24h_ago) * 100, 2) if close_24h_ago else 0
         volume_24h = float(df["volume"].iloc[-24:].sum()) if len(df) >= 24 else float(df["volume"].sum())
 
+        cg = _cg_metadata.get(symbol, {})
         coins_list.append(CoinStats(
             symbol=symbol,
             price=round(last_close, 6),
@@ -683,6 +721,13 @@ def _build_coin_stats(strategy) -> dict:
             win_rate=result.win_rate,
             profit_factor=result.profit_factor,
             total_return_pct=result.total_return_pct,
+            name=cg.get("name"),
+            image=cg.get("image"),
+            change_1h=cg.get("change_1h"),
+            change_7d=cg.get("change_7d"),
+            market_cap=cg.get("market_cap"),
+            market_cap_rank=cg.get("market_cap_rank"),
+            sparkline_7d=cg.get("sparkline_7d"),
         ))
 
     return {

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -161,10 +161,18 @@ class CoinStats(BaseModel):
     price: float
     change_24h: float
     volume_24h: float
-    trades: int
-    win_rate: float
-    profit_factor: float
-    total_return_pct: float
+    trades: int = 0
+    win_rate: float = 0.0
+    profit_factor: float = 0.0
+    total_return_pct: float = 0.0
+    # CoinGecko metadata (enriched from coins-stats.json)
+    name: Optional[str] = None
+    image: Optional[str] = None
+    change_1h: Optional[float] = None
+    change_7d: Optional[float] = None
+    market_cap: Optional[float] = None
+    market_cap_rank: Optional[int] = None
+    sparkline_7d: Optional[list] = None
 
 
 class CoinResult(BaseModel):

--- a/src/components/CoinListTable.tsx
+++ b/src/components/CoinListTable.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'preact/hooks';
 import { formatPrice, formatVolume } from '../utils/format';
 import { generateCSV, downloadCSV } from '../utils/csv';
-import { STATIC_DATA, fetchWithFallback } from '../config/api';
+import { STATIC_DATA, fetchWithFallback, fetchLiveFirst } from '../config/api';
 import MiniSparkline from './MiniSparkline';
 
 interface CoinRow {
@@ -167,11 +167,26 @@ export default function CoinListTable({ lang = 'en' }: { lang?: 'en' | 'ko' }) {
   const [generatedAt, setGeneratedAt] = useState<string | null>(null);
 
   useEffect(() => {
+    // Hybrid: load static first (metadata: name, image, sparkline), then overlay live prices
     fetchWithFallback('/coins/stats', STATIC_DATA.coinsStats)
       .then((json: StatsData) => {
         setData(json.coins || []);
         setGeneratedAt(json.generated || null);
         setLoading(false);
+        // Overlay live prices from API
+        fetchLiveFirst('/market/live', STATIC_DATA.coinsStats)
+          .then((live: any) => {
+            const priceMap = new Map<string, { price: number; change_24h: number; volume_24h: number }>();
+            for (const c of (live.coins || [])) {
+              priceMap.set(c.symbol, { price: c.price, change_24h: c.change_24h, volume_24h: c.volume_24h });
+            }
+            setData(prev => prev.map(coin => {
+              const lp = priceMap.get(coin.symbol);
+              return lp ? { ...coin, price: lp.price, change_24h: lp.change_24h, volume_24h: lp.volume_24h } : coin;
+            }));
+            setGeneratedAt(live.generated || json.generated || null);
+          })
+          .catch(() => {}); // Live price overlay failure is non-critical
       })
       .catch(err => {
         setError(err.message);


### PR DESCRIPTION
## Summary
- Add CoinGecko metadata fields (name, image, market_cap, sparkline_7d, change_1h, change_7d) to `/coins/stats` API response
- Load CoinGecko data from `coins-stats.json` at startup and on data refresh
- Frontend hybrid fetch: static metadata first, then live price overlay from `/market/live`

## Changes
- `backend/api/schemas.py`: CoinStats model extended with Optional CoinGecko fields
- `backend/api/main.py`: `_load_coingecko_metadata()` function + enrichment in `_build_coin_stats()`
- `src/components/CoinListTable.tsx`: Hybrid fetch (static → live overlay)

## Test plan
- [ ] API returns CoinGecko fields: `curl https://api.pruviq.com/coins/stats | jq '.coins[0]'`
- [ ] Coin page shows correct names, images, market caps
- [ ] Live prices overlay within 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)