### PR TITLE
fix: root-cause 7 issues — TS errors, SEO gaps, chart API, i18n

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -45,6 +45,27 @@ export default defineConfig({
           { url: enUrl, lang: 'x-default' },
         ];
 
+        // Priority + crawl frequency by page type
+        // @ts-ignore — EnumChangefreq accepts these string values at runtime
+        const p = basePath;
+        if (p === '/') {
+          item.priority = 1.0; item.changefreq = /** @type {any} */ ('daily');
+        } else if (['/simulate', '/strategies', '/market', '/leaderboard'].includes(p)) {
+          item.priority = 0.9; item.changefreq = /** @type {any} */ ('daily');
+        } else if (p === '/strategies/ranking') {
+          item.priority = 0.9; item.changefreq = /** @type {any} */ ('daily');
+        } else if (p.startsWith('/strategies/') || p.startsWith('/coins/')) {
+          item.priority = 0.8; item.changefreq = /** @type {any} */ ('weekly');
+        } else if (p.startsWith('/compare/') || p.startsWith('/vs/') || p.startsWith('/vs-')) {
+          item.priority = 0.7; item.changefreq = /** @type {any} */ ('monthly');
+        } else if (p.startsWith('/blog/')) {
+          item.priority = 0.6; item.changefreq = /** @type {any} */ ('monthly');
+        } else if (['/fees', '/learn', '/about', '/api'].includes(p)) {
+          item.priority = 0.6; item.changefreq = /** @type {any} */ ('monthly');
+        } else {
+          item.priority = 0.5; item.changefreq = /** @type {any} */ ('monthly');
+        }
+
         return item;
       }
     }),

--- a/src/components/ChartPanel.tsx
+++ b/src/components/ChartPanel.tsx
@@ -1,10 +1,10 @@
 /**
  * ChartPanel.tsx - Chart display with symbol switching
  */
-import { useEffect, useRef } from 'preact/hooks';
-import type { OhlcvBar, TradeItem } from './simulator-types';
-import { getCssVar, COLORS } from './simulator-types';
-import type { IChartApi, UTCTimestamp } from 'lightweight-charts';
+import { useEffect, useRef } from "preact/hooks";
+import type { OhlcvBar, TradeItem } from "./simulator-types";
+import { getCssVar, COLORS } from "./simulator-types";
+import type { IChartApi, UTCTimestamp } from "lightweight-charts";
 
 interface Props {
   chartSymbol: string;
@@ -21,7 +21,20 @@ interface Props {
   symbolPlaceholder?: string;
 }
 
-export default function ChartPanel({ chartSymbol, setChartSymbol, chartData, chartLoading, loadingText, trades, error, onRetry, timeframe = '1H', retryLabel = 'Retry', noDataError = 'Unable to load chart data. Check API connection.', symbolPlaceholder = 'Symbol...' }: Props) {
+export default function ChartPanel({
+  chartSymbol,
+  setChartSymbol,
+  chartData,
+  chartLoading,
+  loadingText,
+  trades,
+  error,
+  onRetry,
+  timeframe = "1H",
+  retryLabel = "Retry",
+  noDataError = "Unable to load chart data. Check API connection.",
+  symbolPlaceholder = "Symbol...",
+}: Props) {
   const chartContainerRef = useRef<HTMLDivElement>(null);
   const chartInstanceRef = useRef<IChartApi | null>(null);
 
@@ -31,125 +44,181 @@ export default function ChartPanel({ chartSymbol, setChartSymbol, chartData, cha
     let disposed = false;
     let ro: ResizeObserver | null = null;
 
-    import('lightweight-charts').then(({ createChart, CandlestickSeries, LineSeries, HistogramSeries }) => {
-      if (disposed || !chartContainerRef.current) return;
+    import("lightweight-charts").then(
+      ({
+        createChart,
+        CandlestickSeries,
+        LineSeries,
+        HistogramSeries,
+        createSeriesMarkers,
+      }) => {
+        if (disposed || !chartContainerRef.current) return;
 
-      if (chartInstanceRef.current) {
-        chartInstanceRef.current.remove();
-        chartInstanceRef.current = null;
-      }
-
-      const chart = createChart(chartContainerRef.current, {
-        width: chartContainerRef.current.clientWidth,
-        height: chartContainerRef.current.clientHeight || 640,
-        layout: {
-          background: { color: getCssVar('--color-bg-card') },
-          textColor: getCssVar('--color-text-muted'),
-          fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
-          fontSize: 10,
-        },
-        grid: {
-          vertLines: { color: getCssVar('--color-bg-hover') },
-          horzLines: { color: getCssVar('--color-bg-hover') },
-        },
-        rightPriceScale: { borderColor: getCssVar('--color-border') },
-        timeScale: { borderColor: getCssVar('--color-border'), timeVisible: true },
-        crosshair: { mode: 0 },
-      });
-
-      const candleSeries = chart.addSeries(CandlestickSeries, {
-        upColor: getCssVar('--color-up') || COLORS.green,
-        downColor: getCssVar('--color-down') || COLORS.red,
-        wickUpColor: getCssVar('--color-up') || COLORS.green,
-        wickDownColor: getCssVar('--color-down') || COLORS.red,
-        borderVisible: false,
-      });
-      candleSeries.setData(chartData.map((b) => ({
-        time: b.t as UTCTimestamp, open: b.o, high: b.h, low: b.l, close: b.c,
-      })));
-
-      // BB bands
-      const hasBB = chartData.some((b) => b.bb_upper != null);
-      if (hasBB) {
-        const bbUpper = chart.addSeries(LineSeries, {
-          color: getCssVar('--color-chart-bb'), lineWidth: 1, priceLineVisible: false,
-          lastValueVisible: false,
-        });
-        bbUpper.setData(chartData.filter((b) => b.bb_upper != null).map((b) => ({
-          time: b.t as UTCTimestamp, value: b.bb_upper!,
-        })));
-
-        const bbLower = chart.addSeries(LineSeries, {
-          color: getCssVar('--color-chart-bb'), lineWidth: 1, priceLineVisible: false,
-          lastValueVisible: false,
-        });
-        bbLower.setData(chartData.filter((b) => b.bb_lower != null).map((b) => ({
-          time: b.t as UTCTimestamp, value: b.bb_lower!,
-        })));
-
-        const bbMid = chart.addSeries(LineSeries, {
-          color: getCssVar('--color-chart-bb-mid'), lineWidth: 1, lineStyle: 2,
-          priceLineVisible: false, lastValueVisible: false,
-        });
-        bbMid.setData(chartData.filter((b) => b.bb_mid != null).map((b) => ({
-          time: b.t as UTCTimestamp, value: b.bb_mid!,
-        })));
-      }
-
-      // Volume
-      const volSeries = chart.addSeries(HistogramSeries, {
-        priceFormat: { type: 'volume' },
-        priceScaleId: 'vol',
-      });
-      chart.priceScale('vol').applyOptions({
-        scaleMargins: { top: 0.85, bottom: 0 },
-      });
-      volSeries.setData(chartData.map((b) => ({
-        time: b.t as UTCTimestamp,
-        value: b.v,
-        color: b.c >= b.o ? COLORS.greenFill : COLORS.redFill,
-      })));
-
-      // Trade entry/exit markers
-      if (trades && trades.length > 0) {
-        const symbolTrades = trades.filter((t) => t.symbol === chartSymbol);
-        if (symbolTrades.length > 0) {
-          const markers = symbolTrades.flatMap((t) => {
-            const entryTs = Math.floor(new Date(t.entry_time).getTime() / 1000);
-            const exitTs = Math.floor(new Date(t.exit_time).getTime() / 1000);
-            const isShort = t.direction === 'short';
-            const isWin = t.pnl_pct > 0;
-            return [
-              {
-                time: entryTs as UTCTimestamp,
-                position: isShort ? 'aboveBar' as const : 'belowBar' as const,
-                color: COLORS.accent,
-                shape: isShort ? 'arrowDown' as const : 'arrowUp' as const,
-                text: isShort ? 'S' : 'L',
-              },
-              {
-                time: exitTs as UTCTimestamp,
-                position: isShort ? 'belowBar' as const : 'aboveBar' as const,
-                color: isWin ? COLORS.green : COLORS.red,
-                shape: 'circle' as const,
-                text: `${t.pnl_pct > 0 ? '+' : ''}${t.pnl_pct.toFixed(1)}%`,
-              },
-            ];
-          }).sort((a, b) => (a.time as number) - (b.time as number));
-          candleSeries.setMarkers(markers);
+        if (chartInstanceRef.current) {
+          chartInstanceRef.current.remove();
+          chartInstanceRef.current = null;
         }
-      }
 
-      chart.timeScale().fitContent();
-      chartInstanceRef.current = chart;
+        const chart = createChart(chartContainerRef.current, {
+          width: chartContainerRef.current.clientWidth,
+          height: chartContainerRef.current.clientHeight || 640,
+          layout: {
+            background: { color: getCssVar("--color-bg-card") },
+            textColor: getCssVar("--color-text-muted"),
+            fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
+            fontSize: 10,
+          },
+          grid: {
+            vertLines: { color: getCssVar("--color-bg-hover") },
+            horzLines: { color: getCssVar("--color-bg-hover") },
+          },
+          rightPriceScale: { borderColor: getCssVar("--color-border") },
+          timeScale: {
+            borderColor: getCssVar("--color-border"),
+            timeVisible: true,
+          },
+          crosshair: { mode: 0 },
+        });
 
-      ro = new ResizeObserver((entries) => {
-        for (const entry of entries) {
-          chart.applyOptions({ width: entry.contentRect.width, height: entry.contentRect.height });
+        const candleSeries = chart.addSeries(CandlestickSeries, {
+          upColor: getCssVar("--color-up") || COLORS.green,
+          downColor: getCssVar("--color-down") || COLORS.red,
+          wickUpColor: getCssVar("--color-up") || COLORS.green,
+          wickDownColor: getCssVar("--color-down") || COLORS.red,
+          borderVisible: false,
+        });
+        candleSeries.setData(
+          chartData.map((b) => ({
+            time: b.t as UTCTimestamp,
+            open: b.o,
+            high: b.h,
+            low: b.l,
+            close: b.c,
+          })),
+        );
+
+        // BB bands
+        const hasBB = chartData.some((b) => b.bb_upper != null);
+        if (hasBB) {
+          const bbUpper = chart.addSeries(LineSeries, {
+            color: getCssVar("--color-chart-bb"),
+            lineWidth: 1,
+            priceLineVisible: false,
+            lastValueVisible: false,
+          });
+          bbUpper.setData(
+            chartData
+              .filter((b) => b.bb_upper != null)
+              .map((b) => ({
+                time: b.t as UTCTimestamp,
+                value: b.bb_upper!,
+              })),
+          );
+
+          const bbLower = chart.addSeries(LineSeries, {
+            color: getCssVar("--color-chart-bb"),
+            lineWidth: 1,
+            priceLineVisible: false,
+            lastValueVisible: false,
+          });
+          bbLower.setData(
+            chartData
+              .filter((b) => b.bb_lower != null)
+              .map((b) => ({
+                time: b.t as UTCTimestamp,
+                value: b.bb_lower!,
+              })),
+          );
+
+          const bbMid = chart.addSeries(LineSeries, {
+            color: getCssVar("--color-chart-bb-mid"),
+            lineWidth: 1,
+            lineStyle: 2,
+            priceLineVisible: false,
+            lastValueVisible: false,
+          });
+          bbMid.setData(
+            chartData
+              .filter((b) => b.bb_mid != null)
+              .map((b) => ({
+                time: b.t as UTCTimestamp,
+                value: b.bb_mid!,
+              })),
+          );
         }
-      });
-      ro.observe(chartContainerRef.current);
-    });
+
+        // Volume
+        const volSeries = chart.addSeries(HistogramSeries, {
+          priceFormat: { type: "volume" },
+          priceScaleId: "vol",
+        });
+        chart.priceScale("vol").applyOptions({
+          scaleMargins: { top: 0.85, bottom: 0 },
+        });
+        volSeries.setData(
+          chartData.map((b) => ({
+            time: b.t as UTCTimestamp,
+            value: b.v,
+            color: b.c >= b.o ? COLORS.greenFill : COLORS.redFill,
+          })),
+        );
+
+        // Trade entry/exit markers
+        if (trades && trades.length > 0) {
+          const symbolTrades = trades.filter((t) => t.symbol === chartSymbol);
+          if (symbolTrades.length > 0) {
+            const markers = symbolTrades
+              .flatMap((t) => {
+                const entryTs = Math.floor(
+                  new Date(t.entry_time).getTime() / 1000,
+                );
+                const exitTs = Math.floor(
+                  new Date(t.exit_time).getTime() / 1000,
+                );
+                const isShort = t.direction === "short";
+                const isWin = t.pnl_pct > 0;
+                return [
+                  {
+                    time: entryTs as UTCTimestamp,
+                    position: isShort
+                      ? ("aboveBar" as const)
+                      : ("belowBar" as const),
+                    color: COLORS.accent,
+                    shape: isShort
+                      ? ("arrowDown" as const)
+                      : ("arrowUp" as const),
+                    text: isShort ? "S" : "L",
+                  },
+                  {
+                    time: exitTs as UTCTimestamp,
+                    position: isShort
+                      ? ("belowBar" as const)
+                      : ("aboveBar" as const),
+                    color: isWin ? COLORS.green : COLORS.red,
+                    shape: "circle" as const,
+                    text: `${t.pnl_pct > 0 ? "+" : ""}${t.pnl_pct.toFixed(1)}%`,
+                  },
+                ];
+              })
+              .sort((a, b) => (a.time as number) - (b.time as number));
+            createSeriesMarkers(candleSeries, markers);
+          }
+        }
+
+        chart.timeScale().fitContent();
+        chartInstanceRef.current = chart;
+
+        ro = new ResizeObserver((entries) => {
+          for (const entry of entries) {
+            chart.applyOptions({
+              width: entry.contentRect.width,
+              height: entry.contentRect.height,
+            });
+          }
+        });
+        ro.observe(chartContainerRef.current);
+      },
+    );
 
     return () => {
       disposed = true;
@@ -170,15 +239,22 @@ export default function ChartPanel({ chartSymbol, setChartSymbol, chartData, cha
           <span class="text-[--color-text-muted] text-xs">{timeframe}</span>
         </div>
         <div class="flex items-center gap-1.5">
-          {['BTCUSDT', 'ETHUSDT', 'SOLUSDT'].map((sym) => (
+          {["BTCUSDT", "ETHUSDT", "SOLUSDT"].map((sym) => (
             <button
               key={sym}
               onClick={() => setChartSymbol(sym)}
               class={`px-2 py-1 text-xs font-mono rounded transition-colors
-                ${chartSymbol === sym ? 'font-bold text-white' : 'text-[--color-text-muted] hover:text-[--color-text] hover:bg-[--color-bg-hover]'}`}
-              style={chartSymbol === sym ? { background: COLORS.accent, boxShadow: `0 0 8px ${COLORS.accentGlow}` } : undefined}
+                ${chartSymbol === sym ? "font-bold text-white" : "text-[--color-text-muted] hover:text-[--color-text] hover:bg-[--color-bg-hover]"}`}
+              style={
+                chartSymbol === sym
+                  ? {
+                      background: COLORS.accent,
+                      boxShadow: `0 0 8px ${COLORS.accentGlow}`,
+                    }
+                  : undefined
+              }
             >
-              {sym.replace('USDT', '')}
+              {sym.replace("USDT", "")}
             </button>
           ))}
           <input
@@ -187,21 +263,27 @@ export default function ChartPanel({ chartSymbol, setChartSymbol, chartData, cha
             aria-label={symbolPlaceholder}
             class="w-20 px-2 py-1 text-xs font-mono bg-[--color-bg-tooltip] border border-[--color-border] rounded outline-none focus:border-[--color-accent] hidden sm:block"
             onKeyDown={(e: KeyboardEvent) => {
-              if (e.key === 'Enter') {
+              if (e.key === "Enter") {
                 const target = e.target as HTMLInputElement;
                 const val = target.value.toUpperCase().trim();
-                if (val) setChartSymbol(val.endsWith('USDT') ? val : val + 'USDT');
-                target.value = '';
+                if (val)
+                  setChartSymbol(val.endsWith("USDT") ? val : val + "USDT");
+                target.value = "";
               }
             }}
           />
         </div>
       </div>
       {/* Chart body — responsive height: 360px mobile, 640px desktop */}
-      <div ref={chartContainerRef} class="h-[360px] md:h-[640px]" style={{ minHeight: '300px' }}>
+      <div
+        ref={chartContainerRef}
+        class="h-[360px] md:h-[640px]"
+        style={{ minHeight: "300px" }}
+      >
         {chartLoading && (
           <div class="flex items-center justify-center h-full text-[--color-text-muted] text-sm">
-            <div class="spinner mr-2" />{loadingText}
+            <div class="spinner mr-2" />
+            {loadingText}
           </div>
         )}
         {!chartLoading && chartData.length === 0 && (

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,22 +1,29 @@
-import { defineCollection, z } from 'astro:content';
-import { glob } from 'astro/loaders';
+import { defineCollection, z } from "astro:content";
+import { glob } from "astro/loaders";
 
 const blogSchema = z.object({
   title: z.string(),
   description: z.string(),
   date: z.string(),
-  category: z.enum(['market', 'quant', 'strategy', 'weekly', 'education']),
+  category: z.enum(["market", "quant", "strategy", "weekly", "education"]),
   tags: z.array(z.string()).optional(),
-  author: z.string().optional().default('PRUVIQ Research'),
+  author: z.string().optional().default("PRUVIQ Research"),
+  image: z.string().optional(),
 });
 
 const strategySchema = z.object({
   name: z.string(),
   description: z.string(),
-  status: z.enum(['verified', 'testing', 'killed', 'shelved']),
-  category: z.enum(['mean-reversion', 'momentum', 'breakout', 'volatility', 'hybrid']),
-  direction: z.enum(['long', 'short', 'both']),
-  difficulty: z.enum(['beginner', 'intermediate', 'advanced']),
+  status: z.enum(["verified", "testing", "killed", "shelved"]),
+  category: z.enum([
+    "mean-reversion",
+    "momentum",
+    "breakout",
+    "volatility",
+    "hybrid",
+  ]),
+  direction: z.enum(["long", "short", "both"]),
+  difficulty: z.enum(["beginner", "intermediate", "advanced"]),
   winRate: z.number().optional(),
   profitFactor: z.number().optional(),
   maxDrawdown: z.number().optional(),
@@ -30,23 +37,28 @@ const strategySchema = z.object({
 });
 
 const blog = defineCollection({
-  loader: glob({ pattern: '**/*.md', base: './src/content/blog' }),
+  loader: glob({ pattern: "**/*.md", base: "./src/content/blog" }),
   schema: blogSchema,
 });
 
 const strategies = defineCollection({
-  loader: glob({ pattern: '**/*.md', base: './src/content/strategies' }),
+  loader: glob({ pattern: "**/*.md", base: "./src/content/strategies" }),
   schema: strategySchema,
 });
 
 const blogKo = defineCollection({
-  loader: glob({ pattern: '**/*.md', base: './src/content/blog-ko' }),
+  loader: glob({ pattern: "**/*.md", base: "./src/content/blog-ko" }),
   schema: blogSchema,
 });
 
 const strategiesKo = defineCollection({
-  loader: glob({ pattern: '**/*.md', base: './src/content/strategies-ko' }),
+  loader: glob({ pattern: "**/*.md", base: "./src/content/strategies-ko" }),
   schema: strategySchema,
 });
 
-export const collections = { blog, strategies, 'blog-ko': blogKo, 'strategies-ko': strategiesKo };
+export const collections = {
+  blog,
+  strategies,
+  "blog-ko": blogKo,
+  "strategies-ko": strategiesKo,
+};

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1285,6 +1285,9 @@ export const en = {
 
   // Coins page
   "coins.explore_next": "Found interesting coins? Test them in a strategy.",
+  "coins.noscript_title": "JavaScript required to browse coins.",
+  "coins.noscript_desc":
+    "Enable JavaScript to search and filter 549+ coins. Popular coins:",
 
   // Changelog context callout
   "changelog.context_title": "What\u2019s versioned here?",
@@ -1304,41 +1307,6 @@ export const en = {
   "meta.terms_tag": "TERMS OF SERVICE",
   "meta.terms_heading": "Terms of Service",
   "meta.terms_updated": "Last updated: March 1, 2026",
-
-  // Performance: Metrics table labels
-  "perf.tbl_header_metric": "Metric",
-  "perf.tbl_header_value": "Value",
-  "perf.tbl_sl": "Stop Loss",
-  "perf.tbl_tp": "Take Profit",
-  "perf.tbl_hold": "Max Hold Time",
-  "perf.tbl_hold_val": "48 hours",
-  "perf.tbl_sl_rate": "SL Hit Rate",
-  "perf.tbl_tp_rate": "TP Hit Rate",
-  "perf.tbl_mdd": "Max Drawdown",
-  "perf.tbl_breakeven": "Break-Even Win Rate",
-  "perf.tbl_safety": "Safety Margin",
-
-  // Daily Ranking page
-  "ranking.tag": "DAILY RANKING",
-  "ranking.title": "Daily Strategy Ranking",
-  "ranking.date_label": "{date} · PRUVIQ Simulator Backtest Results",
-  "ranking.desc":
-    "Best and worst strategies today ranked by Profit Factor (PF). Strategies with fewer than 100 trades have low statistical reliability.",
-  "ranking.open_sim": "Open Simulator",
-  "ranking.strategy_lib": "Strategy Library",
-  "ranking.leaderboard": "Leaderboard",
-  "ranking.disclaimer_note": "Note:",
-  "ranking.disclaimer_text":
-    "This ranking is based on historical backtests. Past performance does not guarantee future returns. Strategies with fewer than 100 trades (< 100) may be overfitted.",
-  "ranking.footer_text":
-    "Adjust parameters for any strategy directly in the simulator.",
-  "ranking.try_sim": "Try in Simulator",
-  "ranking.live_perf": "Live Performance",
-
-  // Strategies: Simulator Presets section
-  "strategies.presets_title": "All Simulator Presets ({count})",
-  "strategies.presets_desc":
-    "Click any preset to load it directly in the simulator. Tests on 549+ coins simultaneously.",
 
   // Ranking component inline strings (QW6)
   "ranking.card_wr": "Win Rate",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -1004,6 +1004,7 @@ export const ko: Record<TranslationKey, string> = {
   "compare_table.tv_free": "$14.95/월~",
   "compare_table.qc_nocode": "Python/C#",
   "compare_table.qc_coins": "제한적",
+  "compare_table.qc_free": "무료 플랜 (제한적)",
   "compare_table.qc_verification": "모의만",
   "compare_table.pruviq_free": "100% 무료",
   "compare_table.pruviq_verification": "전체 공개",
@@ -1030,6 +1031,17 @@ export const ko: Record<TranslationKey, string> = {
   "trust.stat_datapoints": "처리된 데이터 포인트",
   "trust.stat_live_days": "백테스트 코인 수",
   "trust.stat_strategies": "테스트된 전략 (4개 실패)",
+
+  // Homepage misc
+  "home.social_simulations": "12,847회 시뮬레이션 실행",
+  "home.social_simulations_note": "(2026년 3월 기준)",
+  "home.trust_documented": "문서화된 전략",
+  "home.trust_verified_active": "검증 완료 및 활성",
+  "home.trust_oos_label": "OOS 검증 전략",
+  "home.cta_survives": "살아남는 전략 보기",
+  "home.cta_test_yourself": "직접 테스트 — 무료",
+  "home.quotes_heading": "트레이더들의 이야기",
+  "home.ranking_shortcut": "오늘의 상위 전략",
 
   // TradingView comparison page
   "meta.vs_tv_title": "PRUVIQ vs 트레이딩뷰 - 무료 크립토 백테스팅 비교",
@@ -1248,6 +1260,9 @@ export const ko: Record<TranslationKey, string> = {
   // Coins page
   "coins.explore_next":
     "관심 있는 코인을 찾으셨나요? 전략에서 테스트해 보세요.",
+  "coins.noscript_title": "코인 목록을 보려면 JavaScript가 필요합니다.",
+  "coins.noscript_desc":
+    "549개 이상의 코인을 탐색하려면 JavaScript를 활성화하세요. 인기 코인:",
 
   // Changelog context callout
   "changelog.context_title": "여기서 추적하는 버전은?",
@@ -1267,41 +1282,6 @@ export const ko: Record<TranslationKey, string> = {
   "meta.terms_tag": "이용약관",
   "meta.terms_heading": "이용약관",
   "meta.terms_updated": "최종 수정일: 2026년 3월 1일",
-
-  // Performance: Metrics table labels
-  "perf.tbl_header_metric": "지표",
-  "perf.tbl_header_value": "값",
-  "perf.tbl_sl": "손절 (SL)",
-  "perf.tbl_tp": "익절 (TP)",
-  "perf.tbl_hold": "최대 보유 시간",
-  "perf.tbl_hold_val": "48시간",
-  "perf.tbl_sl_rate": "SL 비율",
-  "perf.tbl_tp_rate": "TP 비율",
-  "perf.tbl_mdd": "최대 손실폭 (MDD)",
-  "perf.tbl_breakeven": "손익분기 승률",
-  "perf.tbl_safety": "안전 마진",
-
-  // Daily Ranking page
-  "ranking.tag": "DAILY RANKING",
-  "ranking.title": "오늘의 전략 랭킹",
-  "ranking.date_label": "{date} 기준 · PRUVIQ 시뮬레이터 백테스트 결과",
-  "ranking.desc":
-    "수익팩터(PF) 기준으로 오늘 가장 성과가 좋은 전략과 나쁜 전략을 확인하세요. 샘플 수가 100건 미만인 전략은 통계적 신뢰도가 낮습니다.",
-  "ranking.open_sim": "시뮬레이터 열기",
-  "ranking.strategy_lib": "전략 라이브러리",
-  "ranking.leaderboard": "리더보드",
-  "ranking.disclaimer_note": "참고:",
-  "ranking.disclaimer_text":
-    "이 랭킹은 과거 데이터 백테스트 기반입니다. 미래 수익을 보장하지 않으며, 샘플 수 부족(< 100건) 전략은 과적합 가능성이 높습니다.",
-  "ranking.footer_text":
-    "마음에 드는 전략을 시뮬레이터에서 직접 파라미터 조정해보세요.",
-  "ranking.try_sim": "시뮬레이터에서 직접 확인",
-  "ranking.live_perf": "실거래 성과",
-
-  // Strategies: Simulator Presets section
-  "strategies.presets_title": "시뮬레이터 프리셋 전체 ({count}종)",
-  "strategies.presets_desc":
-    "아래 전략을 클릭하면 시뮬레이터에서 바로 파라미터가 적용됩니다. 549개 코인 동시 테스트.",
 
   // Ranking component inline strings (QW6)
   "ranking.card_wr": "승률",

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -7,9 +7,10 @@ interface Props {
   date: string;
   category: string;
   author?: string;
+  image?: string;
 }
 
-const { title, description, date, category, author = 'PRUVIQ Research' } = Astro.props;
+const { title, description, date, category, author = 'PRUVIQ Research', image } = Astro.props;
 
 const categoryLabels: Record<string, string> = {
   market: 'MARKET ANALYSIS',
@@ -20,7 +21,7 @@ const categoryLabels: Record<string, string> = {
 };
 ---
 
-<Layout title={`${title} - PRUVIQ`} description={description} type="article" date={date} category={category}>
+<Layout title={`${title} - PRUVIQ`} description={description} type="article" date={date} category={category} ogImage={image}>
   <article class="py-12">
     <div class="max-w-[45rem] mx-auto px-4">
       <a href="/learn" class="text-[--color-text-muted] text-sm hover:text-[--color-accent] transition-colors mb-8 inline-block">

--- a/src/pages/blog/[id].astro
+++ b/src/pages/blog/[id].astro
@@ -20,6 +20,7 @@ const { Content } = await render(post);
   date={post.data.date}
   category={post.data.category}
   author={post.data.author}
+  image={post.data.image}
 >
   <Content />
 </BlogPost>

--- a/src/pages/coins/index.astro
+++ b/src/pages/coins/index.astro
@@ -3,6 +3,15 @@ import Layout from '../../layouts/Layout.astro';
 import { useTranslations } from '../../i18n/index';
 
 const t = useTranslations('en');
+
+// Static top-30 coins for noscript/Googlebot crawlability
+const TOP_COINS = [
+  'BTCUSDT','ETHUSDT','SOLUSDT','BNBUSDT','XRPUSDT','DOGEUSDT','ADAUSDT',
+  'AVAXUSDT','LINKUSDT','DOTUSDT','MATICUSDT','LTCUSDT','UNIUSDT','ATOMUSDT',
+  'NEARUSDT','OPUSDT','ARBUSDT','APTUSDT','INJUSDT','SUIUSDT','TIAUSDT',
+  'SEIUSDT','WLDUSDT','ORDIUSDT','STXUSDT','JUPUSDT','FETUSDT','RNDRUSDT',
+  'IMXUSDT','SANDUSDT',
+];
 ---
 
 <Layout title={t('meta.coins_title')} description={t('meta.coins_desc')}>
@@ -25,6 +34,19 @@ const t = useTranslations('en');
             <div class="h-12 bg-[--color-bg-hover] rounded"></div>
           </div>
         </div>
+        <noscript>
+          <p class="font-bold text-sm mb-1">{t('coins.noscript_title')}</p>
+          <p class="text-[--color-text-muted] text-sm mb-4">{t('coins.noscript_desc')}</p>
+          <ul class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-2">
+            {TOP_COINS.map(symbol => (
+              <li>
+                <a href={`/coins/${symbol.toLowerCase()}/`} class="text-[--color-accent] hover:underline text-sm font-mono">
+                  {symbol.replace('USDT', '')}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </noscript>
       </div>
       <div class="mt-10 pt-8 border-t border-[--color-border] text-center">
         <p class="text-[--color-text-muted] text-sm mb-4">{t('coins.explore_next')}</p>

--- a/src/pages/ko/blog/[id].astro
+++ b/src/pages/ko/blog/[id].astro
@@ -37,7 +37,7 @@ const categoryLabels: Record<string, string> = {
 };
 ---
 
-<Layout title={`${post.data.title} - PRUVIQ`} description={post.data.description} type="article" date={post.data.date} category={post.data.category} noAlternate={!isKorean}>
+<Layout title={`${post.data.title} - PRUVIQ`} description={post.data.description} type="article" date={post.data.date} category={post.data.category} ogImage={post.data.image} noAlternate={!isKorean}>
   <article class="py-12">
     <div class="max-w-3xl mx-auto px-4">
       <a href="/ko/learn" class="text-[--color-text-muted] text-sm hover:text-[--color-accent] transition-colors mb-8 inline-block">

--- a/src/pages/ko/coins/index.astro
+++ b/src/pages/ko/coins/index.astro
@@ -3,6 +3,14 @@ import Layout from '../../../layouts/Layout.astro';
 import { useTranslations } from '../../../i18n/index';
 
 const t = useTranslations('ko');
+
+const TOP_COINS = [
+  'BTCUSDT','ETHUSDT','SOLUSDT','BNBUSDT','XRPUSDT','DOGEUSDT','ADAUSDT',
+  'AVAXUSDT','LINKUSDT','DOTUSDT','MATICUSDT','LTCUSDT','UNIUSDT','ATOMUSDT',
+  'NEARUSDT','OPUSDT','ARBUSDT','APTUSDT','INJUSDT','SUIUSDT','TIAUSDT',
+  'SEIUSDT','WLDUSDT','ORDIUSDT','STXUSDT','JUPUSDT','FETUSDT','RNDRUSDT',
+  'IMXUSDT','SANDUSDT',
+];
 ---
 
 <Layout title={t('meta.coins_title')} description={t('meta.coins_desc')}>
@@ -25,6 +33,19 @@ const t = useTranslations('ko');
             <div class="h-12 bg-[--color-bg-hover] rounded"></div>
           </div>
         </div>
+        <noscript>
+          <p class="font-bold text-sm mb-1">{t('coins.noscript_title')}</p>
+          <p class="text-[--color-text-muted] text-sm mb-4">{t('coins.noscript_desc')}</p>
+          <ul class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-2">
+            {TOP_COINS.map(symbol => (
+              <li>
+                <a href={`/ko/coins/${symbol.toLowerCase()}/`} class="text-[--color-accent] hover:underline text-sm font-mono">
+                  {symbol.replace('USDT', '')}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </noscript>
       </div>
       <div class="mt-10 pt-8 border-t border-[--color-border] text-center">
         <p class="text-[--color-text-muted] text-sm mb-4">{t('coins.explore_next')}</p>


### PR DESCRIPTION
## 원론적 해결 — 7개 이슈

### P0: TS 컴파일 에러 52개 → 0개
- **en.ts + ko.ts 중복 키** (perf.tbl_*, ranking.*, strategies.presets_*): 이전 세션들에서 키가 각각 따로 추가되며 이중 정의됨. 중복 블록 제거.
- **ko.ts 누락 키 10개** (compare_table.qc_free, home.social_simulations 등): en.ts 추가분이 ko.ts에 미동기화. 전부 추가.
- **ChartPanel setMarkers**: lightweight-charts v5에서 `series.setMarkers()` 제거 → `createSeriesMarkers(series, markers)` 로 교체.

### P1: SEO 크롤링 직접 영향
- **/coins + /ko/coins noscript**: 페이지 전체가 client-only → Googlebot이 549개 코인 링크 0개 인식. 상위 30개 코인 static fallback 추가.
- **sitemap priority/changefreq**: 1,257개 URL 동등 취급 → core 1.0/daily, coins/strategies 0.8/weekly, static 0.5/monthly 규칙 적용.

### P2: UX/SEO 개선
- **BlogPost ogImage**: 17개 블로그 포스트 모두 generic OG 이미지 공유. `image` frontmatter → `ogImage` prop 파이프라인 구축.

## Test plan
- [x] TS 에러 0개 (`npx tsc --noEmit`)
- [x] 51/51 E2E 통과 (mobile-menu + nav-highlight)
- [ ] CI 4/4 (axe + E2E + SEO + validate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)