### PR TITLE
fix: restrict CORS allow_headers (fixes #201)

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -224,7 +224,7 @@ app.add_middleware(
         "http://localhost:3000",
     ],
     allow_methods=["GET", "POST"],
-    allow_headers=["*"],
+    allow_headers=["Content-Type", "Accept", "Origin"],
 )
 
 


### PR DESCRIPTION
## Summary
- Replaced `allow_headers=["*"]` with explicit `["Content-Type", "Accept", "Origin"]` in FastAPI CORS middleware
- Reduces attack surface by only allowing headers the API actually needs

## Test plan
- [ ] Verify `npm run build` passes
- [ ] Verify API responds correctly to preflight OPTIONS requests from pruviq.com
- [ ] Confirm simulation requests still work end-to-end

Fixes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)