### PR TITLE
fix: weekly_best3 schema — add total_return/sharpe/max_drawdown, cap PF

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -3309,8 +3309,11 @@ async def get_daily_rankings(date: Optional[str] = None):
                 "strategy": meta.get("strategy", ""),
                 "direction": meta.get("direction", ""),
                 "win_rate": round(item["avg_wr"], 2),
-                "profit_factor": round(item["avg_pf"], 2),
+                "profit_factor": min(round(item["avg_pf"], 2), 99.99),  # cap sentinel/low-sample extremes
+                "total_return": round(meta.get("total_return", 0), 2),
                 "total_trades": trades,
+                "sharpe": round(meta.get("sharpe", 0), 2),
+                "max_drawdown": round(meta.get("max_drawdown", 0), 2),
                 "timeframe": meta.get("timeframe", "1H"),
                 "days_in_top": item["days"],
                 "low_sample": trades < 100,


### PR DESCRIPTION
## Summary
- QA found `weekly_best3` missing `total_return`, `sharpe`, `max_drawdown` fields (in `top3`/`worst3` but not weekly)
- `weekly_best3` sorted by avg_pf with no cap → entries with 2-5 trades showed PF=166, PF=142 (misleading)

## Changes
- Added `total_return`, `sharpe`, `max_drawdown` to weekly_best3 entries from daily meta
- Applied `min(pf, 99.99)` cap consistent with `_make_entry()` used for top3/worst3

## Test plan
- [ ] `/rankings/daily` → `weekly_best3[0]` includes `total_return`, `sharpe`, `max_drawdown`
- [ ] `weekly_best3[0].profit_factor` ≤ 99.99 even when underlying avg_pf > 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)