### PR TITLE
fix(security): add auth to /admin/refresh endpoint

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -13,6 +13,7 @@ import os
 import sys
 import time
 import hashlib
+import hmac
 import json
 import asyncio
 import logging
@@ -21,9 +22,11 @@ from typing import Optional, Dict, List
 from collections import OrderedDict
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Request, Header
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+
+ADMIN_TOKEN = os.environ.get("PRUVIQ_ADMIN_TOKEN", "")
 
 import numpy as np
 import pandas as pd
@@ -1069,8 +1072,13 @@ async def simulate_validate(req: ValidateRequest):
 
 
 @app.post("/admin/refresh")
-async def refresh_data():
-    """Manually trigger data refresh from Binance."""
+async def refresh_data(authorization: str = Header(None)):
+    """Manually trigger data refresh from Binance. Requires PRUVIQ_ADMIN_TOKEN."""
+    if not ADMIN_TOKEN:
+        raise HTTPException(status_code=403, detail="Admin endpoint disabled (no token configured)")
+    expected = f"Bearer {ADMIN_TOKEN}"
+    if not authorization or not hmac.compare_digest(authorization, expected):
+        raise HTTPException(status_code=401, detail="Unauthorized")
     await asyncio.to_thread(_refresh_data)
     return {"status": "ok", "coins": indicator_cache.count, "generated": coin_stats_cache["generated"] if coin_stats_cache else None}
 

--- a/backend/scripts/full_pipeline.sh
+++ b/backend/scripts/full_pipeline.sh
@@ -77,7 +77,7 @@ fi
 
 # Step 3: Signal API to reload
 log "Step 3: Reloading API data..."
-RELOAD_RESULT=$(curl -s -X POST http://localhost:8080/admin/refresh 2>/dev/null || echo '{"error": "API not responding"}')
+RELOAD_RESULT=$(curl -s -X POST http://localhost:8080/admin/refresh -H "Authorization: Bearer ${PRUVIQ_ADMIN_TOKEN}" 2>/dev/null || echo '{"error": "API not responding"}')
 log "Reload result: $RELOAD_RESULT"
 
 # Step 4: Git commit + push (auto-deploy)


### PR DESCRIPTION
## Summary
- Adds Bearer token authentication to `/admin/refresh` endpoint via `PRUVIQ_ADMIN_TOKEN` env var
- Returns 403 if no token configured (endpoint disabled by default), 401 if invalid token
- Uses `hmac.compare_digest` for timing-safe comparison
- Updates `full_pipeline.sh` to pass the token

Fixes #184

## Test plan
- [ ] Set `PRUVIQ_ADMIN_TOKEN=test123` and verify `curl -X POST /admin/refresh` returns 401
- [ ] Verify `curl -X POST /admin/refresh -H "Authorization: Bearer test123"` succeeds
- [ ] Verify without env var set, endpoint returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)