### PR TITLE
ci: E2E auto-fix loop (JEPO agent — 10min response)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -137,26 +137,29 @@ jobs:
             i.title.includes(`PR #${prNumber}`) || i.body?.includes(`Branch: \`${branch}\``)
           );
 
-          const issueBody = `## E2E Test Failure (Self-hosted Mac Mini)
-
-**PR:** #${prNumber} — ${prTitle}
-**Branch:** \`${branch}\`
-**Run:** ${runUrl}
-**Runner:** self-hosted macOS arm64 — 로컬과 동일 환경, 재현 가능
-
-## Failing Tests
-\`\`\`
-${failingTests}
-\`\`\`
-
-## 재현 방법
-\`\`\`bash
-cd ~/pruviq && git fetch origin && git checkout ${branch}
-npm ci && npm run build
-npx playwright test tests/e2e/ --timeout 60000 --workers 2
-\`\`\`
-
-*JEPO e2e-autofix agent가 20분 이내 재현 → 수정 → 검증 → PR 생성합니다.*`;
+          const bold = (s) => `**${s}**`;
+          const issueBody = [
+            '## E2E Test Failure (Self-hosted Mac Mini)',
+            '',
+            `${bold('PR:')} #${prNumber} — ${prTitle}`,
+            `${bold('Branch:')} \`${branch}\``,
+            `${bold('Run:')} ${runUrl}`,
+            `${bold('Runner:')} self-hosted macOS arm64 — 로컬과 동일 환경, 재현 가능`,
+            '',
+            '## Failing Tests',
+            '```',
+            failingTests,
+            '```',
+            '',
+            '## 재현 방법',
+            '```bash',
+            `cd ~/pruviq && git fetch origin && git checkout ${branch}`,
+            'npm ci && npm run build',
+            'npx playwright test tests/e2e/ --timeout 60000 --workers 2',
+            '```',
+            '',
+            '*JEPO e2e-autofix agent가 20분 이내 재현 → 수정 → 검증 → PR 생성합니다.*',
+          ].join('\n');
 
           if (matchingIssue) {
             await github.rest.issues.createComment({


### PR DESCRIPTION
## What this does

Closes the gap: **E2E fails → only an alert** → **E2E fails → auto-analyzed + fixed within 10 minutes**

### Flow
```
E2E CI fails
  → Extract failing test names from playwright results.json
  → Create GitHub Issue: [e2e-fix] E2E failed on PR #N
      labels: e2e-fix + claude-auto
      body: branch, run URL, failing test list, fix instructions
  → Post quick comment on PR
         ↓ (within 10 min)
JEPO LaunchAgent: com.pruviq.claude-e2e-autofix (every 10 min)
  → Detect open e2e-fix issues
  → gh run view <run_id> --log-failed  (fetch actual CI log)
  → Claude Opus: analyze log + test specs + source files
  → Make minimal fix (selector, i18n key, route, timing)
  → Create fix PR → CI reruns
         ↓
If CI passes → merge fix PR → original PR can be rebased/retried
```

### Safety
- Max **3 attempts per issue** — then labels `manual`, stops
- Max **15 files / 800 lines** per fix
- Global circuit breaker: 3 global failures in 2h → pause
- Isolated git worktree (never touches main repo directly)
- Claude only uses: Read, Glob, Grep, Edit, Write (no Bash)

### New LaunchAgent
`~/Library/LaunchAgents/com.pruviq.claude-e2e-autofix.plist`
- Interval: 600s (10 min)
- Timeout: 480s (8 min)
- Script: `~/scripts/claude-auto/e2e-autofix.sh`

### Changed in this PR
- `.github/workflows/e2e.yml`: Added `issues: write` permission + `Extract failing test names` step + `Create or update e2e-fix issue` step (replaces simple comment-only approach)