### PR TITLE
fix(ux): noscript fallbacks for JS-dependent pages + OKX clarification

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -322,7 +322,7 @@ export const en = {
   "fees.pruviq_discount": "PRUVIQ Discount",
   "fees.discount_off": "off",
   "fees.signup": "Sign Up",
-  "fees.coming_soon": "Coming Soon",
+  "fees.coming_soon": "Affiliate link — coming soon",
   "fees.visit_okx": "Visit OKX",
   "fees.okx_discount_pending": "20% discount code coming — affiliate pending",
   "fees.footnote":
@@ -1270,14 +1270,18 @@ export const en = {
   "ranking.summary_cta": "Test in Simulator",
 
   // Comparison pages: 3Commas
-  "meta.vs_3commas_title": "PRUVIQ vs 3Commas — Free Crypto Backtesting Alternative",
-  "meta.vs_3commas_desc": "Compare PRUVIQ with 3Commas for crypto strategy backtesting. No subscription fees. Free forever. 549+ coins with real fee simulation.",
+  "meta.vs_3commas_title":
+    "PRUVIQ vs 3Commas — Free Crypto Backtesting Alternative",
+  "meta.vs_3commas_desc":
+    "Compare PRUVIQ with 3Commas for crypto strategy backtesting. No subscription fees. Free forever. 549+ coins with real fee simulation.",
   "vs_3commas.tag": "HONEST COMPARISON",
   "vs_3commas.title": "PRUVIQ vs 3Commas",
   "vs_3commas.subtitle": "for crypto backtesting",
-  "vs_3commas.desc": "3Commas is a solid portfolio automation tool. But if you want to backtest a strategy on hundreds of coins before paying for a subscription, PRUVIQ gives you that for free.",
+  "vs_3commas.desc":
+    "3Commas is a solid portfolio automation tool. But if you want to backtest a strategy on hundreds of coins before paying for a subscription, PRUVIQ gives you that for free.",
   "vs_3commas.tldr": "TL;DR",
-  "vs_3commas.tldr_text": "3Commas excels at live DCA/Grid bot execution. PRUVIQ is built for research-first backtesting — free, no-code, 549+ coins, with real fees and slippage modeled in.",
+  "vs_3commas.tldr_text":
+    "3Commas excels at live DCA/Grid bot execution. PRUVIQ is built for research-first backtesting — free, no-code, 549+ coins, with real fees and slippage modeled in.",
   "vs_3commas.feature": "Feature",
   "vs_3commas.pruviq": "PRUVIQ",
   "vs_3commas.other": "3Commas",
@@ -1322,17 +1326,22 @@ export const en = {
   "vs_3commas.when_other_3": "Pre-built marketplace strategies to copy",
   "vs_3commas.when_other_4": "Live trading without manual order management",
   "vs_3commas.cta_title": "Try PRUVIQ Free Today",
-  "vs_3commas.cta_desc": "Backtest your strategy on 549+ coins before committing to any paid tool. No signup required.",
+  "vs_3commas.cta_desc":
+    "Backtest your strategy on 549+ coins before committing to any paid tool. No signup required.",
 
   // Comparison pages: Coinrule
-  "meta.vs_coinrule_title": "PRUVIQ vs Coinrule — Free Crypto Backtesting Alternative",
-  "meta.vs_coinrule_desc": "Compare PRUVIQ with Coinrule for crypto strategy backtesting. Free forever, no IF-THEN limits, 549+ coins with real fee simulation.",
+  "meta.vs_coinrule_title":
+    "PRUVIQ vs Coinrule — Free Crypto Backtesting Alternative",
+  "meta.vs_coinrule_desc":
+    "Compare PRUVIQ with Coinrule for crypto strategy backtesting. Free forever, no IF-THEN limits, 549+ coins with real fee simulation.",
   "vs_coinrule.tag": "HONEST COMPARISON",
   "vs_coinrule.title": "PRUVIQ vs Coinrule",
   "vs_coinrule.subtitle": "for crypto backtesting",
-  "vs_coinrule.desc": "Coinrule lets you automate trading with IF-THEN rules. If you want to rigorously backtest a strategy on hundreds of coins before deploying it, PRUVIQ is built for that — and it's free.",
+  "vs_coinrule.desc":
+    "Coinrule lets you automate trading with IF-THEN rules. If you want to rigorously backtest a strategy on hundreds of coins before deploying it, PRUVIQ is built for that — and it's free.",
   "vs_coinrule.tldr": "TL;DR",
-  "vs_coinrule.tldr_text": "Coinrule is a rule-based automation tool. PRUVIQ is a backtesting-first research tool — free, no-code, 549+ coins, with slippage and fees built in.",
+  "vs_coinrule.tldr_text":
+    "Coinrule is a rule-based automation tool. PRUVIQ is a backtesting-first research tool — free, no-code, 549+ coins, with slippage and fees built in.",
   "vs_coinrule.feature": "Feature",
   "vs_coinrule.pruviq": "PRUVIQ",
   "vs_coinrule.other": "Coinrule",
@@ -1372,22 +1381,29 @@ export const en = {
   "vs_coinrule.when_pruviq_3": "See realistic results with fees and slippage",
   "vs_coinrule.when_pruviq_4": "Verify with transparent backtest results",
   "vs_coinrule.when_other": "Choose Coinrule when you want...",
-  "vs_coinrule.when_other_1": "Automate trades with IF-THEN logic without coding",
-  "vs_coinrule.when_other_2": "Connect to multiple exchanges from one dashboard",
+  "vs_coinrule.when_other_1":
+    "Automate trades with IF-THEN logic without coding",
+  "vs_coinrule.when_other_2":
+    "Connect to multiple exchanges from one dashboard",
   "vs_coinrule.when_other_3": "Use pre-built rule templates from the community",
   "vs_coinrule.when_other_4": "Run live automated strategies around the clock",
   "vs_coinrule.cta_title": "Try PRUVIQ Free Today",
-  "vs_coinrule.cta_desc": "Backtest your strategy on 549+ coins before paying for any automation tool. No account required.",
+  "vs_coinrule.cta_desc":
+    "Backtest your strategy on 549+ coins before paying for any automation tool. No account required.",
 
   // Comparison pages: Cryptohopper
-  "meta.vs_cryptohopper_title": "PRUVIQ vs Cryptohopper — Free Crypto Backtesting Alternative",
-  "meta.vs_cryptohopper_desc": "Compare PRUVIQ with Cryptohopper for crypto strategy backtesting. Free forever, no cloud subscription, 549+ coins with real fee and slippage simulation.",
+  "meta.vs_cryptohopper_title":
+    "PRUVIQ vs Cryptohopper — Free Crypto Backtesting Alternative",
+  "meta.vs_cryptohopper_desc":
+    "Compare PRUVIQ with Cryptohopper for crypto strategy backtesting. Free forever, no cloud subscription, 549+ coins with real fee and slippage simulation.",
   "vs_cryptohopper.tag": "HONEST COMPARISON",
   "vs_cryptohopper.title": "PRUVIQ vs Cryptohopper",
   "vs_cryptohopper.subtitle": "for crypto backtesting",
-  "vs_cryptohopper.desc": "Cryptohopper is a cloud-based bot with a marketplace of strategies. If you want to backtest an idea thoroughly across hundreds of coins before deploying it, PRUVIQ does that for free.",
+  "vs_cryptohopper.desc":
+    "Cryptohopper is a cloud-based bot with a marketplace of strategies. If you want to backtest an idea thoroughly across hundreds of coins before deploying it, PRUVIQ does that for free.",
   "vs_cryptohopper.tldr": "TL;DR",
-  "vs_cryptohopper.tldr_text": "Cryptohopper is a cloud bot with a paid marketplace. PRUVIQ is a free, no-code backtesting tool — 549+ coins, real fees modeled, all results published transparently.",
+  "vs_cryptohopper.tldr_text":
+    "Cryptohopper is a cloud bot with a paid marketplace. PRUVIQ is a free, no-code backtesting tool — 549+ coins, real fees modeled, all results published transparently.",
   "vs_cryptohopper.feature": "Feature",
   "vs_cryptohopper.pruviq": "PRUVIQ",
   "vs_cryptohopper.other": "Cryptohopper",
@@ -1396,7 +1412,8 @@ export const en = {
   "vs_cryptohopper.row_price_other": "$19–107/mo (Pioneer–Hero)",
   "vs_cryptohopper.row_coding": "Coding Required",
   "vs_cryptohopper.row_coding_p": "No code — visual builder",
-  "vs_cryptohopper.row_coding_other": "No coding — template-based configuration",
+  "vs_cryptohopper.row_coding_other":
+    "No coding — template-based configuration",
   "vs_cryptohopper.row_coins": "Coins Supported",
   "vs_cryptohopper.row_coins_p": "549+ coins (Binance Futures)",
   "vs_cryptohopper.row_coins_other": "Multiple exchanges, varies by plan",
@@ -1408,41 +1425,54 @@ export const en = {
   "vs_cryptohopper.row_fees_other": "Exchange fees applied at live execution",
   "vs_cryptohopper.row_multi": "Multi-coin Test",
   "vs_cryptohopper.row_multi_p": "549+ coins simultaneously",
-  "vs_cryptohopper.row_multi_other": "Per-bot configuration, not batch backtest",
+  "vs_cryptohopper.row_multi_other":
+    "Per-bot configuration, not batch backtest",
   "vs_cryptohopper.row_live": "Live Trading",
   "vs_cryptohopper.row_live_p": "Research tool — backtest only",
   "vs_cryptohopper.row_live_other": "Yes — cloud bots running continuously",
   "vs_cryptohopper.row_builder": "Strategy Builder",
   "vs_cryptohopper.row_builder_p": "Visual indicator builder",
-  "vs_cryptohopper.row_builder_other": "Template designer and marketplace strategies",
+  "vs_cryptohopper.row_builder_other":
+    "Template designer and marketplace strategies",
   "vs_cryptohopper.row_api": "API Access",
   "vs_cryptohopper.row_api_p": "Open REST API",
   "vs_cryptohopper.row_api_other": "Available on paid plans",
   "vs_cryptohopper.row_community": "Community",
   "vs_cryptohopper.row_community_p": "Public rankings & leaderboard",
-  "vs_cryptohopper.row_community_other": "Marketplace for buying/selling strategies",
+  "vs_cryptohopper.row_community_other":
+    "Marketplace for buying/selling strategies",
   "vs_cryptohopper.when_pruviq": "Choose PRUVIQ when you want...",
   "vs_cryptohopper.when_pruviq_1": "Free crypto backtesting with zero coding",
-  "vs_cryptohopper.when_pruviq_2": "Test a strategy on 549+ coins simultaneously",
-  "vs_cryptohopper.when_pruviq_3": "See realistic results with fees and slippage",
+  "vs_cryptohopper.when_pruviq_2":
+    "Test a strategy on 549+ coins simultaneously",
+  "vs_cryptohopper.when_pruviq_3":
+    "See realistic results with fees and slippage",
   "vs_cryptohopper.when_pruviq_4": "Verify with transparent backtest results",
   "vs_cryptohopper.when_other": "Choose Cryptohopper when you want...",
-  "vs_cryptohopper.when_other_1": "Cloud bots that run 24/7 without keeping a PC on",
-  "vs_cryptohopper.when_other_2": "Buy or sell ready-made strategies via marketplace",
+  "vs_cryptohopper.when_other_1":
+    "Cloud bots that run 24/7 without keeping a PC on",
+  "vs_cryptohopper.when_other_2":
+    "Buy or sell ready-made strategies via marketplace",
   "vs_cryptohopper.when_other_3": "Automated trading across multiple exchanges",
-  "vs_cryptohopper.when_other_4": "Signal-based trading with third-party providers",
+  "vs_cryptohopper.when_other_4":
+    "Signal-based trading with third-party providers",
   "vs_cryptohopper.cta_title": "Try PRUVIQ Free Today",
-  "vs_cryptohopper.cta_desc": "Test any strategy on 549+ coins for free before buying into a cloud bot subscription. No account needed.",
+  "vs_cryptohopper.cta_desc":
+    "Test any strategy on 549+ coins for free before buying into a cloud bot subscription. No account needed.",
 
   // Comparison pages: Gainium
-  "meta.vs_gainium_title": "PRUVIQ vs Gainium — Free Crypto Backtesting Alternative",
-  "meta.vs_gainium_desc": "Compare PRUVIQ with Gainium for crypto strategy backtesting. Free forever, no DCA-only limits, 549+ coins with real slippage and fee simulation.",
+  "meta.vs_gainium_title":
+    "PRUVIQ vs Gainium — Free Crypto Backtesting Alternative",
+  "meta.vs_gainium_desc":
+    "Compare PRUVIQ with Gainium for crypto strategy backtesting. Free forever, no DCA-only limits, 549+ coins with real slippage and fee simulation.",
   "vs_gainium.tag": "HONEST COMPARISON",
   "vs_gainium.title": "PRUVIQ vs Gainium",
   "vs_gainium.subtitle": "for crypto backtesting",
-  "vs_gainium.desc": "Gainium specializes in DCA bots with solid portfolio management on Binance. If you want to rigorously backtest a strategy across hundreds of coins before committing capital, PRUVIQ provides that research layer for free.",
+  "vs_gainium.desc":
+    "Gainium specializes in DCA bots with solid portfolio management on Binance. If you want to rigorously backtest a strategy across hundreds of coins before committing capital, PRUVIQ provides that research layer for free.",
   "vs_gainium.tldr": "TL;DR",
-  "vs_gainium.tldr_text": "Gainium focuses on DCA execution and portfolio management. PRUVIQ is built for research-first backtesting — free, no-code, 549+ coins, with real cost simulation.",
+  "vs_gainium.tldr_text":
+    "Gainium focuses on DCA execution and portfolio management. PRUVIQ is built for research-first backtesting — free, no-code, 549+ coins, with real cost simulation.",
   "vs_gainium.feature": "Feature",
   "vs_gainium.pruviq": "PRUVIQ",
   "vs_gainium.other": "Gainium",
@@ -1487,17 +1517,22 @@ export const en = {
   "vs_gainium.when_other_3": "Bot-level performance tracking and analytics",
   "vs_gainium.when_other_4": "Automated live trading without manual execution",
   "vs_gainium.cta_title": "Try PRUVIQ Free Today",
-  "vs_gainium.cta_desc": "Research your strategy across 549+ coins for free before deploying any DCA bot. No account needed.",
+  "vs_gainium.cta_desc":
+    "Research your strategy across 549+ coins for free before deploying any DCA bot. No account needed.",
 
   // Comparison pages: Streak
-  "meta.vs_streak_title": "PRUVIQ vs Streak — Free Crypto Backtesting Alternative",
-  "meta.vs_streak_desc": "Compare PRUVIQ with Streak for crypto strategy backtesting. Free forever, no Pine Script required, 549+ coins with real fee and slippage simulation.",
+  "meta.vs_streak_title":
+    "PRUVIQ vs Streak — Free Crypto Backtesting Alternative",
+  "meta.vs_streak_desc":
+    "Compare PRUVIQ with Streak for crypto strategy backtesting. Free forever, no Pine Script required, 549+ coins with real fee and slippage simulation.",
   "vs_streak.tag": "HONEST COMPARISON",
   "vs_streak.title": "PRUVIQ vs Streak",
   "vs_streak.subtitle": "for crypto backtesting",
-  "vs_streak.desc": "Streak is a TradingView-integrated backtesting tool that requires Pine Script and a premium subscription. If you want to test strategy ideas without writing code or paying monthly fees, PRUVIQ is the alternative.",
+  "vs_streak.desc":
+    "Streak is a TradingView-integrated backtesting tool that requires Pine Script and a premium subscription. If you want to test strategy ideas without writing code or paying monthly fees, PRUVIQ is the alternative.",
   "vs_streak.tldr": "TL;DR",
-  "vs_streak.tldr_text": "Streak targets advanced users who already know Pine Script and TradingView. PRUVIQ is for anyone who wants rigorous backtesting without coding skills or a subscription.",
+  "vs_streak.tldr_text":
+    "Streak targets advanced users who already know Pine Script and TradingView. PRUVIQ is for anyone who wants rigorous backtesting without coding skills or a subscription.",
   "vs_streak.feature": "Feature",
   "vs_streak.pruviq": "PRUVIQ",
   "vs_streak.other": "Streak",
@@ -1506,7 +1541,8 @@ export const en = {
   "vs_streak.row_price_other": "$79+/mo",
   "vs_streak.row_coding": "Coding Required",
   "vs_streak.row_coding_p": "No code — visual builder",
-  "vs_streak.row_coding_other": "Pine Script (TradingView integration required)",
+  "vs_streak.row_coding_other":
+    "Pine Script (TradingView integration required)",
   "vs_streak.row_coins": "Coins Supported",
   "vs_streak.row_coins_p": "549+ coins (Binance Futures)",
   "vs_streak.row_coins_other": "Depends on TradingView data connection",
@@ -1537,12 +1573,14 @@ export const en = {
   "vs_streak.when_pruviq_3": "See realistic results with fees and slippage",
   "vs_streak.when_pruviq_4": "Verify with transparent backtest results",
   "vs_streak.when_other": "Choose Streak when you want...",
-  "vs_streak.when_other_1": "Deep TradingView integration with Pine Script strategies",
+  "vs_streak.when_other_1":
+    "Deep TradingView integration with Pine Script strategies",
   "vs_streak.when_other_2": "Advanced custom indicators beyond standard ones",
   "vs_streak.when_other_3": "Live alerts and automated order execution",
   "vs_streak.when_other_4": "Multi-asset coverage beyond crypto futures",
   "vs_streak.cta_title": "Try PRUVIQ Free Today",
-  "vs_streak.cta_desc": "No Pine Script, no TradingView account, no fees. Test 549+ coins and see real results in seconds.",
+  "vs_streak.cta_desc":
+    "No Pine Script, no TradingView account, no fees. Test 549+ coins and see real results in seconds.",
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -323,7 +323,7 @@ export const ko: Record<TranslationKey, string> = {
   "fees.pruviq_discount": "PRUVIQ 할인",
   "fees.discount_off": "할인",
   "fees.signup": "가입하기",
-  "fees.coming_soon": "준비 중",
+  "fees.coming_soon": "제휴 링크 — 준비 중",
   "fees.visit_okx": "OKX 방문",
   "fees.okx_discount_pending": "20% 할인 코드 준비 중 — 제휴 승인 대기",
   "fees.footnote":
@@ -1251,13 +1251,16 @@ export const ko: Record<TranslationKey, string> = {
 
   // 비교 페이지: 3Commas
   "meta.vs_3commas_title": "PRUVIQ vs 3Commas — 무료 암호화폐 백테스트 대안",
-  "meta.vs_3commas_desc": "암호화폐 전략 백테스팅에서 PRUVIQ와 3Commas를 비교하세요. 구독료 없이 무료, 549개 코인, 실제 수수료 시뮬레이션.",
+  "meta.vs_3commas_desc":
+    "암호화폐 전략 백테스팅에서 PRUVIQ와 3Commas를 비교하세요. 구독료 없이 무료, 549개 코인, 실제 수수료 시뮬레이션.",
   "vs_3commas.tag": "솔직한 비교",
   "vs_3commas.title": "PRUVIQ vs 3Commas",
   "vs_3commas.subtitle": "암호화폐 백테스팅 비교",
-  "vs_3commas.desc": "3Commas는 포트폴리오 자동화에 강한 도구입니다. 구독료를 지불하기 전에 수백 개 코인에 전략을 백테스트하고 싶다면, PRUVIQ가 그 연구 단계를 무료로 제공합니다.",
+  "vs_3commas.desc":
+    "3Commas는 포트폴리오 자동화에 강한 도구입니다. 구독료를 지불하기 전에 수백 개 코인에 전략을 백테스트하고 싶다면, PRUVIQ가 그 연구 단계를 무료로 제공합니다.",
   "vs_3commas.tldr": "한 줄 요약",
-  "vs_3commas.tldr_text": "3Commas는 DCA/그리드 봇 실거래 실행에 강합니다. PRUVIQ는 연구 우선 백테스팅 도구 — 무료, 코딩 불필요, 549개 코인, 실제 수수료와 슬리피지 반영.",
+  "vs_3commas.tldr_text":
+    "3Commas는 DCA/그리드 봇 실거래 실행에 강합니다. PRUVIQ는 연구 우선 백테스팅 도구 — 무료, 코딩 불필요, 549개 코인, 실제 수수료와 슬리피지 반영.",
   "vs_3commas.feature": "기능",
   "vs_3commas.pruviq": "PRUVIQ",
   "vs_3commas.other": "3Commas",
@@ -1294,25 +1297,33 @@ export const ko: Record<TranslationKey, string> = {
   "vs_3commas.when_pruviq": "PRUVIQ를 선택하세요, 만약...",
   "vs_3commas.when_pruviq_1": "코딩 없이 무료로 암호화폐 백테스트를 원할 때",
   "vs_3commas.when_pruviq_2": "549개 코인에 전략을 동시에 테스트하고 싶을 때",
-  "vs_3commas.when_pruviq_3": "수수료·슬리피지를 반영한 현실적인 결과를 원할 때",
+  "vs_3commas.when_pruviq_3":
+    "수수료·슬리피지를 반영한 현실적인 결과를 원할 때",
   "vs_3commas.when_pruviq_4": "투명한 백테스트 결과로 전략을 검증하고 싶을 때",
   "vs_3commas.when_other": "3Commas를 선택하세요, 만약...",
   "vs_3commas.when_other_1": "24/7 자동 DCA 또는 그리드 봇이 필요할 때",
-  "vs_3commas.when_other_2": "여러 거래소에 걸쳐 포트폴리오를 리밸런싱하고 싶을 때",
-  "vs_3commas.when_other_3": "마켓플레이스의 전략을 그대로 복사해 사용하고 싶을 때",
-  "vs_3commas.when_other_4": "수동 주문 없이 자동으로 실거래를 실행하고 싶을 때",
+  "vs_3commas.when_other_2":
+    "여러 거래소에 걸쳐 포트폴리오를 리밸런싱하고 싶을 때",
+  "vs_3commas.when_other_3":
+    "마켓플레이스의 전략을 그대로 복사해 사용하고 싶을 때",
+  "vs_3commas.when_other_4":
+    "수동 주문 없이 자동으로 실거래를 실행하고 싶을 때",
   "vs_3commas.cta_title": "PRUVIQ 지금 무료로 시작하기",
-  "vs_3commas.cta_desc": "유료 도구를 결정하기 전에 549개 코인으로 전략을 무료로 백테스트하세요. 회원가입 불필요.",
+  "vs_3commas.cta_desc":
+    "유료 도구를 결정하기 전에 549개 코인으로 전략을 무료로 백테스트하세요. 회원가입 불필요.",
 
   // 비교 페이지: Coinrule
   "meta.vs_coinrule_title": "PRUVIQ vs Coinrule — 무료 암호화폐 백테스트 대안",
-  "meta.vs_coinrule_desc": "암호화폐 전략 백테스팅에서 PRUVIQ와 Coinrule을 비교하세요. 무료, IF-THEN 제한 없음, 549개 코인 + 실제 수수료 시뮬레이션.",
+  "meta.vs_coinrule_desc":
+    "암호화폐 전략 백테스팅에서 PRUVIQ와 Coinrule을 비교하세요. 무료, IF-THEN 제한 없음, 549개 코인 + 실제 수수료 시뮬레이션.",
   "vs_coinrule.tag": "솔직한 비교",
   "vs_coinrule.title": "PRUVIQ vs Coinrule",
   "vs_coinrule.subtitle": "암호화폐 백테스팅 비교",
-  "vs_coinrule.desc": "Coinrule은 IF-THEN 규칙으로 거래를 자동화하는 도구입니다. 전략을 실제로 배포하기 전에 수백 개 코인에 대해 엄격하게 백테스트하고 싶다면, PRUVIQ가 그 역할을 무료로 합니다.",
+  "vs_coinrule.desc":
+    "Coinrule은 IF-THEN 규칙으로 거래를 자동화하는 도구입니다. 전략을 실제로 배포하기 전에 수백 개 코인에 대해 엄격하게 백테스트하고 싶다면, PRUVIQ가 그 역할을 무료로 합니다.",
   "vs_coinrule.tldr": "한 줄 요약",
-  "vs_coinrule.tldr_text": "Coinrule은 규칙 기반 자동화 도구입니다. PRUVIQ는 백테스팅 우선 연구 도구 — 무료, 코딩 불필요, 549개 코인, 슬리피지·수수료 내장.",
+  "vs_coinrule.tldr_text":
+    "Coinrule은 규칙 기반 자동화 도구입니다. PRUVIQ는 백테스팅 우선 연구 도구 — 무료, 코딩 불필요, 549개 코인, 슬리피지·수수료 내장.",
   "vs_coinrule.feature": "기능",
   "vs_coinrule.pruviq": "PRUVIQ",
   "vs_coinrule.other": "Coinrule",
@@ -1349,25 +1360,33 @@ export const ko: Record<TranslationKey, string> = {
   "vs_coinrule.when_pruviq": "PRUVIQ를 선택하세요, 만약...",
   "vs_coinrule.when_pruviq_1": "코딩 없이 무료로 암호화폐 백테스트를 원할 때",
   "vs_coinrule.when_pruviq_2": "549개 코인에 전략을 동시에 테스트하고 싶을 때",
-  "vs_coinrule.when_pruviq_3": "수수료·슬리피지를 반영한 현실적인 결과를 원할 때",
+  "vs_coinrule.when_pruviq_3":
+    "수수료·슬리피지를 반영한 현실적인 결과를 원할 때",
   "vs_coinrule.when_pruviq_4": "투명한 백테스트 결과로 전략을 검증하고 싶을 때",
   "vs_coinrule.when_other": "Coinrule을 선택하세요, 만약...",
-  "vs_coinrule.when_other_1": "코딩 없이 IF-THEN 로직으로 거래를 자동화하고 싶을 때",
-  "vs_coinrule.when_other_2": "하나의 대시보드에서 여러 거래소를 연결하고 싶을 때",
+  "vs_coinrule.when_other_1":
+    "코딩 없이 IF-THEN 로직으로 거래를 자동화하고 싶을 때",
+  "vs_coinrule.when_other_2":
+    "하나의 대시보드에서 여러 거래소를 연결하고 싶을 때",
   "vs_coinrule.when_other_3": "커뮤니티 규칙 템플릿을 바로 활용하고 싶을 때",
   "vs_coinrule.when_other_4": "24시간 자동 실거래 전략을 운영하고 싶을 때",
   "vs_coinrule.cta_title": "PRUVIQ 지금 무료로 시작하기",
-  "vs_coinrule.cta_desc": "어떤 자동화 도구에 비용을 지불하기 전에 549개 코인으로 전략을 백테스트하세요. 회원가입 불필요.",
+  "vs_coinrule.cta_desc":
+    "어떤 자동화 도구에 비용을 지불하기 전에 549개 코인으로 전략을 백테스트하세요. 회원가입 불필요.",
 
   // 비교 페이지: Cryptohopper
-  "meta.vs_cryptohopper_title": "PRUVIQ vs Cryptohopper — 무료 암호화폐 백테스트 대안",
-  "meta.vs_cryptohopper_desc": "암호화폐 전략 백테스팅에서 PRUVIQ와 Cryptohopper를 비교하세요. 무료, 클라우드 구독 불필요, 549개 코인 + 실제 수수료·슬리피지 시뮬레이션.",
+  "meta.vs_cryptohopper_title":
+    "PRUVIQ vs Cryptohopper — 무료 암호화폐 백테스트 대안",
+  "meta.vs_cryptohopper_desc":
+    "암호화폐 전략 백테스팅에서 PRUVIQ와 Cryptohopper를 비교하세요. 무료, 클라우드 구독 불필요, 549개 코인 + 실제 수수료·슬리피지 시뮬레이션.",
   "vs_cryptohopper.tag": "솔직한 비교",
   "vs_cryptohopper.title": "PRUVIQ vs Cryptohopper",
   "vs_cryptohopper.subtitle": "암호화폐 백테스팅 비교",
-  "vs_cryptohopper.desc": "Cryptohopper는 전략 마켓플레이스를 갖춘 클라우드 기반 봇 서비스입니다. 실제 배포 전에 수백 개 코인에서 아이디어를 엄밀하게 테스트하고 싶다면, PRUVIQ가 그 연구 레이어를 무료로 제공합니다.",
+  "vs_cryptohopper.desc":
+    "Cryptohopper는 전략 마켓플레이스를 갖춘 클라우드 기반 봇 서비스입니다. 실제 배포 전에 수백 개 코인에서 아이디어를 엄밀하게 테스트하고 싶다면, PRUVIQ가 그 연구 레이어를 무료로 제공합니다.",
   "vs_cryptohopper.tldr": "한 줄 요약",
-  "vs_cryptohopper.tldr_text": "Cryptohopper는 유료 마켓플레이스를 갖춘 클라우드 봇입니다. PRUVIQ는 무료 백테스팅 연구 도구 — 549개 코인, 실제 수수료 반영, 모든 결과 투명하게 공개.",
+  "vs_cryptohopper.tldr_text":
+    "Cryptohopper는 유료 마켓플레이스를 갖춘 클라우드 봇입니다. PRUVIQ는 무료 백테스팅 연구 도구 — 549개 코인, 실제 수수료 반영, 모든 결과 투명하게 공개.",
   "vs_cryptohopper.feature": "기능",
   "vs_cryptohopper.pruviq": "PRUVIQ",
   "vs_cryptohopper.other": "Cryptohopper",
@@ -1402,27 +1421,39 @@ export const ko: Record<TranslationKey, string> = {
   "vs_cryptohopper.row_community_p": "공개 랭킹 & 리더보드",
   "vs_cryptohopper.row_community_other": "전략 구매·판매 마켓플레이스",
   "vs_cryptohopper.when_pruviq": "PRUVIQ를 선택하세요, 만약...",
-  "vs_cryptohopper.when_pruviq_1": "코딩 없이 무료로 암호화폐 백테스트를 원할 때",
-  "vs_cryptohopper.when_pruviq_2": "549개 코인에 전략을 동시에 테스트하고 싶을 때",
-  "vs_cryptohopper.when_pruviq_3": "수수료·슬리피지를 반영한 현실적인 결과를 원할 때",
-  "vs_cryptohopper.when_pruviq_4": "투명한 백테스트 결과로 전략을 검증하고 싶을 때",
+  "vs_cryptohopper.when_pruviq_1":
+    "코딩 없이 무료로 암호화폐 백테스트를 원할 때",
+  "vs_cryptohopper.when_pruviq_2":
+    "549개 코인에 전략을 동시에 테스트하고 싶을 때",
+  "vs_cryptohopper.when_pruviq_3":
+    "수수료·슬리피지를 반영한 현실적인 결과를 원할 때",
+  "vs_cryptohopper.when_pruviq_4":
+    "투명한 백테스트 결과로 전략을 검증하고 싶을 때",
   "vs_cryptohopper.when_other": "Cryptohopper를 선택하세요, 만약...",
-  "vs_cryptohopper.when_other_1": "PC를 켜 두지 않아도 되는 24/7 클라우드 봇이 필요할 때",
-  "vs_cryptohopper.when_other_2": "마켓플레이스에서 완성된 전략을 구매해 사용하고 싶을 때",
-  "vs_cryptohopper.when_other_3": "여러 거래소에서 자동 거래를 운영하고 싶을 때",
-  "vs_cryptohopper.when_other_4": "서드파티 시그널 제공업체와 연동한 트레이딩을 원할 때",
+  "vs_cryptohopper.when_other_1":
+    "PC를 켜 두지 않아도 되는 24/7 클라우드 봇이 필요할 때",
+  "vs_cryptohopper.when_other_2":
+    "마켓플레이스에서 완성된 전략을 구매해 사용하고 싶을 때",
+  "vs_cryptohopper.when_other_3":
+    "여러 거래소에서 자동 거래를 운영하고 싶을 때",
+  "vs_cryptohopper.when_other_4":
+    "서드파티 시그널 제공업체와 연동한 트레이딩을 원할 때",
   "vs_cryptohopper.cta_title": "PRUVIQ 지금 무료로 시작하기",
-  "vs_cryptohopper.cta_desc": "클라우드 봇 구독을 결정하기 전에 549개 코인으로 전략을 무료로 테스트하세요. 회원가입 불필요.",
+  "vs_cryptohopper.cta_desc":
+    "클라우드 봇 구독을 결정하기 전에 549개 코인으로 전략을 무료로 테스트하세요. 회원가입 불필요.",
 
   // 비교 페이지: Gainium
   "meta.vs_gainium_title": "PRUVIQ vs Gainium — 무료 암호화폐 백테스트 대안",
-  "meta.vs_gainium_desc": "암호화폐 전략 백테스팅에서 PRUVIQ와 Gainium을 비교하세요. 무료, DCA 전용 제약 없음, 549개 코인 + 실제 슬리피지·수수료 시뮬레이션.",
+  "meta.vs_gainium_desc":
+    "암호화폐 전략 백테스팅에서 PRUVIQ와 Gainium을 비교하세요. 무료, DCA 전용 제약 없음, 549개 코인 + 실제 슬리피지·수수료 시뮬레이션.",
   "vs_gainium.tag": "솔직한 비교",
   "vs_gainium.title": "PRUVIQ vs Gainium",
   "vs_gainium.subtitle": "암호화폐 백테스팅 비교",
-  "vs_gainium.desc": "Gainium은 바이낸스 중심의 DCA 봇과 포트폴리오 관리에 특화된 도구입니다. 자본을 투입하기 전에 수백 개 코인에서 전략을 엄밀하게 검증하고 싶다면, PRUVIQ가 그 연구 레이어를 무료로 제공합니다.",
+  "vs_gainium.desc":
+    "Gainium은 바이낸스 중심의 DCA 봇과 포트폴리오 관리에 특화된 도구입니다. 자본을 투입하기 전에 수백 개 코인에서 전략을 엄밀하게 검증하고 싶다면, PRUVIQ가 그 연구 레이어를 무료로 제공합니다.",
   "vs_gainium.tldr": "한 줄 요약",
-  "vs_gainium.tldr_text": "Gainium은 DCA 실행과 포트폴리오 관리에 집중합니다. PRUVIQ는 연구 우선 백테스팅 도구 — 무료, 코딩 불필요, 549개 코인, 실제 비용 시뮬레이션.",
+  "vs_gainium.tldr_text":
+    "Gainium은 DCA 실행과 포트폴리오 관리에 집중합니다. PRUVIQ는 연구 우선 백테스팅 도구 — 무료, 코딩 불필요, 549개 코인, 실제 비용 시뮬레이션.",
   "vs_gainium.feature": "기능",
   "vs_gainium.pruviq": "PRUVIQ",
   "vs_gainium.other": "Gainium",
@@ -1459,25 +1490,31 @@ export const ko: Record<TranslationKey, string> = {
   "vs_gainium.when_pruviq": "PRUVIQ를 선택하세요, 만약...",
   "vs_gainium.when_pruviq_1": "코딩 없이 무료로 암호화폐 백테스트를 원할 때",
   "vs_gainium.when_pruviq_2": "549개 코인에 전략을 동시에 테스트하고 싶을 때",
-  "vs_gainium.when_pruviq_3": "수수료·슬리피지를 반영한 현실적인 결과를 원할 때",
+  "vs_gainium.when_pruviq_3":
+    "수수료·슬리피지를 반영한 현실적인 결과를 원할 때",
   "vs_gainium.when_pruviq_4": "투명한 백테스트 결과로 전략을 검증하고 싶을 때",
   "vs_gainium.when_other": "Gainium을 선택하세요, 만약...",
   "vs_gainium.when_other_1": "자동 평균단가 분할 매수(DCA) 봇이 필요할 때",
-  "vs_gainium.when_other_2": "바이낸스에서 포트폴리오 관리 대시보드가 필요할 때",
+  "vs_gainium.when_other_2":
+    "바이낸스에서 포트폴리오 관리 대시보드가 필요할 때",
   "vs_gainium.when_other_3": "봇별 성과 추적과 분석이 필요할 때",
   "vs_gainium.when_other_4": "수동 주문 없이 자동 실거래를 운영하고 싶을 때",
   "vs_gainium.cta_title": "PRUVIQ 지금 무료로 시작하기",
-  "vs_gainium.cta_desc": "DCA 봇을 배포하기 전에 549개 코인으로 전략을 무료로 리서치하세요. 회원가입 불필요.",
+  "vs_gainium.cta_desc":
+    "DCA 봇을 배포하기 전에 549개 코인으로 전략을 무료로 리서치하세요. 회원가입 불필요.",
 
   // 비교 페이지: Streak
   "meta.vs_streak_title": "PRUVIQ vs Streak — 무료 암호화폐 백테스트 대안",
-  "meta.vs_streak_desc": "암호화폐 전략 백테스팅에서 PRUVIQ와 Streak을 비교하세요. 무료, Pine Script 불필요, 549개 코인 + 실제 수수료·슬리피지 시뮬레이션.",
+  "meta.vs_streak_desc":
+    "암호화폐 전략 백테스팅에서 PRUVIQ와 Streak을 비교하세요. 무료, Pine Script 불필요, 549개 코인 + 실제 수수료·슬리피지 시뮬레이션.",
   "vs_streak.tag": "솔직한 비교",
   "vs_streak.title": "PRUVIQ vs Streak",
   "vs_streak.subtitle": "암호화폐 백테스팅 비교",
-  "vs_streak.desc": "Streak은 TradingView와 연동되는 백테스팅 도구로, Pine Script 사용과 프리미엄 구독이 필요합니다. 코딩이나 월 구독료 없이 전략 아이디어를 검증하고 싶다면 PRUVIQ가 대안입니다.",
+  "vs_streak.desc":
+    "Streak은 TradingView와 연동되는 백테스팅 도구로, Pine Script 사용과 프리미엄 구독이 필요합니다. 코딩이나 월 구독료 없이 전략 아이디어를 검증하고 싶다면 PRUVIQ가 대안입니다.",
   "vs_streak.tldr": "한 줄 요약",
-  "vs_streak.tldr_text": "Streak은 Pine Script와 TradingView를 이미 쓰는 고급 사용자를 위한 도구입니다. PRUVIQ는 코딩 실력이나 구독 없이도 엄밀한 백테스팅을 원하는 모든 사람을 위한 도구입니다.",
+  "vs_streak.tldr_text":
+    "Streak은 Pine Script와 TradingView를 이미 쓰는 고급 사용자를 위한 도구입니다. PRUVIQ는 코딩 실력이나 구독 없이도 엄밀한 백테스팅을 원하는 모든 사람을 위한 도구입니다.",
   "vs_streak.feature": "기능",
   "vs_streak.pruviq": "PRUVIQ",
   "vs_streak.other": "Streak",
@@ -1517,10 +1554,12 @@ export const ko: Record<TranslationKey, string> = {
   "vs_streak.when_pruviq_3": "수수료·슬리피지를 반영한 현실적인 결과를 원할 때",
   "vs_streak.when_pruviq_4": "투명한 백테스트 결과로 전략을 검증하고 싶을 때",
   "vs_streak.when_other": "Streak을 선택하세요, 만약...",
-  "vs_streak.when_other_1": "Pine Script 전략을 TradingView와 깊이 연동하고 싶을 때",
+  "vs_streak.when_other_1":
+    "Pine Script 전략을 TradingView와 깊이 연동하고 싶을 때",
   "vs_streak.when_other_2": "표준 지표 이상의 고급 커스텀 지표가 필요할 때",
   "vs_streak.when_other_3": "라이브 알림과 자동 주문 실행이 필요할 때",
   "vs_streak.when_other_4": "암호화폐 선물 이외 다양한 자산군을 다루고 싶을 때",
   "vs_streak.cta_title": "PRUVIQ 지금 무료로 시작하기",
-  "vs_streak.cta_desc": "Pine Script도, TradingView 계정도, 구독료도 필요 없습니다. 549개 코인으로 실제 결과를 몇 초 만에 확인하세요.",
+  "vs_streak.cta_desc":
+    "Pine Script도, TradingView 계정도, 구독료도 필요 없습니다. 549개 코인으로 실제 결과를 몇 초 만에 확인하세요.",
 };

--- a/src/pages/ko/market/index.astro
+++ b/src/pages/ko/market/index.astro
@@ -27,6 +27,12 @@ const t = useTranslations('ko');
           </div>
           <div class="h-64 bg-[--color-bg-hover] rounded-lg"></div>
         </div>
+        <noscript>
+          <div class="border border-[--color-border] rounded-lg p-6 text-center text-[--color-text-muted] text-sm font-mono mt-4">
+            <p class="mb-2 font-bold">실시간 시장 데이터를 표시하려면 JavaScript가 필요합니다.</p>
+            <p>시장 가격은 JavaScript가 필요합니다. 라이브 암호화폐 데이터를 보려면 JavaScript를 활성화하세요.</p>
+          </div>
+        </noscript>
       </div>
     </div>
     <div class="mt-10 pt-8 border-t border-[--color-border] text-center max-w-5xl mx-auto px-4">

--- a/src/pages/ko/strategies/ranking.astro
+++ b/src/pages/ko/strategies/ranking.astro
@@ -76,6 +76,13 @@ const today = new Date().toLocaleDateString('ko-KR', {
       </div>
 
       <!-- Ranking component (client-side fetch) -->
+      <noscript>
+        <div class="border border-[--color-border] rounded-lg p-6 text-center text-[--color-text-muted] text-sm font-mono">
+          <p class="mb-2 font-bold">랭킹을 표시하려면 JavaScript가 필요합니다.</p>
+          <p>랭킹은 매일 업데이트되며 JavaScript가 필요합니다. 브라우저에서 JavaScript를 활성화해 주세요.</p>
+          <p class="mt-3"><a href="/ko/simulate" class="text-[--color-accent] underline">시뮬레이터 열기 →</a></p>
+        </div>
+      </noscript>
       <ErrorBoundary name="Strategy Ranking" client:load>
         <StrategyRanking lang="ko" client:load />
       </ErrorBoundary>

--- a/src/pages/market/index.astro
+++ b/src/pages/market/index.astro
@@ -27,6 +27,12 @@ const t = useTranslations('en');
           </div>
           <div class="h-64 bg-[--color-bg-hover] rounded-lg"></div>
         </div>
+        <noscript>
+          <div class="border border-[--color-border] rounded-lg p-6 text-center text-[--color-text-muted] text-sm font-mono mt-4">
+            <p class="mb-2 font-bold">JavaScript required for live market data.</p>
+            <p>Market prices require JavaScript to load. Please enable JavaScript to view live crypto data.</p>
+          </div>
+        </noscript>
       </div>
     </div>
     <div class="mt-10 pt-8 border-t border-[--color-border] text-center max-w-5xl mx-auto px-4">

--- a/src/pages/strategies/ranking.astro
+++ b/src/pages/strategies/ranking.astro
@@ -76,6 +76,13 @@ const today = new Date().toLocaleDateString('en-US', {
       </div>
 
       <!-- Ranking component (client-side fetch) -->
+      <noscript>
+        <div class="border border-[--color-border] rounded-lg p-6 text-center text-[--color-text-muted] text-sm font-mono">
+          <p class="mb-2 font-bold">JavaScript required to display rankings.</p>
+          <p>Rankings are updated daily and require JavaScript to load. Please enable JavaScript in your browser.</p>
+          <p class="mt-3"><a href="/simulate" class="text-[--color-accent] underline">Open Simulator →</a></p>
+        </div>
+      </noscript>
       <ErrorBoundary name="Strategy Ranking" client:load>
         <StrategyRanking lang="en" client:load />
       </ErrorBoundary>


### PR DESCRIPTION
## Summary
- Add `<noscript>` fallbacks to ranking and market pages (EN + KO) — users with JS disabled see informative message instead of skeleton
- OKX fees button: "Coming Soon" → "Affiliate link — coming soon" (clearer intent)

## Test plan
- [ ] Load /strategies/ranking with JS disabled → noscript message visible
- [ ] Load /market with JS disabled → noscript message visible
- [ ] /fees OKX button shows new text
- [ ] KO versions same as EN

🤖 Generated with [Claude Code](https://claude.com/claude-code)