### PR TITLE
fix: condition nesting depth limit + fail-closed admin auth (#354, #355)

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -28,7 +28,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import JSONResponse
 
-ADMIN_API_KEY = os.environ.get("ADMIN_API_KEY", "")
+_admin_key_raw = os.environ.get("ADMIN_API_KEY", "")
+ADMIN_API_KEY: Optional[str] = _admin_key_raw if len(_admin_key_raw) >= 32 else None
 COINGECKO_API_KEY = os.environ.get("COINGECKO_API_KEY", "")
 CG_HEADERS = {"x-cg-demo-api-key": COINGECKO_API_KEY} if COINGECKO_API_KEY else {}
 
@@ -37,6 +38,9 @@ import pandas as pd
 from datetime import datetime, timedelta, timezone
 
 logger = logging.getLogger("pruviq")
+
+if ADMIN_API_KEY is None:
+    logger.warning("ADMIN_API_KEY too short or missing — /admin/refresh disabled")
 
 # Add backend to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -1349,7 +1353,7 @@ async def simulate_validate(req: ValidateRequest):
 @app.post("/admin/refresh")
 async def refresh_data(x_admin_key: str = Header(default="", alias="X-Admin-Key")):
     """Manually trigger data refresh from Binance."""
-    if not ADMIN_API_KEY or not hmac.compare_digest(x_admin_key, ADMIN_API_KEY):
+    if ADMIN_API_KEY is None or not hmac.compare_digest(x_admin_key, ADMIN_API_KEY):
         raise HTTPException(status_code=403, detail="Forbidden")
     await asyncio.to_thread(_refresh_data)
     return {"status": "ok", "coins": indicator_cache.count, "generated": coin_stats_cache["generated"] if coin_stats_cache else None}

--- a/backend/src/engine/condition_engine.py
+++ b/backend/src/engine/condition_engine.py
@@ -35,6 +35,8 @@ from .indicator_pipeline import compute_indicators, get_required_indicators
 
 
 # Supported comparison operators
+MAX_NESTING_DEPTH = 5
+
 _OPS = {
     ">": lambda a, b: a > b,
     ">=": lambda a, b: a >= b,
@@ -181,11 +183,14 @@ class ConditionEngine:
 
     # --- Vectorized evaluation ---
 
-    def _eval_group_vectorized(self, df: pd.DataFrame, group: dict) -> np.ndarray:
+    def _eval_group_vectorized(self, df: pd.DataFrame, group: dict, _depth: int = 0) -> np.ndarray:
         """
         Recursively evaluate AND/OR group of conditions.
         Returns boolean numpy array (length = len(df)).
         """
+        if _depth > MAX_NESTING_DEPTH:
+            raise ValueError(f"Condition nesting exceeds max depth ({MAX_NESTING_DEPTH})")
+
         group_type = group.get("type", "AND").upper()
         conditions = group.get("conditions", [])
 
@@ -196,7 +201,7 @@ class ConditionEngine:
         for cond in conditions:
             if "conditions" in cond:
                 # Nested group
-                results.append(self._eval_group_vectorized(df, cond))
+                results.append(self._eval_group_vectorized(df, cond, _depth=_depth + 1))
             else:
                 # Leaf condition
                 results.append(self._eval_condition_vectorized(df, cond))
@@ -290,8 +295,11 @@ class ConditionEngine:
 
     # --- Per-bar evaluation ---
 
-    def _eval_group_at_bar(self, df: pd.DataFrame, group: dict, idx: int) -> bool:
+    def _eval_group_at_bar(self, df: pd.DataFrame, group: dict, idx: int, _depth: int = 0) -> bool:
         """Evaluate AND/OR group at a specific bar index."""
+        if _depth > MAX_NESTING_DEPTH:
+            raise ValueError(f"Condition nesting exceeds max depth ({MAX_NESTING_DEPTH})")
+
         group_type = group.get("type", "AND").upper()
         conditions = group.get("conditions", [])
 
@@ -300,7 +308,7 @@ class ConditionEngine:
 
         for cond in conditions:
             if "conditions" in cond:
-                result = self._eval_group_at_bar(df, cond, idx)
+                result = self._eval_group_at_bar(df, cond, idx, _depth=_depth + 1)
             else:
                 result = self._eval_condition_at_bar(df, cond, idx)
 


### PR DESCRIPTION
## Summary
- **#354**: Add `MAX_NESTING_DEPTH=5` to `_eval_group_vectorized` and `_eval_group_at_bar` — prevents DoS via deeply nested condition JSON
- **#355**: Require `ADMIN_API_KEY` >= 32 chars at startup; if missing/short, `/admin/refresh` always returns 403

## Test plan
- [ ] Verify existing backtests still produce identical results (depth limit only affects >5 levels, no presets use nesting)
- [ ] Confirm `/admin/refresh` returns 403 without valid 32+ char key
- [ ] Build: 2452 pages, 0 errors

Closes #354
Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)