### PR TITLE
fix(api): trust proxy IP headers only from localhost

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -230,8 +230,16 @@ app.add_middleware(
 
 # --- Rate Limiting ---
 
+TRUSTED_PROXIES = {"127.0.0.1", "::1"}
+
+
 def get_client_ip(request: Request) -> str:
-    """Extract real client IP from proxy headers (Cloudflare → X-Forwarded-For fallback)."""
+    """Extract real client IP, only trusting proxy headers from trusted sources."""
+    direct_ip = request.client.host if request.client else "unknown"
+
+    if direct_ip not in TRUSTED_PROXIES:
+        return direct_ip
+
     cf_ip = request.headers.get("cf-connecting-ip")
     if cf_ip:
         return cf_ip.strip()
@@ -240,7 +248,11 @@ def get_client_ip(request: Request) -> str:
     if forwarded:
         return forwarded.split(",")[0].strip()
 
-    return request.client.host if request.client else "unknown"
+    real_ip = request.headers.get("x-real-ip")
+    if real_ip:
+        return real_ip.strip()
+
+    return direct_ip
 
 
 def check_rate_limit(client_ip: str) -> bool:


### PR DESCRIPTION
## Summary
- Rate limiter now only trusts `cf-connecting-ip`, `x-forwarded-for`, and `x-real-ip` headers when the direct connection comes from a trusted proxy (`127.0.0.1` / `::1`)
- Direct connections from non-trusted sources use the TCP connection IP, preventing header spoofing to bypass rate limits
- Added `x-real-ip` as additional fallback header

Fixes #219

## Test plan
- [ ] Verify rate limiting works correctly through Cloudflare Tunnel (should use `cf-connecting-ip`)
- [ ] Verify direct connections use TCP source IP, ignoring spoofed headers
- [ ] Confirm `curl -H "cf-connecting-ip: fake" localhost:8080/simulate` uses `127.0.0.1` (trusted proxy path), not `fake`

🤖 Generated with [Claude Code](https://claude.com/claude-code)