### PR TITLE
fix: sitemap learn index + simulate noscript (#428, #429)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -24,11 +24,11 @@ export default defineConfig({
         }
       },
       filter(page) {
-        return !page.includes('/learn/') && !page.includes('/demo/') && !page.includes('/builder/');
+        return !(/\/learn\/.+/.test(page)) && !page.includes('/demo/') && !page.includes('/builder/');
       },
       serialize(item) {
         if (!item || !item.url) return item;
-        if (item.url.includes('/learn/')) return undefined;
+        if (/\/learn\/.+/.test(item.url)) return undefined;
         if (item.url.includes('/demo/')) return undefined;
         if (item.url.includes('/builder/')) return undefined;
         if (item.url.includes('/ko/404/')) return undefined;

--- a/src/pages/ko/simulate/index.astro
+++ b/src/pages/ko/simulate/index.astro
@@ -117,6 +117,19 @@ const presetCount = (presetsJson as Array<unknown>).length;
     </div>
   </section>
 
+  <noscript>
+    <section class="max-w-2xl mx-auto px-4 py-12 text-center">
+      <h2 class="text-xl font-semibold mb-4">전략 백테스팅 시뮬레이터</h2>
+      <p class="text-[--color-text-muted] mb-6">
+        인터랙티브 시뮬레이터를 사용하려면 JavaScript가 필요합니다. 검증된 프리셋 전략을 확인하세요:
+      </p>
+      <ul class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-left">
+        <li><a href="/ko/simulate?preset=bb-squeeze-short" class="text-[--color-accent] hover:underline">BB Squeeze SHORT</a></li>
+        <li><a href="/ko/strategies/" class="text-[--color-accent] hover:underline">전체 전략 보기</a></li>
+      </ul>
+    </section>
+  </noscript>
+
   <div id="onboarding-tour-mount"></div>
 
   <script>

--- a/src/pages/simulate/index.astro
+++ b/src/pages/simulate/index.astro
@@ -117,6 +117,19 @@ const presetCount = (presetsJson as Array<unknown>).length;
     </div>
   </section>
 
+  <noscript>
+    <section class="max-w-2xl mx-auto px-4 py-12 text-center">
+      <h2 class="text-xl font-semibold mb-4">Strategy Backtesting Simulator</h2>
+      <p class="text-[--color-text-muted] mb-6">
+        The interactive simulator requires JavaScript. Try a verified preset strategy:
+      </p>
+      <ul class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-left">
+        <li><a href="/simulate?preset=bb-squeeze-short" class="text-[--color-accent] hover:underline">BB Squeeze SHORT</a></li>
+        <li><a href="/strategies/" class="text-[--color-accent] hover:underline">Browse all strategies</a></li>
+      </ul>
+    </section>
+  </noscript>
+
   <div id="onboarding-tour-mount"></div>
 
   <script>


### PR DESCRIPTION
## Summary
- Fix overly broad `/learn/` sitemap filter that excluded the index page (regex match for sub-routes only)
- Add `<noscript>` fallback to `/simulate` (EN+KO) so crawlers see content instead of blank page

## Test plan
- [x] `npm run build` — 2466 pages, 0 errors
- [x] Sitemap includes `/learn/` index (1 match), excludes sub-routes
- [x] `<noscript>` present in built simulate pages (EN+KO)

Closes #428, Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)