### PR TITLE
perf: GZip middleware for API responses

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -24,6 +24,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Request, Header
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import JSONResponse
 
 ADMIN_API_KEY = os.environ.get("ADMIN_API_KEY", "")
@@ -221,6 +222,8 @@ app = FastAPI(
     description="Run crypto strategy simulations with realistic costs.",
     lifespan=lifespan,
 )
+
+app.add_middleware(GZipMiddleware, minimum_size=1000)
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Summary
- Add GZipMiddleware (minimum_size=1000)
- /coins: 45KB → 4.7KB (90% reduction)
- External latency: ~4.6s → ~1.1s

## Test
```
curl -s https://api.pruviq.com/coins -H "Accept-Encoding: gzip" -o /dev/null -w "size: %{size_download}B, time: %{time_total}s"
```

🤖 Generated with Claude Code