### PR TITLE
fix(fees): exchanges.ts SSoT + MDD context label on /performance

### DIFF
--- a/src/config/exchanges.ts
+++ b/src/config/exchanges.ts
@@ -1,0 +1,73 @@
+/**
+ * exchanges.ts — Single Source of Truth for exchange fee configuration.
+ *
+ * All referral discount percentages, standard rates, and display labels
+ * are defined here. Downstream files (fees.astro, FeeCalculator.tsx, etc.)
+ * should derive values from this config rather than hardcoding them inline.
+ */
+
+export interface ExchangeFeeConfig {
+  id: string;
+  name: string;
+  /** Standard maker fee, percent. e.g. 0.10 means 0.10% */
+  standardMakerFee: number;
+  /** Standard taker fee, percent. e.g. 0.05 means 0.05% */
+  standardTakerFee: number;
+  /** Referral discount applied to standard rate, percent. e.g. 10 means 10% off */
+  referralDiscountPct: number;
+  /** Display text for the discount badge, e.g. "10% off" */
+  marketingLabel: string;
+  url: string;
+  referralUrl: string;
+}
+
+/**
+ * Compute the effective taker fee after referral discount.
+ * standardTakerFee * (1 - referralDiscountPct / 100)
+ */
+export function effectiveTakerFee(ex: ExchangeFeeConfig): number {
+  return ex.standardTakerFee * (1 - ex.referralDiscountPct / 100);
+}
+
+/**
+ * Build the tooltip string shown on the referral discount badge.
+ * e.g. "10% off standard rate (0.050% → 0.045%)"
+ */
+export function discountTooltip(ex: ExchangeFeeConfig): string {
+  const from = ex.standardTakerFee.toFixed(3) + "%";
+  const to = effectiveTakerFee(ex).toFixed(3) + "%";
+  return `${ex.referralDiscountPct}% off standard rate (${from} → ${to})`;
+}
+
+export const EXCHANGES: ExchangeFeeConfig[] = [
+  {
+    id: "binance",
+    name: "Binance",
+    standardMakerFee: 0.02, // futures maker: 0.020%
+    standardTakerFee: 0.05, // futures taker: 0.050%
+    referralDiscountPct: 10,
+    marketingLabel: "10% off",
+    url: "https://www.binance.com",
+    referralUrl: "https://accounts.binance.com/register?ref=PRUVIQ",
+  },
+  {
+    id: "bitget",
+    name: "Bitget",
+    standardMakerFee: 0.02, // futures maker: 0.020%
+    standardTakerFee: 0.06, // futures taker: 0.060%
+    referralDiscountPct: 20,
+    marketingLabel: "20% off",
+    url: "https://www.bitget.com",
+    referralUrl: "https://partner.bitget.com/bg/71KRCS",
+  },
+  {
+    id: "okx",
+    name: "OKX",
+    standardMakerFee: 0.02, // futures maker: 0.020%
+    standardTakerFee: 0.05, // futures taker: 0.050%
+    referralDiscountPct: 20,
+    marketingLabel: "20% off",
+    url: "https://www.okx.com",
+    referralUrl: "#",
+  },
+];

--- a/src/pages/fees.astro
+++ b/src/pages/fees.astro
@@ -3,6 +3,10 @@ import Layout from '../layouts/Layout.astro';
 import FeeCalculator from '../components/FeeCalculator';
 import { useTranslations } from '../i18n/index';
 import { exchanges, formatFeeRange } from '../data/exchanges';
+import { EXCHANGES, discountTooltip } from '../config/exchanges';
+
+// Build a lookup map for tooltip data keyed by exchange id
+const exchangeTooltips = Object.fromEntries(EXCHANGES.map((ex) => [ex.id, discountTooltip(ex)]));
 
 const t = useTranslations('en');
 
@@ -71,7 +75,10 @@ const exchangeCards: Record<string, { tagLabel: string; description: string }> =
                 </div>
                 <div class="flex justify-between border-t border-[--color-border] pt-2 mt-2">
                   <span class="text-[--color-accent] font-medium">{t('fees.pruviq_discount')}</span>
-                  <span class="font-mono font-bold text-[--color-accent]">{ex.discountLabel} {t('fees.discount_off')}</span>
+                  <span
+                    class="font-mono font-bold text-[--color-accent] cursor-help underline decoration-dotted"
+                    title={exchangeTooltips[ex.id]}
+                  >{ex.discountLabel} {t('fees.discount_off')}</span>
                 </div>
               </div>
               <p class="text-[--color-text-muted] text-xs mb-4">{card.description}</p>

--- a/src/pages/ko/fees.astro
+++ b/src/pages/ko/fees.astro
@@ -3,6 +3,10 @@ import Layout from '../../layouts/Layout.astro';
 import FeeCalculator from '../../components/FeeCalculator';
 import { useTranslations } from '../../i18n/index';
 import { exchanges, formatFeeRange } from '../../data/exchanges';
+import { EXCHANGES, discountTooltip } from '../../config/exchanges';
+
+// Build a lookup map for tooltip data keyed by exchange id
+const exchangeTooltips = Object.fromEntries(EXCHANGES.map((ex) => [ex.id, discountTooltip(ex)]));
 
 const t = useTranslations('ko');
 
@@ -71,7 +75,10 @@ const exchangeCards: Record<string, { tagLabel: string; description: string }> =
                 </div>
                 <div class="flex justify-between border-t border-[--color-border] pt-2 mt-2">
                   <span class="text-[--color-accent] font-medium">{t('fees.pruviq_discount')}</span>
-                  <span class="font-mono font-bold text-[--color-accent]">{ex.discountLabel} {t('fees.discount_off')}</span>
+                  <span
+                    class="font-mono font-bold text-[--color-accent] cursor-help underline decoration-dotted"
+                    title={exchangeTooltips[ex.id]}
+                  >{ex.discountLabel} {t('fees.discount_off')}</span>
                 </div>
               </div>
               <p class="text-[--color-text-muted] text-xs mb-4">{card.description}</p>

--- a/src/pages/ko/performance/index.astro
+++ b/src/pages/ko/performance/index.astro
@@ -104,7 +104,13 @@ const t = useTranslations('ko');
               <td class="p-3 text-right font-mono">50.0%</td>
             </tr>
             <tr class="border-b border-[--color-border]">
-              <td class="p-3">{t('perf.tbl_mdd')}</td>
+              <td class="p-3">
+                {t('perf.tbl_mdd')}
+                <span
+                  class="ml-1 text-[0.65rem] text-[--color-text-muted] cursor-help"
+                  title="포트폴리오 백테스트 기준; 실거래는 MDD 20% 도달 시 중단"
+                >&#9432;</span>
+              </td>
               <td class="p-3 text-right font-mono text-[--color-red]">33%</td>
             </tr>
             <tr class="border-b border-[--color-border]">

--- a/src/pages/performance/index.astro
+++ b/src/pages/performance/index.astro
@@ -104,7 +104,13 @@ const t = useTranslations('en');
               <td class="p-3 text-right font-mono">50.0%</td>
             </tr>
             <tr class="border-b border-[--color-border]">
-              <td class="p-3">{t('perf.tbl_mdd')}</td>
+              <td class="p-3">
+                {t('perf.tbl_mdd')}
+                <span
+                  class="ml-1 text-[0.65rem] text-[--color-text-muted] cursor-help"
+                  title="portfolio-level backtest; live trading stopped at 20% MDD per risk rules"
+                >&#9432;</span>
+              </td>
               <td class="p-3 text-right font-mono text-[--color-red]">33%</td>
             </tr>
             <tr class="border-b border-[--color-border]">


### PR DESCRIPTION
## Summary

- **Fix 1 — exchanges.ts SSoT**: Creates `src/config/exchanges.ts` as the Single Source of Truth for exchange fee data. Exports `ExchangeFeeConfig` interface, `EXCHANGES` array (Binance 10%, Bitget 20%, OKX 20%), and two helpers: `effectiveTakerFee()` and `discountTooltip()`. Both `fees.astro` (EN and KO) now import `discountTooltip` from the config and render a dotted-underline `title` tooltip on each referral discount badge showing the computed rate (e.g. *"10% off standard rate (0.050% → 0.045%)"*). The underlying `src/data/exchanges.ts` is preserved and still used by `FeeCalculator.tsx`; this PR adds the config layer on top without a breaking refactor.

- **Fix 2 — MDD context label**: Adds a small muted info icon (ℹ, `&#9432;`) with a `title` tooltip next to the MDD row in the performance table on both `/performance/index.astro` (EN: *"portfolio-level backtest; live trading stopped at 20% MDD per risk rules"*) and `/ko/performance/index.astro` (KO: *"포트폴리오 백테스트 기준; 실거래는 MDD 20% 도달 시 중단"*). The label is tooltip-only — no layout change to the table.

## Files changed

| File | Change |
|------|--------|
| `src/config/exchanges.ts` | New — SSoT config |
| `src/pages/fees.astro` | Import + tooltip on discount badge |
| `src/pages/ko/fees.astro` | Import + tooltip on discount badge |
| `src/pages/performance/index.astro` | MDD info tooltip (EN) |
| `src/pages/ko/performance/index.astro` | MDD info tooltip (KO) |

## Test plan

- [ ] Visit `/fees` → hover the discount percentage on each exchange card; tooltip should show e.g. "10% off standard rate (0.050% → 0.045%)"
- [ ] Visit `/ko/fees` → same check in Korean locale
- [ ] Visit `/performance` → hover the ℹ next to MDD row; tooltip should read "portfolio-level backtest; live trading stopped at 20% MDD per risk rules"
- [ ] Visit `/ko/performance` → tooltip should read in Korean
- [ ] No visual regressions on page layout (tooltip uses `title` attribute only — no added DOM blocks)
- [ ] `src/config/exchanges.ts` has no import errors (TypeScript build passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)