### PR TITLE
feat: 10 famous strategy presets (ADX, Turtle, RSI+BB, MACD, HV)

### DIFF
--- a/backend/src/engine/condition_engine.py
+++ b/backend/src/engine/condition_engine.py
@@ -585,6 +585,269 @@ PRESET_STRATEGIES = {
         "tp_pct": 8.0,
         "max_bars": 48,
     },
+
+    # ═══════════════════════════════════════════════════════════════
+    # Phase 2 Presets — Famous Trading Techniques (2026-03-08)
+    # ═══════════════════════════════════════════════════════════════
+
+    # ─── ADX Trend Strength (Wilder 1978) ─────────────────────────
+    # ADX > 25 = strong trend + DI direction + EMA confirmation
+    "adx-trend-short": {
+        "name": "ADX Trend SHORT",
+        "name_ko": "ADX 추세 숏",
+        "description": "Strong downtrend confirmed by ADX + DMI directional index",
+        "direction": "short",
+        "indicators": {
+            "adx": {"period": 14, "threshold": 25},
+            "ema": {"fast": 20, "slow": 50},
+            "volume": {"ma_period": 10},
+            "candle": {},
+        },
+        "entry": {
+            "type": "AND",
+            "conditions": [
+                {"field": "strong_trend", "op": "==", "value": True, "shift": 1},
+                {"field": "minus_di", "op": ">", "field2": "plus_di", "shift": 1},
+                {"field": "downtrend", "op": "==", "value": True, "shift": 1},
+                {"field": "bearish", "op": "==", "value": True, "shift": 1},
+                {"field": "vol_ratio", "op": ">=", "value": 1.3, "shift": 1},
+            ],
+        },
+        "avoid_hours": [],
+        "sl_pct": 8.0,
+        "tp_pct": 10.0,
+        "max_bars": 48,
+    },
+    "adx-trend-long": {
+        "name": "ADX Trend LONG",
+        "name_ko": "ADX 추세 롱",
+        "description": "Strong uptrend confirmed by ADX + DMI directional index",
+        "direction": "long",
+        "indicators": {
+            "adx": {"period": 14, "threshold": 25},
+            "ema": {"fast": 20, "slow": 50},
+            "volume": {"ma_period": 10},
+            "candle": {},
+        },
+        "entry": {
+            "type": "AND",
+            "conditions": [
+                {"field": "strong_trend", "op": "==", "value": True, "shift": 1},
+                {"field": "plus_di", "op": ">", "field2": "minus_di", "shift": 1},
+                {"field": "uptrend", "op": "==", "value": True, "shift": 1},
+                {"field": "bullish", "op": "==", "value": True, "shift": 1},
+                {"field": "vol_ratio", "op": ">=", "value": 1.3, "shift": 1},
+            ],
+        },
+        "avoid_hours": [],
+        "sl_pct": 8.0,
+        "tp_pct": 10.0,
+        "max_bars": 48,
+    },
+
+    # ─── RSI + BB Combo (Classic overbought/oversold at band extremes) ──
+    "rsi-bb-overbought-short": {
+        "name": "RSI+BB Overbought SHORT",
+        "name_ko": "RSI+BB 과매수 숏",
+        "description": "RSI overbought + price at BB upper band = mean reversion short",
+        "direction": "short",
+        "indicators": {
+            "rsi": {"period": 14, "overbought": 70},
+            "bb": {"period": 20, "std": 2.0},
+            "volume": {"ma_period": 10},
+            "candle": {},
+        },
+        "entry": {
+            "type": "AND",
+            "conditions": [
+                {"field": "rsi_overbought", "op": "==", "value": True, "shift": 1},
+                {"field": "close", "op": ">=", "field2": "bb_upper", "shift": 1},
+                {"field": "bearish", "op": "==", "value": True, "shift": 1},
+                {"field": "vol_ratio", "op": ">=", "value": 1.2, "shift": 1},
+            ],
+        },
+        "avoid_hours": [],
+        "sl_pct": 8.0,
+        "tp_pct": 6.0,
+        "max_bars": 36,
+    },
+    "rsi-bb-oversold-long": {
+        "name": "RSI+BB Oversold LONG",
+        "name_ko": "RSI+BB 과매도 롱",
+        "description": "RSI oversold + price at BB lower band = mean reversion long",
+        "direction": "long",
+        "indicators": {
+            "rsi": {"period": 14, "oversold": 30},
+            "bb": {"period": 20, "std": 2.0},
+            "volume": {"ma_period": 10},
+            "candle": {},
+        },
+        "entry": {
+            "type": "AND",
+            "conditions": [
+                {"field": "rsi_oversold", "op": "==", "value": True, "shift": 1},
+                {"field": "close", "op": "<=", "field2": "bb_lower", "shift": 1},
+                {"field": "bullish", "op": "==", "value": True, "shift": 1},
+                {"field": "vol_ratio", "op": ">=", "value": 1.2, "shift": 1},
+            ],
+        },
+        "avoid_hours": [],
+        "sl_pct": 8.0,
+        "tp_pct": 6.0,
+        "max_bars": 36,
+    },
+
+    # ─── Turtle Breakout (Donchian Channel / Richard Dennis 1983) ──
+    # 20-bar high/low breakout + volume + trend confirmation
+    "turtle-breakout-short": {
+        "name": "Turtle Breakout SHORT",
+        "name_ko": "거북이 돌파 숏",
+        "description": "20-bar low breakout (Donchian) + downtrend + volume spike",
+        "direction": "short",
+        "indicators": {
+            "price_action": {"lookback": 20},
+            "ema": {"fast": 20, "slow": 50},
+            "volume": {"ma_period": 10},
+        },
+        "entry": {
+            "type": "AND",
+            "conditions": [
+                {"field": "breakout_down", "op": "==", "value": True, "shift": 1},
+                {"field": "downtrend", "op": "==", "value": True, "shift": 1},
+                {"field": "vol_ratio", "op": ">=", "value": 1.5, "shift": 1},
+            ],
+        },
+        "avoid_hours": [],
+        "sl_pct": 10.0,
+        "tp_pct": 12.0,
+        "max_bars": 72,
+    },
+    "turtle-breakout-long": {
+        "name": "Turtle Breakout LONG",
+        "name_ko": "거북이 돌파 롱",
+        "description": "20-bar high breakout (Donchian) + uptrend + volume spike",
+        "direction": "long",
+        "indicators": {
+            "price_action": {"lookback": 20},
+            "ema": {"fast": 20, "slow": 50},
+            "volume": {"ma_period": 10},
+        },
+        "entry": {
+            "type": "AND",
+            "conditions": [
+                {"field": "breakout_up", "op": "==", "value": True, "shift": 1},
+                {"field": "uptrend", "op": "==", "value": True, "shift": 1},
+                {"field": "vol_ratio", "op": ">=", "value": 1.5, "shift": 1},
+            ],
+        },
+        "avoid_hours": [],
+        "sl_pct": 10.0,
+        "tp_pct": 12.0,
+        "max_bars": 72,
+    },
+
+    # ─── MACD Crossover SHORT (mirror of existing MACD Momentum LONG) ──
+    "macd-crossover-short": {
+        "name": "MACD Crossover SHORT",
+        "name_ko": "MACD 크로스 숏",
+        "description": "MACD death cross + strong trend + volume confirmation",
+        "direction": "short",
+        "indicators": {
+            "macd": {"fast": 12, "slow": 26, "signal": 9},
+            "adx": {"period": 14, "threshold": 25},
+            "volume": {"ma_period": 10},
+        },
+        "entry": {
+            "type": "AND",
+            "conditions": [
+                {"field": "macd", "op": "cross_below", "field2": "macd_signal", "shift": 1},
+                {"field": "strong_trend", "op": "==", "value": True, "shift": 1},
+                {"field": "vol_ratio", "op": ">=", "value": 1.5, "shift": 1},
+            ],
+        },
+        "avoid_hours": [],
+        "sl_pct": 7.0,
+        "tp_pct": 10.0,
+        "max_bars": 48,
+    },
+
+    # ─── EMA Crossover SHORT (mirror of existing EMA Crossover LONG) ──
+    "ema-crossover-short": {
+        "name": "EMA Crossover SHORT",
+        "name_ko": "EMA 크로스 숏",
+        "description": "EMA 9/21 death cross + ADX strong trend + volume",
+        "direction": "short",
+        "indicators": {
+            "ema": {"fast": 9, "slow": 21},
+            "adx": {"period": 14, "threshold": 25},
+            "volume": {"ma_period": 10},
+        },
+        "entry": {
+            "type": "AND",
+            "conditions": [
+                {"field": "ema_fast", "op": "cross_below", "field2": "ema_slow", "shift": 1},
+                {"field": "strong_trend", "op": "==", "value": True, "shift": 1},
+                {"field": "vol_ratio", "op": ">=", "value": 1.3, "shift": 1},
+            ],
+        },
+        "avoid_hours": [],
+        "sl_pct": 7.0,
+        "tp_pct": 10.0,
+        "max_bars": 48,
+    },
+
+    # ─── HV Squeeze Breakout (Volatility compression → explosion) ──
+    # Like BB Squeeze but using Historical Volatility — different signal
+    "hv-squeeze-breakout-short": {
+        "name": "HV Squeeze Breakout SHORT",
+        "name_ko": "변동성압축 돌파 숏",
+        "description": "Historical volatility squeeze + price breakdown + volume",
+        "direction": "short",
+        "indicators": {
+            "hv": {"period": 20, "ma_period": 50},
+            "price_action": {"lookback": 20},
+            "ema": {"fast": 20, "slow": 50},
+            "volume": {"ma_period": 10},
+        },
+        "entry": {
+            "type": "AND",
+            "conditions": [
+                {"field": "hv_squeeze", "op": "==", "value": True, "shift": 1},
+                {"field": "breakout_down", "op": "==", "value": True, "shift": 0},
+                {"field": "downtrend", "op": "==", "value": True, "shift": 1},
+                {"field": "vol_ratio", "op": ">=", "value": 1.5, "shift": 1},
+            ],
+        },
+        "avoid_hours": [],
+        "sl_pct": 8.0,
+        "tp_pct": 10.0,
+        "max_bars": 48,
+    },
+    "hv-squeeze-breakout-long": {
+        "name": "HV Squeeze Breakout LONG",
+        "name_ko": "변동성압축 돌파 롱",
+        "description": "Historical volatility squeeze + price breakout + volume",
+        "direction": "long",
+        "indicators": {
+            "hv": {"period": 20, "ma_period": 50},
+            "price_action": {"lookback": 20},
+            "ema": {"fast": 20, "slow": 50},
+            "volume": {"ma_period": 10},
+        },
+        "entry": {
+            "type": "AND",
+            "conditions": [
+                {"field": "hv_squeeze", "op": "==", "value": True, "shift": 1},
+                {"field": "breakout_up", "op": "==", "value": True, "shift": 0},
+                {"field": "uptrend", "op": "==", "value": True, "shift": 1},
+                {"field": "vol_ratio", "op": ">=", "value": 1.5, "shift": 1},
+            ],
+        },
+        "avoid_hours": [],
+        "sl_pct": 8.0,
+        "tp_pct": 10.0,
+        "max_bars": 48,
+    },
 }
 
 

--- a/src/components/QuickTestPanel.tsx
+++ b/src/components/QuickTestPanel.tsx
@@ -30,11 +30,12 @@ interface Props {
 }
 
 const CATEGORIES: QuickCategory[] = [
-  { id: 'breakout',  icon: '💥', presets: ['bb-squeeze-short', 'bb-squeeze-long'],        defaultPreset: 'bb-squeeze-short' },
-  { id: 'bounce',    icon: '📈', presets: ['rsi-reversal-long', 'dca-oversold-long'],      defaultPreset: 'rsi-reversal-long' },
-  { id: 'sideways',  icon: '↔️',  presets: ['grid-mean-reversion-long', 'bb-band-bounce-long'], defaultPreset: 'grid-mean-reversion-long' },
-  { id: 'trend',     icon: '🚀', presets: ['macd-momentum-long', 'ema-crossover-long'],    defaultPreset: 'macd-momentum-long' },
-  { id: 'allweather', icon: '🛡️', presets: ['stochastic-oversold-short', 'stoch-rsi-overbought-short'], defaultPreset: 'stochastic-oversold-short' },
+  { id: 'breakout',    icon: '💥', presets: ['bb-squeeze-short', 'bb-squeeze-long', 'hv-squeeze-breakout-short', 'hv-squeeze-breakout-long'], defaultPreset: 'bb-squeeze-short' },
+  { id: 'bounce',      icon: '📈', presets: ['rsi-reversal-long', 'dca-oversold-long', 'rsi-bb-oversold-long'],  defaultPreset: 'rsi-reversal-long' },
+  { id: 'sideways',    icon: '↔️',  presets: ['grid-mean-reversion-long', 'bb-band-bounce-long', 'rsi-bb-overbought-short'], defaultPreset: 'grid-mean-reversion-long' },
+  { id: 'trend',       icon: '🚀', presets: ['macd-momentum-long', 'ema-crossover-long', 'adx-trend-long', 'adx-trend-short'], defaultPreset: 'adx-trend-long' },
+  { id: 'allweather',  icon: '🛡️', presets: ['stochastic-oversold-short', 'stoch-rsi-overbought-short', 'macd-crossover-short', 'ema-crossover-short'], defaultPreset: 'stochastic-oversold-short' },
+  { id: 'turtle',      icon: '🐢', presets: ['turtle-breakout-long', 'turtle-breakout-short'], defaultPreset: 'turtle-breakout-long' },
 ];
 
 const L = {
@@ -48,9 +49,11 @@ const L = {
     sideways: 'Sideways Profit',
     sidewaysDesc: 'Range-bound mean reversion',
     trend: 'Ride the Trend',
-    trendDesc: 'Momentum & trend following',
+    trendDesc: 'ADX + MACD + EMA trend',
     allweather: 'All Weather',
     allweatherDesc: 'Hedging & short strategies',
+    turtle: 'Turtle Trading',
+    turtleDesc: '20-bar breakout system',
     run: 'Test Now',
     running: 'Running...',
     aiPick: 'AI Recommended',
@@ -67,9 +70,11 @@ const L = {
     sideways: '횡보 수익',
     sidewaysDesc: '박스권 평균회귀',
     trend: '추세 탑승',
-    trendDesc: '모멘텀 & 추세추종',
+    trendDesc: 'ADX + MACD + EMA 추세',
     allweather: '전천후',
     allweatherDesc: '헤징 & 숏 전략',
+    turtle: '거북이 트레이딩',
+    turtleDesc: '20봉 돌파 시스템',
     run: '지금 테스트',
     running: '실행 중...',
     aiPick: 'AI 추천',
@@ -90,6 +95,16 @@ const PRESET_LABELS: Record<string, { en: string; ko: string }> = {
   'ema-crossover-long':          { en: 'EMA Crossover',    ko: 'EMA 교차' },
   'stochastic-oversold-short':   { en: 'Stoch Overbought', ko: '스토캐스틱 과매수' },
   'stoch-rsi-overbought-short':  { en: 'Stoch RSI Short',  ko: '스톡RSI 숏' },
+  'adx-trend-short':             { en: 'ADX Trend SHORT',  ko: 'ADX 추세 숏' },
+  'adx-trend-long':              { en: 'ADX Trend LONG',   ko: 'ADX 추세 롱' },
+  'rsi-bb-overbought-short':     { en: 'RSI+BB SHORT',     ko: 'RSI+BB 과매수 숏' },
+  'rsi-bb-oversold-long':        { en: 'RSI+BB LONG',      ko: 'RSI+BB 과매도 롱' },
+  'turtle-breakout-short':       { en: 'Turtle SHORT',     ko: '거북이 숏' },
+  'turtle-breakout-long':        { en: 'Turtle LONG',      ko: '거북이 롱' },
+  'macd-crossover-short':        { en: 'MACD Cross SHORT', ko: 'MACD 크로스 숏' },
+  'ema-crossover-short':         { en: 'EMA Cross SHORT',  ko: 'EMA 크로스 숏' },
+  'hv-squeeze-breakout-short':   { en: 'HV Squeeze SHORT', ko: 'HV 스퀴즈 숏' },
+  'hv-squeeze-breakout-long':    { en: 'HV Squeeze LONG',  ko: 'HV 스퀴즈 롱' },
 };
 
 export default function QuickTestPanel({ lang, onRunPreset, isRunning, hasResult }: Props) {
@@ -127,7 +142,7 @@ export default function QuickTestPanel({ lang, onRunPreset, isRunning, hasResult
       </div>
 
       {/* Category Cards Grid */}
-      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-2">
+      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2">
         {CATEGORIES.map((cat) => {
           const isSelected = selectedCat === cat.id;
           const isCatRunning = runningPreset && cat.presets.includes(runningPreset);


### PR DESCRIPTION
## Summary
- 10 new preset strategies based on famous trading techniques (all SHORT+LONG pairs)
- ADX Trend (Wilder 1978), RSI+BB Combo, Turtle Breakout (Dennis 1983), MACD/EMA Cross SHORT, HV Squeeze Breakout
- Quick Test updated: 6 categories (was 5), 20 total presets (was 10)
- New "Turtle Trading" (🐢) category in Quick Test

## Strategies added
| Strategy | Direction | Key Indicators |
|----------|-----------|---------------|
| ADX Trend | SHORT/LONG | ADX + DMI + EMA + Volume |
| RSI+BB Combo | SHORT/LONG | RSI overbought/oversold + BB bands |
| Turtle Breakout | SHORT/LONG | 20-bar high/low breakout (Donchian) |
| MACD Crossover | SHORT | MACD death cross + ADX |
| EMA Crossover | SHORT | EMA 9/21 death cross + ADX |
| HV Squeeze Breakout | SHORT/LONG | Historical Volatility squeeze + breakout |

## Test plan
- [ ] All 20 presets load via `/builder/presets` API
- [ ] Each preset runs backtest with >0 trades
- [ ] Quick Test 6 categories render correctly
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)