### PR TITLE
feat: 랭킹 페이지 내비게이션 연결 (orphaned page 해결)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -46,6 +46,7 @@ const compareTvPath = lang === 'ko' ? '/ko/compare/tradingview' : '/compare/trad
 const privacyPath = lang === 'ko' ? '/ko/privacy' : '/privacy';
 const termsPath = lang === 'ko' ? '/ko/terms' : '/terms';
 const leaderboardPath = lang === 'ko' ? '/ko/leaderboard' : '/leaderboard';
+const rankingPath = lang === 'ko' ? '/ko/strategies/ranking' : '/strategies/ranking';
 
 // Legacy paths (for footer/redirects)
 const strategiesPath = lang === 'ko' ? '/ko/strategies' : '/strategies';
@@ -383,6 +384,10 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
           {navItems.map(item => (
             <a href={item.href} aria-current={isActive(item.match) ? "page" : undefined} class="min-h-[44px] flex items-center" style={isActive(item.match) ? 'color:var(--color-accent);font-weight:500' : 'color:var(--color-text-muted)'}>{item.label}</a>
           ))}
+          <a href={rankingPath} class="min-h-[44px] flex items-center gap-2 text-[--color-text-muted]">
+            <span class="inline-block w-1.5 h-1.5 rounded-full bg-[--color-accent] animate-pulse shrink-0"></span>
+            {lang === 'ko' ? '오늘의 전략 랭킹' : 'Daily Strategy Ranking'}
+          </a>
           <a href={leaderboardPath} class="min-h-[44px] flex items-center text-[--color-text-muted]">{t('nav.leaderboard')}</a>
           <a href={methodologyPath} class="min-h-[44px] flex items-center text-[--color-text-muted]">{t('footer.methodology')}</a>
           <a href={performancePath} class="min-h-[44px] flex items-center text-[--color-text-muted]">{t('nav.performance')}</a>

--- a/src/pages/ko/strategies/index.astro
+++ b/src/pages/ko/strategies/index.astro
@@ -83,6 +83,18 @@ const isKorean = (id: string) => koIds.has(id);
         }
       </p>
 
+      <!-- 오늘의 전략 랭킹 배너 -->
+      <a href="/ko/strategies/ranking" class="flex items-center justify-between gap-3 mb-6 border border-[--color-accent]/30 rounded-lg px-4 py-3 bg-[--color-accent]/5 hover:bg-[--color-accent]/10 transition-colors group">
+        <div class="flex items-center gap-3">
+          <span class="inline-block w-2 h-2 rounded-full bg-[--color-accent] animate-pulse shrink-0"></span>
+          <div>
+            <p class="font-semibold text-sm text-[--color-text]">📊 오늘의 전략 랭킹</p>
+            <p class="text-xs text-[--color-text-muted]">수익팩터 기준 오늘의 Best/Worst 전략 — 매일 업데이트</p>
+          </div>
+        </div>
+        <span class="text-[--color-accent] text-sm font-semibold shrink-0 group-hover:translate-x-1 transition-transform">&rarr;</span>
+      </a>
+
       <div class="mb-4 flex flex-col sm:flex-row gap-3">
         <a href="/ko/simulate"
            class="btn-primary inline-flex items-center gap-2 bg-[--color-accent] text-[--color-bg] px-5 py-2.5 rounded-lg font-semibold text-sm hover:bg-[--color-accent-dim]">

--- a/src/pages/strategies/index.astro
+++ b/src/pages/strategies/index.astro
@@ -86,6 +86,18 @@ const difficultyColors: Record<string, string> = {
         }
       </p>
 
+      <!-- Daily Ranking Banner -->
+      <a href="/strategies/ranking" class="flex items-center justify-between gap-3 mb-6 border border-[--color-accent]/30 rounded-lg px-4 py-3 bg-[--color-accent]/5 hover:bg-[--color-accent]/10 transition-colors group">
+        <div class="flex items-center gap-3">
+          <span class="inline-block w-2 h-2 rounded-full bg-[--color-accent] animate-pulse shrink-0"></span>
+          <div>
+            <p class="font-semibold text-sm text-[--color-text]">📊 Daily Strategy Ranking</p>
+            <p class="text-xs text-[--color-text-muted]">Today's best and worst strategies ranked by Profit Factor — updated daily</p>
+          </div>
+        </div>
+        <span class="text-[--color-accent] text-sm font-semibold shrink-0 group-hover:translate-x-1 transition-transform">&rarr;</span>
+      </a>
+
       <div class="mb-4 flex flex-col sm:flex-row gap-3">
         <a href="/simulate"
            class="btn-primary inline-flex items-center gap-2 bg-[--color-accent] text-[--color-bg] px-5 py-2.5 rounded-lg font-semibold text-sm hover:bg-[--color-accent-dim]">
@@ -183,9 +195,9 @@ const difficultyColors: Record<string, string> = {
 
       {simulatorPresets.length > 0 && (
         <div class="mt-12">
-          <h2 class="text-xl font-bold mb-2">시뮬레이터 프리셋 전체 ({simulatorPresets.length}종)</h2>
+          <h2 class="text-xl font-bold mb-2">All Simulator Presets ({simulatorPresets.length})</h2>
           <p class="text-[--color-text-muted] text-sm mb-6">
-            아래 전략을 클릭하면 시뮬레이터에서 바로 파라미터가 적용됩니다. 549개 코인 동시 테스트.
+            Click any preset to load it directly in the simulator. Tests on 549+ coins simultaneously.
           </p>
           <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
             {simulatorPresets.map((preset) => (


### PR DESCRIPTION
## Summary
UX 감사에서 발견: `/strategies/ranking` 페이지로의 인바운드 링크가 **전혀 없음**.

수정:
- 모바일 메뉴에 "Daily Strategy Ranking" 링크 추가 (라이브 펄스 도트)
- `/strategies` EN 페이지 상단 랭킹 배너
- `/ko/strategies` 페이지 상단 랭킹 배너
- EN 프리셋 섹션 제목: "시뮬레이터 프리셋 전체 (26종)" → "All Simulator Presets (26)"

## Impact
- Tim/Sam 랭킹 페이지 자연 발견율 0% → 유입 경로 3개 추가
- 모바일 메뉴를 통해 모든 페이지에서 접근 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)