### PR TITLE
fix(api): P1 validation — date strings, market_type, top_n bounds

### DIFF
--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -18,7 +18,7 @@ class SimulationRequest(BaseModel):
     max_bars: int = Field(default=48, ge=6, le=168, description="Max holding period (bars)")
     market_type: Literal["futures", "spot"] = Field(default="futures", description="spot | futures")
     symbols: Optional[List[str]] = Field(default=None, description="Specific symbols (null = use top_n)")
-    top_n: Optional[int] = Field(default=None, ge=1, description="Number of coins (null = top 50)")
+    top_n: Optional[int] = Field(default=None, ge=1, le=535, description="Number of coins (null = top 50)")
     start_date: Optional[str] = Field(default=None, description="Backtest start date (YYYY-MM-DD)")
     end_date: Optional[str] = Field(default=None, description="Backtest end date (YYYY-MM-DD)")
     timeframe: str = Field(default="1H", description="Candle timeframe: 1H, 2H, 4H, 6H, 12H, 1D, 1W")
@@ -275,7 +275,7 @@ class CompareRequest(BaseModel):
     sl_pct: float = Field(default=10.0, ge=1.0, le=30.0, description="Stop Loss %")
     tp_pct: float = Field(default=8.0, ge=1.0, le=30.0, description="Take Profit %")
     max_bars: int = Field(default=48, ge=6, le=168, description="Max holding period (bars)")
-    top_n: Optional[int] = Field(default=None, ge=1, description="Number of coins (null = top 50)")
+    top_n: Optional[int] = Field(default=None, ge=1, le=535, description="Number of coins (null = top 50)")
 
 
 class StrategyResult(BaseModel):
@@ -337,7 +337,7 @@ class BacktestRequest(BaseModel):
     sl_pct: float = Field(default=10.0, ge=0.5, le=50.0, description="Stop Loss %")
     tp_pct: float = Field(default=8.0, ge=0.5, le=100.0, description="Take Profit %")
     max_bars: int = Field(default=48, ge=1, le=168, description="Max holding period (bars)")
-    top_n: Optional[int] = Field(default=None, ge=1, description="Number of coins (null = top 50)")
+    top_n: Optional[int] = Field(default=None, ge=1, le=535, description="Number of coins (null = top 50)")
     symbols: Optional[List[str]] = Field(default=None, description="Specific symbols")
     start_date: Optional[str] = Field(default=None, description="Backtest start date (YYYY-MM-DD)")
     end_date: Optional[str] = Field(default=None, description="Backtest end date (YYYY-MM-DD)")
@@ -580,7 +580,7 @@ class ValidateRequest(BaseModel):
     tp_pct: float = Field(default=8.0, ge=1.0, le=30.0)
     max_bars: int = Field(default=48, ge=6, le=168)
     market_type: Literal["futures", "spot"] = Field(default="futures")
-    top_n: Optional[int] = Field(default=None, ge=1, description="Number of coins (null = top 50)")
+    top_n: Optional[int] = Field(default=None, ge=1, le=535, description="Number of coins (null = top 50)")
     symbols: Optional[List[str]] = Field(default=None)
     oos_pct: float = Field(default=30.0, ge=10.0, le=50.0, description="OOS split %")
     mc_runs: int = Field(default=1000, ge=100, le=5000, description="Monte Carlo runs")


### PR DESCRIPTION
## Summary

Fixes 3 P1 issues from backend audit (`improvements-backend-20260315-08.md`), effective 2026-03-16.

- **Fix 1 (date validation):** Invalid date strings now return HTTP 400 instead of silently producing wrong output. `filter_df_by_date()` in `main.py` already raises `HTTPException(400, ...)` — confirmed pre-existing and correct, no change needed.
- **Fix 2 (market_type):** `market_type` field already uses `Literal["futures", "spot"]` in all 3 schema classes (`SimulationRequest`, `CoinSimRequest`, `ValidateRequest`) — Pydantic enforces this at deserialization, prevents wrong cost model. Pre-existing, no change needed.
- **Fix 3 (top_n upper bound):** Added `le=535` to `top_n` in all 4 schema classes — `SimulationRequest`, `CompareRequest`, `BacktestRequest`, `ValidateRequest`. Prevents cache pollution and unbounded coin iteration beyond the 535-coin dataset.

## Changed files

- `backend/api/schemas.py` — 4 `top_n` fields: `ge=1` → `ge=1, le=535`

## Test plan

- [ ] `POST /simulate` with `top_n=600` → returns HTTP 422 (Pydantic validation error)
- [ ] `POST /simulate` with `top_n=535` → accepted
- [ ] `POST /backtest` with `top_n=1000` → returns HTTP 422
- [ ] `POST /validate` with `top_n=536` → returns HTTP 422
- [ ] `POST /compare` with `top_n=536` → returns HTTP 422
- [ ] `POST /simulate` with `start_date="not-a-date"` → returns HTTP 400
- [ ] `POST /simulate` with `market_type="invalid"` → returns HTTP 422

Source: `improvements-backend-20260315-08.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)