### PR TITLE
fix: remove Telegram from terms/privacy pages

### DIFF
--- a/src/pages/ko/privacy.astro
+++ b/src/pages/ko/privacy.astro
@@ -95,7 +95,6 @@ import Layout from '../../layouts/Layout.astro';
           <p>개인정보처리방침에 대한 문의:</p>
           <ul class="list-disc pl-5 mt-2 space-y-1">
             <li>이메일: <a href="mailto:contact@pruviq.com" class="text-[--color-accent] hover:underline">contact@pruviq.com</a></li>
-            <li>텔레그램: <a href="https://t.me/PRUVIQ" class="text-[--color-accent] hover:underline" target="_blank" rel="noopener noreferrer">t.me/PRUVIQ</a></li>
           </ul>
         </div>
 

--- a/src/pages/ko/terms.astro
+++ b/src/pages/ko/terms.astro
@@ -134,7 +134,6 @@ import Layout from '../../layouts/Layout.astro';
           <p>이용약관에 대한 문의:</p>
           <ul class="list-disc pl-5 mt-2 space-y-1">
             <li>이메일: <a href="mailto:contact@pruviq.com" class="text-[--color-accent] hover:underline">contact@pruviq.com</a></li>
-            <li>텔레그램: <a href="https://t.me/PRUVIQ" class="text-[--color-accent] hover:underline" target="_blank" rel="noopener noreferrer">t.me/PRUVIQ</a></li>
           </ul>
         </div>
 

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -114,7 +114,6 @@ import Layout from '../layouts/Layout.astro';
           <p>If you have questions about this Privacy Policy or our data practices:</p>
           <ul class="list-disc pl-5 mt-2 space-y-1">
             <li>Email: <a href="mailto:contact@pruviq.com" class="text-[--color-accent] hover:underline">contact@pruviq.com</a></li>
-            <li>Telegram: <a href="https://t.me/PRUVIQ" class="text-[--color-accent] hover:underline" target="_blank" rel="noopener noreferrer">t.me/PRUVIQ</a></li>
           </ul>
         </div>
 

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -162,7 +162,6 @@ import Layout from '../layouts/Layout.astro';
           <p>If you have questions about these Terms of Service:</p>
           <ul class="list-disc pl-5 mt-2 space-y-1">
             <li>Email: <a href="mailto:contact@pruviq.com" class="text-[--color-accent] hover:underline">contact@pruviq.com</a></li>
-            <li>Telegram: <a href="https://t.me/PRUVIQ" class="text-[--color-accent] hover:underline" target="_blank" rel="noopener noreferrer">t.me/PRUVIQ</a></li>
           </ul>
         </div>
 


### PR DESCRIPTION
## Summary
- Remove Telegram contact links from terms.astro, privacy.astro (EN+KO)
- Email (contact@pruviq.com) is now the sole contact method

## Test plan
- [ ] Verify terms/privacy pages only show email contact
- [ ] No t.me links anywhere on site

🤖 Generated with [Claude Code](https://claude.com/claude-code)