### PR TITLE
fix: remove remaining Telegram references from schema and content

### DIFF
--- a/src/content/blog-ko/crypto-futures-beginners-guide.md
+++ b/src/content/blog-ko/crypto-futures-beginners-guide.md
@@ -117,4 +117,4 @@ tags: ["futures", "leverage", "beginners", "perpetual-contracts"]
 
 ---
 
-*PRUVIQ는 535개 코인에서 5배 레버리지로 무기한 선물을 거래합니다. 모든 거래는 [텔레그램](https://t.me/PRUVIQ)에서 실시간 공개됩니다. [전략](/ko/strategies)과 [버전 이력](/ko/changelog)을 확인하세요.*
+*PRUVIQ는 535개 코인에서 5배 레버리지로 무기한 선물을 거래합니다. 모든 거래는 [성과 페이지](/ko/performance)에서 실시간 공개됩니다. [전략](/ko/strategies)과 [버전 이력](/ko/changelog)을 확인하세요.*

--- a/src/content/blog/crypto-futures-beginners-guide.md
+++ b/src/content/blog/crypto-futures-beginners-guide.md
@@ -117,4 +117,4 @@ We use Binance Futures (highest liquidity, 500+ perpetual pairs). See our [full 
 
 ---
 
-*PRUVIQ trades perpetual futures on 535 coins with 5x leverage. Every trade is published in real-time on [Telegram](https://t.me/PRUVIQ). See our [approach](/), [killed strategies](/strategies), and [version history](/changelog).*
+*PRUVIQ trades perpetual futures on 535 coins with 5x leverage. Every trade is published in real-time on the [performance page](/performance). See our [approach](/), [killed strategies](/strategies), and [version history](/changelog).*

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -712,7 +712,7 @@ export const en = {
   'api.example_curl': 'cURL',
   'api.example_js': 'JavaScript',
   'api.sdk_title': 'Coming Soon',
-  'api.sdk_desc': 'Python SDK and WebSocket feed are in development. Join our Telegram for updates.',
+  'api.sdk_desc': 'Python SDK and WebSocket feed are in development. Follow us on X for updates.',
   'footer.api': 'API',
   'footer.compare': 'vs TradingView',
 
@@ -801,7 +801,7 @@ export const en = {
   'vs.row_api_p': 'Free REST API (30 req/min)',
   'vs.row_api_tv': 'Paid plans only',
   'vs.row_community': 'Community',
-  'vs.row_community_p': 'Growing (Telegram)',
+  'vs.row_community_p': 'Growing (X, GitHub)',
   'vs.row_community_tv': '50M+ users, social features',
   'vs.when_pruviq': 'Choose PRUVIQ when you want...',
   'vs.when_pruviq_1': 'Free crypto backtesting with zero coding',

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -714,7 +714,7 @@ export const ko: Record<TranslationKey, string> = {
   'api.example_curl': 'cURL',
   'api.example_js': 'JavaScript',
   'api.sdk_title': '출시 예정',
-  'api.sdk_desc': 'Python SDK와 WebSocket 피드가 개발 중입니다. 업데이트는 텔레그램에서 확인하세요.',
+  'api.sdk_desc': 'Python SDK와 WebSocket 피드가 개발 중입니다. X에서 최신 소식을 확인하세요.',
   'footer.api': 'API',
   'footer.compare': 'vs 트레이딩뷰',
 
@@ -803,7 +803,7 @@ export const ko: Record<TranslationKey, string> = {
   'vs.row_api_p': '무료 REST API (분당 30회)',
   'vs.row_api_tv': '유료 플랜만',
   'vs.row_community': '커뮤니티',
-  'vs.row_community_p': '성장 중 (텔레그램)',
+  'vs.row_community_p': '성장 중 (X, GitHub)',
   'vs.row_community_tv': '5000만+ 사용자, 소셜 기능',
   'vs.when_pruviq': 'PRUVIQ를 선택할 때...',
   'vs.when_pruviq_1': '코딩 없이 무료 크립토 백테스팅',

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -144,7 +144,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
           ? '무료 크립토 전략 백테스팅 플랫폼. 549개 이상 코인에서 2년 이상의 실제 시장 데이터로 트레이딩 전략을 만들고 테스트하세요.'
           : 'Free crypto strategy backtesting platform. Build and test trading strategies on 549+ coins with 2+ years of real market data.',
         "founder": { "@type": "Organization", "name": "PRUVIQ Team" },
-        "sameAs": ["https://t.me/PRUVIQ", "https://x.com/pruviq", "https://github.com/pruviq/pruviq"],
+        "sameAs": ["https://x.com/pruviq", "https://github.com/pruviq/pruviq"],
         "knowsAbout": lang === 'ko'
           ? ['암호화폐 트레이딩', '백테스팅', '알고리즘 트레이딩', '퀀트 금융']
           : ['cryptocurrency trading', 'backtesting', 'algorithmic trading', 'quantitative finance']


### PR DESCRIPTION
## Summary
- Remove `t.me/PRUVIQ` from schema.org `sameAs` in Layout.astro
- Update SDK description and community comparison to reference X instead of Telegram
- Update blog CTAs to link to performance page instead of Telegram

Legal pages (terms/privacy) retain Telegram as contact method.

## Test plan
- [ ] Verify no Telegram links in schema markup
- [ ] Verify blog posts reference /performance instead of t.me
- [ ] Verify terms/privacy still have Telegram contact

🤖 Generated with [Claude Code](https://claude.com/claude-code)