### PR TITLE
fix: canonical/hreflang conflict + sitemap lastmod (#314, #315)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -32,7 +32,6 @@ export default defineConfig({
         if (item.url.includes('/demo/')) return undefined;
         if (item.url.includes('/builder/')) return undefined;
         if (item.url.includes('/ko/404/')) return undefined;
-        item.lastmod = new Date().toISOString();
         return item;
       }
     }),

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -28,8 +28,9 @@ const ogImageAvif = ogImage.replace(/\.(png|jpe?g)(\?.*)?$/i, '.avif$2');
 const ogImageWebp = ogImage.replace(/\.(png|jpe?g)(\?.*)?$/i, '.webp$2');
 const canonicalPath = canonicalOverride || Astro.url.pathname;
 const canonicalURL = new URL(canonicalPath, Astro.site || 'https://pruviq.com');
-const enURL = new URL(basePath, Astro.site || 'https://pruviq.com');
-const koURL = new URL(`/ko${basePath === '/' ? '/' : basePath}`, Astro.site || 'https://pruviq.com');
+const hreflangBase = canonicalPath.replace(/^\/ko(\/|$)/, '/');
+const enURL = new URL(hreflangBase, Astro.site || 'https://pruviq.com');
+const koURL = new URL(`/ko${hreflangBase === '/' ? '/' : hreflangBase}`, Astro.site || 'https://pruviq.com');
 
 const marketPath = lang === 'ko' ? '/ko/market' : '/market';
 const simulatePath = lang === 'ko' ? '/ko/simulate' : '/simulate';


### PR DESCRIPTION
## Summary
- **#314**: hreflang URLs now derive from `canonicalPath` instead of `basePath`, fixing canonical/hreflang mismatch on ~1,098 non-USDT coin alias pages (e.g. `/coins/btc/` now has hreflang pointing to `/coins/btcusdt/`)
- **#315**: Removed forced `new Date().toISOString()` lastmod in sitemap serializer — Google prefers no lastmod over inaccurate lastmod

## Test plan
- [x] `npx astro build` — 2450 pages, 0 errors
- [x] Verified `/coins/btc/index.html`: canonical + all hreflang tags point to `/coins/btcusdt/`
- [x] Verified sitemap has no `lastmod` entries

Closes #314, closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)