### PR TITLE
fix: nest Ranking/Leaderboard under Strategies in mobile menu

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -424,16 +424,19 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
       <div id="mobile-menu" class="hidden md:hidden border-t border-[--color-border] bg-[--color-bg]" aria-hidden="true">
         <div class="flex flex-col px-4 py-4 gap-1 text-sm">
           {navItems.map(item => (
-            <a href={item.href} aria-current={isActive(item.match) ? "page" : undefined} class="min-h-[44px] flex items-center" style={isActive(item.match) ? 'color:var(--color-accent);font-weight:500' : 'color:var(--color-text-muted)'}>{item.label}</a>
+            <Fragment>
+              <a href={item.href} aria-current={isActive(item.match) ? "page" : undefined} class="min-h-[44px] flex items-center" style={isActive(item.match) ? 'color:var(--color-accent);font-weight:500' : 'color:var(--color-text-muted)'}>{item.label}</a>
+              {item.match === '/strategies' && (
+                <div class="flex flex-col ml-1 pl-2 border-l border-[--color-border] mb-1">
+                  <a href={rankingPath} aria-current={isActive('/strategies/ranking') ? "page" : undefined} class="min-h-[44px] flex items-center gap-2 rounded hover:bg-[--color-bg-subtle]" style={isActive('/strategies/ranking') ? 'color:var(--color-accent);font-weight:500' : 'color:var(--color-text-muted)'}>
+                    <span class="inline-block w-1.5 h-1.5 rounded-full bg-[--color-accent] animate-pulse shrink-0"></span>
+                    {t('nav.ranking')}
+                  </a>
+                  <a href={leaderboardPath} aria-current={isActive('/leaderboard') ? "page" : undefined} class="min-h-[44px] flex items-center pl-[22px] rounded hover:bg-[--color-bg-subtle]" style={isActive('/leaderboard') ? 'color:var(--color-accent);font-weight:500' : 'color:var(--color-text-muted)'}>{t('nav.leaderboard')}</a>
+                </div>
+              )}
+            </Fragment>
           ))}
-          {/* --- Sub-navigation --- */}
-          <div class="border-t border-[--color-border] mt-1 pt-2">
-            <a href={rankingPath} aria-current={isActive('/strategies/ranking') ? "page" : undefined} class="min-h-[44px] flex items-center gap-2 pl-3 rounded hover:bg-[--color-bg-subtle]" style={isActive('/strategies/ranking') ? 'color:var(--color-accent);font-weight:500' : 'color:var(--color-text-muted)'}>
-              <span class="inline-block w-1.5 h-1.5 rounded-full bg-[--color-accent] animate-pulse shrink-0"></span>
-              {t('nav.ranking')}
-            </a>
-            <a href={leaderboardPath} aria-current={isActive('/leaderboard') ? "page" : undefined} class="min-h-[44px] flex items-center pl-[22px] rounded hover:bg-[--color-bg-subtle]" style={isActive('/leaderboard') ? 'color:var(--color-accent);font-weight:500' : 'color:var(--color-text-muted)'}>{t('nav.leaderboard')}</a>
-          </div>
           <div class="border-t border-[--color-border] mt-2 pt-2">
             <a href={altPath} class="font-mono text-xs px-2 py-1 border border-[--color-border] rounded text-[--color-text-muted] w-fit min-h-[44px] flex items-center hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">{t('nav.lang')}</a>
           </div>


### PR DESCRIPTION
## Summary
- Ranking and Leaderboard sub-items now appear **directly below the Strategies item** with a left-border indent, making the hierarchy visually clear
- Removed the disconnected bottom section (border-t divider that pushed sub-items away from their parent)
- New structure: `Strategies` → `├ • Daily Strategy Ranking` → `└ Leaderboard` (left-border visual nesting)
- Preserved `pl-[22px]` on Leaderboard and `gap-2` on Ranking — all 51 E2E tests pass

## Test plan
- [x] 51/51 mobile-menu + nav-highlight E2E tests pass locally
- [x] `Leaderboard has pl-[22px]` test still passes
- [x] `Ranking has gap-2` test still passes
- [x] aria-current active state tests for /strategies/ranking and /leaderboard pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)