### PR TITLE
fix: [claude-auto][P2] Sitemap missing hreflang `<xhtml:link>` alternate entries

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,22 +16,24 @@ export default defineConfig({
   },
   integrations: [
     sitemap({
-      // Exclude legacy redirect routes and builder redirects from the generated sitemap.
-      // Those pages redirect to other pages and should not be indexed as separate URLs.
+      i18n: {
+        defaultLocale: 'en',
+        locales: {
+          en: 'en',
+          ko: 'ko'
+        }
+      },
       filter(page) {
         return !page.includes('/learn/') && !page.includes('/demo/') && !page.includes('/builder/');
       },
-      // Add `lastmod` and filter out unwanted paths (double-check /learn/ and /ko/404/)
       serialize(item) {
         if (!item || !item.url) return item;
         if (item.url.includes('/learn/')) return undefined;
         if (item.url.includes('/demo/')) return undefined;
         if (item.url.includes('/builder/')) return undefined;
         if (item.url.includes('/ko/404/')) return undefined;
-        return {
-          url: item.url,
-          lastmod: new Date().toISOString()
-        };
+        item.lastmod = new Date().toISOString();
+        return item;
       }
     }),
     preact()


### PR DESCRIPTION
## Auto-fix for #272

**[claude-auto][P2] Sitemap missing hreflang `<xhtml:link>` alternate entries**

### Changes
```
 astro.config.mjs | 16 +++++++++-------
 1 file changed, 9 insertions(+), 7 deletions(-)
```

### Safety Checks
- Files changed: **1** (limit: 10)
- Lines changed: **16** (limit: 500)

---
*Auto-generated by JEPO auto-fix agent. Requires auto-test pass before merge.*