### PR TITLE
fix: NameError in /simulate — coins_used → coins

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -767,7 +767,7 @@ async def simulate(req: SimulationRequest):
         day_key = t.get("exit_time", t["time"])[:10]  # YYYY-MM-DD (exit time)
         daily_pnl_sim[day_key] += t["pnl_pct"]
     # Normalize by number of concurrent positions for capital-weighted daily returns
-    n_coins = len(coins_used) if coins_used else 1
+    n_coins = len(coins) if coins else 1
     # Fill zero-return days so Sharpe isn't inflated by excluding non-trading days
     if daily_pnl_sim and len(daily_pnl_sim) >= 2:
         from datetime import datetime as _dt_sim, timedelta as _td_sim


### PR DESCRIPTION
## Summary
- `/simulate` endpoint crashed with `NameError: name 'coins_used' is not defined`
- Introduced in PR#345 Sharpe zero-fill patch — referenced wrong variable name
- The correct variable in `/simulate` scope is `coins`, not `coins_used`

## Test plan
- [ ] `POST /simulate {"symbol":"BTCUSDT","direction":"SHORT"}` → returns trades (not 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)