### PR TITLE
feat: add avoid_months filter for regime-based signal filtering

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -557,6 +557,12 @@ async def simulate(req: SimulationRequest):
 
     strategy, default_direction, defaults = get_strategy(strategy_id)
 
+    # Override avoid_hours/avoid_months from request if provided
+    if req.avoid_hours is not None:
+        strategy.avoid_hours = req.avoid_hours
+    if getattr(req, 'avoid_months', None) is not None:
+        strategy.avoid_months = req.avoid_months
+
     if is_both:
         directions_to_run = ["short", "long"]
         direction = "both"
@@ -1267,6 +1273,13 @@ async def simulate_validate(req: ValidateRequest):
 
     strategy, default_direction, defaults = get_strategy(strategy_id)
     direction = req.direction if req.direction is not None else default_direction
+
+    # Override avoid_hours/avoid_months from request if provided
+    if getattr(req, 'avoid_hours', None) is not None:
+        strategy.avoid_hours = req.avoid_hours
+    if getattr(req, 'avoid_months', None) is not None:
+        strategy.avoid_months = req.avoid_months
+
     cost_model = CostModel.futures() if req.market_type == "futures" else CostModel.spot()
 
     if resampled:

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -23,6 +23,8 @@ class SimulationRequest(BaseModel):
     end_date: Optional[str] = Field(default=None, description="Backtest end date (YYYY-MM-DD)")
     timeframe: str = Field(default="1H", description="Candle timeframe: 1H, 2H, 4H, 6H, 12H, 1D, 1W")
     compounding: bool = Field(default=False, description="True = reinvest profits (compound), False = fixed position size (simple)")
+    avoid_hours: Optional[List[int]] = Field(default=None, description="UTC hours to avoid entering trades (0-23). null = use strategy default")
+    avoid_months: Optional[List[int]] = Field(default=None, description="Months to avoid entering trades (1-12). null = no month filter")
 
 
 class TradeItem(BaseModel):
@@ -309,6 +311,7 @@ class BacktestRequest(BaseModel):
         description="Entry conditions tree: {'type': 'AND', 'conditions': [...]}"
     )
     avoid_hours: List[int] = Field(default=[], description="UTC hours to avoid (0-23)")
+    avoid_months: Optional[List[int]] = Field(default=None, description="Months to avoid entering trades (1-12). null = no month filter")
     sl_pct: float = Field(default=10.0, ge=0.5, le=50.0, description="Stop Loss %")
     tp_pct: float = Field(default=8.0, ge=0.5, le=100.0, description="Take Profit %")
     max_bars: int = Field(default=48, ge=1, le=168, description="Max holding period (bars)")
@@ -542,6 +545,8 @@ class ValidateRequest(BaseModel):
     start_date: Optional[str] = Field(default=None, description="Backtest start date (YYYY-MM-DD)")
     end_date: Optional[str] = Field(default=None, description="Backtest end date (YYYY-MM-DD)")
     timeframe: str = Field(default="1H", description="Candle timeframe: 1H, 2H, 4H, 6H, 12H, 1D, 1W")
+    avoid_hours: Optional[List[int]] = Field(default=None, description="UTC hours to avoid entering trades (0-23). null = use strategy default")
+    avoid_months: Optional[List[int]] = Field(default=None, description="Months to avoid entering trades (1-12). null = no month filter")
 
 
 class ValidateResponse(BaseModel):

--- a/backend/src/simulation/engine_fast.py
+++ b/backend/src/simulation/engine_fast.py
@@ -125,10 +125,22 @@ def find_signals_vectorized(df: pd.DataFrame, strategy, direction: str = "short"
                 next_hour_ok[i] = False
     next_hour_ok[n - 1] = False  # Can't enter on last bar
 
+    # avoid_months filter (entry bar = idx+1 month)
+    avoid_months_set = set(getattr(strategy, 'avoid_months', None) or [])
+    next_month_ok = np.ones(n, dtype=bool)
+    if avoid_months_set and "timestamp" in df.columns:
+        months = pd.to_datetime(df["timestamp"]).dt.month.values
+        next_months = np.empty(n, dtype=int)
+        next_months[:-1] = months[1:]
+        next_months[-1] = 0
+        for m in avoid_months_set:
+            next_month_ok &= (next_months != m)
+    next_month_ok[n - 1] = False
+
     # Combine base conditions
     base_ok = (
         valid_range & has_recent_squeeze & has_bb_expanding
-        & has_bb_above_ma & has_volume & has_expansion_speed & next_hour_ok
+        & has_bb_above_ma & has_volume & has_expansion_speed & next_hour_ok & next_month_ok
     )
 
     # Direction-specific conditions
@@ -190,8 +202,20 @@ def find_signals_momentum(df: pd.DataFrame, strategy, direction: str = "long") -
             next_hour_ok &= (next_hour != h)
     next_hour_ok[-1] = False  # Can't enter on last bar
 
+    # avoid_months filter (entry bar = idx+1 month)
+    avoid_months_set = set(getattr(strategy, 'avoid_months', None) or [])
+    next_month_ok = np.ones(n, dtype=bool)
+    if avoid_months_set and "timestamp" in df.columns:
+        months = pd.to_datetime(df["timestamp"]).dt.month.values
+        next_months = np.empty(n, dtype=int)
+        next_months[:-1] = months[1:]
+        next_months[-1] = 0
+        for m in avoid_months_set:
+            next_month_ok &= (next_months != m)
+    next_month_ok[-1] = False
+
     # Combine all conditions
-    signal = valid_range & has_breakout & has_volume & has_uptrend & next_hour_ok
+    signal = valid_range & has_breakout & has_volume & has_uptrend & next_hour_ok & next_month_ok
 
     # For "short" direction (unlikely but for completeness), no signals
     if direction != "long":
@@ -268,8 +292,20 @@ def find_signals_hv_squeeze(df: pd.DataFrame, strategy, direction: str = "short"
             next_hour_ok &= (next_hour != h)
     next_hour_ok[-1] = False
 
+    # avoid_months filter (entry bar = idx+1 month)
+    avoid_months_set = set(getattr(strategy, 'avoid_months', None) or [])
+    next_month_ok = np.ones(n, dtype=bool)
+    if avoid_months_set and "timestamp" in df.columns:
+        months = pd.to_datetime(df["timestamp"]).dt.month.values
+        next_months = np.empty(n, dtype=int)
+        next_months[:-1] = months[1:]
+        next_months[-1] = 0
+        for m in avoid_months_set:
+            next_month_ok &= (next_months != m)
+    next_month_ok[-1] = False
+
     # Base conditions
-    base_ok = valid_range & has_recent_squeeze & has_expanding & has_volume & valid_bb & next_hour_ok
+    base_ok = valid_range & has_recent_squeeze & has_expanding & has_volume & valid_bb & next_hour_ok & next_month_ok
 
     # Direction
     if direction == "long":
@@ -322,7 +358,19 @@ def find_signals_atr_breakout(df: pd.DataFrame, strategy, direction: str = "long
             next_hour_ok &= (next_hour != h)
     next_hour_ok[-1] = False
 
-    base = valid_range & next_hour_ok
+    # avoid_months filter (entry bar = idx+1 month)
+    avoid_months_set = set(getattr(strategy, 'avoid_months', None) or [])
+    next_month_ok = np.ones(n, dtype=bool)
+    if avoid_months_set and "timestamp" in df.columns:
+        months = pd.to_datetime(df["timestamp"]).dt.month.values
+        next_months = np.empty(n, dtype=int)
+        next_months[:-1] = months[1:]
+        next_months[-1] = 0
+        for m in avoid_months_set:
+            next_month_ok &= (next_months != m)
+    next_month_ok[-1] = False
+
+    base = valid_range & next_hour_ok & next_month_ok
 
     if strategy.use_trend_filter:
         signal_long = base & breakout_up & uptrend

--- a/backend/src/strategies/atr_breakout.py
+++ b/backend/src/strategies/atr_breakout.py
@@ -36,6 +36,7 @@ class ATRBreakoutStrategy:
         ema_slow: int = 50,
         use_trend_filter: bool = True,
         avoid_hours: list = None,
+        avoid_months: list = None,
     ):
         self.atr_period = atr_period
         self.atr_multiplier = atr_multiplier
@@ -43,6 +44,7 @@ class ATRBreakoutStrategy:
         self.ema_slow = ema_slow
         self.use_trend_filter = use_trend_filter
         self.avoid_hours = avoid_hours or []
+        self.avoid_months = avoid_months or []
 
     def get_params(self) -> dict:
         return {
@@ -52,6 +54,7 @@ class ATRBreakoutStrategy:
             "ema_slow": self.ema_slow,
             "use_trend_filter": self.use_trend_filter,
             "avoid_hours": self.avoid_hours,
+            "avoid_months": self.avoid_months,
         }
 
     def calculate_indicators(self, df: pd.DataFrame) -> pd.DataFrame:

--- a/backend/src/strategies/bb_squeeze.py
+++ b/backend/src/strategies/bb_squeeze.py
@@ -38,6 +38,7 @@ class BBSqueezeStrategy:
         ema_fast: int = 20,
         ema_slow: int = 50,
         avoid_hours: list = None,
+        avoid_months: list = None,
     ):
         self.bb_period = bb_period
         self.bb_std = bb_std
@@ -50,6 +51,7 @@ class BBSqueezeStrategy:
         self.ema_fast = ema_fast
         self.ema_slow = ema_slow
         self.avoid_hours = avoid_hours or []
+        self.avoid_months = avoid_months or []
 
     def get_params(self) -> dict:
         return {
@@ -62,6 +64,7 @@ class BBSqueezeStrategy:
             "ema_fast": self.ema_fast,
             "ema_slow": self.ema_slow,
             "avoid_hours": self.avoid_hours,
+            "avoid_months": self.avoid_months,
         }
 
     def calculate_indicators(self, df: pd.DataFrame) -> pd.DataFrame:

--- a/backend/src/strategies/hv_squeeze.py
+++ b/backend/src/strategies/hv_squeeze.py
@@ -38,6 +38,7 @@ class HVSqueezeStrategy:
         volume_ratio: float = 1.5,
         volume_ma_period: int = 20,
         avoid_hours: list = None,
+        avoid_months: list = None,
     ):
         self.bb_period = bb_period
         self.bb_std = bb_std
@@ -46,6 +47,7 @@ class HVSqueezeStrategy:
         self.volume_ratio = volume_ratio
         self.volume_ma_period = volume_ma_period
         self.avoid_hours = avoid_hours or []
+        self.avoid_months = avoid_months or []
 
     def get_params(self) -> dict:
         return {
@@ -55,6 +57,7 @@ class HVSqueezeStrategy:
             "squeeze_threshold": self.squeeze_threshold,
             "volume_ratio": self.volume_ratio,
             "avoid_hours": self.avoid_hours,
+            "avoid_months": self.avoid_months,
         }
 
     def calculate_indicators(self, df: pd.DataFrame) -> pd.DataFrame:

--- a/backend/src/strategies/momentum_long.py
+++ b/backend/src/strategies/momentum_long.py
@@ -32,6 +32,7 @@ class MomentumLongStrategy:
         ema_fast: int = 20,
         ema_slow: int = 50,
         avoid_hours: list = None,
+        avoid_months: list = None,
     ):
         self.breakout_lookback = breakout_lookback
         self.volume_ratio = volume_ratio
@@ -39,6 +40,7 @@ class MomentumLongStrategy:
         self.ema_fast = ema_fast
         self.ema_slow = ema_slow
         self.avoid_hours = avoid_hours or [1, 2, 3, 8, 9, 13, 15, 16, 17, 18, 19, 20, 21, 22, 23]
+        self.avoid_months = avoid_months or []
 
     def get_params(self) -> dict:
         return {
@@ -47,6 +49,7 @@ class MomentumLongStrategy:
             "ema_fast": self.ema_fast,
             "ema_slow": self.ema_slow,
             "avoid_hours": self.avoid_hours,
+            "avoid_months": self.avoid_months,
         }
 
     def calculate_indicators(self, df: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- Add `avoid_months` parameter to all 4 strategies for month-based trade filtering
- Add `avoid_hours` + `avoid_months` fields to `SimulationRequest` and `ValidateRequest` (previously only in `BacktestRequest`)
- Override strategy defaults from API request params in `/simulate` and `/simulate/validate` endpoints
- Entry bar (idx+1) month is checked, consistent with `avoid_hours` pattern

## Changes
- `schemas.py`: 3 schemas updated (SimulationRequest, BacktestRequest, ValidateRequest)
- `bb_squeeze.py`, `momentum_long.py`, `hv_squeeze.py`, `atr_breakout.py`: `avoid_months` param added
- `engine_fast.py`: 4 signal detection functions updated with month filter
- `main.py`: 2 endpoints updated with request param override logic

## Test plan
- [ ] `avoid_months=null` → same behavior as before (backward compatible)
- [ ] `avoid_months=[1]` → January trades filtered out (fewer trades)
- [ ] `avoid_hours=[]` → time filter disabled (more trades)
- [ ] `avoid_hours=null` → strategy default used

🤖 Generated with [Claude Code](https://claude.com/claude-code)