### PR TITLE
fix(trust): Terms legal clauses + About social proof section

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -485,6 +485,12 @@ export const en = {
   "about.explore_desc":
     "Ready to test strategies? Try our simulator or browse verified strategies.",
 
+  "about.proof_tag": "BUILT IN PUBLIC",
+  "about.proof_desc": "PRUVIQ is actively developed. The simulation engine, API, and all strategy logic are continuously updated based on real backtesting data.",
+  "about.proof_github": "View on GitHub",
+  "about.proof_commits": "Active development",
+  "about.proof_since": "In development since 2025",
+
   // Performance page static fallback
   "perf.tag": "BACKTEST RESULTS",
   "perf.title": "Every Trade Published. Including Losses.",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -486,6 +486,12 @@ export const ko: Record<TranslationKey, string> = {
   "about.explore_desc":
     "전략을 테스트할 준비가 되셨나요? 시뮬레이터를 사용하거나 검증된 전략을 둘러보세요.",
 
+  "about.proof_tag": "공개 개발",
+  "about.proof_desc": "PRUVIQ는 지속적으로 개발 중입니다. 시뮬레이션 엔진, API, 전략 로직은 실제 백테스트 데이터를 바탕으로 꾸준히 업데이트됩니다.",
+  "about.proof_github": "GitHub에서 보기",
+  "about.proof_commits": "활발한 개발 진행 중",
+  "about.proof_since": "2025년부터 개발 중",
+
   // Performance page static fallback
   "perf.tag": "백테스트 결과",
   "perf.title": "모든 거래 공개. 손실 포함.",

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -73,6 +73,28 @@ const t = useTranslations('en');
         </div>
       </div>
 
+      <!-- Social Proof -->
+      <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] mb-8">
+        <p class="font-mono text-[--color-accent] text-xs tracking-wider mb-3">{t('about.proof_tag')}</p>
+        <p class="text-[--color-text-muted] text-sm leading-relaxed mb-4">{t('about.proof_desc')}</p>
+        <div class="flex flex-wrap gap-3">
+          <a href="https://github.com/pruviq" target="_blank" rel="noopener noreferrer"
+             class="inline-flex items-center gap-2 font-mono text-xs px-3 py-2 rounded border border-[--color-border] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
+            <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+            </svg>
+            {t('about.proof_github')}
+          </a>
+          <span class="inline-flex items-center gap-2 font-mono text-xs px-3 py-2 rounded border border-[--color-border] text-[--color-text-muted]">
+            <span class="w-2 h-2 rounded-full bg-[--color-accent] animate-pulse inline-block"></span>
+            {t('about.proof_commits')}
+          </span>
+          <span class="inline-flex items-center font-mono text-xs px-3 py-2 rounded border border-[--color-border] text-[--color-text-muted]">
+            {t('about.proof_since')}
+          </span>
+        </div>
+      </div>
+
       <!-- Contact -->
       <div class="text-center">
         <p class="font-mono text-[--color-accent] text-xs tracking-wider mb-2">{t('about.contact_tag')}</p>

--- a/src/pages/ko/about.astro
+++ b/src/pages/ko/about.astro
@@ -73,6 +73,28 @@ const t = useTranslations('ko');
         </div>
       </div>
 
+      <!-- Social Proof -->
+      <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] mb-8">
+        <p class="font-mono text-[--color-accent] text-xs tracking-wider mb-3">{t('about.proof_tag')}</p>
+        <p class="text-[--color-text-muted] text-sm leading-relaxed mb-4">{t('about.proof_desc')}</p>
+        <div class="flex flex-wrap gap-3">
+          <a href="https://github.com/pruviq" target="_blank" rel="noopener noreferrer"
+             class="inline-flex items-center gap-2 font-mono text-xs px-3 py-2 rounded border border-[--color-border] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
+            <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+            </svg>
+            {t('about.proof_github')}
+          </a>
+          <span class="inline-flex items-center gap-2 font-mono text-xs px-3 py-2 rounded border border-[--color-border] text-[--color-text-muted]">
+            <span class="w-2 h-2 rounded-full bg-[--color-accent] animate-pulse inline-block"></span>
+            {t('about.proof_commits')}
+          </span>
+          <span class="inline-flex items-center font-mono text-xs px-3 py-2 rounded border border-[--color-border] text-[--color-text-muted]">
+            {t('about.proof_since')}
+          </span>
+        </div>
+      </div>
+
       <!-- Contact -->
       <div class="text-center">
         <p class="font-mono text-[--color-accent] text-xs tracking-wider mb-2">{t('about.contact_tag')}</p>

--- a/src/pages/ko/terms.astro
+++ b/src/pages/ko/terms.astro
@@ -140,6 +140,36 @@ const t = useTranslations('ko');
           </ul>
         </div>
 
+        <!-- 14. 분리 가능성 -->
+        <div>
+          <h2 class="text-lg font-bold text-[--color-text] mb-3">14. 분리 가능성</h2>
+          <p>본 약관의 어떤 조항이 집행 불가능하거나 무효로 판명될 경우, 해당 조항은 본 약관의 나머지 부분이 완전한 효력을 유지할 수 있도록 필요한 최소한의 범위에서 제한되거나 삭제됩니다.</p>
+        </div>
+
+        <!-- 15. 데이터 주체 권리 (GDPR) -->
+        <div>
+          <h2 class="text-lg font-bold text-[--color-text] mb-3">15. 데이터 주체 권리</h2>
+          <p>유럽 경제 지역(EEA)에 거주하시는 경우, 당사가 보유한 개인 데이터에 대한 접근, 수정 또는 삭제를 요청할 권리가 있습니다. PRUVIQ는 서비스 운영에 엄격히 필요한 범위(필수 보안 쿠키)를 초과하는 개인 데이터를 수집하지 않습니다. 권리 행사를 위해서는 <a href="mailto:contact@pruviq.com" class="text-[--color-accent] hover:underline">contact@pruviq.com</a>으로 연락하십시오.</p>
+        </div>
+
+        <!-- 16. 데이터 보존 -->
+        <div>
+          <h2 class="text-lg font-bold text-[--color-text] mb-3">16. 데이터 보존</h2>
+          <p>PRUVIQ는 서버에 사용자 계정이나 개인 데이터를 저장하지 않습니다. CDN 제공업체(Cloudflare)가 설정한 필수 보안 쿠키는 해당 업체의 표준 정책에 따라 자동으로 만료됩니다. 사용자가 생성한 콘텐츠는 브라우저 세션이 종료되면 유지되지 않습니다.</p>
+        </div>
+
+        <!-- 17. 분쟁 해결 -->
+        <div>
+          <h2 class="text-lg font-bold text-[--color-text] mb-3">17. 분쟁 해결</h2>
+          <p>본 약관에서 발생하는 모든 분쟁은 먼저 <a href="mailto:contact@pruviq.com" class="text-[--color-accent] hover:underline">contact@pruviq.com</a>에 연락하여 성실한 협상을 통해 해결하도록 합니다. 30일 이내에 해결되지 않는 경우, 분쟁은 대한민국 법률에 따라 규율되며, 당사자들은 대한민국 서울에 위치한 법원의 전속 관할권에 동의합니다.</p>
+        </div>
+
+        <!-- 18. 전체 합의 -->
+        <div>
+          <h2 class="text-lg font-bold text-[--color-text] mb-3">18. 전체 합의</h2>
+          <p>본 약관은 서비스 이용과 관련하여 귀하와 PRUVIQ 간의 전체 합의를 구성하며 모든 이전 합의에 우선합니다. PRUVIQ는 언제든지 본 약관을 업데이트할 수 있습니다. 서비스를 계속 사용하면 업데이트된 약관에 동의한 것으로 간주됩니다.</p>
+        </div>
+
       </div>
     </div>
   </section>

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -168,6 +168,36 @@ const t = useTranslations('en');
           </ul>
         </div>
 
+        <!-- 14. Severability -->
+        <div>
+          <h2 class="text-lg font-bold text-[--color-text] mb-3">14. Severability</h2>
+          <p>If any provision of these Terms is found to be unenforceable or invalid, that provision will be limited or eliminated to the minimum extent necessary so that these Terms will otherwise remain in full force and effect and enforceable.</p>
+        </div>
+
+        <!-- 15. Data Subject Rights (GDPR) -->
+        <div>
+          <h2 class="text-lg font-bold text-[--color-text] mb-3">15. Data Subject Rights</h2>
+          <p>If you are located in the European Economic Area (EEA), you have the right to access, correct, or delete any personal data we hold about you. PRUVIQ does not collect personal data beyond what is strictly necessary for the operation of the service (essential security cookies only). To exercise your rights, contact us at <a href="mailto:contact@pruviq.com" class="text-[--color-accent] hover:underline">contact@pruviq.com</a>.</p>
+        </div>
+
+        <!-- 16. Data Retention -->
+        <div>
+          <h2 class="text-lg font-bold text-[--color-text] mb-3">16. Data Retention</h2>
+          <p>PRUVIQ does not store user accounts or personal data on our servers. Essential security cookies set by our CDN provider (Cloudflare) expire automatically per their standard policies. No user-generated content is retained beyond your browser session.</p>
+        </div>
+
+        <!-- 17. Dispute Resolution -->
+        <div>
+          <h2 class="text-lg font-bold text-[--color-text] mb-3">17. Dispute Resolution</h2>
+          <p>Any dispute arising from these Terms shall first be attempted to be resolved through good faith negotiation by contacting <a href="mailto:contact@pruviq.com" class="text-[--color-accent] hover:underline">contact@pruviq.com</a>. If not resolved within 30 days, disputes shall be governed by the laws of the Republic of Korea, and the parties consent to the exclusive jurisdiction of the courts located in Seoul, Republic of Korea.</p>
+        </div>
+
+        <!-- 18. Entire Agreement -->
+        <div>
+          <h2 class="text-lg font-bold text-[--color-text] mb-3">18. Entire Agreement</h2>
+          <p>These Terms constitute the entire agreement between you and PRUVIQ regarding your use of the service and supersede all prior agreements. PRUVIQ may update these Terms at any time. Continued use of the service constitutes acceptance of the updated Terms.</p>
+        </div>
+
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Changes

### Terms (EN + KO)
Added 5 missing legal sections (sections 14–18):
- **Severability** — invalid provisions severed without voiding whole agreement
- **Data Subject Rights** — GDPR EEA rights, contact email for requests
- **Data Retention** — no server-side user data; Cloudflare cookie expiry policy
- **Dispute Resolution** — 30-day good faith negotiation → Seoul courts, Korean law
- **Entire Agreement** — supersedes prior agreements, continued use = acceptance

### About (EN + KO)
Added **"Built in Public"** social proof section between Tech Stack and Contact:
- GitHub org link (`github.com/pruviq`) with GitHub icon
- Active development pulse indicator badge
- "In development since 2025" badge
- i18n keys added to `en.ts` and `ko.ts`

## Files Changed
- `src/pages/terms.astro`
- `src/pages/ko/terms.astro`
- `src/pages/about.astro`
- `src/pages/ko/about.astro`
- `src/i18n/en.ts`
- `src/i18n/ko.ts`

## Test plan
- [ ] `/terms` — sections 14–18 render correctly with proper numbering
- [ ] `/ko/terms` — KO sections 14–18 render correctly
- [ ] `/about` — "BUILT IN PUBLIC" card appears between Tech Stack and Contact
- [ ] `/ko/about` — same section renders with KO copy
- [ ] GitHub link opens `https://github.com/pruviq` in new tab
- [ ] No missing translation key warnings in build output

Fixes P1-Terms, P2-SocialProof from site audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)