### PR TITLE
fix: move cron self-healing before data fetch (#324)

### DIFF
--- a/backend/scripts/refresh_static.sh
+++ b/backend/scripts/refresh_static.sh
@@ -69,6 +69,14 @@ acquire_lock
 
 cd "$REPO_DIR"
 
+# --- Cron self-healing (run EARLY so it works even if later steps fail) ---
+CRON_ENTRY="*/20 * * * * bash $SCRIPT_PATH >> /tmp/pruviq-refresh.log 2>&1"
+if ! crontab -l 2>/dev/null | grep -qF "refresh_static.sh"; then
+    log "Cron entry missing — auto-installing..."
+    ( crontab -l 2>/dev/null; echo "$CRON_ENTRY" ) | crontab -
+    send_alert "WARN" "Cron entry was missing — auto-installed"
+fi
+
 # Ensure we're on main and clean
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
 if [[ "$CURRENT_BRANCH" != "main" ]]; then
@@ -161,14 +169,6 @@ fi
     log "Git data commit skipped (non-critical)"
     git checkout main -q 2>/dev/null || true
 }
-
-# --- Step 4: Ensure cron entry exists (self-healing) ---
-CRON_ENTRY="*/20 * * * * bash $SCRIPT_PATH >> /tmp/pruviq-refresh.log 2>&1"
-if ! crontab -l 2>/dev/null | grep -qF "refresh_static.sh"; then
-    log "Cron entry missing — auto-installing..."
-    ( crontab -l 2>/dev/null; echo "$CRON_ENTRY" ) | crontab -
-    send_alert "WARN" "Cron entry was missing — auto-installed"
-fi
 
 send_alert "OK" "Static data refreshed + deployed"
 exit 0


### PR DESCRIPTION
## Summary
- Moved cron auto-install check from end of `refresh_static.sh` to before data fetch
- Previously, if cron disappeared AND any step failed (`exit 1`), the self-healing never ran — pipeline stayed dead permanently
- Now cron is reinstalled on every run regardless of downstream failures

Fixes #324

## Test plan
- [ ] Verify `bash -n` syntax check passes
- [ ] Confirm cron entry exists on Mac Mini after next run
- [ ] Monitor market.json staleness over 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)