### PR TITLE
fix: compound mode UX and capital model bugs

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -2269,11 +2269,17 @@ async def run_backtest(req: BacktestRequest):
     # Portfolio USD calculations
     per_coin_usd = getattr(req, 'per_coin_usd', 60.0)
     leverage_val = getattr(req, 'leverage', 5)
-    # Capital = min(max_concurrent, coins_used) × per_coin_usd
-    # This reflects the actual capital needed at peak utilization, not total coins
     effective_positions = min(max_concurrent, len(coin_list))
-    initial_capital = per_coin_usd * effective_positions
-    base_position_size = per_coin_usd * leverage_val
+
+    if is_compounding:
+        # Compound mode: per_coin_usd = total capital, divide by coins for per-position
+        initial_capital = per_coin_usd
+        per_position_usd = per_coin_usd / max(effective_positions, 1)
+        base_position_size = per_position_usd * leverage_val
+    else:
+        # Simple mode: per_coin_usd = per-position capital
+        initial_capital = per_coin_usd * effective_positions
+        base_position_size = per_coin_usd * leverage_val
 
     # Compounding vs Simple: Recalculate pnl_usd
     if is_compounding:
@@ -2293,9 +2299,8 @@ async def run_backtest(req: BacktestRequest):
 
     # total_return_pct: compound vs simple
     if is_compounding:
-        # Portfolio compound: use USD-based equity tracking (already computed above)
-        # pnl_usd was scaled by equity/capital, so total_pnl_usd reflects compound growth
-        total_return = round(total_pnl_usd / initial_capital * 100, 4) if initial_capital > 0 else 0
+        # Compound: use final equity from equity tracking (includes reinvestment effects)
+        total_return = round((equity_usd_compound - initial_capital) / initial_capital * 100, 4) if initial_capital > 0 else 0
     else:
         total_return = round(total_pnl_usd / initial_capital * 100, 4) if initial_capital > 0 else 0
 

--- a/src/components/BuilderPanel.tsx
+++ b/src/components/BuilderPanel.tsx
@@ -254,7 +254,7 @@ export default function BuilderPanel(props: Props) {
                 class="w-full mt-0.5 px-2 py-1 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
               />
             </div>
-            {/* Capital input — compound: total capital for 1 coin; simple: per-coin */}
+            {/* Capital input — compound: total portfolio capital; simple: per-coin amount */}
             <div>
               <label class="text-[10px] text-[--color-text-muted]">
                 {props.compounding
@@ -370,7 +370,7 @@ export default function BuilderPanel(props: Props) {
                 class="w-full px-2 py-1 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
                 placeholder="Number of top coins"
               />
-              <p class="text-[10px] text-[--color-text-muted] mt-0.5 font-mono">Top {localTopN} coins by data size (most candles available)</p>
+              <p class="text-[10px] text-[--color-text-muted] mt-0.5 font-mono">{props.t.topNCoinsHint || `Top ${localTopN} coins by data availability`}</p>
             </div>
           )}
           {props.coinMode === 'select' && (

--- a/src/components/SimulatorPage.tsx
+++ b/src/components/SimulatorPage.tsx
@@ -121,6 +121,7 @@ const L = {
     leverageTip:
       "Position size multiplier. 5x means $60 acts like $300. Higher = higher risk",
     perCoinUsdtTip: "Investment amount per coin position",
+    topNCoinsHint: "Top coins by data availability (most candle history)",
     // Results guide
     resultsGuide: "How to read results:",
     resultsGuideWr: "Win Rate > 50%: Good",
@@ -230,6 +231,7 @@ const L = {
     maxBarsTip: "최대 보유 기간(캔들 수). 1시간봉 기준 48 = 48시간",
     leverageTip: "포지션 배율. 5배면 $60이 $300 효과. 높을수록 위험",
     perCoinUsdtTip: "코인당 투자 금액",
+    topNCoinsHint: "데이터 보유량 기준 상위 코인 (캔들 이력 순)",
     // Results guide
     resultsGuide: "결과 해석 가이드:",
     resultsGuideWr: "승률 > 50%: 양호",
@@ -334,23 +336,9 @@ export default function SimulatorPage({ lang = "en" }: Props) {
   const [perCoinUsdt, setPerCoinUsdt] = useState(60);
   const [leverage, setLeverage] = useState(5);
   const [compounding, setCompounding] = useState(false);
-  const prevCoinModeRef = useRef<"all" | "top" | "select">("all");
   const handleCompoundToggle = (v: boolean) => {
     setCompounding(v);
     setPerCoinUsdt(v ? 1000 : 60);  // swap default: total capital vs per-coin
-    if (v) {
-      // Compound ON: if "all" coins, auto-switch to "top" with reasonable default
-      if (coinMode === "all") {
-        prevCoinModeRef.current = "all";
-        setCoinMode("top");
-        setTopN(10);
-      }
-    } else {
-      // Compound OFF: restore to "all" if we auto-switched it
-      if (prevCoinModeRef.current === "all" && coinMode === "top") {
-        setCoinMode("all");
-      }
-    }
   };
 
   // Timeframe


### PR DESCRIPTION
## Summary
- **P0.1**: Remove forced coinMode auto-switch when compound toggled — users can now freely choose all/top/select in both modes
- **P0.2**: Fix capital model — compound mode treats `per_coin_usd` as total portfolio capital, divides by N coins for per-position sizing (was inflating capital by N×)
- **P0.3**: Fix identical `total_return` branches — compound now uses equity tracking for accurate return calculation
- **P0.4**: Fix "Top N coins by data size" label — now i18n with meaningful description (EN/KO)

## Root Cause
Expert analysis (trading + UX) found that compound mode had:
1. No mathematical reason to force "Top 10" — just a defensive hack
2. `initial_capital = per_coin_usd × N_coins` inflated capital in compound mode (user sets $1000 total, backend calculates $1000 × 50 = $50,000)
3. Both compound/simple `total_return` used identical formula `total_pnl_usd / initial_capital`

## Test plan
- [ ] Toggle compound ON → verify coinMode stays unchanged (all/top/select)
- [ ] Run compound backtest with $1000 on 50 coins → verify initial_capital = $1000 (not $50,000)
- [ ] Compare compound vs simple total_return — should differ
- [ ] Check "Top N" hint text in EN and KO

🤖 Generated with [Claude Code](https://claude.com/claude-code)