### PR TITLE
fix: date filter off-by-one + data_range clarification

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -429,7 +429,9 @@ def filter_df_by_date(df: pd.DataFrame, start_date=None, end_date=None) -> pd.Da
             raise HTTPException(400, f"Invalid start_date '{start_date}'. Use YYYY-MM-DD format.")
     if end_date:
         try:
-            mask &= ts <= pd.Timestamp(end_date) + pd.Timedelta(days=1)
+            # Include all 1H candles on end_date (up to and including 23:00) but
+            # exclude the midnight candle of the next day (off-by-one fix).
+            mask &= ts <= pd.Timestamp(end_date) + pd.Timedelta(hours=23)
         except ValueError:
             raise HTTPException(400, f"Invalid end_date '{end_date}'. Use YYYY-MM-DD format.")
     filtered = df[mask].copy()
@@ -822,10 +824,16 @@ async def simulate(req: SimulationRequest):
     else:
         sharpe, sortino, calmar = 0.0, 0.0, 0.0
 
-    # Use actual date range if tracked, otherwise fallback to data_manager
-    data_range = data_manager.data_range()
+    # Use actual date range: actual candle range > requested range > full dataset range
     if actual_date_min and actual_date_max:
         data_range = f"{actual_date_min} ~ {actual_date_max}"
+    elif req.start_date or req.end_date:
+        # Filtered but no trades found (e.g. future date) — show requested window
+        start_label = req.start_date or data_manager.data_range().split(" ~ ")[0]
+        end_label = req.end_date or data_manager.data_range().split(" ~ ")[-1]
+        data_range = f"{start_label} ~ {end_label} (no data)"
+    else:
+        data_range = data_manager.data_range()
 
     resp_data = {
         "strategy": req.strategy,


### PR DESCRIPTION
## Summary
- **off-by-one**: `end_date=2024-12-31` was including the 2025-01-01 00:00 candle due to `+pd.Timedelta(days=1)`. Fixed to `+pd.Timedelta(hours=23)` — covers all 1H candles of end_date (00:00~23:00) without spilling into next day.
- **data_range misleading**: When start_date/end_date filter produces 0 rows (e.g. future dates), `data_range` fell back to full OHLCV range (2023-12-12 ~ 2026-03-15) instead of the requested window. Fixed to show `start ~ end (no data)` in that case.

## Test plan
- [ ] `end_date=2024-12-31` → `data_range` ends with `2024-12-31`, not `2025-01-01`
- [ ] `start_date=2026-06-01, end_date=2026-06-30` (future) → `data_range: '2026-06-01 ~ 2026-06-30 (no data)'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)