### PR TITLE
fix(seo): sitemap lastmod + leaderboard noscript (#457, #458)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -66,6 +66,9 @@ export default defineConfig({
           item.priority = 0.5; item.changefreq = /** @type {any} */ ('monthly');
         }
 
+        // Freshness signal for search engines
+        item.lastmod = new Date().toISOString().split('T')[0];
+
         return item;
       }
     }),

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1195,6 +1195,9 @@ export const en = {
   "leaderboard.profit_factor": "PF",
   "leaderboard.total_return": "Return",
   "leaderboard.weekly_note": "Data updates weekly",
+  "leaderboard.noscript_title": "Weekly Strategy Rankings",
+  "leaderboard.noscript_desc":
+    "Enable JavaScript to view live weekly strategy performance rankings with win rate, profit factor, and return data.",
   "meta.leaderboard_title": "Weekly Strategy Leaderboard - PRUVIQ",
   "meta.leaderboard_desc":
     "See this week's best and worst performing crypto trading strategies. Updated weekly with real backtest data.",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -1171,6 +1171,9 @@ export const ko: Record<TranslationKey, string> = {
   "leaderboard.profit_factor": "PF",
   "leaderboard.total_return": "수익률",
   "leaderboard.weekly_note": "매주 업데이트",
+  "leaderboard.noscript_title": "주간 전략 순위",
+  "leaderboard.noscript_desc":
+    "승률, 수익률 등 실시간 주간 전략 순위를 보려면 JavaScript를 활성화하세요.",
   "meta.leaderboard_title": "주간 전략 순위 - PRUVIQ",
   "meta.leaderboard_desc":
     "이번 주 최고 및 최악의 암호화폐 전략을 확인하세요. 실제 백테스트 데이터로 매주 업데이트.",

--- a/src/pages/ko/leaderboard.astro
+++ b/src/pages/ko/leaderboard.astro
@@ -21,6 +21,12 @@ const t = useTranslations('ko');
       <ErrorBoundary name="Weekly Leaderboard" lang="ko" client:load>
         <WeeklyLeaderboard lang="ko" client:load />
       </ErrorBoundary>
+      <noscript>
+        <div class="border border-[--color-border] rounded-lg p-6 text-center text-[--color-text-muted] text-sm font-mono mt-4">
+          <p class="mb-2 font-bold">{t('leaderboard.noscript_title')}</p>
+          <p>{t('leaderboard.noscript_desc')}</p>
+        </div>
+      </noscript>
 
     </div>
   </section>

--- a/src/pages/leaderboard.astro
+++ b/src/pages/leaderboard.astro
@@ -34,6 +34,12 @@ const t = useTranslations('en');
       <ErrorBoundary name="Weekly Leaderboard" client:load>
         <WeeklyLeaderboard lang="en" client:load />
       </ErrorBoundary>
+      <noscript>
+        <div class="border border-[--color-border] rounded-lg p-6 text-center text-[--color-text-muted] text-sm font-mono mt-4">
+          <p class="mb-2 font-bold">{t('leaderboard.noscript_title')}</p>
+          <p>{t('leaderboard.noscript_desc')}</p>
+        </div>
+      </noscript>
 
     </div>
   </section>


### PR DESCRIPTION
## Summary
- **#457**: Sitemap `serialize()` now emits `<lastmod>` on all 2,466 URLs — search engines get freshness signals
- **#458**: `leaderboard.astro` (EN/KO) gets `<noscript>` fallback with meaningful content per Rule 2

## Changes
- `astro.config.mjs`: Add `item.lastmod` in sitemap serialize
- `src/pages/leaderboard.astro` + `src/pages/ko/leaderboard.astro`: noscript block
- `src/i18n/en.ts` + `ko.ts`: 2 new i18n keys each

## Test plan
- [x] `npm run build` → 2,466 pages, 0 errors
- [x] `dist/sitemap-0.xml` contains `<lastmod>` on every `<url>`
- [x] `dist/leaderboard/index.html` contains `<noscript>` block

Closes #457, closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)