### PR TITLE
fix: /strategies/ranking 영문 페이지 한국어 표시 버그

### DIFF
--- a/src/components/RankingCard.tsx
+++ b/src/components/RankingCard.tsx
@@ -18,6 +18,7 @@ export interface RankingEntry {
 interface RankingCardProps {
   entry: RankingEntry;
   variant?: "best" | "worst" | "weekly";
+  lang?: "en" | "ko";
 }
 
 const RANK_MEDALS = ["🥇", "🥈", "🥉"];
@@ -54,9 +55,33 @@ function pfColor(pf: number): string {
   return "text-[--color-red]";
 }
 
-export function RankingCard({ entry, variant = "best" }: RankingCardProps) {
+const STRINGS = {
+  en: {
+    winRate: "Win Rate",
+    pf: "PF",
+    trades: "Trades",
+    daysInTop: "Days in Top",
+    daysSuffix: "",
+    lowSample: (n: number) => `Low sample (${n} trades < 100)`,
+  },
+  ko: {
+    winRate: "승률",
+    pf: "PF",
+    trades: "거래 수",
+    daysInTop: "집계 일수",
+    daysSuffix: "일",
+    lowSample: (n: number) => `샘플 부족 (${n}건 < 100건)`,
+  },
+};
+
+export function RankingCard({
+  entry,
+  variant = "best",
+  lang = "ko",
+}: RankingCardProps) {
   const medal = rankBadge(entry.rank);
   const isWeekly = variant === "weekly";
+  const s = STRINGS[lang];
 
   return (
     <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] hover:border-[--color-accent]/40 transition-colors">
@@ -68,10 +93,10 @@ export function RankingCard({ entry, variant = "best" }: RankingCardProps) {
           </span>
           <div class="min-w-0">
             <p class="font-semibold text-[--color-text] text-sm leading-tight truncate">
-              {entry.name_ko}
+              {lang === "ko" ? entry.name_ko : entry.name_en}
             </p>
             <p class="text-[--color-text-muted] text-xs font-mono truncate">
-              {entry.name_en}
+              {lang === "ko" ? entry.name_en : entry.strategy}
             </p>
           </div>
         </div>
@@ -86,24 +111,24 @@ export function RankingCard({ entry, variant = "best" }: RankingCardProps) {
       {/* Stats row */}
       <div class="grid grid-cols-3 gap-2 font-mono text-sm">
         <div>
-          <p class="text-[--color-text-muted] text-xs mb-0.5">승률</p>
+          <p class="text-[--color-text-muted] text-xs mb-0.5">{s.winRate}</p>
           <p class={`font-bold text-base ${winRateColor(entry.win_rate)}`}>
             {entry.win_rate.toFixed(1)}%
           </p>
         </div>
         <div>
-          <p class="text-[--color-text-muted] text-xs mb-0.5">PF</p>
+          <p class="text-[--color-text-muted] text-xs mb-0.5">{s.pf}</p>
           <p class={`font-bold text-base ${pfColor(entry.profit_factor)}`}>
             {entry.profit_factor.toFixed(2)}
           </p>
         </div>
         <div>
           <p class="text-[--color-text-muted] text-xs mb-0.5">
-            {isWeekly ? "집계 일수" : "거래 수"}
+            {isWeekly ? s.daysInTop : s.trades}
           </p>
           <p class="font-bold text-base text-[--color-text]">
             {isWeekly && entry.days_in_top != null
-              ? `${entry.days_in_top}일`
+              ? `${entry.days_in_top}${s.daysSuffix}`
               : entry.total_trades}
           </p>
         </div>
@@ -113,7 +138,7 @@ export function RankingCard({ entry, variant = "best" }: RankingCardProps) {
       {entry.low_sample && (
         <p class="mt-2 text-[--color-yellow] text-xs font-mono flex items-center gap-1">
           <span aria-hidden="true">⚠</span>
-          샘플 부족 ({entry.total_trades}건 &lt; 100건)
+          {s.lowSample(entry.total_trades)}
         </p>
       )}
     </div>

--- a/src/components/StrategyRanking.tsx
+++ b/src/components/StrategyRanking.tsx
@@ -3,6 +3,37 @@ import { useState, useEffect } from "preact/hooks";
 import { RankingCard } from "./RankingCard";
 import type { RankingEntry } from "./RankingCard";
 
+const STRINGS = {
+  en: {
+    loadError: "Failed to load ranking data.",
+    loadErrorTitle: "Failed to load data",
+    best3Title: "Best 3 Strategies",
+    best3Sub: "Top 3 by Profit Factor",
+    worst3Title: "Worst 3 Strategies",
+    worst3Sub: "Bottom 3 by PF — combinations to avoid",
+    weeklyTitle: "This Week's Best 3",
+    weeklySub: "Ranked by 7-day average PF",
+    summaryLabel: "Win Rate 50%+ strategies:",
+    summaryTotal: (n: number) => `/ ${n}`,
+    simulatorCta: "Try in Simulator →",
+    simulatorHref: "/simulate",
+  },
+  ko: {
+    loadError: "랭킹 데이터를 불러오지 못했습니다.",
+    loadErrorTitle: "데이터 로드 실패",
+    best3Title: "Best 3 전략",
+    best3Sub: "PF(수익팩터) 기준 상위 3개",
+    worst3Title: "Worst 3 전략",
+    worst3Sub: "PF 기준 하위 3개 — 피해야 할 조합",
+    weeklyTitle: "이번 주 Best 3",
+    weeklySub: "최근 7일 평균 PF 기준",
+    summaryLabel: "WR 50%+ 전략:",
+    summaryTotal: (n: number) => `/ ${n}개`,
+    simulatorCta: "시뮬레이터에서 직접 확인 →",
+    simulatorHref: "/ko/simulate",
+  },
+};
+
 const API_BASE = import.meta.env.PUBLIC_API_URL ?? "https://api.pruviq.com";
 
 interface RankingData {
@@ -56,10 +87,11 @@ function SkeletonCard() {
   );
 }
 
-export function StrategyRanking() {
+export function StrategyRanking({ lang = "ko" }: { lang?: "en" | "ko" }) {
   const [data, setData] = useState<RankingData | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const s = STRINGS[lang];
 
   useEffect(() => {
     const controller = new AbortController();
@@ -77,7 +109,7 @@ export function StrategyRanking() {
       })
       .catch((err) => {
         if (err.name === "AbortError") return;
-        setError(err.message ?? "랭킹 데이터를 불러오지 못했습니다.");
+        setError(err.message ?? s.loadError);
         setLoading(false);
       });
 
@@ -87,7 +119,7 @@ export function StrategyRanking() {
   if (error) {
     return (
       <div class="border border-[--color-red]/30 rounded-lg p-5 bg-[--color-down-fill] text-[--color-red] text-sm font-mono">
-        <p class="font-bold mb-1">데이터 로드 실패</p>
+        <p class="font-bold mb-1">{s.loadErrorTitle}</p>
         <p class="text-xs opacity-80">{error}</p>
       </div>
     );
@@ -107,10 +139,7 @@ export function StrategyRanking() {
 
       {/* Top 3 */}
       <section>
-        <SectionHeader
-          title="Best 3 전략"
-          subtitle="PF(수익팩터) 기준 상위 3개"
-        />
+        <SectionHeader title={s.best3Title} subtitle={s.best3Sub} />
         <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
           {loading
             ? [0, 1, 2].map((i) => <SkeletonCard key={i} />)
@@ -119,6 +148,7 @@ export function StrategyRanking() {
                   key={`top-${entry.rank}`}
                   entry={entry}
                   variant="best"
+                  lang={lang}
                 />
               ))}
         </div>
@@ -126,10 +156,7 @@ export function StrategyRanking() {
 
       {/* Worst 3 */}
       <section>
-        <SectionHeader
-          title="Worst 3 전략"
-          subtitle="PF 기준 하위 3개 — 피해야 할 조합"
-        />
+        <SectionHeader title={s.worst3Title} subtitle={s.worst3Sub} />
         <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
           {loading
             ? [0, 1, 2].map((i) => <SkeletonCard key={i} />)
@@ -138,6 +165,7 @@ export function StrategyRanking() {
                   key={`worst-${entry.rank}`}
                   entry={entry}
                   variant="worst"
+                  lang={lang}
                 />
               ))}
         </div>
@@ -146,10 +174,7 @@ export function StrategyRanking() {
       {/* Weekly Best 3 */}
       {(loading || (data?.weekly_best3 && data.weekly_best3.length > 0)) && (
         <section>
-          <SectionHeader
-            title="이번 주 Best 3"
-            subtitle="최근 7일 평균 PF 기준"
-          />
+          <SectionHeader title={s.weeklyTitle} subtitle={s.weeklySub} />
           <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
             {loading
               ? [0, 1, 2].map((i) => <SkeletonCard key={i} />)
@@ -158,6 +183,7 @@ export function StrategyRanking() {
                     key={`weekly-${entry.rank}`}
                     entry={entry}
                     variant="weekly"
+                    lang={lang}
                   />
                 ))}
           </div>
@@ -168,20 +194,20 @@ export function StrategyRanking() {
       {!loading && data && (
         <div class="border border-[--color-border] rounded-lg px-5 py-4 bg-[--color-bg-card] flex flex-col sm:flex-row sm:items-center justify-between gap-4">
           <p class="font-mono text-sm text-[--color-text]">
-            WR 50%+ 전략:{" "}
+            {s.summaryLabel}{" "}
             <span class="text-[--color-accent] font-bold">
               {data.summary.wr_50plus}
             </span>
             <span class="text-[--color-text-muted]">
               {" "}
-              / {data.summary.total}개
+              {s.summaryTotal(data.summary.total)}
             </span>
           </p>
           <a
-            href="/simulate"
+            href={s.simulatorHref}
             class="shrink-0 inline-flex items-center gap-2 bg-[--color-accent] text-[--color-bg] px-5 py-2 rounded font-semibold text-sm hover:bg-[--color-accent-dim] transition-colors"
           >
-            시뮬레이터에서 직접 확인 &rarr;
+            {s.simulatorCta}
           </a>
         </div>
       )}

--- a/src/pages/ko/strategies/ranking.astro
+++ b/src/pages/ko/strategies/ranking.astro
@@ -64,7 +64,7 @@ const today = new Date().toLocaleDateString('ko-KR', {
 
       <!-- Ranking component (client-side fetch) -->
       <ErrorBoundary name="Strategy Ranking" client:load>
-        <StrategyRanking client:load />
+        <StrategyRanking lang="ko" client:load />
       </ErrorBoundary>
 
     </div>

--- a/src/pages/strategies/ranking.astro
+++ b/src/pages/strategies/ranking.astro
@@ -64,7 +64,7 @@ const today = new Date().toLocaleDateString('en-US', {
 
       <!-- Ranking component (client-side fetch) -->
       <ErrorBoundary name="Strategy Ranking" client:load>
-        <StrategyRanking client:load />
+        <StrategyRanking lang="en" client:load />
       </ErrorBoundary>
 
     </div>


### PR DESCRIPTION
## 문제
`/strategies/ranking` (EN 페이지)에서 컴포넌트 내부 텍스트가 모두 한국어로 표시됨.

## 원인
`StrategyRanking.tsx`와 `RankingCard.tsx`가 `lang` prop 없이 한국어 문자열 하드코딩.
두 컴포넌트는 EN/KO 페이지에서 공용으로 쓰이지만 언어 분기가 없었음.

## 수정
- `StrategyRanking`: `lang?: "en" | "ko"` prop 추가, 11개 문자열 EN/KO 분기
- `RankingCard`: `lang?: "en" | "ko"` prop 추가, 5개 문자열 + 전략명(name_en/name_ko) 분기
- `/strategies/ranking.astro`: `lang="en"` 명시
- `/ko/strategies/ranking.astro`: `lang="ko"` 명시

## 검증
- `npm run build` ✅ (2454 pages, 3.36s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)