### PR TITLE
fix(security): require API key for /admin/refresh endpoint

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,5 +13,9 @@ TELEGRAM_CHAT_ID=
 BINANCE_API_KEY=
 BINANCE_SECRET_KEY=
 
+# Admin API key (required for /admin/* endpoints)
+# Generate with: python3 -c "import secrets; print(secrets.token_urlsafe(32))"
+ADMIN_API_KEY=
+
 # Data directory (default: ~/pruviq-data/futures)
 # PRUVIQ_DATA_DIR=/Users/jepo/pruviq-data/futures

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -21,9 +21,11 @@ from typing import Optional, Dict, List
 from collections import OrderedDict
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Request, Header
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+
+ADMIN_API_KEY = os.environ.get("ADMIN_API_KEY", "")
 
 import numpy as np
 import pandas as pd
@@ -1069,8 +1071,10 @@ async def simulate_validate(req: ValidateRequest):
 
 
 @app.post("/admin/refresh")
-async def refresh_data():
+async def refresh_data(x_admin_key: str = Header(alias="X-Admin-Key")):
     """Manually trigger data refresh from Binance."""
+    if not ADMIN_API_KEY or x_admin_key != ADMIN_API_KEY:
+        raise HTTPException(status_code=403, detail="Forbidden")
     await asyncio.to_thread(_refresh_data)
     return {"status": "ok", "coins": indicator_cache.count, "generated": coin_stats_cache["generated"] if coin_stats_cache else None}
 

--- a/backend/scripts/full_pipeline.sh
+++ b/backend/scripts/full_pipeline.sh
@@ -77,7 +77,7 @@ fi
 
 # Step 3: Signal API to reload
 log "Step 3: Reloading API data..."
-RELOAD_RESULT=$(curl -s -X POST http://localhost:8080/admin/refresh 2>/dev/null || echo '{"error": "API not responding"}')
+RELOAD_RESULT=$(curl -s -X POST http://localhost:8080/admin/refresh -H "X-Admin-Key: ${ADMIN_API_KEY}" 2>/dev/null || echo '{"error": "API not responding"}')
 log "Reload result: $RELOAD_RESULT"
 
 # Step 4: Git commit + push (auto-deploy)


### PR DESCRIPTION
## Summary
- Added `X-Admin-Key` header authentication to `/admin/refresh` endpoint
- Key is read from `ADMIN_API_KEY` env var; requests without valid key get 403
- Updated `full_pipeline.sh` to pass the key header

Closes #184

## Deploy notes
Set `ADMIN_API_KEY` env var on Mac Mini before deploying:
```
python3 -c "import secrets; print(secrets.token_urlsafe(32))"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)