### PR TITLE
fix: Sharpe capital-weighting + Calmar CAGR

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -742,7 +742,9 @@ async def simulate(req: SimulationRequest):
     for t in all_trades:
         day_key = t.get("exit_time", t["time"])[:10]  # YYYY-MM-DD (exit time)
         daily_pnl_sim[day_key] += t["pnl_pct"]
-    daily_returns_sim = np.array(list(daily_pnl_sim.values())) if daily_pnl_sim else np.array([])
+    # Normalize by number of concurrent positions for capital-weighted daily returns
+    n_coins = len(coins_used) if coins_used else 1
+    daily_returns_sim = np.array(list(daily_pnl_sim.values())) / max(n_coins, 1) if daily_pnl_sim else np.array([])
 
     if len(daily_returns_sim) >= 5:
         dr_avg = float(np.mean(daily_returns_sim))
@@ -754,7 +756,7 @@ async def simulate(req: SimulationRequest):
         sortino = round(dr_avg / tdd * np.sqrt(365), 2) if tdd > 0 else 0.0
         # Calmar: CAGR / MDD (compound annualized growth rate — industry standard)
         n_days_sim = len(daily_pnl_sim)
-        growth_ratio_sim = (equity + 100) / 100 if equity > -100 else 0.001
+        growth_ratio_sim = equity / 100.0 if equity > 0 else 0.001
         years_sim = max(n_days_sim, 1) / 365
         cagr_pct_sim = (growth_ratio_sim ** (1 / years_sim) - 1) * 100 if years_sim > 0 else 0.0
         calmar = round(cagr_pct_sim / max_dd, 2) if max_dd > 0 else 0.0
@@ -2298,7 +2300,7 @@ async def run_backtest(req: BacktestRequest):
         bt_sortino = round(dr_avg / tdd_bt * np.sqrt(365), 2) if tdd_bt > 0 else 0.0
         # Calmar = CAGR / MDD (compound annualized growth rate — industry standard)
         n_days = len(daily_pnl)
-        growth_ratio_bt = (equity + 100) / 100 if equity > -100 else 0.001
+        growth_ratio_bt = equity / 100.0 if equity > 0 else 0.001
         years_bt = max(n_days, 1) / 365
         cagr_pct_bt = (growth_ratio_bt ** (1 / years_bt) - 1) * 100 if years_bt > 0 else 0.0
         bt_calmar = round(cagr_pct_bt / max_dd, 2) if max_dd > 0 else 0.0

--- a/tests/SIM_AUDIT_PROGRESS.md
+++ b/tests/SIM_AUDIT_PROGRESS.md
@@ -45,13 +45,36 @@
 | E13 | sim_audit.py: 6 hardcoded WARNs replaced with 1 dynamic slippage verification note | DONE |
 | E14 | sim_audit.py: MDD check updated to verify 0-100 cap | DONE |
 
+## Phase 4: Full Coverage + CI + Deploy (COMPLETE — PR#336)
+
+| # | Enhancement | Status |
+|---|-------------|--------|
+| F1 | Dynamic slippage integrated in 6 call sites (/simulate, /backtest, /validate, /compare, /coin, _build_coin_stats) | DONE |
+| F2 | sim_audit.py expanded: 607→1060+ lines, 146 tests | DONE |
+| F3 | All 26 presets validated via /backtest × BTCUSDT | DONE |
+| F4 | 6 boundary value tests (SL 0.5-50%, TP 0.5-100%, leverage 125x, max_bars 1-168) | DONE |
+| F5 | Cross-engine deep comparison: 12 fields (/simulate vs /backtest) | DONE |
+| F6 | Simple/Compound full metric comparison (7 fields) | DONE |
+| F7 | Frontend label ↔ backend mapping (7 new fields verified) | DONE |
+| F8 | api_call error normalization (HTTPError "detail" → "error") | DONE |
+| F9 | 429 rate-limit retry with exponential backoff | DONE |
+| F10 | Auto-detect localhost on Mac Mini | DONE |
+| F11 | CI integration: post-deploy-pipeline.yml sim_audit quick mode | DONE |
+| F12 | Production deploy + verification: 146 PASS / 0 FAIL / 2 WARN | DONE |
+
+## Final Score: 146 PASS / 0 FAIL / 2 WARN / 0 SKIP (2026-03-11)
+
+## Phase 5: Final Metric Fixes (COMPLETE — PR#337)
+
+| # | Fix | Status |
+|---|-----|--------|
+| G1 | /simulate Sharpe: raw pnl_pct → capital-weighted (÷ n_coins) | DONE |
+| G2 | /simulate Calmar CAGR: `(equity+100)/100` → `equity/100` (100-based) | DONE |
+| G3 | /backtest Calmar CAGR: same fix (100-based equity) | DONE |
+
 ## Remaining TODO
 
-- [ ] Integrate `_get_dynamic_slippage(sym)` per-coin in /backtest simulation loop
-- [ ] /simulate Sharpe capital-weighting (currently raw pnl_pct)
-- [ ] Calmar CAGR for compound mode
-- [ ] sim_audit.py CI integration
-- [ ] Production deployment + re-verification
+(none)
 
 ## Files
 


### PR DESCRIPTION
## Summary
Fix the last 2 remaining simulator calculation issues.

### Sharpe capital-weighting (/simulate)
- Previously: summed raw `pnl_pct` per day → inflated Sharpe for multi-coin portfolios
- Now: normalize by number of concurrent coins (`÷ n_coins`) for capital-weighted daily returns

### Calmar CAGR (/simulate + /backtest)
- Previously: `growth_ratio = (equity + 100) / 100` → WRONG (equity starts at 100, so 100+100=200 → 200% growth ratio at baseline)
- Now: `growth_ratio = equity / 100.0` → CORRECT (equity=110 means 10% growth)
- Affects both `/simulate` and `/backtest` endpoints

## Test plan
- [ ] Deploy to Mac Mini, restart uvicorn
- [ ] Run sim_audit.py full → verify 146+ PASS / 0 FAIL
- [ ] Verify Sharpe values are reasonable (not inflated)
- [ ] Verify Calmar ratio is realistic

🤖 Generated with [Claude Code](https://claude.com/claude-code)