### PR TITLE
fix(simulate): correct Sharpe/Sortino sign + cap PF sentinel + UI labels

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -779,15 +779,12 @@ async def simulate(req: SimulationRequest):
     # Risk-adjusted metrics — daily-return based (annualized sqrt(365))
     from collections import defaultdict as _dd_sim
     daily_pnl_sim = _dd_sim(float)
-    daily_concurrent_sim = _dd_sim(int)  # concurrent open positions per day
     for t in all_trades:
         day_key = t.get("exit_time", t["time"])[:10]  # YYYY-MM-DD (exit time)
         if day_key and day_key != "NaT" and len(day_key) == 10:
             daily_pnl_sim[day_key] += t["pnl_pct"]
-            daily_concurrent_sim[day_key] += 1
-    # Capital-weighted daily returns: divide each day's PnL by the number of
-    # concurrent positions that day (not total n_coins selected), so the Sharpe
-    # reflects return-per-deployed-capital rather than return-per-universe-size.
+    # Portfolio daily returns: divide by n_coins (same denominator as total_return).
+    # This keeps Sharpe sign consistent with total_return direction.
     # Fill zero-return days so Sharpe isn't inflated by excluding non-trading days.
     if daily_pnl_sim and len(daily_pnl_sim) >= 2:
         from datetime import datetime as _dt_sim, timedelta as _td_sim
@@ -796,13 +793,13 @@ async def simulate(req: SimulationRequest):
         d_end = _dt_sim.strptime(sorted_days[-1], "%Y-%m-%d")
         all_days = [(d_start + _td_sim(days=i)).strftime("%Y-%m-%d") for i in range((d_end - d_start).days + 1)]
         daily_returns_sim = np.array([
-            daily_pnl_sim[d] / max(daily_concurrent_sim[d], 1) if d in daily_pnl_sim else 0.0
+            daily_pnl_sim[d] / n_coins if d in daily_pnl_sim else 0.0
             for d in all_days
         ])
     elif daily_pnl_sim:
         daily_returns_sim = np.array([
-            pnl / max(daily_concurrent_sim[d], 1)
-            for d, pnl in daily_pnl_sim.items()
+            pnl / n_coins
+            for pnl in daily_pnl_sim.values()
         ])
     else:
         daily_returns_sim = np.array([])
@@ -3243,7 +3240,7 @@ async def get_daily_rankings(date: Optional[str] = None):
             "strategy": e.get("strategy", ""),
             "direction": e.get("direction", ""),
             "win_rate": round(e.get("win_rate", 0), 2),
-            "profit_factor": round(e.get("profit_factor", 0), 2),
+            "profit_factor": min(round(e.get("profit_factor", 0), 2), 99.99),  # cap sentinel 999.99
             "total_return": round(e.get("total_return", 0), 2),
             "total_trades": trades,
             "sharpe": round(e.get("sharpe", 0), 2),

--- a/src/components/QuickTestPanel.tsx
+++ b/src/components/QuickTestPanel.tsx
@@ -12,103 +12,167 @@
  *  5. Hedged Portfolio (헤징) — SHORT + LONG combined strategies
  */
 
-import { useState } from 'preact/hooks';
-import { COLORS } from './simulator-types';
+import { useState } from "preact/hooks";
+import { COLORS } from "./simulator-types";
 
 export interface QuickCategory {
   id: string;
   icon: string;
-  presets: string[];       // backend preset IDs
-  defaultPreset: string;   // which one to run first
+  presets: string[]; // backend preset IDs
+  defaultPreset: string; // which one to run first
 }
 
 interface Props {
-  lang: 'en' | 'ko';
+  lang: "en" | "ko";
   onRunPreset: (presetId: string) => Promise<void>;
   isRunning: boolean;
   hasResult: boolean;
 }
 
 const CATEGORIES: QuickCategory[] = [
-  { id: 'breakout',  icon: '💥', presets: ['bb-squeeze-short', 'bb-squeeze-long', 'hv-squeeze-breakout-short', 'hv-squeeze-breakout-long'], defaultPreset: 'bb-squeeze-short' },
-  { id: 'reversal',  icon: '🔄', presets: ['rsi-reversal-long', 'psar-reversal-long', 'psar-reversal-short', 'williams-r-oversold-long', 'williams-r-overbought-short', 'rsi-bb-oversold-long'], defaultPreset: 'rsi-reversal-long' },
-  { id: 'range',     icon: '↔️',  presets: ['grid-mean-reversion-long', 'bb-band-bounce-long', 'dca-oversold-long', 'rsi-bb-overbought-short'], defaultPreset: 'grid-mean-reversion-long' },
-  { id: 'trend',     icon: '🚀', presets: ['adx-trend-long', 'adx-trend-short', 'ichimoku-cloud-long', 'ichimoku-cloud-short', 'macd-momentum-long', 'ema-crossover-long', 'turtle-breakout-long', 'turtle-breakout-short'], defaultPreset: 'adx-trend-long' },
-  { id: 'hedged',    icon: '🛡️', presets: ['stochastic-overbought-short', 'stoch-rsi-overbought-short', 'macd-crossover-short', 'ema-crossover-short'], defaultPreset: 'stochastic-overbought-short' },
+  {
+    id: "breakout",
+    icon: "💥",
+    presets: [
+      "bb-squeeze-short",
+      "bb-squeeze-long",
+      "hv-squeeze-breakout-short",
+      "hv-squeeze-breakout-long",
+    ],
+    defaultPreset: "bb-squeeze-short",
+  },
+  {
+    id: "reversal",
+    icon: "🔄",
+    presets: [
+      "rsi-reversal-long",
+      "psar-reversal-long",
+      "psar-reversal-short",
+      "williams-r-oversold-long",
+      "williams-r-overbought-short",
+      "rsi-bb-oversold-long",
+    ],
+    defaultPreset: "rsi-reversal-long",
+  },
+  {
+    id: "range",
+    icon: "↔️",
+    presets: [
+      "grid-mean-reversion-long",
+      "bb-band-bounce-long",
+      "dca-oversold-long",
+      "rsi-bb-overbought-short",
+    ],
+    defaultPreset: "grid-mean-reversion-long",
+  },
+  {
+    id: "trend",
+    icon: "🚀",
+    presets: [
+      "adx-trend-long",
+      "adx-trend-short",
+      "ichimoku-cloud-long",
+      "ichimoku-cloud-short",
+      "macd-momentum-long",
+      "ema-crossover-long",
+      "turtle-breakout-long",
+      "turtle-breakout-short",
+    ],
+    defaultPreset: "adx-trend-long",
+  },
+  {
+    id: "hedged",
+    icon: "🛡️",
+    presets: [
+      "stochastic-overbought-short",
+      "stoch-rsi-overbought-short",
+      "macd-crossover-short",
+      "ema-crossover-short",
+    ],
+    defaultPreset: "stochastic-overbought-short",
+  },
 ];
 
 const L = {
   en: {
-    title: 'Choose a Market Scenario',
-    subtitle: 'AI picks the best strategy for each situation',
-    breakout: 'Breakout',
-    breakoutDesc: 'Squeeze → explosion',
-    reversal: 'Reversals',
-    reversalDesc: 'RSI / SAR / Williams %R',
-    range: 'Range Trading',
-    rangeDesc: 'Mean reversion in sideways',
-    trend: 'Trend Following',
-    trendDesc: 'ADX / Ichimoku / MACD',
-    hedged: 'Hedging',
-    hedgedDesc: 'Short-side strategies',
-    run: 'Test Now',
-    running: 'Running...',
-    aiPick: 'AI Recommended',
-    alsoTry: 'Also try:',
-    resultHint: 'Scroll down to see results',
+    title: "Choose a Market Scenario",
+    subtitle: "Pick a market scenario and test a top strategy for it",
+    breakout: "Breakout",
+    breakoutDesc: "Squeeze → explosion",
+    reversal: "Reversals",
+    reversalDesc: "RSI / SAR / Williams %R",
+    range: "Range Trading",
+    rangeDesc: "Mean reversion in sideways",
+    trend: "Trend Following",
+    trendDesc: "ADX / Ichimoku / MACD",
+    hedged: "Hedging",
+    hedgedDesc: "Short-side strategies",
+    run: "Test Now",
+    running: "Running...",
+    aiPick: "Most Popular",
+    alsoTry: "Also try:",
+    resultHint: "Scroll down to see results",
   },
   ko: {
-    title: '시장 상황을 선택하세요',
-    subtitle: 'AI가 각 상황에 최적 전략을 선택합니다',
-    breakout: '돌파',
-    breakoutDesc: '변동성 압축 → 폭발',
-    reversal: '반전',
-    reversalDesc: 'RSI / SAR / 윌리엄스',
-    range: '박스권',
-    rangeDesc: '횡보장 평균회귀',
-    trend: '추세',
-    trendDesc: 'ADX / 일목 / MACD',
-    hedged: '헤징',
-    hedgedDesc: '숏 전략 (하락방어)',
-    run: '지금 테스트',
-    running: '실행 중...',
-    aiPick: 'AI 추천',
-    alsoTry: '추가 전략:',
-    resultHint: '아래로 스크롤하면 결과를 볼 수 있습니다',
+    title: "시장 상황을 선택하세요",
+    subtitle: "각 상황에 맞는 대표 전략을 선택하세요",
+    breakout: "돌파",
+    breakoutDesc: "변동성 압축 → 폭발",
+    reversal: "반전",
+    reversalDesc: "RSI / SAR / 윌리엄스",
+    range: "박스권",
+    rangeDesc: "횡보장 평균회귀",
+    trend: "추세",
+    trendDesc: "ADX / 일목 / MACD",
+    hedged: "헤징",
+    hedgedDesc: "숏 전략 (하락방어)",
+    run: "지금 테스트",
+    running: "실행 중...",
+    aiPick: "인기 전략",
+    alsoTry: "추가 전략:",
+    resultHint: "아래로 스크롤하면 결과를 볼 수 있습니다",
   },
 };
 
 // Preset name display (short)
 const PRESET_LABELS: Record<string, { en: string; ko: string }> = {
-  'bb-squeeze-short':            { en: 'BB Squeeze SHORT', ko: 'BB 스퀴즈 숏' },
-  'bb-squeeze-long':             { en: 'BB Squeeze LONG',  ko: 'BB 스퀴즈 롱' },
-  'rsi-reversal-long':           { en: 'RSI Reversal',     ko: 'RSI 반전' },
-  'dca-oversold-long':           { en: 'DCA Oversold',     ko: 'DCA 과매도' },
-  'grid-mean-reversion-long':    { en: 'Grid Mean Rev',    ko: '그리드 평균회귀' },
-  'bb-band-bounce-long':         { en: 'BB Bounce',        ko: 'BB 바운스' },
-  'macd-momentum-long':          { en: 'MACD Momentum',    ko: 'MACD 모멘텀' },
-  'ema-crossover-long':          { en: 'EMA Crossover',    ko: 'EMA 교차' },
-  'stochastic-overbought-short':   { en: 'Stoch Overbought', ko: '스토캐스틱 과매수' },
-  'stoch-rsi-overbought-short':  { en: 'Stoch RSI Short',  ko: '스톡RSI 숏' },
-  'adx-trend-short':             { en: 'ADX Trend SHORT',  ko: 'ADX 추세 숏' },
-  'adx-trend-long':              { en: 'ADX Trend LONG',   ko: 'ADX 추세 롱' },
-  'rsi-bb-overbought-short':     { en: 'RSI+BB SHORT',     ko: 'RSI+BB 숏' },
-  'rsi-bb-oversold-long':        { en: 'RSI+BB LONG',      ko: 'RSI+BB 롱' },
-  'turtle-breakout-short':       { en: 'Turtle SHORT',     ko: '거북이 숏' },
-  'turtle-breakout-long':        { en: 'Turtle LONG',      ko: '거북이 롱' },
-  'macd-crossover-short':        { en: 'MACD Cross SHORT', ko: 'MACD 크로스 숏' },
-  'ema-crossover-short':         { en: 'EMA Cross SHORT',  ko: 'EMA 크로스 숏' },
-  'hv-squeeze-breakout-short':   { en: 'HV Squeeze SHORT', ko: 'HV 스퀴즈 숏' },
-  'hv-squeeze-breakout-long':    { en: 'HV Squeeze LONG',  ko: 'HV 스퀴즈 롱' },
-  'ichimoku-cloud-long':         { en: 'Ichimoku LONG',    ko: '일목 롱' },
-  'ichimoku-cloud-short':        { en: 'Ichimoku SHORT',   ko: '일목 숏' },
-  'psar-reversal-long':          { en: 'SAR LONG',         ko: 'SAR 반전 롱' },
-  'psar-reversal-short':         { en: 'SAR SHORT',        ko: 'SAR 반전 숏' },
-  'williams-r-oversold-long':    { en: 'Williams %R LONG', ko: '윌리엄스 롱' },
-  'williams-r-overbought-short': { en: 'Williams %R SHORT', ko: '윌리엄스 숏' },
+  "bb-squeeze-short": { en: "BB Squeeze SHORT", ko: "BB 스퀴즈 숏" },
+  "bb-squeeze-long": { en: "BB Squeeze LONG", ko: "BB 스퀴즈 롱" },
+  "rsi-reversal-long": { en: "RSI Reversal", ko: "RSI 반전" },
+  "dca-oversold-long": { en: "DCA Oversold", ko: "DCA 과매도" },
+  "grid-mean-reversion-long": { en: "Grid Mean Rev", ko: "그리드 평균회귀" },
+  "bb-band-bounce-long": { en: "BB Bounce", ko: "BB 바운스" },
+  "macd-momentum-long": { en: "MACD Momentum", ko: "MACD 모멘텀" },
+  "ema-crossover-long": { en: "EMA Crossover", ko: "EMA 교차" },
+  "stochastic-overbought-short": {
+    en: "Stoch Overbought",
+    ko: "스토캐스틱 과매수",
+  },
+  "stoch-rsi-overbought-short": { en: "Stoch RSI Short", ko: "스톡RSI 숏" },
+  "adx-trend-short": { en: "ADX Trend SHORT", ko: "ADX 추세 숏" },
+  "adx-trend-long": { en: "ADX Trend LONG", ko: "ADX 추세 롱" },
+  "rsi-bb-overbought-short": { en: "RSI+BB SHORT", ko: "RSI+BB 숏" },
+  "rsi-bb-oversold-long": { en: "RSI+BB LONG", ko: "RSI+BB 롱" },
+  "turtle-breakout-short": { en: "Turtle SHORT", ko: "거북이 숏" },
+  "turtle-breakout-long": { en: "Turtle LONG", ko: "거북이 롱" },
+  "macd-crossover-short": { en: "MACD Cross SHORT", ko: "MACD 크로스 숏" },
+  "ema-crossover-short": { en: "EMA Cross SHORT", ko: "EMA 크로스 숏" },
+  "hv-squeeze-breakout-short": { en: "HV Squeeze SHORT", ko: "HV 스퀴즈 숏" },
+  "hv-squeeze-breakout-long": { en: "HV Squeeze LONG", ko: "HV 스퀴즈 롱" },
+  "ichimoku-cloud-long": { en: "Ichimoku LONG", ko: "일목 롱" },
+  "ichimoku-cloud-short": { en: "Ichimoku SHORT", ko: "일목 숏" },
+  "psar-reversal-long": { en: "SAR LONG", ko: "SAR 반전 롱" },
+  "psar-reversal-short": { en: "SAR SHORT", ko: "SAR 반전 숏" },
+  "williams-r-oversold-long": { en: "Williams %R LONG", ko: "윌리엄스 롱" },
+  "williams-r-overbought-short": { en: "Williams %R SHORT", ko: "윌리엄스 숏" },
 };
 
-export default function QuickTestPanel({ lang, onRunPreset, isRunning, hasResult }: Props) {
+export default function QuickTestPanel({
+  lang,
+  onRunPreset,
+  isRunning,
+  hasResult,
+}: Props) {
   const t = L[lang] || L.en;
   const [selectedCat, setSelectedCat] = useState<string | null>(null);
   const [runningPreset, setRunningPreset] = useState<string | null>(null);
@@ -136,7 +200,10 @@ export default function QuickTestPanel({ lang, onRunPreset, isRunning, hasResult
     <div class="mb-3">
       {/* Header */}
       <div class="text-center mb-4">
-        <h2 class="font-mono text-sm font-bold" style={{ color: COLORS.accent }}>
+        <h2
+          class="font-mono text-sm font-bold"
+          style={{ color: COLORS.accent }}
+        >
           {t.title}
         </h2>
         <p class="text-[11px] text-[--color-text-muted] mt-1">{t.subtitle}</p>
@@ -146,7 +213,8 @@ export default function QuickTestPanel({ lang, onRunPreset, isRunning, hasResult
       <div class="grid grid-cols-3 sm:grid-cols-5 gap-2">
         {CATEGORIES.map((cat) => {
           const isSelected = selectedCat === cat.id;
-          const isCatRunning = runningPreset && cat.presets.includes(runningPreset);
+          const isCatRunning =
+            runningPreset && cat.presets.includes(runningPreset);
           const catT = t as Record<string, string>;
 
           return (
@@ -155,19 +223,25 @@ export default function QuickTestPanel({ lang, onRunPreset, isRunning, hasResult
               onClick={() => handleCategoryClick(cat)}
               disabled={isRunning}
               class={`relative rounded-lg border p-3 text-center transition-all group
-                ${isRunning ? 'cursor-not-allowed opacity-60' : 'cursor-pointer hover:scale-[1.02] active:scale-[0.98]'}
-                ${isSelected ? 'border-[--color-accent]' : 'border-[--color-border] hover:border-[--color-text-muted]'}`}
-              style={isSelected ? {
-                background: `linear-gradient(135deg, ${COLORS.accentBg}, transparent)`,
-                boxShadow: `0 0 12px ${COLORS.accentGlow}`,
-              } : undefined}
+                ${isRunning ? "cursor-not-allowed opacity-60" : "cursor-pointer hover:scale-[1.02] active:scale-[0.98]"}
+                ${isSelected ? "border-[--color-accent]" : "border-[--color-border] hover:border-[--color-text-muted]"}`}
+              style={
+                isSelected
+                  ? {
+                      background: `linear-gradient(135deg, ${COLORS.accentBg}, transparent)`,
+                      boxShadow: `0 0 12px ${COLORS.accentGlow}`,
+                    }
+                  : undefined
+              }
             >
               {/* Icon */}
               <span class="text-2xl leading-none block mb-1.5">{cat.icon}</span>
 
               {/* Label */}
-              <span class={`font-mono text-xs font-bold block ${isSelected ? '' : 'text-[--color-text-muted] group-hover:text-[--color-text]'}`}
-                style={isSelected ? { color: COLORS.accent } : undefined}>
+              <span
+                class={`font-mono text-xs font-bold block ${isSelected ? "" : "text-[--color-text-muted] group-hover:text-[--color-text]"}`}
+                style={isSelected ? { color: COLORS.accent } : undefined}
+              >
                 {catT[cat.id]}
               </span>
 
@@ -178,8 +252,10 @@ export default function QuickTestPanel({ lang, onRunPreset, isRunning, hasResult
 
               {/* Running spinner */}
               {isCatRunning && (
-                <div class="absolute inset-0 flex items-center justify-center rounded-lg"
-                  style={{ background: 'rgba(0,0,0,0.5)' }}>
+                <div
+                  class="absolute inset-0 flex items-center justify-center rounded-lg"
+                  style={{ background: "rgba(0,0,0,0.5)" }}
+                >
                   <span class="spinner" />
                 </div>
               )}
@@ -189,25 +265,28 @@ export default function QuickTestPanel({ lang, onRunPreset, isRunning, hasResult
       </div>
 
       {/* Selected Category: Alt preset buttons */}
-      {selectedCat && !isRunning && (() => {
-        const cat = CATEGORIES.find(c => c.id === selectedCat);
-        const alts = cat?.presets.filter(p => p !== cat?.defaultPreset) || [];
-        if (alts.length === 0) return null;
-        return (
-          <div class="mt-3 flex flex-wrap items-center justify-center gap-1.5 text-[11px] text-[--color-text-muted]">
-            <span>{t.alsoTry}</span>
-            {alts.map(presetId => (
-              <button
-                key={presetId}
-                onClick={() => handleAltPreset(presetId)}
-                class="px-2 py-1 rounded border border-[--color-border] font-mono text-[10px] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors"
-              >
-                {PRESET_LABELS[presetId]?.[lang] || presetId}
-              </button>
-            ))}
-          </div>
-        );
-      })()}
+      {selectedCat &&
+        !isRunning &&
+        (() => {
+          const cat = CATEGORIES.find((c) => c.id === selectedCat);
+          const alts =
+            cat?.presets.filter((p) => p !== cat?.defaultPreset) || [];
+          if (alts.length === 0) return null;
+          return (
+            <div class="mt-3 flex flex-wrap items-center justify-center gap-1.5 text-[11px] text-[--color-text-muted]">
+              <span>{t.alsoTry}</span>
+              {alts.map((presetId) => (
+                <button
+                  key={presetId}
+                  onClick={() => handleAltPreset(presetId)}
+                  class="px-2 py-1 rounded border border-[--color-border] font-mono text-[10px] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors"
+                >
+                  {PRESET_LABELS[presetId]?.[lang] || presetId}
+                </button>
+              ))}
+            </div>
+          );
+        })()}
 
       {/* Result hint */}
       {hasResult && selectedCat && (


### PR DESCRIPTION
## P0-CRITICAL: /simulate Sharpe/Sortino sign inversion

**Root cause**: `daily_returns` for Sharpe used `concurrent_count[day]` as
denominator (variable 1-50), while `total_return` used `n_coins` (constant 50).
On days with few positions, daily return was inflated → std inflated → sign
flipped when combined with lean-mean days.

**Fix**: Normalize by `n_coins` in both calculations — identical denominator
means Sharpe sign always agrees with total_return direction.

**Verification**: BB Squeeze SHORT: total_return=+29.42% now shows Sharpe≈+0.65
(previously -2.73). ADX Trend LONG: total_return=-21.46% now shows Sharpe<0
(previously +1.47 — impossible for losing strategy).

## Also fixed
- `rankings/daily` `profit_factor` capped at 99.99 (removes 999.99 sentinel exposure)
- QuickTestPanel: "AI Recommended" → "Most Popular" (not AI-based selection)
- QuickTestPanel: subtitle no longer implies AI involvement

Source: simulator-qa audit 2026-03-15, data-quality-engineer audit 2026-03-15