### PR TITLE
fix(backend): silent exceptions + race condition in data reload

### DIFF
--- a/backend/api/data_manager.py
+++ b/backend/api/data_manager.py
@@ -4,11 +4,14 @@ PRUVIQ Data Manager — Singleton with in-memory caching.
 Loads OHLCV CSV files once at startup, serves them from RAM.
 """
 
+import logging
 import time
 from pathlib import Path
 from typing import Optional, Dict, List, Tuple
 
 import pandas as pd
+
+logger = logging.getLogger("pruviq")
 
 
 class DataManager:
@@ -36,8 +39,8 @@ class DataManager:
     def load(self, data_dir: Path):
         """Load all 1H OHLCV CSV files into memory."""
         start = time.time()
-        self._data.clear()
-        self._coin_info.clear()
+        new_data: Dict[str, pd.DataFrame] = {}
+        new_coin_info: List[dict] = []
 
         # Skip problematic symbols
         skip = {"intcusdt", "tslausdt", "hoodusdt", "paxgusdt", "gunusdt",
@@ -64,16 +67,20 @@ class DataManager:
                 df["timestamp"] = pd.to_datetime(df["timestamp"])
                 df = df.drop_duplicates(subset=["timestamp"], keep="last").reset_index(drop=True)
                 symbol = stem.upper()
-                self._data[symbol] = df
-                self._coin_info.append({
+                new_data[symbol] = df
+                new_coin_info.append({
                     "symbol": symbol,
                     "rows": len(df),
                     "date_from": str(df["timestamp"].min().date()),
                     "date_to": str(df["timestamp"].max().date()),
                 })
-            except Exception:
+            except Exception as e:
+                logger.warning(f"[data_manager] Failed to load {f.stem}: {type(e).__name__}: {e}")
                 continue
 
+        # Atomic swap — prevents race condition with concurrent readers
+        self._data = new_data
+        self._coin_info = new_coin_info
         self._load_time = time.time() - start
 
     @property

--- a/backend/api/indicator_cache.py
+++ b/backend/api/indicator_cache.py
@@ -6,12 +6,15 @@ The primary strategy (bb-squeeze-short) also populates a flat cache for
 backwards compatibility with existing endpoints.
 """
 
+import logging
 import time
 from typing import Dict, List, Tuple, Optional
 
 import pandas as pd
 
 from api.data_manager import DataManager
+
+logger = logging.getLogger("pruviq")
 
 
 class IndicatorCache:
@@ -48,7 +51,8 @@ class IndicatorCache:
                 continue
             try:
                 self._cache[symbol] = strategy.calculate_indicators(df.copy())
-            except Exception:
+            except Exception as e:
+                logger.warning(f"[indicator_cache] Failed to compute {symbol}: {type(e).__name__}: {e}")
                 continue
 
         # Also store in multi-cache
@@ -69,7 +73,8 @@ class IndicatorCache:
                     continue
                 try:
                     cache[symbol] = strategy.calculate_indicators(df.copy())
-                except Exception:
+                except Exception as e:
+                    logger.warning(f"[indicator_cache] Failed to compute {strategy_id}/{symbol}: {type(e).__name__}: {e}")
                     continue
             self._multi_cache[strategy_id] = cache
 


### PR DESCRIPTION
## Summary
- **#454**: Replace bare `except Exception: continue` with `logger.warning()` in `data_manager.py` and `indicator_cache.py` (3 sites). Violates CLAUDE.md rule: "bare pass/except 절대 금지"
- **#455**: Atomic dict swap in `DataManager.load()` — build into `new_data`/`new_coin_info`, then assign references. Eliminates race window where `.clear()` empties the dict while concurrent requests read it

## Changes
- `backend/api/data_manager.py`: Add logging import, build into local dicts, swap atomically, log failures
- `backend/api/indicator_cache.py`: Add logging import, log indicator computation failures (2 sites)

## Test plan
- [ ] `python3 -c "import ast; ..."` syntax check passes
- [ ] Backend starts without errors
- [ ] Corrupt a CSV → verify warning appears in logs instead of silent skip

Closes #454, closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)