### PR TITLE
feat: update homepage stats and strategy labels

### DIFF
--- a/src/components/LiveStats.tsx
+++ b/src/components/LiveStats.tsx
@@ -12,13 +12,13 @@ const L = {
     trades: 'Backtested Trades',
     coins: 'Coins Tested',
     strategies: 'Variations Tested',
-    verified: 'Verified Strategy',
+    history: 'Historical Data',
   },
   ko: {
     trades: '백테스트 거래',
     coins: '테스트 코인',
     strategies: '테스트 조합',
-    verified: '검증된 전략',
+    history: '과거 데이터',
   },
 };
 
@@ -72,8 +72,11 @@ export default function LiveStats({ lang = 'en' }: Props) {
         <p class="text-[--color-text-muted] text-sm mt-1">{t.strategies}</p>
       </div>
       <div class="text-center p-4">
-        <p class="font-mono text-[--color-accent] text-3xl md:text-4xl font-bold">1</p>
-        <p class="text-[--color-text-muted] text-sm mt-1">{t.verified}</p>
+        <p class="font-mono text-[--color-accent] text-3xl md:text-4xl font-bold">
+          <AnimatedNumber value={2} suffix="+" />
+          <span class="text-xl ml-1">{lang === 'ko' ? '년' : 'yrs'}</span>
+        </p>
+        <p class="text-[--color-text-muted] text-sm mt-1">{t.history}</p>
       </div>
     </div>
   );

--- a/src/components/StrategyComparison.tsx
+++ b/src/components/StrategyComparison.tsx
@@ -38,7 +38,7 @@ const labels = {
     sl: 'Stop Loss %',
     tp: 'Take Profit %',
     run: 'Compare',
-    running: 'Running 5 backtests...',
+    running: 'Running backtests...',
     loading: 'Loading strategies...',
     strategy: 'Strategy',
     direction: 'Dir',
@@ -64,7 +64,7 @@ const labels = {
     sl: '손절 %',
     tp: '익절 %',
     run: '비교 실행',
-    running: '5개 백테스트 실행 중...',
+    running: '백테스트 실행 중...',
     loading: '전략 로딩 중...',
     strategy: '전략',
     direction: '방향',
@@ -86,11 +86,7 @@ const labels = {
 };
 
 const STATUS_MAP: Record<string, { en: string; ko: string; color: string }> = {
-  'bb-squeeze-short': { en: 'VERIFIED', ko: '검증됨', color: 'var(--color-accent)' },
-  'bb-squeeze-long': { en: 'KILLED', ko: '중단됨', color: 'var(--color-red)' },
-  'momentum-long': { en: 'KILLED', ko: '중단됨', color: 'var(--color-red)' },
-  'atr-breakout': { en: 'SHELVED', ko: '보류', color: 'var(--color-text-muted)' },
-  'hv-squeeze': { en: 'SHELVED', ko: '보류', color: 'var(--color-text-muted)' },
+  'bb-squeeze-short': { en: 'LIVE', ko: '실거래 중', color: 'var(--color-accent)' },
 };
 
 interface Props {
@@ -155,7 +151,7 @@ export default function StrategyComparison({ lang = 'en' }: Props) {
     const newResults: Record<string, BacktestResult> = {};
     let totalMs = 0;
 
-    // Run all 5 backtests in parallel
+    // Run all backtests in parallel
     const promises = presets.map(async (preset) => {
       try {
         const body = {


### PR DESCRIPTION
## Summary
- Replace "1 Verified Strategy" → "2+ Years Historical Data" on homepage
- Change BB Squeeze SHORT badge: VERIFIED → LIVE (실거래 중)
- Remove outdated strategy IDs from STATUS_MAP
- Dynamic backtest count text (was hardcoded "5")

## Rationale
Users running simulations = backtesting = verification. The platform's value is letting users verify ANY strategy, not just showing "1 verified" preset.

## Test plan
- [ ] Homepage shows "2+ yrs Historical Data" instead of "1 Verified Strategy"
- [ ] /strategies page shows "LIVE" badge on BB Squeeze SHORT
- [ ] Other strategies show no outdated badges
- [ ] Compare button text doesn't reference "5"

🤖 Generated with [Claude Code](https://claude.com/claude-code)