### PR TITLE
chore: migrate openclaw paths to jepo user

### DIFF
--- a/scripts/e2e-monitor.sh
+++ b/scripts/e2e-monitor.sh
@@ -353,7 +353,7 @@ if [[ -z "${PLAYWRIGHT_SKIP:-}" ]]; then
     [[ ! -f "$PW_CONFIG" ]] && PW_CONFIG="playwright.config.ts"
 
     # Run Playwright directly (repo owned by jepo)
-    pw_cmd="cd  && BASE_URL= API_URL= node node_modules/.bin/playwright test tests/e2e/ --config= --reporter=json"
+    pw_cmd="cd '$REPO_DIR' && BASE_URL='${SITE_URL}' API_URL='${API_URL}' node node_modules/.bin/playwright test tests/e2e/ --config='$PW_CONFIG' --reporter=json"
 
     eval "$pw_cmd" \
         > /tmp/pruviq-e2e/playwright-results.json 2>> "$LOG_FILE" || true


### PR DESCRIPTION
## Summary
- All scripts updated: `/Users/openclaw` → `/Users/jepo`
- e2e-monitor.sh: removed sudo -u openclaw, simplified Playwright runner
- refresh_static.sh: removed openclaw/jepo user detection branch
- seo_audit/*: updated hardcoded paths
- skills/pipeline: updated comment and path

## Context
Part of openclaw → jepo user consolidation migration on Mac Mini.
Repo ownership already transferred to jepo. This PR updates remaining hardcoded paths in scripts.

## Test plan
- [x] All scripts grep: 0 openclaw user path references
- [x] API: 575 coins running as jepo
- [x] Gateway: HTTP 200 running as jepo
- [x] n8n: HTTP 200