### PR TITLE
fix(e2e): networkidle timeout — production API polling never settles

### DIFF
--- a/tests/e2e/i18n-language.spec.ts
+++ b/tests/e2e/i18n-language.spec.ts
@@ -75,9 +75,12 @@ test.describe("EN pages: zero Korean text", () => {
       expect(res?.status(), `${path} returned error`).toBeLessThan(400);
 
       // For dynamic pages, wait for hydration to settle
+      // Use 5s timeout (not networkidle) — production pages poll APIs continuously → networkidle never resolves
       if (["/strategies/ranking", "/market", "/simulate"].includes(path)) {
-        await page.waitForLoadState("networkidle").catch(() => {});
-        await page.waitForTimeout(3000); // allow client:load components to render
+        await page
+          .waitForLoadState("networkidle", { timeout: 5000 })
+          .catch(() => {});
+        await page.waitForTimeout(2000); // allow client:load components to render
       }
 
       const text = await getVisibleText(page);

--- a/tests/e2e/simulator-e2e.spec.ts
+++ b/tests/e2e/simulator-e2e.spec.ts
@@ -22,7 +22,8 @@ const skipInCI = !!process.env.CI;
 /** Opens simulator and waits for Preact hydration (lands on Quick Test by default).
  *  Uses event-based waits instead of hardcoded timeouts — reliable on slow CI runners. */
 async function openSimulator(page: Page) {
-  await page.goto("/simulate/", { waitUntil: "networkidle" });
+  // domcontentloaded + waitForFunction: production pages poll APIs → networkidle never resolves → 60s timeout
+  await page.goto("/simulate/", { waitUntil: "domcontentloaded" });
 
   // Wait for ModeSwitcher to fully hydrate: tablist exists AND all 3 tabs are visible.
   // waitForTimeout(1500) was too short on slow GitHub runners (hydration takes 3-5s).


### PR DESCRIPTION
## 원인

`/simulate`, `/market`, `/strategies/ranking` 페이지는 production에서 API를 지속적으로 폴링 → `waitUntil: "networkidle"` 이 절대 resolves되지 않음 → 60s timeout → 53+ 테스트 FAIL + Telegram E2E 알림 반복.

로컬 e2e-monitor가 production을 직접 hit하기 때문에 발생. GitHub CI는 localhost를 쓰므로 영향 없음.

## 수정

- `simulator-e2e.spec.ts`: `openSimulator()` — `networkidle` → `domcontentloaded`  
  (hydration 감지는 이미 `waitForFunction([role="tab"] >= 3)`가 처리)
- `i18n-language.spec.ts`: dynamic pages — `networkidle` 무한 대기 → `5s timeout + catch`

## 테스트

로컬 e2e-monitor 다음 실행 시 53개 timeout fail이 사라질 것.

🤖 Generated with [Claude Code](https://claude.com/claude-code)