### PR TITLE
fix(e2e): exclude visual-regression from E2E workflow (#461)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,11 +57,12 @@ jobs:
         npx playwright test tests/e2e/ \
           --timeout 60000 \
           --workers 2 \
-          --retries 1
+          --retries 1 \
+          --ignore-snapshots
       # Self-hosted M4: timeout 60s (이전 90s는 GitHub→DO 레이턴시 보정용, 불필요)
       # workers 2 (M4 Pro 성능 활용)
       # retries 1 (진짜 flaky는 self-hosted에서도 재현됨, 1회로 충분)
-      # visual regression: tests/visual/ (ubuntu-only, separate workflow)
+      # --ignore-snapshots: visual regression은 tests/visual/ (ubuntu-only, 별도 workflow)
       timeout-minutes: 15
       env:
         CI: true

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,13 +16,14 @@ export default defineConfig({
   projects: [
     {
       name: "desktop",
-      testIgnore: ["**/mobile-menu.spec.ts"],
+      testIgnore: ["**/mobile-menu.spec.ts", "**/visual-regression.spec.ts"],
       use: {
         viewport: { width: 1280, height: 720 },
       },
     },
     {
       name: "mobile",
+      testIgnore: ["**/visual-regression.spec.ts"],
       use: {
         viewport: { width: 375, height: 812 },
         isMobile: true,


### PR DESCRIPTION
## Summary
- Exclude `visual-regression.spec.ts` from E2E projects via `testIgnore` in `playwright.config.ts`
- Add `--ignore-snapshots` to `e2e.yml` as safety net
- Visual regression is already handled by `visual-regression.yml` (ubuntu-latest) — running it in E2E workflow (self-hosted darwin) causes OS-specific baseline mismatches

## Test plan
- [x] Full E2E suite: 224 passed, 13 skipped, 0 failed
- [x] Build: 2466 pages, 0 errors
- [ ] CI passes on this PR

Fixes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)