### PR TITLE
feat: OKX 어필리에이트 신청 준비 — fees 카드 활성화, 면책조항 강화

### DIFF
--- a/src/data/exchanges.ts
+++ b/src/data/exchanges.ts
@@ -1,5 +1,5 @@
 export interface FeeRate {
-  maker: number;  // decimal, e.g. 0.001 = 0.10%
+  maker: number; // decimal, e.g. 0.001 = 0.10%
   taker: number;
 }
 
@@ -8,76 +8,78 @@ export interface Exchange {
   name: string;
   spot: FeeRate;
   futures: FeeRate;
-  discount: number;       // decimal, e.g. 0.10 = 10%
-  discountLabel: string;  // display string, e.g. "10%"
+  discount: number; // decimal, e.g. 0.10 = 10%
+  discountLabel: string; // display string, e.g. "10%"
   referralUrl: string;
+  directUrl?: string; // direct site URL when affiliate link is not yet active
   available: boolean;
-  tag: string;            // English tag, e.g. "#1 Volume"
-  spotOnly?: boolean;     // true for exchanges without futures (e.g. Korean exchanges)
-  infoOnly?: boolean;     // true for non-affiliate info-only exchanges
+  tag: string; // English tag, e.g. "#1 Volume"
+  spotOnly?: boolean; // true for exchanges without futures (e.g. Korean exchanges)
+  infoOnly?: boolean; // true for non-affiliate info-only exchanges
 }
 
 export const exchanges: Exchange[] = [
   {
-    id: 'binance',
-    name: 'Binance',
+    id: "binance",
+    name: "Binance",
     spot: { maker: 0.001, taker: 0.001 },
     futures: { maker: 0.0002, taker: 0.0005 },
-    discount: 0.10,
-    discountLabel: '10%',
-    referralUrl: 'https://accounts.binance.com/register?ref=PRUVIQ',
+    discount: 0.1,
+    discountLabel: "10%",
+    referralUrl: "https://accounts.binance.com/register?ref=PRUVIQ",
     available: true,
-    tag: '#1 Volume',
+    tag: "#1 Volume",
   },
   {
-    id: 'bitget',
-    name: 'Bitget',
+    id: "bitget",
+    name: "Bitget",
     spot: { maker: 0.001, taker: 0.001 },
     futures: { maker: 0.0002, taker: 0.0006 },
-    discount: 0.20,
-    discountLabel: '20%',
-    referralUrl: 'https://partner.bitget.com/bg/71KRCS',
+    discount: 0.2,
+    discountLabel: "20%",
+    referralUrl: "https://partner.bitget.com/bg/71KRCS",
     available: true,
-    tag: 'Copy Trading',
+    tag: "Copy Trading",
   },
   {
-    id: 'okx',
-    name: 'OKX',
+    id: "okx",
+    name: "OKX",
     spot: { maker: 0.0008, taker: 0.001 },
     futures: { maker: 0.0002, taker: 0.0005 },
-    discount: 0.20,
-    discountLabel: '20%',
-    referralUrl: '#',
+    discount: 0.2,
+    discountLabel: "20%",
+    referralUrl: "#",
+    directUrl: "https://www.okx.com",
     available: false,
-    tag: '120+ Countries',
+    tag: "120+ Countries",
   },
 ];
 
 /** Korean exchanges — info-only, no referral */
 export const koreanExchanges: Exchange[] = [
   {
-    id: 'upbit',
-    name: 'Upbit (업비트)',
+    id: "upbit",
+    name: "Upbit (업비트)",
     spot: { maker: 0.0005, taker: 0.0005 },
     futures: { maker: 0, taker: 0 },
     discount: 0,
-    discountLabel: '—',
-    referralUrl: 'https://upbit.com',
+    discountLabel: "—",
+    referralUrl: "https://upbit.com",
     available: true,
-    tag: '#1 Korea',
+    tag: "#1 Korea",
     spotOnly: true,
     infoOnly: true,
   },
   {
-    id: 'bithumb',
-    name: 'Bithumb (빗썸)',
+    id: "bithumb",
+    name: "Bithumb (빗썸)",
     spot: { maker: 0.0004, taker: 0.0004 },
     futures: { maker: 0, taker: 0 },
     discount: 0,
-    discountLabel: '—',
-    referralUrl: 'https://www.bithumb.com',
+    discountLabel: "—",
+    referralUrl: "https://www.bithumb.com",
     available: true,
-    tag: '#2 Korea',
+    tag: "#2 Korea",
     spotOnly: true,
     infoOnly: true,
   },
@@ -94,7 +96,7 @@ export function formatFee(rate: number, decimals: 2 | 3 = 2): string {
 }
 
 /** Format maker/taker as "0.10% / 0.10%" (spot) or "0.020% / 0.050%" (futures) */
-export function formatFeeRange(fee: FeeRate, type: 'spot' | 'futures'): string {
-  const d = type === 'futures' ? 3 : 2;
+export function formatFeeRange(fee: FeeRate, type: "spot" | "futures"): string {
+  const d = type === "futures" ? 3 : 2;
   return `${formatFee(fee.maker, d)} / ${formatFee(fee.taker, d)}`;
 }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -185,7 +185,7 @@ export const en = {
   "footer.privacy": "Privacy",
   "footer.terms": "Terms",
   "footer.disclaimer":
-    "Not financial advice. Past performance does not guarantee future results.",
+    "Not financial advice. Crypto trading involves substantial risk of loss, including total loss of capital when using leverage. Past performance does not guarantee future results. Not available to residents of restricted jurisdictions.",
   "footer.affiliate": "This site contains affiliate links.",
   "footer.details": "Details",
 
@@ -322,6 +322,8 @@ export const en = {
   "fees.discount_off": "off",
   "fees.signup": "Sign Up",
   "fees.coming_soon": "Coming Soon",
+  "fees.visit_okx": "Visit OKX",
+  "fees.okx_discount_pending": "20% discount code coming — affiliate pending",
   "fees.footnote":
     "Maker / Taker rates shown. Higher-volume traders unlock lower tiers automatically. Last updated: Feb 2026.",
   "fees.korean_title": "Korean Exchanges (Reference)",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -186,7 +186,7 @@ export const ko: Record<TranslationKey, string> = {
   "footer.privacy": "개인정보처리방침",
   "footer.terms": "이용약관",
   "footer.disclaimer":
-    "투자 조언이 아닙니다. 과거 성과는 미래 결과를 보장하지 않습니다.",
+    "투자 조언이 아닙니다. 레버리지 사용 시 원금 전액 손실 가능성을 포함한 상당한 손실 위험이 있습니다. 과거 성과는 미래 결과를 보장하지 않습니다. 거래 제한 국가 거주자에게는 제공되지 않습니다.",
   "footer.affiliate": "이 사이트에는 제휴 링크가 포함되어 있습니다.",
   "footer.details": "수수료 자세히 보기",
 
@@ -323,6 +323,8 @@ export const ko: Record<TranslationKey, string> = {
   "fees.discount_off": "할인",
   "fees.signup": "가입하기",
   "fees.coming_soon": "준비 중",
+  "fees.visit_okx": "OKX 방문",
+  "fees.okx_discount_pending": "20% 할인 코드 준비 중 — 제휴 승인 대기",
   "fees.footnote":
     "메이커 / 테이커 수수료 기준. 거래량이 높으면 자동으로 낮은 등급이 적용됩니다. 최종 업데이트: 2026년 2월.",
   "fees.korean_title": "국내 거래소 (참고용)",

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -85,6 +85,17 @@ const t = useTranslations('en');
         </div>
       </div>
 
+      <!-- Legal Entity -->
+      <div class="border border-[--color-border] rounded-lg p-5 bg-[--color-bg-card] mb-12">
+        <p class="font-mono text-[--color-accent] text-xs tracking-wider mb-3">LEGAL</p>
+        <div class="text-sm text-[--color-text-muted] space-y-1.5">
+          <p><span class="text-[--color-text]">Operating entity:</span> PRUVIQ Project (Seoul, Republic of Korea)</p>
+          <p><span class="text-[--color-text]">Platform type:</span> Open-source educational research platform — not a licensed financial institution</p>
+          <p><span class="text-[--color-text]">Contact:</span> <a href="mailto:contact@pruviq.com" class="text-[--color-accent] hover:underline">contact@pruviq.com</a></p>
+          <p><span class="text-[--color-text]">GitHub:</span> <a href="https://github.com/pruviq/pruviq" class="text-[--color-accent] hover:underline" target="_blank" rel="noopener noreferrer">github.com/pruviq/pruviq</a></p>
+        </div>
+      </div>
+
       <!-- Explore CTAs -->
       <div class="mt-12 pt-8 border-t border-[--color-border] text-center">
         <p class="text-[--color-text-muted] text-sm mb-4">{t('about.explore_desc')}</p>

--- a/src/pages/fees.astro
+++ b/src/pages/fees.astro
@@ -80,6 +80,14 @@ const exchangeCards: Record<string, { tagLabel: string; description: string }> =
                    class="block text-center bg-[--color-accent] text-[--color-bg] px-4 py-2 min-h-[44px] flex items-center justify-center rounded text-sm font-semibold hover:opacity-90 transition-opacity">
                   {t('fees.signup')} &rarr;
                 </a>
+              ) : ex.directUrl ? (
+                <div class="flex flex-col gap-2">
+                  <a href={ex.directUrl} target="_blank" rel="noopener noreferrer"
+                     class="block text-center border border-[--color-accent] text-[--color-accent] px-4 py-2 min-h-[44px] flex items-center justify-center rounded text-sm font-semibold hover:bg-[--color-accent]/10 transition-colors">
+                    {t('fees.visit_okx')} &rarr;
+                  </a>
+                  <p class="text-[10px] text-center text-[--color-text-muted] font-mono">{t('fees.okx_discount_pending')}</p>
+                </div>
               ) : (
                 <span class="block text-center bg-[--color-border] text-[--color-text-muted] px-4 py-2 min-h-[44px] flex items-center justify-center rounded text-sm font-semibold cursor-default">
                   {t('fees.coming_soon')}

--- a/src/pages/ko/fees.astro
+++ b/src/pages/ko/fees.astro
@@ -80,6 +80,14 @@ const exchangeCards: Record<string, { tagLabel: string; description: string }> =
                    class="block text-center bg-[--color-accent] text-[--color-bg] px-4 py-2 min-h-[44px] flex items-center justify-center rounded text-sm font-semibold hover:opacity-90 transition-opacity">
                   {t('fees.signup')} &rarr;
                 </a>
+              ) : ex.directUrl ? (
+                <div class="flex flex-col gap-2">
+                  <a href={ex.directUrl} target="_blank" rel="noopener noreferrer"
+                     class="block text-center border border-[--color-accent] text-[--color-accent] px-4 py-2 min-h-[44px] flex items-center justify-center rounded text-sm font-semibold hover:bg-[--color-accent]/10 transition-colors">
+                    {t('fees.visit_okx')} &rarr;
+                  </a>
+                  <p class="text-[10px] text-center text-[--color-text-muted] font-mono">{t('fees.okx_discount_pending')}</p>
+                </div>
               ) : (
                 <span class="block text-center bg-[--color-border] text-[--color-text-muted] px-4 py-2 min-h-[44px] flex items-center justify-center rounded text-sm font-semibold cursor-default">
                   {t('fees.coming_soon')}

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -78,6 +78,31 @@ const t = useTranslations('en');
           <p class="mt-3">Do not base investment decisions solely on backtested or simulated performance. PRUVIQ publishes both successful and failed strategies to promote transparency and education.</p>
         </div>
 
+        <!-- 4a. Leverage Risk Warning -->
+        <div class="border border-[--color-red]/30 rounded-lg p-6 bg-[--color-down-fill]">
+          <h2 class="text-lg font-bold text-[--color-text] mb-3">4a. Leverage &amp; Derivatives Risk Warning</h2>
+          <p class="font-bold text-[--color-red] mb-3">TRADING WITH LEVERAGE CAN RESULT IN TOTAL LOSS OF YOUR INVESTED CAPITAL.</p>
+          <ul class="list-disc pl-5 space-y-2">
+            <li>PRUVIQ simulations use <strong class="text-[--color-text]">5x leverage</strong> by default. Leveraged trading amplifies both gains and losses.</li>
+            <li>A <strong class="text-[--color-text]">20% adverse price move at 5x leverage</strong> results in complete liquidation of your position.</li>
+            <li>Crypto futures and derivatives are <strong class="text-[--color-text]">complex instruments</strong> with high risk of losing money rapidly.</li>
+            <li>You should not trade leveraged instruments unless you fully understand how they work and can afford to lose all invested capital.</li>
+            <li>PRUVIQ backtest results do <strong class="text-[--color-text]">not account for liquidation cascades</strong>, funding rate extremes, or exchange-specific liquidation mechanisms.</li>
+          </ul>
+        </div>
+
+        <!-- 4b. Geographic Restrictions -->
+        <div>
+          <h2 class="text-lg font-bold text-[--color-text] mb-3">4b. Geographic Restrictions</h2>
+          <p class="mb-3">PRUVIQ's content and any affiliated exchange services may not be available to residents of all jurisdictions. You are responsible for ensuring that your use of PRUVIQ and any linked exchange services complies with local laws and regulations.</p>
+          <ul class="list-disc pl-5 space-y-2">
+            <li>Cryptocurrency trading is <strong class="text-[--color-text]">restricted or prohibited</strong> in certain countries</li>
+            <li>By using PRUVIQ, you confirm you are not a resident of any jurisdiction where such use is prohibited</li>
+            <li>Linked exchanges operate under their own geographic restrictions — check their terms before registering</li>
+            <li>PRUVIQ does not target users in jurisdictions where these services are not permitted</li>
+          </ul>
+        </div>
+
         <!-- 5. Affiliate Disclosure -->
         <div>
           <h2 class="text-lg font-bold text-[--color-text] mb-3">5. Affiliate Disclosure</h2>


### PR DESCRIPTION
## Summary

OKX 어필리에이트 신청 전 심사팀이 거절할 수 있는 항목 4건 수정.

### 변경 내용

**fees.astro (EN/KO)**
- OKX 카드: 회색 비활성 "Coming Soon" → accent 색상 활성 "Visit OKX →" 버튼 (okx.com 직접 링크)
- 버튼 하단: "20% discount code coming — affiliate pending" 메시지
- OKX 심사팀이 피드: *이 사이트는 이미 OKX를 프로모션 중, 제휴 코드만 기다리는 중*

**exchanges.ts**
- `Exchange` 인터페이스에 `directUrl?: string` 필드 추가
- OKX entry에 `directUrl: 'https://www.okx.com'` 설정

**i18n (en/ko)**
- `fees.visit_okx`, `fees.okx_discount_pending` 키 추가
- `footer.disclaimer`: 레버리지 원금 손실 + 제한 관할권 경고 추가

**terms.astro**
- 섹션 4a: 레버리지 위험 경고 (5x 레버리지, 완전 청산 리스크, 복잡 상품 경고)
- 섹션 4b: 지역 제한 (제한 국가 거주자 사용 불가 확인)

**about.astro**
- LEGAL 섹션 추가: 운영 주체 (PRUVIQ Project, Seoul, ROK), 플랫폼 유형, 연락처, GitHub

## OKX 심사 기준 대응

| 거절 사유 | 이전 | 이후 |
|----------|------|------|
| OKX commitment 없음 | ❌ Coming Soon 회색 | ✅ Visit OKX 활성 버튼 |
| 법인 정보 없음 | ❌ Footer에만 짧게 | ✅ About 페이지 LEGAL 섹션 |
| 레버리지 면책조항 미흡 | ⚠️ 전략 페이지에만 | ✅ Terms 4a + footer |
| 관할권 제한 미표시 | ❌ 없음 | ✅ Terms 4b + footer |

## Test plan
- [ ] `/fees` OKX 카드: "Visit OKX →" 링크 클릭 → okx.com 이동 확인
- [ ] `/ko/fees` 동일 확인
- [ ] `/terms` 섹션 4a, 4b 렌더링 확인
- [ ] `/about` LEGAL 섹션 렌더링 확인
- [ ] Footer 면책조항 업데이트 전체 페이지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)