### PR TITLE
fix: remove Telegram CTA links from public pages

### DIFF
--- a/src/components/StrategyDemo.tsx
+++ b/src/components/StrategyDemo.tsx
@@ -346,9 +346,6 @@ export default function StrategyDemo({
              class="inline-block border border-[--color-border] text-[--color-text] px-5 py-2.5 rounded-lg font-semibold text-sm no-underline hover:border-[--color-accent] transition-colors">
             {t.ctaFees}
           </a>
-          <a href="https://t.me/PRUVIQ" target="_blank" rel="noopener noreferrer" class="inline-block border border-[--color-border] text-[--color-text] px-5 py-2.5 rounded-lg font-semibold text-sm no-underline hover:border-[--color-accent] transition-colors">
-            {t.ctaCommunity}
-          </a>
         </div>
       </div>
     </div>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -43,15 +43,6 @@ const categoryLabels: Record<string, string> = {
         <slot />
       </div>
 
-      <!-- Newsletter CTA -->
-      <div class="mt-10 border border-[--color-accent]/30 rounded-lg p-5 bg-[--color-accent]/5 text-center">
-        <p class="font-bold text-sm mb-1">Get strategy updates</p>
-        <p class="text-[--color-text-muted] text-xs mb-3">Market analysis, new strategies, and backtest results — delivered to Telegram.</p>
-        <a href="https://t.me/PRUVIQ" target="_blank" rel="noopener noreferrer"
-           class="inline-flex items-center gap-2 bg-[--color-accent] text-[--color-bg] px-5 py-2 rounded font-semibold text-sm hover:bg-[--color-accent-dim]">
-          Join PRUVIQ Channel &rarr;
-        </a>
-      </div>
 
       <!-- Article end CTA -->
       <div class="mt-12 border-t border-[--color-border] pt-8">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -392,7 +392,6 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
                 <a href={methodologyPath} class="text-[--color-text-muted] hover:text-[--color-text] transition-colors">{t('footer.methodology')}</a>
                 <a href={apiPath} class="text-[--color-text-muted] hover:text-[--color-text] transition-colors">{t('footer.api')}</a>
                 <a href={compareTvPath} class="text-[--color-text-muted] hover:text-[--color-text] transition-colors">{t('footer.compare')}</a>
-                <a href="https://t.me/PRUVIQ" target="_blank" rel="noopener noreferrer" class="text-[--color-text-muted] hover:text-[--color-text] transition-colors">{t('footer.telegram')}</a>
                 <a href="https://x.com/pruviq" target="_blank" rel="noopener noreferrer" class="text-[--color-text-muted] hover:text-[--color-text] transition-colors">X / Twitter</a>
                 <a href="https://github.com/pruviq/pruviq" target="_blank" rel="noopener noreferrer" class="text-[--color-text-muted] hover:text-[--color-text] transition-colors">GitHub</a>
               </div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -82,10 +82,6 @@ const t = useTranslations('en');
              class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-6 py-2 rounded font-semibold text-sm hover:bg-[--color-accent-dim]">
             {t('about.contact_email')}
           </a>
-          <a href="https://t.me/PRUVIQ" target="_blank" rel="noopener noreferrer"
-             class="inline-block border border-[--color-border] text-[--color-text] px-6 py-2 rounded font-semibold text-sm hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
-            {t('about.contact_telegram')} &rarr;
-          </a>
         </div>
       </div>
 

--- a/src/pages/api.astro
+++ b/src/pages/api.astro
@@ -357,7 +357,6 @@ console.log(\`Trades: \${sim.total_trades}, WR: \${sim.win_rate}%\`);`}</code></
         <p class="text-[--color-text-muted] text-sm">
           {t('api.sdk_desc')}
         </p>
-        <a href="https://t.me/PRUVIQ" target="_blank" rel="noopener noreferrer" class="inline-block mt-3 font-mono text-xs text-[--color-accent] hover:underline">t.me/PRUVIQ</a>
       </div>
     </div>
   </section>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -43,7 +43,7 @@ const categoryColors: Record<string, string> = {
           </p>
           <p class="text-[--color-text-muted] text-sm">
             {t('blog.coming_cta')}
-            <a href="https://t.me/PRUVIQ" target="_blank" rel="noopener noreferrer" class="text-[--color-accent] hover:underline">Telegram</a>
+            <a href="https://x.com/pruviq" target="_blank" rel="noopener noreferrer" class="text-[--color-accent] hover:underline">X / Twitter</a>
             {t('blog.coming_cta2')}
           </p>
           <div class="mt-8 pt-6 border-t border-[--color-border] text-center">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -364,7 +364,7 @@ const lastUpdated = new Date().toLocaleDateString('en-US');
             <div class="w-8 h-8 rounded-full bg-[--color-accent]/20 flex items-center justify-center text-[--color-accent] font-mono text-xs font-bold">DK</div>
             <div>
               <p class="text-sm font-semibold">DK</p>
-              <p class="text-xs text-[--color-text-muted]">Telegram community member</p>
+              <p class="text-xs text-[--color-text-muted]">Community member</p>
             </div>
           </footer>
         </blockquote>
@@ -463,19 +463,6 @@ const lastUpdated = new Date().toLocaleDateString('en-US');
         <a href="/strategies"
            class="inline-block border border-[--color-border] text-[--color-text] px-8 py-3 rounded font-semibold text-lg hover:border-[--color-accent] hover:text-[--color-accent] hover:bg-[--color-accent]/5 transition-colors">
           {t('hero.cta1')}
-        </a>
-      </div>
-
-      <!-- Telegram community CTA -->
-      <div class="mt-8 inline-flex items-center gap-3 border border-[--color-border] rounded-lg px-5 py-3 bg-[--color-bg-card]">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" class="text-[#229ED9] shrink-0" aria-hidden="true"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm4.64 6.8c-.15 1.58-.8 5.42-1.13 7.19-.14.75-.42 1-.68 1.03-.58.05-1.02-.38-1.58-.75-.88-.58-1.38-.94-2.23-1.5-.99-.65-.35-1.01.22-1.59.15-.15 2.71-2.48 2.76-2.69a.2.2 0 00-.05-.18c-.06-.05-.14-.03-.21-.02-.09.02-1.49.95-4.22 2.79-.4.27-.76.41-1.08.4-.36-.01-1.04-.2-1.55-.37-.63-.2-1.12-.31-1.08-.66.02-.18.27-.36.74-.55 2.92-1.27 4.86-2.11 5.83-2.51 2.78-1.16 3.35-1.36 3.73-1.36.08 0 .27.02.39.12.1.08.13.19.14.27-.01.06.01.24 0 .38z"/></svg>
-        <div class="text-left">
-          <p class="text-sm font-semibold">Join the community</p>
-          <p class="text-xs text-[--color-text-muted]">Strategy updates, market insights, discussion</p>
-        </div>
-        <a href="https://t.me/PRUVIQ" target="_blank" rel="noopener noreferrer"
-           class="ml-2 bg-[--color-accent] text-white px-4 py-1.5 rounded text-xs font-semibold hover:bg-[--color-accent-dim] transition-colors whitespace-nowrap">
-          Join Telegram
         </a>
       </div>
 

--- a/src/pages/ko/about.astro
+++ b/src/pages/ko/about.astro
@@ -82,10 +82,6 @@ const t = useTranslations('ko');
              class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-6 py-2 rounded font-semibold text-sm hover:bg-[--color-accent-dim]">
             {t('about.contact_email')}
           </a>
-          <a href="https://t.me/PRUVIQ" target="_blank" rel="noopener noreferrer"
-             class="inline-block border border-[--color-border] text-[--color-text] px-6 py-2 rounded font-semibold text-sm hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
-            {t('about.contact_telegram')} &rarr;
-          </a>
         </div>
       </div>
 

--- a/src/pages/ko/api.astro
+++ b/src/pages/ko/api.astro
@@ -357,7 +357,6 @@ console.log(\`거래: \${sim.total_trades}, 승률: \${sim.win_rate}%\`);`}</cod
         <p class="text-[--color-text-muted] text-sm">
           {t('api.sdk_desc')}
         </p>
-        <a href="https://t.me/PRUVIQ" target="_blank" rel="noopener noreferrer" class="inline-block mt-3 font-mono text-xs text-[--color-accent] hover:underline">t.me/PRUVIQ</a>
       </div>
     </div>
   </section>

--- a/src/pages/ko/blog/[id].astro
+++ b/src/pages/ko/blog/[id].astro
@@ -66,15 +66,6 @@ const categoryLabels: Record<string, string> = {
         <Content />
       </div>
 
-      <!-- Newsletter CTA -->
-      <div class="mt-10 border border-[--color-accent]/30 rounded-lg p-5 bg-[--color-accent]/5 text-center">
-        <p class="font-bold text-sm mb-1">전략 업데이트 받기</p>
-        <p class="text-[--color-text-muted] text-xs mb-3">시장 분석, 새 전략, 백테스트 결과를 텔레그램으로 받아보세요.</p>
-        <a href="https://t.me/PRUVIQ" target="_blank" rel="noopener noreferrer"
-           class="inline-flex items-center gap-2 bg-[--color-accent] text-[--color-bg] px-5 py-2 rounded font-semibold text-sm hover:bg-[--color-accent-dim]">
-          PRUVIQ 채널 참여 &rarr;
-        </a>
-      </div>
 
       <!-- Article end CTA -->
       <div class="mt-12 border-t border-[--color-border] pt-8">

--- a/src/pages/ko/blog/index.astro
+++ b/src/pages/ko/blog/index.astro
@@ -51,7 +51,7 @@ const categoryColors: Record<string, string> = {
           </p>
           <p class="text-[--color-text-muted] text-sm">
             {t('blog.coming_cta')}
-            <a href="https://t.me/PRUVIQ" target="_blank" rel="noopener noreferrer" class="text-[--color-accent] hover:underline">Telegram</a>
+            <a href="https://x.com/pruviq" target="_blank" rel="noopener noreferrer" class="text-[--color-accent] hover:underline">X / Twitter</a>
             {t('blog.coming_cta2')}
           </p>
           <div class="mt-8 pt-6 border-t border-[--color-border] text-center">

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -363,7 +363,7 @@ const lastUpdated = new Date().toLocaleDateString('ko-KR');
             <div class="w-8 h-8 rounded-full bg-[--color-accent]/20 flex items-center justify-center text-[--color-accent] font-mono text-xs font-bold">DK</div>
             <div>
               <p class="text-sm font-semibold">DK</p>
-              <p class="text-xs text-[--color-text-muted]">텔레그램 커뮤니티 멤버</p>
+              <p class="text-xs text-[--color-text-muted]">커뮤니티 멤버</p>
             </div>
           </footer>
         </blockquote>
@@ -462,19 +462,6 @@ const lastUpdated = new Date().toLocaleDateString('ko-KR');
         <a href="/ko/strategies"
            class="inline-block border border-[--color-border] text-[--color-text] px-8 py-3 rounded font-semibold text-lg hover:border-[--color-accent] hover:text-[--color-accent] hover:bg-[--color-accent]/5 transition-colors">
           {t('hero.cta1')}
-        </a>
-      </div>
-
-      <!-- 텔레그램 커뮤니티 CTA -->
-      <div class="mt-8 inline-flex items-center gap-3 border border-[--color-border] rounded-lg px-5 py-3 bg-[--color-bg-card]">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" class="text-[#229ED9] shrink-0" aria-hidden="true"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm4.64 6.8c-.15 1.58-.8 5.42-1.13 7.19-.14.75-.42 1-.68 1.03-.58.05-1.02-.38-1.58-.75-.88-.58-1.38-.94-2.23-1.5-.99-.65-.35-1.01.22-1.59.15-.15 2.71-2.48 2.76-2.69a.2.2 0 00-.05-.18c-.06-.05-.14-.03-.21-.02-.09.02-1.49.95-4.22 2.79-.4.27-.76.41-1.08.4-.36-.01-1.04-.2-1.55-.37-.63-.2-1.12-.31-1.08-.66.02-.18.27-.36.74-.55 2.92-1.27 4.86-2.11 5.83-2.51 2.78-1.16 3.35-1.36 3.73-1.36.08 0 .27.02.39.12.1.08.13.19.14.27-.01.06.01.24 0 .38z"/></svg>
-        <div class="text-left">
-          <p class="text-sm font-semibold">커뮤니티 참여</p>
-          <p class="text-xs text-[--color-text-muted]">전략 업데이트, 시장 인사이트, 토론</p>
-        </div>
-        <a href="https://t.me/PRUVIQ" target="_blank" rel="noopener noreferrer"
-           class="ml-2 bg-[--color-accent] text-white px-4 py-1.5 rounded text-xs font-semibold hover:bg-[--color-accent-dim] transition-colors whitespace-nowrap">
-          텔레그램 참여
         </a>
       </div>
 

--- a/src/pages/ko/strategies/index.astro
+++ b/src/pages/ko/strategies/index.astro
@@ -183,11 +183,7 @@ const isKorean = (id: string) => koIds.has(id);
         <p class="text-[--color-text-muted] text-sm mb-4">
           {t('strategies.more_desc')}
         </p>
-        <a href="https://t.me/PRUVIQ" target="_blank" rel="noopener noreferrer"
-           class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-6 py-2 rounded font-semibold text-sm hover:bg-[--color-accent-dim]">
-          {t('strategies.join')} &rarr;
-        </a>
-        <div class="flex flex-wrap gap-3 justify-center mt-4">
+        <div class="flex flex-wrap gap-3 justify-center">
           <a href="/ko/performance" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
             {t('strategies.performance_cta')} &rarr;
           </a>

--- a/src/pages/strategies/index.astro
+++ b/src/pages/strategies/index.astro
@@ -182,11 +182,7 @@ const difficultyColors: Record<string, string> = {
         <p class="text-[--color-text-muted] text-sm mb-4">
           {t('strategies.more_desc')}
         </p>
-        <a href="https://t.me/PRUVIQ" target="_blank" rel="noopener noreferrer"
-           class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-6 py-2 rounded font-semibold text-sm hover:bg-[--color-accent-dim]">
-          {t('strategies.join')} &rarr;
-        </a>
-        <div class="flex flex-wrap gap-3 justify-center mt-4">
+        <div class="flex flex-wrap gap-3 justify-center">
           <a href="/performance" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
             {t('strategies.performance_cta')} &rarr;
           </a>


### PR DESCRIPTION
## Summary
- Remove all Telegram community CTA links and sections from 14 public-facing files
- Update testimonial attribution from "Telegram community member" to "Community member" (EN/KO)
- Replace Telegram with X/Twitter in blog coming-soon sections
- Preserve legal contact pages (terms/privacy), blog .md content, schema.org sameAs, and i18n keys

## Files changed (14)
| File | Change |
|------|--------|
| Layout.astro | Remove footer Telegram link |
| index.astro (EN/KO) | Remove CTA block + update testimonial |
| strategies/index.astro (EN/KO) | Remove join Telegram button |
| blog/index.astro (EN/KO) | Replace Telegram → X/Twitter |
| about.astro (EN/KO) | Remove Telegram contact button |
| api.astro (EN/KO) | Remove Telegram link from SDK section |
| StrategyDemo.tsx | Remove Telegram CTA button |
| BlogPost.astro | Remove newsletter CTA section |
| ko/blog/[id].astro | Remove newsletter CTA section |

## Test plan
- [x] `npm run build` passes (2450 pages, 0 errors)
- [ ] Verify no broken HTML structure on affected pages
- [ ] Confirm terms.astro, privacy.astro, and blog .md files are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)