### PR TITLE
fix: secure XML parsing + add Retry-After header (#329, #330)

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -317,9 +317,12 @@ async def rate_limit_middleware(request: Request, call_next):
     if request.url.path in ("/simulate", "/simulate/coin", "/simulate/compare", "/simulate/validate", "/backtest", "/export/csv"):
         client_ip = get_client_ip(request)
         if not check_rate_limit(client_ip):
+            oldest = rate_limits.get(client_ip, [0])[0]
+            retry_after = max(1, int(60 - (time.time() - oldest)))
             return JSONResponse(
                 status_code=429,
-                content={"detail": "Rate limit exceeded. Max 30 requests per minute."},
+                content={"detail": f"Rate limit exceeded. Retry after {retry_after}s."},
+                headers={"Retry-After": str(retry_after)},
             )
     return await call_next(request)
 
@@ -1259,10 +1262,7 @@ async def refresh_data(x_admin_key: str = Header(default="", alias="X-Admin-Key"
 
 # --- Market Dashboard ---
 
-try:
-    import defusedxml.ElementTree as ET
-except ImportError:
-    import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 import requests as http_requests
 from email.utils import parsedate_to_datetime
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ numpy>=1.24.0
 fastapi>=0.115.0
 uvicorn[standard]>=0.30.0
 pydantic>=2.0.0
+defusedxml>=0.7.0

--- a/backend/scripts/refresh_static.py
+++ b/backend/scripts/refresh_static.py
@@ -33,10 +33,7 @@ import sys
 import time
 import urllib.request
 import urllib.error
-try:
-    import defusedxml.ElementTree as ET
-except ImportError:
-    import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 from datetime import datetime, timedelta, timezone
 from email.utils import parsedate_to_datetime
 from pathlib import Path


### PR DESCRIPTION
## Summary
- **#329 XXE fix**: Add `defusedxml>=0.7.0` to `requirements.txt` and remove unsafe `xml.etree.ElementTree` fallback in `main.py` and `refresh_static.py`
- **#330 Retry-After**: Add `Retry-After` header to 429 rate limit responses per RFC 6585

## Test plan
- [ ] `pip install -r backend/requirements.txt` succeeds with defusedxml
- [ ] Rate-limited requests return `Retry-After` header
- [ ] RSS news feed parsing still works

Closes #329, closes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)