### PR TITLE
feat: 6 new strategies — RSI Divergence, MACD Cross, Donchian, Mean Reversion, SuperTrend, Keltner Squeeze

### DIFF
--- a/backend/src/simulation/engine_fast.py
+++ b/backend/src/simulation/engine_fast.py
@@ -450,6 +450,439 @@ def find_signals_atr_breakout(df: pd.DataFrame, strategy, direction: str = "long
     return np.where(signal)[0]
 
 
+def find_signals_rsi_divergence(df: pd.DataFrame, strategy, direction: str = "both") -> np.ndarray:
+    """
+    Vectorized signal detection for RSI Divergence strategy.
+
+    LONG: RSI < oversold + 가격 신저점 + RSI는 lookback 내 RSI min보다 높음
+    SHORT: RSI > overbought + 가격 신고점 + RSI는 lookback 내 RSI max보다 낮음
+
+    lookback 롤링 통계를 shift(1)로 계산해 look-ahead 방지.
+    """
+    n = len(df)
+    if n < 100:
+        return np.array([], dtype=int)
+
+    def col(name, default=None):
+        if name in df.columns:
+            return df[name].values
+        if default is not None:
+            return default
+        return np.zeros(n)
+
+    close = col("close")
+    rsi = col("rsi")
+    hour = col("hour", np.zeros(n, dtype=int))
+
+    lookback = strategy.lookback
+    min_idx = strategy.rsi_period + lookback
+    valid_range = np.arange(n) >= min_idx
+
+    # Rolling min/max over lookback window (shift=1: 현재 캔들 제외)
+    rsi_series = pd.Series(rsi)
+    close_series = pd.Series(close)
+
+    # shift(1)한 뒤 rolling: 현재 idx 제외하고 이전 lookback 캔들의 통계
+    rsi_min_prev = rsi_series.shift(1).rolling(lookback, min_periods=1).min().values
+    rsi_max_prev = rsi_series.shift(1).rolling(lookback, min_periods=1).max().values
+    close_min_prev = close_series.shift(1).rolling(lookback, min_periods=1).min().values
+    close_max_prev = close_series.shift(1).rolling(lookback, min_periods=1).max().values
+
+    valid_rsi = ~np.isnan(rsi) & ~np.isnan(rsi_min_prev) & ~np.isnan(rsi_max_prev)
+
+    # LONG conditions
+    is_oversold = rsi < strategy.oversold
+    price_new_low = close < close_min_prev
+    rsi_diverge_up = rsi > rsi_min_prev  # RSI는 이전 최저보다 높음
+    long_cond = valid_range & valid_rsi & is_oversold & price_new_low & rsi_diverge_up
+
+    # SHORT conditions
+    is_overbought = rsi > strategy.overbought
+    price_new_high = close > close_max_prev
+    rsi_diverge_down = rsi < rsi_max_prev  # RSI는 이전 최고보다 낮음
+    short_cond = valid_range & valid_rsi & is_overbought & price_new_high & rsi_diverge_down
+
+    # Time filter (entry bar = idx+1)
+    avoid_set = set(strategy.avoid_hours)
+    next_hour_ok = np.ones(n, dtype=bool)
+    if avoid_set:
+        for i in range(n - 1):
+            if int(hour[i + 1]) in avoid_set:
+                next_hour_ok[i] = False
+    next_hour_ok[n - 1] = False
+
+    # avoid_months filter
+    avoid_months_set = set(getattr(strategy, 'avoid_months', None) or [])
+    next_month_ok = np.ones(n, dtype=bool)
+    if avoid_months_set and "timestamp" in df.columns:
+        months = pd.to_datetime(df["timestamp"]).dt.month.values
+        next_months = np.empty(n, dtype=int)
+        next_months[:-1] = months[1:]
+        next_months[-1] = 0
+        for m in avoid_months_set:
+            next_month_ok &= (next_months != m)
+    next_month_ok[n - 1] = False
+
+    min_vol_regime = getattr(strategy, 'min_vol_regime', None)
+    vol_regime_ok = _compute_vol_regime_filter(df, n, min_vol_regime)
+
+    filters = next_hour_ok & next_month_ok & vol_regime_ok
+
+    if direction == "long":
+        signal = long_cond & filters
+    elif direction == "short":
+        signal = short_cond & filters
+    else:
+        signal = (long_cond | short_cond) & filters
+
+    return np.where(signal)[0]
+
+
+def find_signals_macd_cross(df: pd.DataFrame, strategy, direction: str = "both") -> np.ndarray:
+    """
+    Vectorized signal detection for MACD Cross strategy.
+
+    LONG: macd_cross_up (골든크로스) + macd_line < 0
+    SHORT: macd_cross_down (데드크로스) + macd_line > 0
+    """
+    n = len(df)
+    if n < 100:
+        return np.array([], dtype=int)
+
+    def col(name, default=None):
+        if name in df.columns:
+            return df[name].values
+        if default is not None:
+            return default
+        return np.zeros(n)
+
+    macd_line = col("macd_line")
+    macd_hist = col("macd_hist")
+    hour = col("hour", np.zeros(n, dtype=int))
+
+    min_idx = strategy.slow + strategy.signal + 1
+    valid_range = np.arange(n) >= min_idx
+
+    # 교차 감지: hist 부호 전환 (shift=1로 prev hist)
+    prev_hist = np.roll(macd_hist, 1)
+    prev_hist[0] = 0.0
+    cross_up = (prev_hist < 0) & (macd_hist > 0)    # 골든크로스
+    cross_down = (prev_hist > 0) & (macd_hist < 0)  # 데드크로스
+
+    valid_macd = ~np.isnan(macd_line) & ~np.isnan(macd_hist)
+
+    long_cond = valid_range & valid_macd & cross_up & (macd_line < 0)
+    short_cond = valid_range & valid_macd & cross_down & (macd_line > 0)
+
+    # Time filter (entry bar = idx+1)
+    avoid_set = set(strategy.avoid_hours)
+    next_hour_ok = np.ones(n, dtype=bool)
+    if avoid_set:
+        for i in range(n - 1):
+            if int(hour[i + 1]) in avoid_set:
+                next_hour_ok[i] = False
+    next_hour_ok[n - 1] = False
+
+    # avoid_months filter
+    avoid_months_set = set(getattr(strategy, 'avoid_months', None) or [])
+    next_month_ok = np.ones(n, dtype=bool)
+    if avoid_months_set and "timestamp" in df.columns:
+        months = pd.to_datetime(df["timestamp"]).dt.month.values
+        next_months = np.empty(n, dtype=int)
+        next_months[:-1] = months[1:]
+        next_months[-1] = 0
+        for m in avoid_months_set:
+            next_month_ok &= (next_months != m)
+    next_month_ok[n - 1] = False
+
+    min_vol_regime = getattr(strategy, 'min_vol_regime', None)
+    vol_regime_ok = _compute_vol_regime_filter(df, n, min_vol_regime)
+
+    filters = next_hour_ok & next_month_ok & vol_regime_ok
+
+    if direction == "long":
+        signal = long_cond & filters
+    elif direction == "short":
+        signal = short_cond & filters
+    else:
+        signal = (long_cond | short_cond) & filters
+
+    return np.where(signal)[0]
+
+
+def find_signals_donchian_breakout(df: pd.DataFrame, strategy, direction: str = "both") -> np.ndarray:
+    """
+    Vectorized signal detection for Donchian Breakout strategy.
+
+    LONG: close > dc_upper (채널 상단 돌파)
+    SHORT: close < dc_lower (채널 하단 이탈)
+
+    dc_upper/dc_lower는 calculate_indicators에서 shift(1) 적용됨.
+    """
+    n = len(df)
+    if n < 100:
+        return np.array([], dtype=int)
+
+    def col(name, default=None):
+        if name in df.columns:
+            return df[name].values
+        if default is not None:
+            return default
+        return np.zeros(n)
+
+    close = col("close")
+    dc_upper = col("dc_upper")
+    dc_lower = col("dc_lower")
+    hour = col("hour", np.zeros(n, dtype=int))
+
+    min_idx = strategy.channel_period + 1
+    valid_range = np.arange(n) >= min_idx
+
+    valid_dc = ~np.isnan(dc_upper) & ~np.isnan(dc_lower) & (dc_upper > 0) & (dc_lower > 0)
+
+    long_cond = valid_range & valid_dc & (close > dc_upper)
+    short_cond = valid_range & valid_dc & (close < dc_lower)
+
+    # Time filter (entry bar = idx+1)
+    avoid_set = set(strategy.avoid_hours)
+    next_hour_ok = np.ones(n, dtype=bool)
+    if avoid_set:
+        for i in range(n - 1):
+            if int(hour[i + 1]) in avoid_set:
+                next_hour_ok[i] = False
+    next_hour_ok[n - 1] = False
+
+    # avoid_months filter
+    avoid_months_set = set(getattr(strategy, 'avoid_months', None) or [])
+    next_month_ok = np.ones(n, dtype=bool)
+    if avoid_months_set and "timestamp" in df.columns:
+        months = pd.to_datetime(df["timestamp"]).dt.month.values
+        next_months = np.empty(n, dtype=int)
+        next_months[:-1] = months[1:]
+        next_months[-1] = 0
+        for m in avoid_months_set:
+            next_month_ok &= (next_months != m)
+    next_month_ok[n - 1] = False
+
+    min_vol_regime = getattr(strategy, 'min_vol_regime', None)
+    vol_regime_ok = _compute_vol_regime_filter(df, n, min_vol_regime)
+
+    filters = next_hour_ok & next_month_ok & vol_regime_ok
+
+    if direction == "long":
+        signal = long_cond & filters
+    elif direction == "short":
+        signal = short_cond & filters
+    else:
+        signal = (long_cond | short_cond) & filters
+
+    return np.where(signal)[0]
+
+
+def find_signals_mean_reversion(df: pd.DataFrame, strategy, direction: str = "both") -> np.ndarray:
+    """
+    Vectorized signal detection for Mean Reversion strategy.
+
+    LONG: close < band_lower + rsi < rsi_oversold
+    SHORT: close > band_upper + rsi > rsi_overbought
+    """
+    n = len(df)
+    if n < 100:
+        return np.array([], dtype=int)
+
+    def col(name, default=None):
+        if name in df.columns:
+            return df[name].values
+        if default is not None:
+            return default
+        return np.zeros(n)
+
+    close = col("close")
+    band_upper = col("band_upper")
+    band_lower = col("band_lower")
+    rsi = col("rsi")
+    hour = col("hour", np.zeros(n, dtype=int))
+
+    min_idx = max(strategy.sma_period, strategy.rsi_period) + 1
+    valid_range = np.arange(n) >= min_idx
+
+    valid_bands = ~np.isnan(band_upper) & ~np.isnan(band_lower) & ~np.isnan(rsi)
+
+    long_cond = valid_range & valid_bands & (close < band_lower) & (rsi < strategy.rsi_oversold)
+    short_cond = valid_range & valid_bands & (close > band_upper) & (rsi > strategy.rsi_overbought)
+
+    # Time filter (entry bar = idx+1)
+    avoid_set = set(strategy.avoid_hours)
+    next_hour_ok = np.ones(n, dtype=bool)
+    if avoid_set:
+        for i in range(n - 1):
+            if int(hour[i + 1]) in avoid_set:
+                next_hour_ok[i] = False
+    next_hour_ok[n - 1] = False
+
+    # avoid_months filter
+    avoid_months_set = set(getattr(strategy, 'avoid_months', None) or [])
+    next_month_ok = np.ones(n, dtype=bool)
+    if avoid_months_set and "timestamp" in df.columns:
+        months = pd.to_datetime(df["timestamp"]).dt.month.values
+        next_months = np.empty(n, dtype=int)
+        next_months[:-1] = months[1:]
+        next_months[-1] = 0
+        for m in avoid_months_set:
+            next_month_ok &= (next_months != m)
+    next_month_ok[n - 1] = False
+
+    min_vol_regime = getattr(strategy, 'min_vol_regime', None)
+    vol_regime_ok = _compute_vol_regime_filter(df, n, min_vol_regime)
+
+    filters = next_hour_ok & next_month_ok & vol_regime_ok
+
+    if direction == "long":
+        signal = long_cond & filters
+    elif direction == "short":
+        signal = short_cond & filters
+    else:
+        signal = (long_cond | short_cond) & filters
+
+    return np.where(signal)[0]
+
+
+def find_signals_supertrend(df: pd.DataFrame, strategy, direction: str = "both") -> np.ndarray:
+    """
+    Vectorized signal detection for SuperTrend strategy.
+
+    LONG: st_cross_up (SuperTrend 상향 전환)
+    SHORT: st_cross_down (SuperTrend 하향 전환)
+    """
+    n = len(df)
+    if n < 100:
+        return np.array([], dtype=int)
+
+    def col(name, default=None):
+        if name in df.columns:
+            return df[name].values
+        if default is not None:
+            return default
+        return np.zeros(n)
+
+    supertrend = col("supertrend")
+    cross_up = col("st_cross_up", np.zeros(n, dtype=bool)).astype(bool)
+    cross_down = col("st_cross_down", np.zeros(n, dtype=bool)).astype(bool)
+    hour = col("hour", np.zeros(n, dtype=int))
+
+    min_idx = strategy.atr_period * 2
+    valid_range = np.arange(n) >= min_idx
+
+    valid_st = ~np.isnan(supertrend)
+
+    long_cond = valid_range & valid_st & cross_up
+    short_cond = valid_range & valid_st & cross_down
+
+    # Time filter (entry bar = idx+1)
+    avoid_set = set(strategy.avoid_hours)
+    next_hour_ok = np.ones(n, dtype=bool)
+    if avoid_set:
+        for i in range(n - 1):
+            if int(hour[i + 1]) in avoid_set:
+                next_hour_ok[i] = False
+    next_hour_ok[n - 1] = False
+
+    # avoid_months filter
+    avoid_months_set = set(getattr(strategy, 'avoid_months', None) or [])
+    next_month_ok = np.ones(n, dtype=bool)
+    if avoid_months_set and "timestamp" in df.columns:
+        months = pd.to_datetime(df["timestamp"]).dt.month.values
+        next_months = np.empty(n, dtype=int)
+        next_months[:-1] = months[1:]
+        next_months[-1] = 0
+        for m in avoid_months_set:
+            next_month_ok &= (next_months != m)
+    next_month_ok[n - 1] = False
+
+    min_vol_regime = getattr(strategy, 'min_vol_regime', None)
+    vol_regime_ok = _compute_vol_regime_filter(df, n, min_vol_regime)
+
+    filters = next_hour_ok & next_month_ok & vol_regime_ok
+
+    if direction == "long":
+        signal = long_cond & filters
+    elif direction == "short":
+        signal = short_cond & filters
+    else:
+        signal = (long_cond | short_cond) & filters
+
+    return np.where(signal)[0]
+
+
+def find_signals_keltner_squeeze(df: pd.DataFrame, strategy, direction: str = "both") -> np.ndarray:
+    """
+    Vectorized signal detection for Keltner Squeeze strategy.
+
+    스퀴즈 해소 + 방향성 돌파:
+    LONG: squeeze_release + close > kc_upper
+    SHORT: squeeze_release + close < kc_lower
+    """
+    n = len(df)
+    if n < 100:
+        return np.array([], dtype=int)
+
+    def col(name, default=None):
+        if name in df.columns:
+            return df[name].values
+        if default is not None:
+            return default
+        return np.zeros(n)
+
+    close = col("close")
+    kc_upper = col("kc_upper")
+    kc_lower = col("kc_lower")
+    squeeze_release = col("squeeze_release", np.zeros(n, dtype=bool)).astype(bool)
+    hour = col("hour", np.zeros(n, dtype=int))
+
+    min_idx = max(strategy.kc_period, strategy.bb_period, strategy.atr_period) + 2
+    valid_range = np.arange(n) >= min_idx
+
+    valid_kc = ~np.isnan(kc_upper) & ~np.isnan(kc_lower) & ~np.isnan(close)
+
+    long_cond = valid_range & valid_kc & squeeze_release & (close > kc_upper)
+    short_cond = valid_range & valid_kc & squeeze_release & (close < kc_lower)
+
+    # Time filter (entry bar = idx+1)
+    avoid_set = set(strategy.avoid_hours)
+    next_hour_ok = np.ones(n, dtype=bool)
+    if avoid_set:
+        for i in range(n - 1):
+            if int(hour[i + 1]) in avoid_set:
+                next_hour_ok[i] = False
+    next_hour_ok[n - 1] = False
+
+    # avoid_months filter
+    avoid_months_set = set(getattr(strategy, 'avoid_months', None) or [])
+    next_month_ok = np.ones(n, dtype=bool)
+    if avoid_months_set and "timestamp" in df.columns:
+        months = pd.to_datetime(df["timestamp"]).dt.month.values
+        next_months = np.empty(n, dtype=int)
+        next_months[:-1] = months[1:]
+        next_months[-1] = 0
+        for m in avoid_months_set:
+            next_month_ok &= (next_months != m)
+    next_month_ok[n - 1] = False
+
+    min_vol_regime = getattr(strategy, 'min_vol_regime', None)
+    vol_regime_ok = _compute_vol_regime_filter(df, n, min_vol_regime)
+
+    filters = next_hour_ok & next_month_ok & vol_regime_ok
+
+    if direction == "long":
+        signal = long_cond & filters
+    elif direction == "short":
+        signal = short_cond & filters
+    else:
+        signal = (long_cond | short_cond) & filters
+
+    return np.where(signal)[0]
+
+
 def find_signals_generic(df: pd.DataFrame, strategy, direction: str) -> np.ndarray:
     """
     Generic signal detection fallback — calls strategy.check_signal() per bar.
@@ -616,6 +1049,18 @@ def run_fast(
         signal_indices = find_signals_hv_squeeze(df, strategy, direction)
     elif strategy_id == "atr-breakout":
         signal_indices = find_signals_atr_breakout(df, strategy, direction)
+    elif strategy_id == "rsi-divergence":
+        signal_indices = find_signals_rsi_divergence(df, strategy, direction)
+    elif strategy_id == "macd-cross":
+        signal_indices = find_signals_macd_cross(df, strategy, direction)
+    elif strategy_id == "donchian-breakout":
+        signal_indices = find_signals_donchian_breakout(df, strategy, direction)
+    elif strategy_id == "mean-reversion":
+        signal_indices = find_signals_mean_reversion(df, strategy, direction)
+    elif strategy_id == "supertrend":
+        signal_indices = find_signals_supertrend(df, strategy, direction)
+    elif strategy_id == "keltner-squeeze":
+        signal_indices = find_signals_keltner_squeeze(df, strategy, direction)
     else:
         signal_indices = find_signals_generic(df, strategy, direction)
 

--- a/backend/src/strategies/donchian_breakout.py
+++ b/backend/src/strategies/donchian_breakout.py
@@ -1,0 +1,109 @@
+"""
+Donchian Breakout Strategy — 터틀 트레이딩 방식
+
+채널 돌파를 이용한 추세 추종 전략 (리처드 데니스 / 터틀 트레이딩 기반).
+
+진입 조건:
+- LONG: close > 직전 channel_period 캔들의 최고가 (상단 채널 돌파)
+- SHORT: close < 직전 channel_period 캔들의 최저가 (하단 채널 이탈)
+
+중요: 시그널 캔들(idx)의 close가 돌파 기준이므로
+      채널은 idx-1까지의 데이터로 계산 (look-ahead 방지).
+
+진입: 시그널 캔들(idx) 다음 캔들(idx+1) open.
+"""
+
+import pandas as pd
+import numpy as np
+from typing import Optional
+
+
+class DonchianBreakoutStrategy:
+    """도치안 채널 돌파 전략"""
+
+    name = "Donchian Breakout"
+
+    def __init__(
+        self,
+        channel_period: int = 20,
+        exit_period: int = 10,
+        avoid_hours: list = None,
+        avoid_months: list = None,
+        min_vol_regime: float = None,
+    ):
+        self.channel_period = channel_period
+        self.exit_period = exit_period
+        self.avoid_hours = avoid_hours or []
+        self.avoid_months = avoid_months or []
+        self.min_vol_regime = min_vol_regime
+
+    def get_params(self) -> dict:
+        return {
+            "channel_period": self.channel_period,
+            "exit_period": self.exit_period,
+            "avoid_hours": self.avoid_hours,
+            "avoid_months": self.avoid_months,
+        }
+
+    def calculate_indicators(self, df: pd.DataFrame) -> pd.DataFrame:
+        """도치안 채널 계산"""
+        high = df["high"]
+        low = df["low"]
+
+        # 채널은 shift(1) 적용: 현재 캔들 제외, idx-1까지의 최고/최저
+        # rolling(N).max()는 현재 포함이므로 shift(1)로 이전 캔들까지만 포함
+        df["dc_upper"] = high.shift(1).rolling(self.channel_period).max()
+        df["dc_lower"] = low.shift(1).rolling(self.channel_period).min()
+
+        # 출구 채널 (더 좁음)
+        df["dc_exit_upper"] = high.shift(1).rolling(self.exit_period).max()
+        df["dc_exit_lower"] = low.shift(1).rolling(self.exit_period).min()
+
+        # 중간선
+        df["dc_mid"] = (df["dc_upper"] + df["dc_lower"]) / 2
+
+        # Hour (UTC)
+        if "timestamp" in df.columns:
+            ts = pd.to_datetime(df["timestamp"])
+            df["hour"] = ts.dt.hour
+        else:
+            df["hour"] = 0
+
+        return df
+
+    def check_signal(self, df: pd.DataFrame, idx: int) -> Optional[str]:
+        """
+        시그널 확인.
+        idx = 시그널 캔들 (완성). 진입은 idx+1 open.
+        """
+        min_idx = self.channel_period + 1
+        if idx < min_idx:
+            return None
+        if idx + 1 >= len(df):
+            return None
+
+        # 시간 필터 (entry bar 기준)
+        if self.avoid_hours:
+            next_hour = df.iloc[idx + 1].get("hour", 0)
+            if next_hour in self.avoid_hours:
+                return None
+
+        curr = df.iloc[idx]
+        curr_close = curr.get("close", np.nan)
+        dc_upper = curr.get("dc_upper", np.nan)
+        dc_lower = curr.get("dc_lower", np.nan)
+
+        if pd.isna(curr_close) or pd.isna(dc_upper) or pd.isna(dc_lower):
+            return None
+        if dc_upper <= 0 or dc_lower <= 0:
+            return None
+
+        # LONG: 상단 채널 돌파
+        if curr_close > dc_upper:
+            return "long"
+
+        # SHORT: 하단 채널 이탈
+        if curr_close < dc_lower:
+            return "short"
+
+        return None

--- a/backend/src/strategies/keltner_squeeze.py
+++ b/backend/src/strategies/keltner_squeeze.py
@@ -1,0 +1,140 @@
+"""
+Keltner Channel Squeeze Strategy
+
+BB가 Keltner Channel 안으로 완전히 들어가면 스퀴즈(낮은 변동성).
+스퀴즈 해소 후 방향성 돌파 시 진입.
+
+BB Squeeze vs Keltner Squeeze:
+- BB Squeeze: BB Width 자체의 수축/확장
+- Keltner Squeeze: BB가 KC 내부에 있으면 스퀴즈, KC 밖으로 나오면 해소
+
+진입 조건:
+- 스퀴즈 해소: BB upper가 KC upper 위로 나옴 (LONG) 또는
+               BB lower가 KC lower 아래로 나옴 (SHORT)
+- LONG: squeeze 해소 + close > KC upper
+- SHORT: squeeze 해소 + close < KC lower
+
+진입: 시그널 캔들(idx) 다음 캔들(idx+1) open.
+"""
+
+import pandas as pd
+import numpy as np
+from typing import Optional
+
+
+class KeltnerSqueezeStrategy:
+    """Keltner Channel 스퀴즈 전략"""
+
+    name = "Keltner Squeeze"
+
+    def __init__(
+        self,
+        kc_period: int = 20,
+        kc_mult: float = 1.5,
+        bb_period: int = 20,
+        bb_std: float = 2.0,
+        atr_period: int = 10,
+        avoid_hours: list = None,
+        avoid_months: list = None,
+        min_vol_regime: float = None,
+    ):
+        self.kc_period = kc_period
+        self.kc_mult = kc_mult
+        self.bb_period = bb_period
+        self.bb_std = bb_std
+        self.atr_period = atr_period
+        self.avoid_hours = avoid_hours or []
+        self.avoid_months = avoid_months or []
+        self.min_vol_regime = min_vol_regime
+
+    def get_params(self) -> dict:
+        return {
+            "kc_period": self.kc_period,
+            "kc_mult": self.kc_mult,
+            "bb_period": self.bb_period,
+            "bb_std": self.bb_std,
+            "atr_period": self.atr_period,
+            "avoid_hours": self.avoid_hours,
+            "avoid_months": self.avoid_months,
+        }
+
+    def calculate_indicators(self, df: pd.DataFrame) -> pd.DataFrame:
+        """BB + Keltner Channel 계산"""
+        high = df["high"]
+        low = df["low"]
+        close = df["close"]
+
+        # Bollinger Bands
+        bb_sma = close.rolling(self.bb_period).mean()
+        bb_std = close.rolling(self.bb_period).std()
+        df["bb_upper"] = bb_sma + self.bb_std * bb_std
+        df["bb_lower"] = bb_sma - self.bb_std * bb_std
+        df["bb_mid"] = bb_sma
+
+        # ATR (Wilder's smoothing)
+        tr = pd.concat([
+            high - low,
+            (high - close.shift(1)).abs(),
+            (low - close.shift(1)).abs(),
+        ], axis=1).max(axis=1)
+        atr = tr.ewm(com=self.atr_period - 1, min_periods=self.atr_period).mean()
+
+        # Keltner Channel (EMA 기반)
+        kc_mid = close.ewm(span=self.kc_period, adjust=False).mean()
+        df["kc_upper"] = kc_mid + self.kc_mult * atr
+        df["kc_lower"] = kc_mid - self.kc_mult * atr
+        df["kc_mid"] = kc_mid
+
+        # 스퀴즈 상태: BB upper < KC upper AND BB lower > KC lower
+        df["in_squeeze"] = (df["bb_upper"] < df["kc_upper"]) & (df["bb_lower"] > df["kc_lower"])
+
+        # 스퀴즈 해소: 이전 캔들 in_squeeze=True, 현재 in_squeeze=False
+        prev_squeeze = df["in_squeeze"].shift(1)
+        df["squeeze_release"] = prev_squeeze & (~df["in_squeeze"])
+
+        # Hour (UTC)
+        if "timestamp" in df.columns:
+            ts = pd.to_datetime(df["timestamp"])
+            df["hour"] = ts.dt.hour
+        else:
+            df["hour"] = 0
+
+        return df
+
+    def check_signal(self, df: pd.DataFrame, idx: int) -> Optional[str]:
+        """
+        시그널 확인.
+        idx = 시그널 캔들 (완성). 진입은 idx+1 open.
+        """
+        min_idx = max(self.kc_period, self.bb_period, self.atr_period) + 2
+        if idx < min_idx:
+            return None
+        if idx + 1 >= len(df):
+            return None
+
+        # 시간 필터 (entry bar 기준)
+        if self.avoid_hours:
+            next_hour = df.iloc[idx + 1].get("hour", 0)
+            if next_hour in self.avoid_hours:
+                return None
+
+        curr = df.iloc[idx]
+        squeeze_release = curr.get("squeeze_release", False)
+        curr_close = curr.get("close", np.nan)
+        kc_upper = curr.get("kc_upper", np.nan)
+        kc_lower = curr.get("kc_lower", np.nan)
+
+        if not squeeze_release:
+            return None
+        if any(pd.isna(v) for v in [curr_close, kc_upper, kc_lower]):
+            return None
+
+        # LONG: 스퀴즈 해소 + close > KC upper
+        if curr_close > kc_upper:
+            return "long"
+
+        # SHORT: 스퀴즈 해소 + close < KC lower
+        if curr_close < kc_lower:
+            return "short"
+
+        return None

--- a/backend/src/strategies/macd_cross.py
+++ b/backend/src/strategies/macd_cross.py
@@ -1,0 +1,108 @@
+"""
+MACD Cross Strategy
+
+MACD 교차를 이용한 추세 추종 전략.
+추가 필터: 제로라인 아래에서 교차(LONG) / 제로라인 위에서 교차(SHORT).
+
+진입 조건:
+- LONG: MACD line이 signal line 위로 교차 + MACD < 0 (저점에서 상승 전환)
+- SHORT: MACD line이 signal line 아래로 교차 + MACD > 0 (고점에서 하락 전환)
+
+진입: 시그널 캔들(idx) 다음 캔들(idx+1) open.
+"""
+
+import pandas as pd
+import numpy as np
+from typing import Optional
+
+
+class MACDCrossStrategy:
+    """MACD 교차 전략"""
+
+    name = "MACD Cross"
+
+    def __init__(
+        self,
+        fast: int = 12,
+        slow: int = 26,
+        signal: int = 9,
+        avoid_hours: list = None,
+        avoid_months: list = None,
+        min_vol_regime: float = None,
+    ):
+        self.fast = fast
+        self.slow = slow
+        self.signal = signal
+        self.avoid_hours = avoid_hours or []
+        self.avoid_months = avoid_months or []
+        self.min_vol_regime = min_vol_regime
+
+    def get_params(self) -> dict:
+        return {
+            "fast": self.fast,
+            "slow": self.slow,
+            "signal": self.signal,
+            "avoid_hours": self.avoid_hours,
+            "avoid_months": self.avoid_months,
+        }
+
+    def calculate_indicators(self, df: pd.DataFrame) -> pd.DataFrame:
+        """MACD 계산"""
+        close = df["close"]
+
+        ema_fast = close.ewm(span=self.fast, adjust=False).mean()
+        ema_slow = close.ewm(span=self.slow, adjust=False).mean()
+        df["macd_line"] = ema_fast - ema_slow
+        df["macd_signal"] = df["macd_line"].ewm(span=self.signal, adjust=False).mean()
+        df["macd_hist"] = df["macd_line"] - df["macd_signal"]
+
+        # 교차 여부: curr에서 교차 발생 (prev hist 부호 != curr hist 부호)
+        prev_hist = df["macd_hist"].shift(1)
+        # 골든크로스: hist가 음→양 (macd_line이 signal 위로)
+        df["macd_cross_up"] = (prev_hist < 0) & (df["macd_hist"] > 0)
+        # 데드크로스: hist가 양→음 (macd_line이 signal 아래로)
+        df["macd_cross_down"] = (prev_hist > 0) & (df["macd_hist"] < 0)
+
+        # Hour (UTC)
+        if "timestamp" in df.columns:
+            ts = pd.to_datetime(df["timestamp"])
+            df["hour"] = ts.dt.hour
+        else:
+            df["hour"] = 0
+
+        return df
+
+    def check_signal(self, df: pd.DataFrame, idx: int) -> Optional[str]:
+        """
+        시그널 확인.
+        idx = 시그널 캔들 (완성). 진입은 idx+1 open.
+        """
+        min_idx = self.slow + self.signal + 1
+        if idx < min_idx:
+            return None
+        if idx + 1 >= len(df):
+            return None
+
+        # 시간 필터 (entry bar 기준)
+        if self.avoid_hours:
+            next_hour = df.iloc[idx + 1].get("hour", 0)
+            if next_hour in self.avoid_hours:
+                return None
+
+        curr = df.iloc[idx]
+        macd_line = curr.get("macd_line", np.nan)
+        cross_up = curr.get("macd_cross_up", False)
+        cross_down = curr.get("macd_cross_down", False)
+
+        if pd.isna(macd_line):
+            return None
+
+        # LONG: 골든크로스 + MACD < 0 (저점 교차)
+        if cross_up and macd_line < 0:
+            return "long"
+
+        # SHORT: 데드크로스 + MACD > 0 (고점 교차)
+        if cross_down and macd_line > 0:
+            return "short"
+
+        return None

--- a/backend/src/strategies/mean_reversion.py
+++ b/backend/src/strategies/mean_reversion.py
@@ -1,0 +1,117 @@
+"""
+Mean Reversion Strategy
+
+평균 회귀 전략. 가격이 SMA에서 크게 이탈했을 때 회귀를 노림.
+RSI 필터로 과매도/과매수 상태를 추가 확인.
+
+진입 조건:
+- LONG: close < SMA - std_mult * σ (하단 밴드 이탈) + RSI < rsi_oversold
+- SHORT: close > SMA + std_mult * σ (상단 밴드 이탈) + RSI > rsi_overbought
+
+진입: 시그널 캔들(idx) 다음 캔들(idx+1) open.
+"""
+
+import pandas as pd
+import numpy as np
+from typing import Optional
+
+
+class MeanReversionStrategy:
+    """평균 회귀 전략"""
+
+    name = "Mean Reversion"
+
+    def __init__(
+        self,
+        sma_period: int = 20,
+        std_mult: float = 2.0,
+        rsi_period: int = 14,
+        rsi_oversold: float = 30.0,
+        rsi_overbought: float = 70.0,
+        avoid_hours: list = None,
+        avoid_months: list = None,
+        min_vol_regime: float = None,
+    ):
+        self.sma_period = sma_period
+        self.std_mult = std_mult
+        self.rsi_period = rsi_period
+        self.rsi_oversold = rsi_oversold
+        self.rsi_overbought = rsi_overbought
+        self.avoid_hours = avoid_hours or []
+        self.avoid_months = avoid_months or []
+        self.min_vol_regime = min_vol_regime
+
+    def get_params(self) -> dict:
+        return {
+            "sma_period": self.sma_period,
+            "std_mult": self.std_mult,
+            "rsi_period": self.rsi_period,
+            "rsi_oversold": self.rsi_oversold,
+            "rsi_overbought": self.rsi_overbought,
+            "avoid_hours": self.avoid_hours,
+            "avoid_months": self.avoid_months,
+        }
+
+    def calculate_indicators(self, df: pd.DataFrame) -> pd.DataFrame:
+        """SMA 밴드 + RSI 계산"""
+        close = df["close"]
+
+        # SMA와 표준편차 밴드
+        df["sma"] = close.rolling(self.sma_period).mean()
+        std = close.rolling(self.sma_period).std()
+        df["band_upper"] = df["sma"] + self.std_mult * std
+        df["band_lower"] = df["sma"] - self.std_mult * std
+
+        # RSI (Wilder's smoothing)
+        delta = close.diff()
+        gain = delta.clip(lower=0)
+        loss = -delta.clip(upper=0)
+        avg_gain = gain.ewm(com=self.rsi_period - 1, min_periods=self.rsi_period).mean()
+        avg_loss = loss.ewm(com=self.rsi_period - 1, min_periods=self.rsi_period).mean()
+        rs = avg_gain / avg_loss.replace(0, np.nan)
+        df["rsi"] = 100 - (100 / (1 + rs))
+
+        # Hour (UTC)
+        if "timestamp" in df.columns:
+            ts = pd.to_datetime(df["timestamp"])
+            df["hour"] = ts.dt.hour
+        else:
+            df["hour"] = 0
+
+        return df
+
+    def check_signal(self, df: pd.DataFrame, idx: int) -> Optional[str]:
+        """
+        시그널 확인.
+        idx = 시그널 캔들 (완성). 진입은 idx+1 open.
+        """
+        min_idx = max(self.sma_period, self.rsi_period) + 1
+        if idx < min_idx:
+            return None
+        if idx + 1 >= len(df):
+            return None
+
+        # 시간 필터 (entry bar 기준)
+        if self.avoid_hours:
+            next_hour = df.iloc[idx + 1].get("hour", 0)
+            if next_hour in self.avoid_hours:
+                return None
+
+        curr = df.iloc[idx]
+        curr_close = curr.get("close", np.nan)
+        band_upper = curr.get("band_upper", np.nan)
+        band_lower = curr.get("band_lower", np.nan)
+        rsi = curr.get("rsi", np.nan)
+
+        if any(pd.isna(v) for v in [curr_close, band_upper, band_lower, rsi]):
+            return None
+
+        # LONG: 하단 밴드 이탈 + RSI 과매도
+        if curr_close < band_lower and rsi < self.rsi_oversold:
+            return "long"
+
+        # SHORT: 상단 밴드 이탈 + RSI 과매수
+        if curr_close > band_upper and rsi > self.rsi_overbought:
+            return "short"
+
+        return None

--- a/backend/src/strategies/registry.py
+++ b/backend/src/strategies/registry.py
@@ -10,6 +10,12 @@ from src.strategies.bb_squeeze import BBSqueezeStrategy
 from src.strategies.momentum_long import MomentumLongStrategy
 from src.strategies.atr_breakout import ATRBreakoutStrategy
 from src.strategies.hv_squeeze import HVSqueezeStrategy
+from src.strategies.rsi_divergence import RSIDivergenceStrategy
+from src.strategies.macd_cross import MACDCrossStrategy
+from src.strategies.donchian_breakout import DonchianBreakoutStrategy
+from src.strategies.mean_reversion import MeanReversionStrategy
+from src.strategies.supertrend import SuperTrendStrategy
+from src.strategies.keltner_squeeze import KeltnerSqueezeStrategy
 
 
 AVOID_HOURS_BB = [2, 3, 10, 20, 21, 22, 23]
@@ -60,6 +66,60 @@ STRATEGY_REGISTRY = {
         "name": "HV Squeeze",
         "description": "Historical volatility squeeze with candle color direction filter.",
         "status": "shelved",
+    },
+    "rsi-divergence": {
+        "class": RSIDivergenceStrategy,
+        "init_kwargs": {"avoid_hours": []},
+        "direction": "both",
+        "defaults": {"sl": 7, "tp": 5},
+        "name": "RSI Divergence",
+        "description": "Bullish/bearish RSI divergence. Enters when price makes new extreme but RSI disagrees.",
+        "status": "research",
+    },
+    "macd-cross": {
+        "class": MACDCrossStrategy,
+        "init_kwargs": {"avoid_hours": []},
+        "direction": "both",
+        "defaults": {"sl": 8, "tp": 6},
+        "name": "MACD Cross",
+        "description": "MACD line crosses signal line with zero-line filter (cross below zero = long, above = short).",
+        "status": "research",
+    },
+    "donchian-breakout": {
+        "class": DonchianBreakoutStrategy,
+        "init_kwargs": {"avoid_hours": []},
+        "direction": "both",
+        "defaults": {"sl": 8, "tp": 10},
+        "name": "Donchian Breakout",
+        "description": "Turtle Trading channel breakout. Enters on 20-period high/low breakout.",
+        "status": "research",
+    },
+    "mean-reversion": {
+        "class": MeanReversionStrategy,
+        "init_kwargs": {"avoid_hours": []},
+        "direction": "both",
+        "defaults": {"sl": 5, "tp": 4},
+        "name": "Mean Reversion",
+        "description": "Price reverts to 20-period SMA after extreme deviation (2σ) confirmed by RSI.",
+        "status": "research",
+    },
+    "supertrend": {
+        "class": SuperTrendStrategy,
+        "init_kwargs": {"avoid_hours": []},
+        "direction": "both",
+        "defaults": {"sl": 8, "tp": 8},
+        "name": "SuperTrend",
+        "description": "ATR-based dynamic support/resistance. Enters on SuperTrend direction flip.",
+        "status": "research",
+    },
+    "keltner-squeeze": {
+        "class": KeltnerSqueezeStrategy,
+        "init_kwargs": {"avoid_hours": []},
+        "direction": "both",
+        "defaults": {"sl": 7, "tp": 6},
+        "name": "Keltner Squeeze",
+        "description": "Enters when BB exits Keltner Channel (squeeze release) with directional breakout.",
+        "status": "research",
     },
 }
 

--- a/backend/src/strategies/rsi_divergence.py
+++ b/backend/src/strategies/rsi_divergence.py
@@ -1,0 +1,125 @@
+"""
+RSI Divergence Strategy
+
+강세/약세 다이버전스를 포착하는 전략.
+가격과 RSI의 방향이 엇갈릴 때(다이버전스) 추세 전환을 노림.
+
+진입 조건:
+- LONG: RSI < oversold(30) + 가격 신저점이지만 RSI는 이전보다 높음 (강세 다이버전스)
+- SHORT: RSI > overbought(70) + 가격 신고점이지만 RSI는 이전보다 낮음 (약세 다이버전스)
+
+룩백 윈도우(lookback=10) 내에서 이전 극값과 비교.
+진입: 시그널 캔들(idx) 다음 캔들(idx+1) open.
+"""
+
+import pandas as pd
+import numpy as np
+from typing import Optional
+
+
+class RSIDivergenceStrategy:
+    """RSI 다이버전스 전략"""
+
+    name = "RSI Divergence"
+
+    def __init__(
+        self,
+        rsi_period: int = 14,
+        oversold: float = 30.0,
+        overbought: float = 70.0,
+        lookback: int = 10,
+        avoid_hours: list = None,
+        avoid_months: list = None,
+        min_vol_regime: float = None,
+    ):
+        self.rsi_period = rsi_period
+        self.oversold = oversold
+        self.overbought = overbought
+        self.lookback = lookback
+        self.avoid_hours = avoid_hours or []
+        self.avoid_months = avoid_months or []
+        self.min_vol_regime = min_vol_regime
+
+    def get_params(self) -> dict:
+        return {
+            "rsi_period": self.rsi_period,
+            "oversold": self.oversold,
+            "overbought": self.overbought,
+            "lookback": self.lookback,
+            "avoid_hours": self.avoid_hours,
+            "avoid_months": self.avoid_months,
+        }
+
+    def calculate_indicators(self, df: pd.DataFrame) -> pd.DataFrame:
+        """RSI 계산"""
+        close = df["close"]
+
+        # RSI (Wilder's smoothing)
+        delta = close.diff()
+        gain = delta.clip(lower=0)
+        loss = -delta.clip(upper=0)
+        avg_gain = gain.ewm(com=self.rsi_period - 1, min_periods=self.rsi_period).mean()
+        avg_loss = loss.ewm(com=self.rsi_period - 1, min_periods=self.rsi_period).mean()
+        rs = avg_gain / avg_loss.replace(0, np.nan)
+        df["rsi"] = 100 - (100 / (1 + rs))
+
+        # Hour (UTC)
+        if "timestamp" in df.columns:
+            ts = pd.to_datetime(df["timestamp"])
+            df["hour"] = ts.dt.hour
+        else:
+            df["hour"] = 0
+
+        return df
+
+    def check_signal(self, df: pd.DataFrame, idx: int) -> Optional[str]:
+        """
+        시그널 확인.
+        idx = 시그널 캔들 (완성된 캔들). 진입은 idx+1 open.
+        """
+        min_idx = self.rsi_period + self.lookback
+        if idx < min_idx:
+            return None
+        if idx + 1 >= len(df):
+            return None
+
+        # 시간 필터 (entry bar 기준)
+        if self.avoid_hours:
+            next_hour = df.iloc[idx + 1].get("hour", 0)
+            if next_hour in self.avoid_hours:
+                return None
+
+        curr = df.iloc[idx]
+        curr_rsi = curr.get("rsi", np.nan)
+        curr_close = curr.get("close", np.nan)
+        if pd.isna(curr_rsi) or pd.isna(curr_close):
+            return None
+
+        # lookback 윈도우 (idx-lookback ~ idx-1)
+        window = df.iloc[max(0, idx - self.lookback): idx]
+        if len(window) < 2:
+            return None
+
+        # LONG: 강세 다이버전스
+        # 가격 신저점(curr < window min close) + RSI는 window RSI min보다 높음
+        if curr_rsi < self.oversold:
+            window_low = window["close"].min()
+            window_rsi_low = window["rsi"].min() if "rsi" in window.columns else np.nan
+            if not pd.isna(window_rsi_low):
+                price_new_low = curr_close < window_low
+                rsi_higher = curr_rsi > window_rsi_low
+                if price_new_low and rsi_higher:
+                    return "long"
+
+        # SHORT: 약세 다이버전스
+        # 가격 신고점(curr > window max close) + RSI는 window RSI max보다 낮음
+        if curr_rsi > self.overbought:
+            window_high = window["close"].max()
+            window_rsi_high = window["rsi"].max() if "rsi" in window.columns else np.nan
+            if not pd.isna(window_rsi_high):
+                price_new_high = curr_close > window_high
+                rsi_lower = curr_rsi < window_rsi_high
+                if price_new_high and rsi_lower:
+                    return "short"
+
+        return None

--- a/backend/src/strategies/supertrend.py
+++ b/backend/src/strategies/supertrend.py
@@ -1,0 +1,176 @@
+"""
+SuperTrend Strategy
+
+ATR 기반 동적 지지/저항선(SuperTrend)을 이용한 추세 추종 전략.
+
+SuperTrend 계산:
+  Basic Upper = (high + low) / 2 + multiplier * ATR
+  Basic Lower = (high + low) / 2 - multiplier * ATR
+  SuperTrend: 추세에 따라 upper/lower 중 하나로 결정
+
+진입 조건:
+- LONG: close가 SuperTrend line 위로 전환 (하락 → 상승 전환)
+- SHORT: close가 SuperTrend line 아래로 전환 (상승 → 하락 전환)
+
+진입: 시그널 캔들(idx) 다음 캔들(idx+1) open.
+"""
+
+import pandas as pd
+import numpy as np
+from typing import Optional
+
+
+class SuperTrendStrategy:
+    """SuperTrend 전략"""
+
+    name = "SuperTrend"
+
+    def __init__(
+        self,
+        atr_period: int = 10,
+        multiplier: float = 3.0,
+        avoid_hours: list = None,
+        avoid_months: list = None,
+        min_vol_regime: float = None,
+    ):
+        self.atr_period = atr_period
+        self.multiplier = multiplier
+        self.avoid_hours = avoid_hours or []
+        self.avoid_months = avoid_months or []
+        self.min_vol_regime = min_vol_regime
+
+    def get_params(self) -> dict:
+        return {
+            "atr_period": self.atr_period,
+            "multiplier": self.multiplier,
+            "avoid_hours": self.avoid_hours,
+            "avoid_months": self.avoid_months,
+        }
+
+    def calculate_indicators(self, df: pd.DataFrame) -> pd.DataFrame:
+        """SuperTrend 계산"""
+        high = df["high"]
+        low = df["low"]
+        close = df["close"]
+
+        # ATR (Wilder's smoothing)
+        tr = pd.concat([
+            high - low,
+            (high - close.shift(1)).abs(),
+            (low - close.shift(1)).abs(),
+        ], axis=1).max(axis=1)
+        atr = tr.ewm(com=self.atr_period - 1, min_periods=self.atr_period).mean()
+
+        # Basic bands
+        hl2 = (high + low) / 2
+        basic_upper = hl2 + self.multiplier * atr
+        basic_lower = hl2 - self.multiplier * atr
+
+        # SuperTrend 계산 (pandas loop 불가피 — 순차 의존성)
+        n = len(df)
+        supertrend = np.full(n, np.nan)
+        direction = np.zeros(n, dtype=int)  # 1 = bullish, -1 = bearish
+
+        final_upper = basic_upper.values.copy()
+        final_lower = basic_lower.values.copy()
+        close_arr = close.values
+        atr_arr = atr.values
+
+        for i in range(1, n):
+            if np.isnan(atr_arr[i]):
+                continue
+
+            # Final upper band: 이전보다 작거나 이전 close가 이전 upper 이상이면 리셋
+            if i > 0 and not np.isnan(final_upper[i - 1]):
+                if basic_upper.values[i] < final_upper[i - 1] or close_arr[i - 1] > final_upper[i - 1]:
+                    final_upper[i] = basic_upper.values[i]
+                else:
+                    final_upper[i] = final_upper[i - 1]
+            else:
+                final_upper[i] = basic_upper.values[i]
+
+            # Final lower band: 이전보다 크거나 이전 close가 이전 lower 이하이면 리셋
+            if i > 0 and not np.isnan(final_lower[i - 1]):
+                if basic_lower.values[i] > final_lower[i - 1] or close_arr[i - 1] < final_lower[i - 1]:
+                    final_lower[i] = basic_lower.values[i]
+                else:
+                    final_lower[i] = final_lower[i - 1]
+            else:
+                final_lower[i] = basic_lower.values[i]
+
+            # Direction
+            if i > 0 and not np.isnan(supertrend[i - 1]):
+                prev_dir = direction[i - 1]
+                if prev_dir == -1:  # 이전이 bearish
+                    if close_arr[i] > final_upper[i]:
+                        direction[i] = 1  # 전환: bullish
+                        supertrend[i] = final_lower[i]
+                    else:
+                        direction[i] = -1
+                        supertrend[i] = final_upper[i]
+                else:  # 이전이 bullish
+                    if close_arr[i] < final_lower[i]:
+                        direction[i] = -1  # 전환: bearish
+                        supertrend[i] = final_upper[i]
+                    else:
+                        direction[i] = 1
+                        supertrend[i] = final_lower[i]
+            else:
+                # 초기값: close와 비교
+                if close_arr[i] > final_upper[i]:
+                    direction[i] = 1
+                    supertrend[i] = final_lower[i]
+                else:
+                    direction[i] = -1
+                    supertrend[i] = final_upper[i]
+
+        df["supertrend"] = supertrend
+        df["supertrend_dir"] = direction  # 1=bullish, -1=bearish
+        # 전환 감지
+        prev_dir = pd.Series(direction).shift(1)
+        df["st_cross_up"] = (prev_dir == -1) & (pd.Series(direction) == 1)   # 하락→상승 전환
+        df["st_cross_down"] = (prev_dir == 1) & (pd.Series(direction) == -1)  # 상승→하락 전환
+
+        # Hour (UTC)
+        if "timestamp" in df.columns:
+            ts = pd.to_datetime(df["timestamp"])
+            df["hour"] = ts.dt.hour
+        else:
+            df["hour"] = 0
+
+        return df
+
+    def check_signal(self, df: pd.DataFrame, idx: int) -> Optional[str]:
+        """
+        시그널 확인.
+        idx = 시그널 캔들 (완성). 진입은 idx+1 open.
+        """
+        min_idx = self.atr_period * 2
+        if idx < min_idx:
+            return None
+        if idx + 1 >= len(df):
+            return None
+
+        # 시간 필터 (entry bar 기준)
+        if self.avoid_hours:
+            next_hour = df.iloc[idx + 1].get("hour", 0)
+            if next_hour in self.avoid_hours:
+                return None
+
+        curr = df.iloc[idx]
+        st = curr.get("supertrend", np.nan)
+        cross_up = curr.get("st_cross_up", False)
+        cross_down = curr.get("st_cross_down", False)
+
+        if pd.isna(st):
+            return None
+
+        # LONG: SuperTrend 상향 전환
+        if cross_up:
+            return "long"
+
+        # SHORT: SuperTrend 하향 전환
+        if cross_down:
+            return "short"
+
+        return None


### PR DESCRIPTION
## Summary

- **6개 새 전략** 추가 (batch 1): RSI Divergence, MACD Cross, Donchian Breakout, Mean Reversion, SuperTrend, Keltner Squeeze
- 각 전략: strategy class + vectorized signal function + registry entry
- 모든 전략 `direction=both` 지원, `status=research`
- 기존 아키텍처 패턴 100% 준수 (avoid_hours, avoid_months, min_vol_regime 필터 포함)

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `src/strategies/rsi_divergence.py` | 신규: 강세/약세 RSI 다이버전스 |
| `src/strategies/macd_cross.py` | 신규: MACD 제로라인 필터 교차 |
| `src/strategies/donchian_breakout.py` | 신규: 터틀 트레이딩 채널 돌파 |
| `src/strategies/mean_reversion.py` | 신규: SMA 2σ 이탈 + RSI 필터 |
| `src/strategies/supertrend.py` | 신규: ATR 기반 SuperTrend 전환 |
| `src/strategies/keltner_squeeze.py` | 신규: BB-KC 스퀴즈 해소 돌파 |
| `src/strategies/registry.py` | 6개 전략 등록 추가 |
| `src/simulation/engine_fast.py` | 6개 vectorized signal 함수 + run_fast 분기 추가 |

## Look-ahead Bias 방지 확인

- 모든 시그널: `idx` 캔들(완성) 기준 판정, 진입은 `idx+1` open
- Donchian: `shift(1)` 적용으로 현재 캔들 제외
- RSI Divergence: rolling 통계에 `shift(1)` 적용
- SuperTrend: 순차 의존성으로 루프 계산(피할 수 없음), curr 데이터 미사용

## 검증 결과

```
rsi-divergence:    signals=18, trades=5  (500 캔들 테스트)
macd-cross:        signals=22, trades=9
donchian-breakout: signals=12, trades=4
mean-reversion:    signals=20, trades=6
supertrend:        signals=2,  trades=2
keltner-squeeze:   signals=3,  trades=2
All vectorized signal tests passed
```

## Test plan

- [ ] `python3 -c "from src.strategies.registry import STRATEGY_REGISTRY"` 임포트 확인
- [ ] API: `POST /simulate {"strategy": "rsi-divergence", "direction": "both", "top_n": 10}` 응답 확인
- [ ] API: `POST /simulate/coin {"symbol": "BTCUSDT", "strategy": "supertrend"}` 응답 확인
- [ ] 각 전략 `avoid_hours`, `avoid_months`, `min_vol_regime` 파라미터 전달 확인
- [ ] `POST /strategies` 엔드포인트에 6개 신규 전략 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)