### PR TITLE
fix: auto-fix #320

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -160,7 +160,10 @@ async def _background_market_refresh():
             raise
         except Exception as e:
             logger.warning(f"News background refresh failed: {e}")
-        await asyncio.sleep(MARKET_REFRESH_INTERVAL)
+        # Exponential backoff on consecutive failures (cap at 10min)
+        backoff = min(MARKET_REFRESH_INTERVAL * (2 ** min(consecutive_failures, 3)), 600)
+        sleep_time = backoff if consecutive_failures > 0 else MARKET_REFRESH_INTERVAL
+        await asyncio.sleep(sleep_time)
 
 
 @asynccontextmanager

--- a/backend/scripts/refresh_static.py
+++ b/backend/scripts/refresh_static.py
@@ -650,7 +650,7 @@ def main():
     # 2. Fetch Binance tickers (PRIMARY — unlimited, real-time)
     binance_tickers = fetch_binance_tickers()
     if not binance_tickers:
-        print("WARN: Binance unavailable. Keeping existing stale files.")
+        print("ERROR: Binance unavailable. market.json NOT updated.")
         # Still refresh macro + news
         macro_json = build_macro_json()
         if macro_json:
@@ -658,7 +658,7 @@ def main():
         news_json = build_news_json()
         if news_json:
             (OUTPUT_DIR / "news.json").write_text(json.dumps(news_json, ensure_ascii=False))
-        sys.exit(0)
+        sys.exit(1)
 
     # If no coin-symbols.ts, use all Binance USDT symbols
     if not our_symbols:

--- a/backend/scripts/refresh_static.sh
+++ b/backend/scripts/refresh_static.sh
@@ -99,6 +99,14 @@ if ! python3 backend/scripts/refresh_static.py 2>&1; then
     exit 1
 fi
 
+# Post-run staleness check: if market.json is STILL old after a successful run, alert
+if [ -f "$MARKET_JSON" ]; then
+    POST_AGE_SEC=$(( $(date +%s) - $(stat -f %m "$MARKET_JSON") ))
+    if [ "$POST_AGE_SEC" -gt 3600 ]; then
+        send_alert "ERROR" "market.json still stale after refresh (${POST_AGE_SEC}s old). Pipeline may be broken."
+    fi
+fi
+
 # All data files that refresh_static.py may update
 DATA_FILES="public/data/market.json public/data/coins-stats.json public/data/macro.json public/data/news.json public/data/coin-metadata.json"
 


### PR DESCRIPTION
## Auto-fix for 1 issue(s)

#320: data P2: `market.json` is ~18 hours old (generated 2026-03-09 17:45 UTC). Verify refresh pipeline is

### Changes
```
 backend/api/main.py               | 5 ++++-
 backend/scripts/refresh_static.py | 4 ++--
 backend/scripts/refresh_static.sh | 8 ++++++++
 3 files changed, 14 insertions(+), 3 deletions(-)
```

### Safety Checks
- Files changed: **3** (limit: 20)
- Lines changed: **17** (limit: 1500)

---
*Auto-generated by JEPO auto-fix agent. Requires auto-test pass before merge.*