### PR TITLE
fix: /rankings/daily worst3에서 0거래 전략 제외

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -3141,6 +3141,9 @@ async def get_daily_rankings(date: Optional[str] = None):
             seen.add(key)
             unique_entries.append(e)
 
+    # Filter out 0-trade entries (no data = not meaningful for ranking)
+    unique_entries = [e for e in unique_entries if e.get("total_trades", 0) > 0]
+
     # Rank by profit_factor desc (then win_rate as tiebreaker)
     ranked = sorted(
         unique_entries,


### PR DESCRIPTION
## Summary
- worst3에 `total_trades=0` 전략이 표시되는 버그 수정
- 0거래 전략은 통계적 의미 없음 — 랭킹에서 제외

## Test
- API 재시작 후 `/rankings/daily` 응답 확인
- worst3이 WR/PF 0이 아닌 실제 underperforming 전략 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)