### PR TITLE
fix: [claude-auto][P2] Rate Limiter Never Counts the First Request

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -270,10 +270,6 @@ def check_rate_limit(client_ip: str) -> bool:
 
     rate_limits[client_ip] = [t for t in rate_limits[client_ip] if now - t < 60]
 
-    if not rate_limits[client_ip]:
-        del rate_limits[client_ip]
-        return True
-
     if len(rate_limits[client_ip]) >= RATE_LIMIT_PER_MIN:
         return False
 


### PR DESCRIPTION
## Auto-fix for #280

**[claude-auto][P2] Rate Limiter Never Counts the First Request**

### Changes
```
 backend/api/main.py | 4 ----
 1 file changed, 4 deletions(-)
```

### Safety Checks
- Files changed: **1** (limit: 10)
- Lines changed: **4** (limit: 500)

---
*Auto-generated by JEPO auto-fix agent. Requires auto-test pass before merge.*