### PR TITLE
feat: add ATR coin-level volatility filter (min_vol_regime)

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -557,11 +557,13 @@ async def simulate(req: SimulationRequest):
 
     strategy, default_direction, defaults = get_strategy(strategy_id)
 
-    # Override avoid_hours/avoid_months from request if provided
+    # Override avoid_hours/avoid_months/min_vol_regime from request if provided
     if req.avoid_hours is not None:
         strategy.avoid_hours = req.avoid_hours
     if getattr(req, 'avoid_months', None) is not None:
         strategy.avoid_months = req.avoid_months
+    if getattr(req, 'min_vol_regime', None) is not None:
+        strategy.min_vol_regime = req.min_vol_regime
 
     if is_both:
         directions_to_run = ["short", "long"]
@@ -1274,11 +1276,13 @@ async def simulate_validate(req: ValidateRequest):
     strategy, default_direction, defaults = get_strategy(strategy_id)
     direction = req.direction if req.direction is not None else default_direction
 
-    # Override avoid_hours/avoid_months from request if provided
+    # Override avoid_hours/avoid_months/min_vol_regime from request if provided
     if getattr(req, 'avoid_hours', None) is not None:
         strategy.avoid_hours = req.avoid_hours
     if getattr(req, 'avoid_months', None) is not None:
         strategy.avoid_months = req.avoid_months
+    if getattr(req, 'min_vol_regime', None) is not None:
+        strategy.min_vol_regime = req.min_vol_regime
 
     cost_model = CostModel.futures() if req.market_type == "futures" else CostModel.spot()
 

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -25,6 +25,7 @@ class SimulationRequest(BaseModel):
     compounding: bool = Field(default=False, description="True = reinvest profits (compound), False = fixed position size (simple)")
     avoid_hours: Optional[List[int]] = Field(default=None, description="UTC hours to avoid entering trades (0-23). null = use strategy default")
     avoid_months: Optional[List[int]] = Field(default=None, description="Months to avoid entering trades (1-12). null = no month filter")
+    min_vol_regime: Optional[float] = Field(default=None, description="Minimum ATR ratio (current ATR / 14-period ATR MA) to allow entry. e.g., 0.7 = skip low-volatility periods. null = no filter")
 
 
 class TradeItem(BaseModel):
@@ -312,6 +313,7 @@ class BacktestRequest(BaseModel):
     )
     avoid_hours: List[int] = Field(default=[], description="UTC hours to avoid (0-23)")
     avoid_months: Optional[List[int]] = Field(default=None, description="Months to avoid entering trades (1-12). null = no month filter")
+    min_vol_regime: Optional[float] = Field(default=None, description="Minimum ATR ratio (current ATR / 14-period ATR MA) to allow entry. e.g., 0.7 = skip low-volatility periods. null = no filter")
     sl_pct: float = Field(default=10.0, ge=0.5, le=50.0, description="Stop Loss %")
     tp_pct: float = Field(default=8.0, ge=0.5, le=100.0, description="Take Profit %")
     max_bars: int = Field(default=48, ge=1, le=168, description="Max holding period (bars)")
@@ -547,6 +549,7 @@ class ValidateRequest(BaseModel):
     timeframe: str = Field(default="1H", description="Candle timeframe: 1H, 2H, 4H, 6H, 12H, 1D, 1W")
     avoid_hours: Optional[List[int]] = Field(default=None, description="UTC hours to avoid entering trades (0-23). null = use strategy default")
     avoid_months: Optional[List[int]] = Field(default=None, description="Months to avoid entering trades (1-12). null = no month filter")
+    min_vol_regime: Optional[float] = Field(default=None, description="Minimum ATR ratio (current ATR / 14-period ATR MA) to allow entry. e.g., 0.7 = skip low-volatility periods. null = no filter")
 
 
 class ValidateResponse(BaseModel):

--- a/backend/src/simulation/engine_fast.py
+++ b/backend/src/simulation/engine_fast.py
@@ -55,6 +55,50 @@ class SimResult:
     equity_curve: list = field(default_factory=list)
 
 
+def _compute_vol_regime_filter(df: pd.DataFrame, n: int, min_vol_regime: float) -> np.ndarray:
+    """
+    Compute ATR-based volatility regime filter.
+
+    Returns a boolean array of length n where True = volatility is sufficient for entry.
+    ATR ratio = current ATR(14) / 14-period MA of ATR. Entries allowed when ratio >= min_vol_regime.
+    """
+    vol_regime_ok = np.ones(n, dtype=bool)
+    if min_vol_regime is None:
+        return vol_regime_ok
+    if "high" not in df.columns or "low" not in df.columns or "close" not in df.columns:
+        return vol_regime_ok
+
+    high = df["high"].values.astype(float)
+    low = df["low"].values.astype(float)
+    close = df["close"].values.astype(float)
+
+    # True Range calculation
+    tr = np.empty(n)
+    tr[0] = high[0] - low[0]
+    for i in range(1, n):
+        tr[i] = max(high[i] - low[i], abs(high[i] - close[i - 1]), abs(low[i] - close[i - 1]))
+
+    # 14-period ATR (EMA-style, matching standard ATR)
+    atr_period = 14
+    atr = np.full(n, np.nan)
+    if n >= atr_period:
+        atr[atr_period - 1] = np.mean(tr[:atr_period])
+        for i in range(atr_period, n):
+            atr[i] = (atr[i - 1] * (atr_period - 1) + tr[i]) / atr_period
+
+    # ATR moving average (14-period SMA of ATR)
+    atr_ma = np.full(n, np.nan)
+    if n >= 2 * atr_period:
+        for i in range(2 * atr_period - 2, n):
+            atr_ma[i] = np.mean(atr[i - atr_period + 1:i + 1])
+
+    # ATR ratio
+    atr_ratio = np.where((atr_ma > 0) & ~np.isnan(atr_ma), atr / atr_ma, np.nan)
+    vol_regime_ok = np.where(np.isnan(atr_ratio), False, atr_ratio >= min_vol_regime)
+
+    return vol_regime_ok
+
+
 def find_signals_vectorized(df: pd.DataFrame, strategy, direction: str = "short") -> np.ndarray:
     """
     Vectorized signal detection for BB Squeeze — AutoTrader v1.7.0 parity.
@@ -137,10 +181,15 @@ def find_signals_vectorized(df: pd.DataFrame, strategy, direction: str = "short"
             next_month_ok &= (next_months != m)
     next_month_ok[n - 1] = False
 
+    # ATR volatility regime filter
+    min_vol_regime = getattr(strategy, 'min_vol_regime', None)
+    vol_regime_ok = _compute_vol_regime_filter(df, n, min_vol_regime)
+
     # Combine base conditions
     base_ok = (
         valid_range & has_recent_squeeze & has_bb_expanding
         & has_bb_above_ma & has_volume & has_expansion_speed & next_hour_ok & next_month_ok
+        & vol_regime_ok
     )
 
     # Direction-specific conditions
@@ -214,8 +263,12 @@ def find_signals_momentum(df: pd.DataFrame, strategy, direction: str = "long") -
             next_month_ok &= (next_months != m)
     next_month_ok[-1] = False
 
+    # ATR volatility regime filter
+    min_vol_regime = getattr(strategy, 'min_vol_regime', None)
+    vol_regime_ok = _compute_vol_regime_filter(df, n, min_vol_regime)
+
     # Combine all conditions
-    signal = valid_range & has_breakout & has_volume & has_uptrend & next_hour_ok & next_month_ok
+    signal = valid_range & has_breakout & has_volume & has_uptrend & next_hour_ok & next_month_ok & vol_regime_ok
 
     # For "short" direction (unlikely but for completeness), no signals
     if direction != "long":
@@ -304,8 +357,12 @@ def find_signals_hv_squeeze(df: pd.DataFrame, strategy, direction: str = "short"
             next_month_ok &= (next_months != m)
     next_month_ok[-1] = False
 
+    # ATR volatility regime filter
+    min_vol_regime = getattr(strategy, 'min_vol_regime', None)
+    vol_regime_ok = _compute_vol_regime_filter(df, n, min_vol_regime)
+
     # Base conditions
-    base_ok = valid_range & has_recent_squeeze & has_expanding & has_volume & valid_bb & next_hour_ok & next_month_ok
+    base_ok = valid_range & has_recent_squeeze & has_expanding & has_volume & valid_bb & next_hour_ok & next_month_ok & vol_regime_ok
 
     # Direction
     if direction == "long":
@@ -370,7 +427,11 @@ def find_signals_atr_breakout(df: pd.DataFrame, strategy, direction: str = "long
             next_month_ok &= (next_months != m)
     next_month_ok[-1] = False
 
-    base = valid_range & next_hour_ok & next_month_ok
+    # ATR volatility regime filter
+    min_vol_regime = getattr(strategy, 'min_vol_regime', None)
+    vol_regime_ok = _compute_vol_regime_filter(df, n, min_vol_regime)
+
+    base = valid_range & next_hour_ok & next_month_ok & vol_regime_ok
 
     if strategy.use_trend_filter:
         signal_long = base & breakout_up & uptrend

--- a/backend/src/strategies/atr_breakout.py
+++ b/backend/src/strategies/atr_breakout.py
@@ -37,6 +37,7 @@ class ATRBreakoutStrategy:
         use_trend_filter: bool = True,
         avoid_hours: list = None,
         avoid_months: list = None,
+        min_vol_regime: float = None,
     ):
         self.atr_period = atr_period
         self.atr_multiplier = atr_multiplier
@@ -45,6 +46,7 @@ class ATRBreakoutStrategy:
         self.use_trend_filter = use_trend_filter
         self.avoid_hours = avoid_hours or []
         self.avoid_months = avoid_months or []
+        self.min_vol_regime = min_vol_regime
 
     def get_params(self) -> dict:
         return {

--- a/backend/src/strategies/bb_squeeze.py
+++ b/backend/src/strategies/bb_squeeze.py
@@ -39,6 +39,7 @@ class BBSqueezeStrategy:
         ema_slow: int = 50,
         avoid_hours: list = None,
         avoid_months: list = None,
+        min_vol_regime: float = None,
     ):
         self.bb_period = bb_period
         self.bb_std = bb_std
@@ -52,6 +53,7 @@ class BBSqueezeStrategy:
         self.ema_slow = ema_slow
         self.avoid_hours = avoid_hours or []
         self.avoid_months = avoid_months or []
+        self.min_vol_regime = min_vol_regime
 
     def get_params(self) -> dict:
         return {

--- a/backend/src/strategies/hv_squeeze.py
+++ b/backend/src/strategies/hv_squeeze.py
@@ -39,6 +39,7 @@ class HVSqueezeStrategy:
         volume_ma_period: int = 20,
         avoid_hours: list = None,
         avoid_months: list = None,
+        min_vol_regime: float = None,
     ):
         self.bb_period = bb_period
         self.bb_std = bb_std
@@ -48,6 +49,7 @@ class HVSqueezeStrategy:
         self.volume_ma_period = volume_ma_period
         self.avoid_hours = avoid_hours or []
         self.avoid_months = avoid_months or []
+        self.min_vol_regime = min_vol_regime
 
     def get_params(self) -> dict:
         return {

--- a/backend/src/strategies/momentum_long.py
+++ b/backend/src/strategies/momentum_long.py
@@ -33,6 +33,7 @@ class MomentumLongStrategy:
         ema_slow: int = 50,
         avoid_hours: list = None,
         avoid_months: list = None,
+        min_vol_regime: float = None,
     ):
         self.breakout_lookback = breakout_lookback
         self.volume_ratio = volume_ratio
@@ -41,6 +42,7 @@ class MomentumLongStrategy:
         self.ema_slow = ema_slow
         self.avoid_hours = avoid_hours or [1, 2, 3, 8, 9, 13, 15, 16, 17, 18, 19, 20, 21, 22, 23]
         self.avoid_months = avoid_months or []
+        self.min_vol_regime = min_vol_regime
 
     def get_params(self) -> dict:
         return {


### PR DESCRIPTION
## Summary
- Add `min_vol_regime` parameter across the PRUVIQ simulator backend to filter out low-volatility coin entries
- ATR ratio = current ATR(14) / 14-period SMA of ATR. When ratio < threshold, entry signals are suppressed
- Default `null` = no filtering (backward compatible)

## Changes
- **4 strategies** (`bb_squeeze`, `momentum_long`, `hv_squeeze`, `atr_breakout`): add `min_vol_regime: float = None` to `__init__`
- **schemas.py**: add `min_vol_regime` field to `SimulationRequest`, `BacktestRequest`, `ValidateRequest`
- **engine_fast.py**: add `_compute_vol_regime_filter()` helper function, integrate `& vol_regime_ok` into all 4 vectorized signal functions
- **main.py**: add override passthrough in `/simulate` and `/simulate/validate` endpoints

## Test plan
- [x] Unit test: strategy constructors accept `min_vol_regime` parameter
- [x] Unit test: schemas accept `min_vol_regime` field (None default, float values)
- [x] Unit test: `_compute_vol_regime_filter()` returns all-True for `None`, filters correctly for threshold values
- [ ] Integration test: `/simulate` with `min_vol_regime=0.7` returns fewer trades than without
- [ ] Integration test: `/simulate/validate` with `min_vol_regime` passes through correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)