### PR TITLE
fix: auto-fix #340 (+1 related)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -32,6 +32,19 @@ export default defineConfig({
         if (item.url.includes('/demo/')) return undefined;
         if (item.url.includes('/builder/')) return undefined;
         if (item.url.includes('/ko/404/')) return undefined;
+
+        const url = new URL(item.url);
+        const isKo = url.pathname.startsWith('/ko/') || url.pathname === '/ko';
+        const basePath = isKo ? url.pathname.replace(/^\/ko/, '') || '/' : url.pathname;
+        const enUrl = `https://pruviq.com${basePath}`;
+        const koUrl = `https://pruviq.com/ko${basePath === '/' ? '/' : basePath}`;
+
+        item.links = [
+          { url: enUrl, lang: 'en' },
+          { url: koUrl, lang: 'ko' },
+          { url: enUrl, lang: 'x-default' },
+        ];
+
         return item;
       }
     }),

--- a/src/pages/ko/strategies/[id].astro
+++ b/src/pages/ko/strategies/[id].astro
@@ -64,7 +64,7 @@ const statusLabels: Record<string, string> = {
     "headline": strategy.data.name,
     "description": strategy.data.description,
     "datePublished": strategy.data.dateAdded,
-    "dateModified": new Date().toISOString().split('T')[0],
+    "dateModified": strategy.data.dateAdded,
     "author": { "@type": "Organization", "name": "PRUVIQ" },
     "publisher": { "@type": "Organization", "name": "PRUVIQ", "url": "https://pruviq.com" },
     "mainEntityOfPage": `https://pruviq.com/ko/strategies/${strategy.id}/`,

--- a/src/pages/strategies/[id].astro
+++ b/src/pages/strategies/[id].astro
@@ -50,7 +50,7 @@ const statusLabels: Record<string, string> = {
     "headline": strategy.data.name,
     "description": strategy.data.description,
     "datePublished": strategy.data.dateAdded,
-    "dateModified": new Date().toISOString().split('T')[0],
+    "dateModified": strategy.data.dateAdded,
     "author": { "@type": "Organization", "name": "PRUVIQ" },
     "publisher": { "@type": "Organization", "name": "PRUVIQ", "url": "https://pruviq.com" },
     "mainEntityOfPage": `https://pruviq.com/strategies/${strategy.id}/`,


### PR DESCRIPTION
## Auto-fix for 2 issue(s)

#340: [claude-auto][P2] TechArticle `dateModified` uses `new Date()` at build time
#341: [claude-auto][P2] Sitemap missing hreflang alternate links

### Changes
```
 astro.config.mjs                   | 13 +++++++++++++
 src/pages/ko/strategies/[id].astro |  2 +-
 src/pages/strategies/[id].astro    |  2 +-
 3 files changed, 15 insertions(+), 2 deletions(-)
```

### Safety Checks
- Files changed: **3** (limit: 20)
- Lines changed: **17** (limit: 1500)

---
*Auto-generated by JEPO auto-fix agent. Requires auto-test pass before merge.*