### PR TITLE
fix: stale market.json — always pull + API-first load

### DIFF
--- a/backend/scripts/refresh_static.sh
+++ b/backend/scripts/refresh_static.sh
@@ -83,8 +83,10 @@ if [[ "$CURRENT_BRANCH" != "main" ]]; then
     log "Not on main (on $CURRENT_BRANCH), switching..."
     git stash -q 2>/dev/null || true
     git checkout main -q 2>/dev/null || true
-    git pull origin main -q 2>/dev/null || true
 fi
+
+# Always pull latest code so pipeline fixes propagate automatically
+git pull --autostash -q origin main 2>/dev/null || true
 
 # Activate venv if exists
 if [ -f "$VENV_DIR/bin/activate" ]; then

--- a/src/hooks/useMarketOverview.ts
+++ b/src/hooks/useMarketOverview.ts
@@ -31,9 +31,9 @@ export function useMarketOverview() {
   const intervalRef = useRef<number | null>(null);
 
   const fetchMarket = () => {
-    // When current data is very stale (>1h), use API-first to recover faster
+    // On initial load (no data yet) or when data is very stale (>1h), use API-first
     const fetcher =
-      market && isVeryStale(market)
+      !market || isVeryStale(market)
         ? fetchLiveFirst("/market", STATIC_DATA.market)
         : fetchWithFallback("/market", STATIC_DATA.market);
     fetcher


### PR DESCRIPTION
## Summary
- **refresh_static.sh**: `git pull` was inside the branch-switch `if` block, so when already on `main` the pipeline never pulled code updates. Moved to unconditional `git pull --autostash` so fixes (like cron self-healing from #325) propagate automatically.
- **useMarketOverview**: Initial page load used static-first fetch. Changed to API-first (`fetchLiveFirst`) when `market` is null, so users get fresh data even if the static pipeline is down.

## Test plan
- [x] Build passes (2450 pages, 0 errors)
- [ ] Verify market dashboard loads fresh data from API on initial visit
- [ ] Verify refresh_static.sh pulls latest code on Mac Mini

Fixes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)