### PR TITLE
fix: KO ranking SSR fallback + coin count 549→569

### DIFF
--- a/src/components/LiveStats.tsx
+++ b/src/components/LiveStats.tsx
@@ -16,7 +16,7 @@ interface SiteStats {
 }
 
 const DEFAULTS: SiteStats = {
-  coins_analyzed: 549,
+  coins_analyzed: 569,
   trading_days: 2898,
   simulations_run: 12847,
   strategies_tested: 88,

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -50,7 +50,7 @@ const categoryLabels: Record<string, string> = {
         {category === 'education' ? (
           <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] text-center">
             <h3 class="font-bold text-lg mb-2">Build Your Own Strategy</h3>
-            <p class="text-[--color-text-muted] text-sm mb-4">Combine indicators, set conditions, and backtest on 549+ coins with 2+ years of data. No code required.</p>
+            <p class="text-[--color-text-muted] text-sm mb-4">Combine indicators, set conditions, and backtest on 569+ coins with 2+ years of data. No code required.</p>
             <div class="flex flex-col sm:flex-row gap-3 justify-center">
               <a href="/simulate"
                  class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-6 py-2 rounded font-semibold text-sm hover:bg-[--color-accent-dim]">
@@ -65,7 +65,7 @@ const categoryLabels: Record<string, string> = {
         ) : (
           <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] text-center">
             <h3 class="font-bold text-lg mb-2">Ready to test strategies yourself?</h3>
-            <p class="text-[--color-text-muted] text-sm mb-4">Simulate trading strategies on 549 coins with 2+ years of data. Free.</p>
+            <p class="text-[--color-text-muted] text-sm mb-4">Simulate trading strategies on 569+ coins with 2+ years of data. Free.</p>
             <div class="flex flex-col sm:flex-row gap-3 justify-center">
               <a href="/simulate"
                  class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-6 py-2 rounded font-semibold text-sm hover:bg-[--color-accent-dim]">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -192,8 +192,8 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
         "alternateName": lang === 'ko' ? '크립토 전략 검증 플랫폼' : 'Crypto Strategy Lab',
         "url": "https://pruviq.com",
         "description": lang === 'ko'
-          ? '무료 크립토 전략 백테스팅 플랫폼. 549개 이상 코인에서 2년 이상의 실제 시장 데이터로 트레이딩 전략을 만들고 테스트하세요.'
-          : 'Free crypto strategy backtesting platform. Build and test trading strategies on 549+ coins with 2+ years of real market data.',
+          ? '무료 크립토 전략 백테스팅 플랫폼. 569개 이상 코인에서 2년 이상의 실제 시장 데이터로 트레이딩 전략을 만들고 테스트하세요.'
+          : 'Free crypto strategy backtesting platform. Build and test trading strategies on 569+ coins with 2+ years of real market data.',
         "founder": { "@type": "Organization", "name": "PRUVIQ Team" },
         "sameAs": ["https://x.com/pruviq", "https://github.com/pruviq/pruviq"],
         "knowsAbout": lang === 'ko'
@@ -215,11 +215,11 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
           "priceCurrency": "USD"
         },
         "description": lang === 'ko'
-          ? '549개 이상 코인에서 크립토 트레이딩 전략을 만들고 테스트하세요. 노코드 전략 빌더, 인터랙티브 차트, 진입/청산 마커 제공.'
-          : 'Build and test crypto trading strategies on 549+ coins. No-code strategy builder with interactive charts and entry/exit markers.',
+          ? '569개 이상 코인에서 크립토 트레이딩 전략을 만들고 테스트하세요. 노코드 전략 빌더, 인터랙티브 차트, 진입/청산 마커 제공.'
+          : 'Build and test crypto trading strategies on 569+ coins. No-code strategy builder with interactive charts and entry/exit markers.',
         "featureList": lang === 'ko'
-          ? ['노코드 전략 빌더', '549+ 코인 백테스팅', '11개 이상 기술 지표', '인터랙티브 차트', '전략 검증']
-          : ['No-code strategy builder', '549+ coin backtesting', '11+ technical indicators', 'Interactive charts', 'Strategy verification']
+          ? ['노코드 전략 빌더', '569+ 코인 백테스팅', '11개 이상 기술 지표', '인터랙티브 차트', '전략 검증']
+          : ['No-code strategy builder', '569+ coin backtesting', '11+ technical indicators', 'Interactive charts', 'Strategy verification']
       })} />
     )}
     <!-- JSON-LD FAQPage (homepage only) -->
@@ -233,7 +233,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
             "name": "PRUVIQ란 무엇인가요?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "PRUVIQ는 무료 크립토 전략 백테스팅 플랫폼입니다. 11개 이상의 기술 지표를 사용하여 맞춤 트레이딩 전략을 만들고, 549개 이상의 코인에서 2년 이상의 실제 시장 데이터로 백테스트하며, 수수료와 슬리피지를 포함한 현실적인 결과를 확인할 수 있습니다. 코딩 불필요."
+              "text": "PRUVIQ는 무료 크립토 전략 백테스팅 플랫폼입니다. 11개 이상의 기술 지표를 사용하여 맞춤 트레이딩 전략을 만들고, 569개 이상의 코인에서 2년 이상의 실제 시장 데이터로 백테스트하며, 수수료와 슬리피지를 포함한 현실적인 결과를 확인할 수 있습니다. 코딩 불필요."
             }
           },
           {
@@ -249,7 +249,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
             "name": "PRUVIQ는 무료인가요?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "네, PRUVIQ의 핵심 백테스팅 기능은 완전 무료입니다. 전략 만들기, 549개 이상 코인 백테스트, 모든 교육 콘텐츠 이용이 결제나 계정 생성 없이 가능합니다."
+              "text": "네, PRUVIQ의 핵심 백테스팅 기능은 완전 무료입니다. 전략 만들기, 569개 이상 코인 백테스트, 모든 교육 콘텐츠 이용이 결제나 계정 생성 없이 가능합니다."
             }
           },
           {
@@ -257,7 +257,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
             "name": "PRUVIQ는 TradingView 등 다른 백테스팅 도구와 어떻게 다른가요?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "PRUVIQ는 코딩 없이 사용할 수 있는 크립토 선물 전용 백테스팅 플랫폼입니다. TradingView(Pine Script 필요)나 QuantConnect(Python/C# 필요)와 달리, 시각적 전략 빌더를 제공합니다. 549개 이상 코인 동시 테스트, 현실적 수수료·슬리피지 반영, 실패 전략까지 모두 공개합니다."
+              "text": "PRUVIQ는 코딩 없이 사용할 수 있는 크립토 선물 전용 백테스팅 플랫폼입니다. TradingView(Pine Script 필요)나 QuantConnect(Python/C# 필요)와 달리, 시각적 전략 빌더를 제공합니다. 569개 이상 코인 동시 테스트, 현실적 수수료·슬리피지 반영, 실패 전략까지 모두 공개합니다."
             }
           },
           {
@@ -265,7 +265,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
             "name": "PRUVIQ의 전략은 어떻게 검증되나요?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "PRUVIQ는 549개 이상의 코인에서 2년 이상의 과거 데이터로 모든 전략을 백테스트합니다. 수수료, 슬리피지, 펀딩비를 포함한 현실적인 시뮬레이션으로 검증하며, 실패한 전략도 모두 공개합니다."
+              "text": "PRUVIQ는 569개 이상의 코인에서 2년 이상의 과거 데이터로 모든 전략을 백테스트합니다. 수수료, 슬리피지, 펀딩비를 포함한 현실적인 시뮬레이션으로 검증하며, 실패한 전략도 모두 공개합니다."
             }
           }
         ] : [
@@ -274,7 +274,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
             "name": "What is PRUVIQ?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "PRUVIQ is a free crypto strategy backtesting platform. You can build custom trading strategies using 11+ technical indicators, backtest them on 549+ coins with 2+ years of real market data, and see realistic results including fees and slippage. No coding required."
+              "text": "PRUVIQ is a free crypto strategy backtesting platform. You can build custom trading strategies using 11+ technical indicators, backtest them on 569+ coins with 2+ years of real market data, and see realistic results including fees and slippage. No coding required."
             }
           },
           {
@@ -290,7 +290,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
             "name": "Is PRUVIQ free?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Yes, PRUVIQ's core backtesting features are completely free. You can build strategies, run backtests on 549+ coins, and access all education content without any payment or account creation."
+              "text": "Yes, PRUVIQ's core backtesting features are completely free. You can build strategies, run backtests on 569+ coins, and access all education content without any payment or account creation."
             }
           },
           {
@@ -298,7 +298,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
             "name": "What makes PRUVIQ different from TradingView or other backtesting tools?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "PRUVIQ is specifically built for crypto futures with no coding required. Unlike TradingView (requires Pine Script) or QuantConnect (requires Python/C#), PRUVIQ offers a visual strategy builder. It also publishes all backtest results including failures, tests on 549+ coins simultaneously, and includes realistic fees and slippage in all simulations."
+              "text": "PRUVIQ is specifically built for crypto futures with no coding required. Unlike TradingView (requires Pine Script) or QuantConnect (requires Python/C#), PRUVIQ offers a visual strategy builder. It also publishes all backtest results including failures, tests on 569+ coins simultaneously, and includes realistic fees and slippage in all simulations."
             }
           },
           {
@@ -306,7 +306,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
             "name": "How does PRUVIQ verify strategies?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "PRUVIQ backtests all strategies on 549+ coins with 2+ years of historical data. Every simulation includes realistic fees, slippage, and funding costs. Failed strategies are published alongside successful ones for full transparency."
+              "text": "PRUVIQ backtests all strategies on 569+ coins with 2+ years of historical data. Every simulation includes realistic fees, slippage, and funding costs. Failed strategies are published alongside successful ones for full transparency."
             }
           }
         ]
@@ -360,11 +360,11 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
         "totalTime": "PT3M",
         "step": lang === 'ko' ? [
           { "@type": "HowToStep", "position": 1, "name": "전략 선택", "text": "라이브러리에서 전략을 고르거나 11개 이상의 지표로 나만의 전략을 만드세요." },
-          { "@type": "HowToStep", "position": 2, "name": "시뮬레이션", "text": "549개 이상의 코인에서 2년 이상의 과거 데이터로 백테스트하세요. 수수료와 슬리피지 포함." },
+          { "@type": "HowToStep", "position": 2, "name": "시뮬레이션", "text": "569개 이상의 코인에서 2년 이상의 과거 데이터로 백테스트하세요. 수수료와 슬리피지 포함." },
           { "@type": "HowToStep", "position": 3, "name": "검증", "text": "승률, 최대 낙폭, 수익 팩터, 연패 기록을 확인한 후 실거래 투입 여부를 결정하세요." }
         ] : [
           { "@type": "HowToStep", "position": 1, "name": "Select", "text": "Pick a strategy from the library or build your own using the no-code builder with 11+ indicators." },
-          { "@type": "HowToStep", "position": 2, "name": "Simulate", "text": "Run it on 549+ coins with 2+ years of historical data. Fees and slippage included." },
+          { "@type": "HowToStep", "position": 2, "name": "Simulate", "text": "Run it on 569+ coins with 2+ years of historical data. Fees and slippage included." },
           { "@type": "HowToStep", "position": 3, "name": "Verify", "text": "Review win rate, drawdown, profit factor, and losing streaks. Then decide if it's worth trading." }
         ]
       })} />

--- a/src/pages/ko/strategies/ranking.astro
+++ b/src/pages/ko/strategies/ranking.astro
@@ -11,6 +11,34 @@ const today = new Date().toLocaleDateString('ko-KR', {
   day: 'numeric',
   timeZone: 'Asia/Seoul',
 });
+
+// Fetch ranking data at build time for SSR fallback
+interface RankingEntry {
+  rank: number;
+  name_en: string;
+  strategy: string;
+  direction: string;
+  win_rate: number;
+  profit_factor: number;
+  total_trades: number;
+  timeframe: string;
+  low_sample: boolean;
+}
+interface RankingData {
+  date: string;
+  top3: RankingEntry[];
+  worst3: RankingEntry[];
+}
+
+let ssrRanking: RankingData | null = null;
+try {
+  const res = await fetch('https://api.pruviq.com/rankings/daily?period=30d&group=Market%20Cap%20Top%2050', {
+    signal: AbortSignal.timeout(5000),
+  });
+  if (res.ok) ssrRanking = await res.json() as RankingData;
+} catch {
+  // SSR fallback unavailable — JS component will handle it
+}
 ---
 
 <Layout title={t('meta.ranking_title')} description={t('meta.ranking_desc')}>
@@ -72,13 +100,91 @@ const today = new Date().toLocaleDateString('ko-KR', {
         </p>
       </div>
 
-      <!-- Ranking component (client-side fetch) -->
-      <noscript>
-        <div class="border border-[--color-border] rounded-lg p-6 text-center text-[--color-text-muted] text-sm font-mono">
-          <p class="mb-2 font-bold">{t('ranking.noscript_title')}</p>
-          <p>{t('ranking.noscript_desc')}</p>
-          <p class="mt-3"><a href="/ko/simulate" class="text-[--color-accent] underline">{t('ranking.open_sim')} →</a></p>
+      <!-- SSR fallback: static top3/worst3 visible before JS loads -->
+      {ssrRanking && (
+        <div id="ranking-ssr-fallback" class="mb-8">
+          <p class="font-mono text-[--color-accent] text-xs mb-3 tracking-wider">BEST 3 — {ssrRanking.date} · 30d · Top 50</p>
+          <div class="grid md:grid-cols-3 gap-4 mb-6">
+            {ssrRanking.top3.map((entry) => {
+              const isLong = entry.direction === 'long';
+              const isBoth = entry.direction === 'both';
+              const medals = ['🥇','🥈','🥉'];
+              const medal = medals[entry.rank - 1] ?? `#${entry.rank}`;
+              const dirLabel = isBoth ? 'BOTH↕' : isLong ? 'LONG↑' : 'SHORT↓';
+              const dirColor = isBoth ? 'text-[--color-yellow] border-[--color-yellow]/40' : isLong ? 'text-[--color-up] border-[--color-up]/40' : 'text-[--color-red] border-[--color-red]/40';
+              const wrColor = entry.win_rate >= 55 ? 'text-[--color-up]' : entry.win_rate >= 50 ? 'text-[--color-yellow]' : 'text-[--color-red]';
+              const pfColor = entry.profit_factor >= 1.5 ? 'text-[--color-up]' : entry.profit_factor >= 1.0 ? 'text-[--color-yellow]' : 'text-[--color-red]';
+              return (
+                <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card]">
+                  <div class="flex items-start justify-between gap-2 mb-3">
+                    <div class="flex items-center gap-2 min-w-0">
+                      <span class="text-xl shrink-0">{medal}</span>
+                      <div class="min-w-0">
+                        <p class="font-semibold text-[--color-text] text-sm leading-tight truncate">{entry.name_en}</p>
+                        <p class="text-[--color-text-muted] text-xs font-mono">{entry.timeframe} · {entry.direction}</p>
+                      </div>
+                    </div>
+                    <span class={`font-mono text-xs px-2 py-0.5 rounded border shrink-0 ${dirColor}`}>{dirLabel}</span>
+                  </div>
+                  <div class="grid grid-cols-3 gap-2 font-mono text-sm">
+                    <div>
+                      <p class="text-[--color-text-muted] text-xs mb-0.5">Win Rate</p>
+                      <p class={`font-bold text-base ${wrColor}`}>{entry.win_rate.toFixed(1)}%</p>
+                    </div>
+                    <div>
+                      <p class="text-[--color-text-muted] text-xs mb-0.5">PF</p>
+                      <p class={`font-bold text-base ${pfColor}`}>{entry.profit_factor.toFixed(2)}</p>
+                    </div>
+                    <div>
+                      <p class="text-[--color-text-muted] text-xs mb-0.5">Trades</p>
+                      <p class="font-bold text-base text-[--color-text]">{entry.total_trades}</p>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          <p class="font-mono text-[--color-red] text-xs mb-3 tracking-wider">WORST 3</p>
+          <div class="grid md:grid-cols-3 gap-4 mb-2">
+            {ssrRanking.worst3.map((entry) => {
+              const medals = ['🥇','🥈','🥉'];
+              const medal = medals[entry.rank - 1] ?? `#${entry.rank}`;
+              const wrColor = entry.win_rate >= 55 ? 'text-[--color-up]' : entry.win_rate >= 50 ? 'text-[--color-yellow]' : 'text-[--color-red]';
+              const pfColor = entry.profit_factor >= 1.5 ? 'text-[--color-up]' : entry.profit_factor >= 1.0 ? 'text-[--color-yellow]' : 'text-[--color-red]';
+              return (
+                <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] opacity-70">
+                  <div class="flex items-center gap-2 mb-3">
+                    <span class="text-xl">{medal}</span>
+                    <div>
+                      <p class="font-semibold text-[--color-text] text-sm">{entry.name_en}</p>
+                      <p class="text-[--color-text-muted] text-xs font-mono">{entry.timeframe}</p>
+                    </div>
+                  </div>
+                  <div class="grid grid-cols-3 gap-2 font-mono text-sm">
+                    <div><p class="text-[--color-text-muted] text-xs mb-0.5">Win Rate</p><p class={`font-bold ${wrColor}`}>{entry.win_rate.toFixed(1)}%</p></div>
+                    <div><p class="text-[--color-text-muted] text-xs mb-0.5">PF</p><p class={`font-bold ${pfColor}`}>{entry.profit_factor.toFixed(2)}</p></div>
+                    <div><p class="text-[--color-text-muted] text-xs mb-0.5">Trades</p><p class="font-bold text-[--color-text]">{entry.total_trades}</p></div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          <p class="text-[--color-text-muted] text-xs font-mono mt-3">인터랙티브 필터 로딩 중...</p>
         </div>
+      )}
+      <!-- Script to hide SSR fallback once JS component renders -->
+      <script>
+        document.addEventListener('astro:page-load', () => {
+          const fallback = document.getElementById('ranking-ssr-fallback');
+          if (fallback) {
+            setTimeout(() => { fallback.style.display = 'none'; }, 1500);
+          }
+        });
+      </script>
+
+      <!-- noscript: show SSR data permanently when JS disabled -->
+      <noscript>
+        <style>#ranking-ssr-fallback { display: block !important; }</style>
       </noscript>
       <ErrorBoundary name="Strategy Ranking" client:load>
         <StrategyRanking lang="ko" client:load />


### PR DESCRIPTION
## Summary
- **W1**: Add build-time API fetch + static top3/worst3 HTML fallback to `/ko/strategies/ranking` — mirrors EN SSR pattern from PR #460. Crawlers now see actual ranking data without JS.
- **W2**: Update stale coin count 549→569 in Layout.astro (schema.org org/webapp/FAQ/HowTo), BlogPost.astro (sidebar CTAs x2), LiveStats.tsx (default fallback)

## Files changed
- `src/pages/ko/strategies/ranking.astro` — SSR interfaces + fetch + `#ranking-ssr-fallback` div + 1.5s hide script
- `src/layouts/Layout.astro` — 549→569 (14 occurrences, EN+KO meta/schema)
- `src/layouts/BlogPost.astro` — 549→569 (2 sidebar CTA strings)
- `src/components/LiveStats.tsx` — `coins_analyzed` default 549→569

## Test plan
- [ ] Build passes (2466 pages, 0 errors) ✅
- [ ] `dist/ko/strategies/ranking/index.html` contains `ranking-ssr-fallback` ✅
- [ ] No "549" remaining in Layout.astro ✅
- [ ] E2E CI passes on self-hosted runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)