### PR TITLE
fix: /rankings/ 404 → 301 redirect to /strategies/ranking

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -10,7 +10,13 @@
 
 /sitemap.xml /sitemap-index.xml 301
 
+# /rankings/ → canonical /strategies/ranking
+/rankings /strategies/ranking 301
+/rankings/ /strategies/ranking 301
+
 # KO equivalents
 /ko/builder /ko/simulate/ 301
 /ko/builder/* /ko/simulate/ 301
 # /ko/performance page exists — no redirect needed
+/ko/rankings /ko/strategies/ranking 301
+/ko/rankings/ /ko/strategies/ranking 301


### PR DESCRIPTION
## Summary
- `/rankings/` and `/ko/rankings/` return 404 — detected by QA agent (2026-03-15)
- Root cause: canonical URL is `/strategies/ranking`, no redirect existed
- Added 301 redirects in `public/_redirects` for both en and ko

## Test plan
- [ ] `curl -sI https://pruviq.com/rankings/` → 301 Location: /strategies/ranking
- [ ] `curl -sI https://pruviq.com/ko/rankings/` → 301 Location: /ko/strategies/ranking

🤖 Generated with [Claude Code](https://claude.com/claude-code)