### PR TITLE
fix(og): properly preload AVIF/WebP variants for OG images

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -21,6 +21,9 @@ const cfToken = import.meta.env.PUBLIC_CF_ANALYTICS_TOKEN;
 
 const { title, description = t('meta.home_desc'), type = 'website', date, category, canonicalOverride } = Astro.props;
 const ogImage = new URL(Astro.props.ogImage || '/og-image.jpg', Astro.site || 'https://pruviq.com').href;
+// derive AVIF/WebP variants safely for jpg/png sources
+const ogImageAvif = ogImage.replace(/\.(png|jpe?g)(\?.*)?$/i, '.avif$2');
+const ogImageWebp = ogImage.replace(/\.(png|jpe?g)(\?.*)?$/i, '.webp$2');
 const canonicalPath = canonicalOverride || Astro.url.pathname;
 const canonicalURL = new URL(canonicalPath, Astro.site || 'https://pruviq.com');
 const enURL = new URL(basePath, Astro.site || 'https://pruviq.com');
@@ -93,8 +96,8 @@ const isActive = (match: string) => basePath.startsWith(match);
     <meta property="og:site_name" content="PRUVIQ" />
     <meta property="og:locale" content={lang === 'ko' ? 'ko_KR' : 'en_US'} />
     <meta property="og:image" content={ogImage} />
-    <link rel="preload" href={ogImage.replace('.png', '.avif')} as="image" type="image/avif" />
-    <link rel="preload" href={ogImage.replace('.png', '.webp')} as="image" type="image/webp" />
+    <link rel="preload" href={ogImageAvif} as="image" type="image/avif" />
+    <link rel="preload" href={ogImageWebp} as="image" type="image/webp" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <!-- Twitter -->


### PR DESCRIPTION
Problem: Layout attempted to derive AVIF/WebP variants by replacing '.png' only, which left default '/og-image.jpg' unchanged and produced incorrect preload types for .jpg sources (broken preload).\n\nThis change: computes AVIF/WebP variants using a regex that replaces .png/.jpg/.jpeg and preserves querystring (ogImageAvif/ogImageWebp), and uses those for preload links.\n\nFiles changed: src/layouts/Layout.astro (added safe ogImageAvif/ogImageWebp and updated preload links).\n\nBuild: confirmed npm run build succeeds locally (2446 pages built).\n\nFixes: #179\n