### PR TITLE
fix: Calmar ratio uses calendar days (27.5x inflation fix)

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -792,7 +792,8 @@ async def simulate(req: SimulationRequest):
         tdd = float(np.sqrt(np.mean(downside_sim ** 2)))
         sortino = round(dr_avg / tdd * np.sqrt(365), 2) if tdd > 0 else 0.0
         # Calmar: CAGR / MDD (compound annualized growth rate — industry standard)
-        n_days_sim = len(daily_pnl_sim)
+        # Use calendar days from daily_returns_sim (already zero-filled) for accurate annualization
+        n_days_sim = len(daily_returns_sim)
         growth_ratio_sim = equity / 100.0 if equity > 0 else 0.001
         years_sim = max(n_days_sim, 1) / 365
         cagr_pct_sim = (growth_ratio_sim ** (1 / years_sim) - 1) * 100 if years_sim > 0 else 0.0
@@ -2456,7 +2457,8 @@ async def run_backtest(req: BacktestRequest):
         tdd_bt = float(np.sqrt(np.mean(downside_bt ** 2)))
         bt_sortino = round(dr_avg / tdd_bt * np.sqrt(365), 2) if tdd_bt > 0 else 0.0
         # Calmar = CAGR / MDD (compound annualized growth rate — industry standard)
-        n_days = len(daily_pnl)
+        # Use calendar days from daily_returns (already zero-filled) for accurate annualization
+        n_days = len(daily_returns)
         growth_ratio_bt = equity / 100.0 if equity > 0 else 0.001
         years_bt = max(n_days, 1) / 365
         cagr_pct_bt = (growth_ratio_bt ** (1 / years_bt) - 1) * 100 if years_bt > 0 else 0.0

--- a/backend/src/simulation/engine.py
+++ b/backend/src/simulation/engine.py
@@ -356,9 +356,12 @@ class SimulationEngine:
             tdd = float(np.sqrt(np.mean(downside ** 2)))
             sortino = round(dr_avg / tdd * np.sqrt(365), 2) if tdd > 0 else 0.0
             # Calmar: CAGR / MDD (compound annualized growth rate)
-            n_days_eng = len(daily_pnl_eng)
+            # Use calendar days (not trade days) for accurate annualization
+            sorted_days_eng = sorted(daily_pnl_eng.keys())
+            from datetime import datetime as _dt_calmar_eng
+            n_calendar_days_eng = (_dt_calmar_eng.strptime(sorted_days_eng[-1], "%Y-%m-%d") - _dt_calmar_eng.strptime(sorted_days_eng[0], "%Y-%m-%d")).days + 1
             growth_ratio_eng = (equity + 100) / 100 if equity > -100 else 0.001
-            years_eng = max(n_days_eng, 1) / 365
+            years_eng = max(n_calendar_days_eng, 1) / 365
             cagr_pct_eng = (growth_ratio_eng ** (1 / years_eng) - 1) * 100 if years_eng > 0 else 0.0
             calmar = round(cagr_pct_eng / max_dd, 2) if max_dd > 0 else 0.0
         else:

--- a/backend/src/simulation/engine_fast.py
+++ b/backend/src/simulation/engine_fast.py
@@ -371,10 +371,13 @@ def run_fast(
         tdd = float(np.sqrt(np.mean(downside ** 2)))
         sortino = round(dr_avg / tdd * np.sqrt(365), 2) if tdd > 0 else 0.0
         # Calmar: CAGR / MDD (CAGR = compound annualized growth rate)
-        n_days = len(daily_pnl)
+        # Use calendar days (not trade days) for accurate annualization
+        sorted_days_fast = sorted(daily_pnl.keys())
+        from datetime import datetime as _dt_calmar_fast
+        n_calendar_days = (_dt_calmar_fast.strptime(sorted_days_fast[-1], "%Y-%m-%d") - _dt_calmar_fast.strptime(sorted_days_fast[0], "%Y-%m-%d")).days + 1
         # equity starts at 0, so final = total_return (pct points). Convert to growth ratio.
         growth_ratio = (equity + 100) / 100 if equity > -100 else 0.001  # avoid <=0
-        years = max(n_days, 1) / 365
+        years = max(n_calendar_days, 1) / 365
         cagr_pct = (growth_ratio ** (1 / years) - 1) * 100 if years > 0 else 0.0
         calmar = round(cagr_pct / max_dd, 2) if max_dd > 0 else 0.0
     else:


### PR DESCRIPTION
## Summary
- **P1 Bug**: Calmar ratio was inflated 27.5x because `n_days = len(daily_pnl)` counted only trade days (48) instead of calendar days (803)
- CAGR period compressed by 16.7x → Calmar = 8.23 instead of correct 0.30
- Fixed in 4 locations across 3 files (engine.py, engine_fast.py, main.py)

## Root Cause
```python
# Before (bug): counts only days with trades
n_days = len(daily_pnl)  # e.g., 48 trade days

# After (fix): uses actual calendar span
# engine.py/engine_fast.py: compute from date keys
n_calendar_days = (last_date - first_date).days + 1  # e.g., 803 days

# main.py: use already zero-filled daily_returns length
n_days = len(daily_returns)  # already filled with all calendar days
```

## Test plan
- [ ] BTCUSDT SHORT bb-squeeze: Calmar should be ~0.30 (was 8.23)
- [ ] Multi-coin simulate: Calmar should be reasonable (< 5.0 for typical strategies)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)