### PR TITLE
fix: [claude-auto][P2] BreadcrumbList JSON-LD always flat 2-level, mismatches visible breadcrumbs

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -59,6 +59,25 @@ const navItems = [
   { href: feesPath, match: '/fees', label: t('nav.fees') },
 ];
 const isActive = (match: string) => basePath.startsWith(match);
+
+// Build multi-level breadcrumb items (matching Breadcrumbs.astro logic)
+const breadcrumbLabelMap: Record<string, Record<string, string>> = {
+  en: { market: 'Market', strategies: 'Strategies', coins: 'Coins', builder: 'Builder', simulate: 'Simulate', learn: 'Learn', fees: 'Fees', blog: 'Blog', about: 'About', changelog: 'Changelog', performance: 'Performance', compare: 'Compare', privacy: 'Privacy', terms: 'Terms', methodology: 'Methodology', api: 'API' },
+  ko: { market: '시장', strategies: '전략', coins: '코인', builder: '빌더', simulate: '시뮬레이션', learn: '학습', fees: '수수료', blog: '블로그', about: '소개', changelog: '변경 이력', performance: '성과', compare: '비교', privacy: '개인정보', terms: '이용약관', methodology: '방법론', api: 'API' },
+};
+const breadcrumbSegments = basePath === '/' ? [] : basePath.split('/').filter(Boolean);
+const breadcrumbItems = [{ name: lang === 'ko' ? '홈' : 'Home', item: 'https://pruviq.com/' }];
+let cumPath = '';
+for (let i = 0; i < breadcrumbSegments.length; i++) {
+  const seg = breadcrumbSegments[i];
+  cumPath += `/${seg}`;
+  const isLast = i === breadcrumbSegments.length - 1;
+  const name = isLast && breadcrumbSegments.length > 1
+    ? (breadcrumbLabelMap[lang]?.[seg] || title)
+    : (breadcrumbLabelMap[lang]?.[seg] || seg.replace(/-/g, ' ').replace(/usdt$/i, '/USDT').toUpperCase());
+  const fullUrl = `https://pruviq.com${lang === 'ko' ? '/ko' : ''}${cumPath}/`;
+  breadcrumbItems.push({ name, item: fullUrl });
+}
 ---
 
 
@@ -266,10 +285,12 @@ const isActive = (match: string) => basePath.startsWith(match);
       <script type="application/ld+json" set:html={JSON.stringify({
         "@context": "https://schema.org",
         "@type": "BreadcrumbList",
-        "itemListElement": [
-          { "@type": "ListItem", "position": 1, "name": lang === 'ko' ? '홈' : 'Home', "item": "https://pruviq.com/" },
-          { "@type": "ListItem", "position": 2, "name": title, "item": canonicalURL.href }
-        ]
+        "itemListElement": breadcrumbItems.map((b, i) => ({
+          "@type": "ListItem",
+          "position": i + 1,
+          "name": b.name,
+          "item": b.item
+        }))
       })} />
     )}
     <!-- JSON-LD HowTo (homepage) -->


### PR DESCRIPTION
## Auto-fix for #273

**[claude-auto][P2] BreadcrumbList JSON-LD always flat 2-level, mismatches visible breadcrumbs**

### Changes
```
 src/layouts/Layout.astro | 29 +++++++++++++++++++++++++----
 1 file changed, 25 insertions(+), 4 deletions(-)
```

### Safety Checks
- Files changed: **1** (limit: 10)
- Lines changed: **29** (limit: 500)

---
*Auto-generated by JEPO auto-fix agent. Requires auto-test pass before merge.*