### PR TITLE
fix: backtest cache serialization + cf-beacon-loader 404

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -2501,7 +2501,7 @@ async def run_backtest(req: BacktestRequest):
     )
 
     # Cache the result
-    set_cached(bt_key, response)
+    set_cached(bt_key, response.model_dump())
 
     return response
 

--- a/public/scripts/cf-beacon-loader.js
+++ b/public/scripts/cf-beacon-loader.js
@@ -1,0 +1,31 @@
+// Load Cloudflare Insights beacon after page is idle or loaded to avoid blocking critical path
+(function () {
+  try {
+    const token = (window?.PRUVIQ?.cfToken) || (new URLSearchParams(window.location.search).get('cf_token')) || null;
+    // If token is provided via data attribute on body (SSR), prefer that
+    const tokenFromDom = document?.querySelector('meta[name="cf-beacon-token"]')?.getAttribute('content');
+    const cfToken = tokenFromDom || token || (window && window.__CF_BEACON_TOKEN__);
+
+    function insertBeacon() {
+      if (!cfToken) return;
+      const s = document.createElement('script');
+      s.src = 'https://static.cloudflareinsights.com/beacon.min.js';
+      s.defer = true;
+      s.setAttribute('data-cf-beacon', JSON.stringify({ token: cfToken }));
+      document.head.appendChild(s);
+    }
+
+    if ('requestIdleCallback' in window) {
+      requestIdleCallback(function () {
+        insertBeacon();
+      }, { timeout: 3000 });
+    } else {
+      window.addEventListener('load', insertBeacon, { once: true, passive: true });
+      // Fallback: after 3s
+      setTimeout(insertBeacon, 3000);
+    }
+  } catch (e) {
+    // silently fail — analytics non-critical
+    console.error && console.debug && console.debug('cf-beacon-loader error', e);
+  }
+})();


### PR DESCRIPTION
## Summary
- **Backtest cache bug (CRITICAL)**: `/backtest` endpoint stored Pydantic model object in LRU cache instead of dict. On cache hit, FastAPI re-serialization caused metrics corruption (wrong WR, PF, MDD values). Fix: `response.model_dump()` before caching, matching `/simulate` behavior.
- **cf-beacon-loader.js 404**: File existed in `src/scripts/` but Astro doesn't auto-copy to dist. Copied to `public/scripts/` for proper static serving.

## Test plan
- [ ] Run backtest with same params twice — verify cached result matches fresh result
- [ ] Check browser console — no 404 for cf-beacon-loader.js
- [ ] Verify /simulate cache still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)