### PR TITLE
fix: auto-fix #290 (+4 related)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,4 +11,4 @@ ENV PRUVIQ_DATA_DIR=/app/data/futures
 
 EXPOSE 8080
 
-CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8080", "--workers", "4"]
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8080", "--workers", "1"]

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -268,9 +268,19 @@ def get_client_ip(request: Request) -> str:
     return direct_ip
 
 
+_last_rate_limit_cleanup = 0.0
+
 def check_rate_limit(client_ip: str) -> bool:
-    """Simple in-memory rate limiter."""
+    """Simple in-memory rate limiter with periodic cleanup."""
+    global _last_rate_limit_cleanup
     now = time.time()
+
+    if now - _last_rate_limit_cleanup > 300 and len(rate_limits) > 200:
+        _last_rate_limit_cleanup = now
+        stale = [ip for ip, ts in rate_limits.items() if not ts or now - ts[-1] > 120]
+        for ip in stale:
+            del rate_limits[ip]
+
     if client_ip not in rate_limits:
         rate_limits[client_ip] = []
 
@@ -283,14 +293,19 @@ def check_rate_limit(client_ip: str) -> bool:
     return True
 
 
+_CACHEABLE_PREFIXES = ("/health", "/coins", "/strategies", "/ohlcv/", "/market", "/stats")
+
 @app.middleware("http")
 async def security_headers_middleware(request: Request, call_next):
     response = await call_next(request)
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
-    response.headers["Cache-Control"] = "no-store"
     response.headers["X-Permitted-Cross-Domain-Policies"] = "none"
+    if request.method == "GET" and any(request.url.path.startswith(p) for p in _CACHEABLE_PREFIXES):
+        response.headers["Cache-Control"] = "public, max-age=60, s-maxage=60"
+    else:
+        response.headers["Cache-Control"] = "no-store"
     return response
 
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -11,6 +11,7 @@ interface Props {
   category?: string;
   ogImage?: string;
   canonicalOverride?: string;
+  noAlternate?: boolean;
 }
 
 const lang = getLangFromUrl(Astro.url);
@@ -20,7 +21,7 @@ const basePath = getBasePath(Astro.url.pathname);
 const cfToken = import.meta.env.PUBLIC_CF_ANALYTICS_TOKEN;
 const buildTime = new Date().toISOString();
 
-const { title, description = t('meta.home_desc'), type = 'website', date, category, canonicalOverride } = Astro.props;
+const { title, description = t('meta.home_desc'), type = 'website', date, category, canonicalOverride, noAlternate = false } = Astro.props;
 const ogImage = new URL(Astro.props.ogImage || '/og-image.jpg', Astro.site || 'https://pruviq.com').href;
 // derive AVIF/WebP variants safely for jpg/png sources
 const ogImageAvif = ogImage.replace(/\.(png|jpe?g)(\?.*)?$/i, '.avif$2');
@@ -88,9 +89,9 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
     <link rel="canonical" href={canonicalURL.href} />
-    <link rel="alternate" hreflang="en" href={enURL.href} />
-    <link rel="alternate" hreflang="ko" href={koURL.href} />
-    <link rel="alternate" hreflang="x-default" href={enURL.href} />
+    {!noAlternate && <link rel="alternate" hreflang="en" href={enURL.href} />}
+    {!noAlternate && <link rel="alternate" hreflang="ko" href={koURL.href} />}
+    {!noAlternate && <link rel="alternate" hreflang="x-default" href={enURL.href} />}
     <meta name="naver-site-verification" content="ece19c45b3e33ec86f4fc79060c3283cea1493ee" />
     <meta name="yandex-verification" content="a20aa9b1eacf8e51" />
     <meta name="keywords" content={lang === 'ko'

--- a/src/pages/ko/blog/[id].astro
+++ b/src/pages/ko/blog/[id].astro
@@ -37,7 +37,7 @@ const categoryLabels: Record<string, string> = {
 };
 ---
 
-<Layout title={`${post.data.title} - PRUVIQ`} description={post.data.description} type="article" date={post.data.date} category={post.data.category}>
+<Layout title={`${post.data.title} - PRUVIQ`} description={post.data.description} type="article" date={post.data.date} category={post.data.category} noAlternate={!isKorean}>
   <article class="py-12">
     <div class="max-w-3xl mx-auto px-4">
       <a href="/ko/learn" class="text-[--color-text-muted] text-sm hover:text-[--color-accent] transition-colors mb-8 inline-block">

--- a/src/pages/ko/strategies/[id].astro
+++ b/src/pages/ko/strategies/[id].astro
@@ -57,17 +57,7 @@ const statusLabels: Record<string, string> = {
 };
 ---
 
-<Layout title={`${strategy.data.name} - PRUVIQ`} description={strategy.data.description} type="article" date={strategy.data.dateAdded}>
-  <!-- 3-level BreadcrumbList -->
-  <script type="application/ld+json" set:html={JSON.stringify({
-    "@context": "https://schema.org",
-    "@type": "BreadcrumbList",
-    "itemListElement": [
-      { "@type": "ListItem", "position": 1, "name": "PRUVIQ", "item": "https://pruviq.com/" },
-      { "@type": "ListItem", "position": 2, "name": "전략", "item": "https://pruviq.com/ko/strategies/" },
-      { "@type": "ListItem", "position": 3, "name": strategy.data.name, "item": `https://pruviq.com/ko/strategies/${strategy.id}/` }
-    ]
-  })} />
+<Layout title={`${strategy.data.name} - PRUVIQ`} description={strategy.data.description} type="article" date={strategy.data.dateAdded} noAlternate={!isKorean}>
   <script type="application/ld+json" set:html={JSON.stringify({
     "@context": "https://schema.org",
     "@type": "TechArticle",

--- a/src/pages/strategies/[id].astro
+++ b/src/pages/strategies/[id].astro
@@ -43,16 +43,6 @@ const statusLabels: Record<string, string> = {
 ---
 
 <Layout title={`${strategy.data.name} - PRUVIQ`} description={strategy.data.description} type="article" date={strategy.data.dateAdded}>
-  <!-- 3-level BreadcrumbList -->
-  <script type="application/ld+json" set:html={JSON.stringify({
-    "@context": "https://schema.org",
-    "@type": "BreadcrumbList",
-    "itemListElement": [
-      { "@type": "ListItem", "position": 1, "name": "PRUVIQ", "item": "https://pruviq.com/" },
-      { "@type": "ListItem", "position": 2, "name": "Strategies", "item": "https://pruviq.com/strategies/" },
-      { "@type": "ListItem", "position": 3, "name": strategy.data.name, "item": `https://pruviq.com/strategies/${strategy.id}/` }
-    ]
-  })} />
   <!-- TechArticle schema with dynamic dateModified -->
   <script type="application/ld+json" set:html={JSON.stringify({
     "@context": "https://schema.org",


### PR DESCRIPTION
## Auto-fix for 5 issue(s)

#290: [claude-auto][P2] `rate_limits` Dict Grows Unbounded — Memory Leak (Security / Performance)
#291: [claude-auto][P2] `Cache-Control: no-store` on ALL Responses Including Read-Only GET Endpoints (Pe
#292: [claude-auto][P2] Duplicate BreadcrumbList JSON-LD on strategy detail pages
#293: [claude-auto][P2] hreflang points Korean URLs to English-only blog content
#294: [claude-auto][P2] Dockerfile `--workers 4` Contradicts Required `--workers 1`

### Changes
```
 src/layouts/Layout.astro           |  9 +++++----
 src/pages/ko/blog/[id].astro       |  2 +-
 src/pages/ko/strategies/[id].astro | 12 +-----------
 src/pages/strategies/[id].astro    | 10 ----------
 6 files changed, 25 insertions(+), 29 deletions(-)
```

### Safety Checks
- Files changed: **6** (limit: 20)
- Lines changed: **54** (limit: 1500)

---
*Auto-generated by JEPO auto-fix agent. Requires auto-test pass before merge.*