### PR TITLE
i18n: replace 3 hardcoded UI strings with en/ko labels

### DIFF
--- a/src/components/BuilderPanel.tsx
+++ b/src/components/BuilderPanel.tsx
@@ -101,7 +101,7 @@ export default function BuilderPanel(props: Props) {
       {/* Panel header */}
       <div class="px-4 py-2 border-b border-[--color-border] flex-shrink-0">
         <div class="flex items-center justify-between">
-          <span class="font-mono text-sm text-[--color-accent] tracking-wider font-bold">STRATEGY BUILDER</span>
+          <span class="font-mono text-sm text-[--color-accent] tracking-wider font-bold">{t.strategyBuilder}</span>
           {props.coinsLoaded > 0 && (
             <span class="text-[--color-text-muted] text-xs font-mono">{props.coinsLoaded} coins</span>
           )}

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,8 +1,20 @@
 import { Component } from 'preact';
 import type { ComponentChildren } from 'preact';
 
+const labels = {
+  en: {
+    errorMsg: (name: string) => `Something went wrong loading ${name}.`,
+    retry: 'Retry',
+  },
+  ko: {
+    errorMsg: (name: string) => `${name} 로딩 중 오류가 발생했습니다.`,
+    retry: '다시 시도',
+  },
+};
+
 interface Props {
   name: string;
+  lang?: 'en' | 'ko';
   children: ComponentChildren;
 }
 
@@ -32,16 +44,17 @@ export default class ErrorBoundary extends Component<Props, State> {
 
   render() {
     if (this.state.error) {
+      const t = labels[this.props.lang || 'en'] || labels.en;
       return (
         <div className="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] text-center my-4">
           <p className="font-mono text-sm text-[--color-red] mb-3">
-            Something went wrong loading {this.props.name}.
+            {t.errorMsg(this.props.name)}
           </p>
           <button
             onClick={this.handleRetry}
             className="px-4 py-2 rounded-lg border border-[--color-border] bg-[--color-bg-card] text-[--color-text] font-mono text-sm cursor-pointer hover:border-[--color-accent] transition-colors min-h-[44px]"
           >
-            Retry
+            {t.retry}
           </button>
         </div>
       );

--- a/src/components/PerformanceDashboard.tsx
+++ b/src/components/PerformanceDashboard.tsx
@@ -70,6 +70,7 @@ const labels = {
     worstDay: "Worst Day",
     avgTrade: "Avg Trade",
     dailyChart: "CUMULATIVE PnL",
+    dailyStats: "DAILY STATS",
     exitBreakdown: "EXIT BREAKDOWN",
     recentTrades: "RECENT TRADES",
     tp: "Take Profit",
@@ -108,6 +109,7 @@ const labels = {
     worstDay: "최대 손실일",
     avgTrade: "평균 거래",
     dailyChart: "누적 손익",
+    dailyStats: "일일 통계",
     exitBreakdown: "청산 유형",
     recentTrades: "최근 거래",
     tp: "이익 실현",
@@ -465,7 +467,7 @@ export default function PerformanceDashboard({
         {/* Daily Stats */}
         <div class="p-5 bg-[--color-bg-card] border border-[--color-border] rounded-xl">
           <div class="font-mono text-[0.6875rem] text-[--color-text-muted] tracking-widest uppercase mb-4">
-            DAILY STATS
+            {t.dailyStats}
           </div>
           <div class="flex flex-col gap-3">
             <div class="flex justify-between items-center">

--- a/src/components/SimulatorPage.tsx
+++ b/src/components/SimulatorPage.tsx
@@ -33,6 +33,7 @@ import StandardPanel from "./StandardPanel";
 const L = {
   en: {
     title: "Strategy Simulator",
+    strategyBuilder: "STRATEGY BUILDER",
     previewChart: "Preview Chart",
     conditions: "Entry Conditions",
     addCondition: "+ Add Condition",
@@ -160,6 +161,7 @@ const L = {
   },
   ko: {
     title: "전략 시뮬레이터",
+    strategyBuilder: "전략 빌더",
     previewChart: "미리보기 차트",
     conditions: "진입 조건",
     addCondition: "+ 조건 추가",

--- a/src/pages/ko/coins/[symbol].astro
+++ b/src/pages/ko/coins/[symbol].astro
@@ -160,7 +160,7 @@ const canonicalOverride = symbol.endsWith('usdt') ? undefined : `/ko/coins/${sym
     const mount = document.getElementById('coin-mount');
     if (mount) {
       const symbol = mount.dataset.symbol;
-      render(h(ErrorBoundary, { name: 'Coin Chart' }, h(CoinChart, { symbol, lang: 'ko' })), mount);
+      render(h(ErrorBoundary, { name: 'Coin Chart', lang: 'ko' }, h(CoinChart, { symbol, lang: 'ko' })), mount);
     }
 
     const ctaMount = document.getElementById('exchange-cta-mount');

--- a/src/pages/ko/coins/index.astro
+++ b/src/pages/ko/coins/index.astro
@@ -47,7 +47,7 @@ const t = useTranslations('ko');
 
     const mount = document.getElementById('coins-mount');
     if (mount) {
-      render(h(ErrorBoundary, { name: 'Coin List' }, h(CoinListTable, { lang: 'ko' })), mount);
+      render(h(ErrorBoundary, { name: 'Coin List', lang: 'ko' }, h(CoinListTable, { lang: 'ko' })), mount);
     }
   </script>
 </Layout>

--- a/src/pages/ko/leaderboard.astro
+++ b/src/pages/ko/leaderboard.astro
@@ -18,7 +18,7 @@ const t = useTranslations('ko');
         {t('leaderboard.desc')}
       </p>
 
-      <ErrorBoundary name="Weekly Leaderboard" client:load>
+      <ErrorBoundary name="Weekly Leaderboard" lang="ko" client:load>
         <WeeklyLeaderboard lang="ko" client:load />
       </ErrorBoundary>
 

--- a/src/pages/ko/market/index.astro
+++ b/src/pages/ko/market/index.astro
@@ -48,7 +48,7 @@ const t = useTranslations('ko');
 
     const mount = document.getElementById('market-mount');
     if (mount) {
-      render(h(ErrorBoundary, { name: 'Market Dashboard' }, h(MarketDashboard, { lang: 'ko' })), mount);
+      render(h(ErrorBoundary, { name: 'Market Dashboard', lang: 'ko' }, h(MarketDashboard, { lang: 'ko' })), mount);
     }
   </script>
 </Layout>

--- a/src/pages/ko/simulate/index.astro
+++ b/src/pages/ko/simulate/index.astro
@@ -99,7 +99,7 @@ const t = useTranslations('ko');
 
     const mount = document.getElementById('simulator-mount');
     if (mount) {
-      render(h(ErrorBoundary, { name: 'Simulator' }, h(SimulatorPage, { lang: 'ko' })), mount);
+      render(h(ErrorBoundary, { name: 'Simulator', lang: 'ko' }, h(SimulatorPage, { lang: 'ko' })), mount);
     }
   </script>
 </Layout>

--- a/src/pages/ko/strategies/compare.astro
+++ b/src/pages/ko/strategies/compare.astro
@@ -51,7 +51,7 @@ const t = useTranslations('ko');
 
     const mount = document.getElementById('compare-mount');
     if (mount) {
-      render(h(ErrorBoundary, { name: 'Strategy Comparison' }, h(StrategyComparison, { lang: 'ko' })), mount);
+      render(h(ErrorBoundary, { name: 'Strategy Comparison', lang: 'ko' }, h(StrategyComparison, { lang: 'ko' })), mount);
     }
   </script>
 </Layout>


### PR DESCRIPTION
## Summary
- **BuilderPanel.tsx**: Replace hardcoded `"STRATEGY BUILDER"` with `t.strategyBuilder` (en: "STRATEGY BUILDER", ko: "전략 빌더")
- **PerformanceDashboard.tsx**: Replace hardcoded `"DAILY STATS"` with `t.dailyStats` (en: "DAILY STATS", ko: "일일 통계")
- **ErrorBoundary.tsx**: Add `labels` object with en/ko translations for error message and retry button; add optional `lang` prop; update 6 ko/ page call sites to pass `lang="ko"`

## Test plan
- [x] `npx astro build` passes (2452 pages, 0 errors)
- [x] Pre-existing TS error in ChartPanel.tsx is unrelated
- [ ] Verify en pages show English strings unchanged
- [ ] Verify ko pages show Korean translations
- [ ] Verify ErrorBoundary renders Korean message on ko/ pages when error occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)