### PR TITLE
fix: trust badge data source + low-sample strategy warning

### DIFF
--- a/src/components/RankingCard.tsx
+++ b/src/components/RankingCard.tsx
@@ -108,6 +108,15 @@ export function RankingCard({
         </div>
       </div>
 
+      {/* Low sample warning badge */}
+      {entry.low_sample && (
+        <div class="mb-3">
+          <span class="inline-flex items-center gap-1 text-xs font-mono px-2 py-0.5 rounded border border-[--color-yellow]/40 text-[--color-yellow] bg-[--color-yellow]/5">
+            ⚠️ {lbl.lowSample(entry.total_trades)}
+          </span>
+        </div>
+      )}
+
       {/* Stats row */}
       <div class="grid grid-cols-3 gap-2 font-mono text-sm">
         <div>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1031,7 +1031,7 @@ export const en = {
   "compare_table.pruviq_verification": "Live",
 
   // Social proof / trust section
-  "trust.badge_api": "Binance API Read-Only",
+  "trust.badge_api": "CoinGecko Data",
   "trust.badge_source": "Source Available",
   "trust.badge_privacy": "No Personal Data",
   "trust.badge_validated": "Monte Carlo Validated",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -1013,7 +1013,7 @@ export const ko: Record<TranslationKey, string> = {
   "compare_table.pruviq_verification": "전체 공개",
 
   // Social proof / trust section
-  "trust.badge_api": "바이낸스 API 읽기 전용",
+  "trust.badge_api": "CoinGecko 데이터",
   "trust.badge_source": "소스 공개",
   "trust.badge_privacy": "개인정보 불필요",
   "trust.badge_validated": "몬테카를로 검증",


### PR DESCRIPTION
## Summary

- **P0 Fix 1 — Trust badge data source**: `trust.badge_api` in `en.ts` was "Binance API Read-Only" and in `ko.ts` was "바이낸스 API 읽기 전용". Updated both to reflect the actual current data source: "CoinGecko Data" / "CoinGecko 데이터".
- **P0 Fix 2 — Low-sample warning badge on ranking cards**: `RankingCard.tsx` already had `low_sample: boolean` on `RankingEntry` and `lowSample(n)` label strings defined in both EN/KO, but the badge was never rendered. Added a ⚠️ badge that appears between the header and stats row when `entry.low_sample === true`. Shows "Low sample (N trades < 100)" / "샘플 부족 (N건 < 100건)" with `--color-yellow` theming consistent with existing direction/timeframe badges.

## Files changed

- `src/i18n/en.ts` — "Binance API Read-Only" → "CoinGecko Data"
- `src/i18n/ko.ts` — "바이낸스 API 읽기 전용" → "CoinGecko 데이터"
- `src/components/RankingCard.tsx` — add low-sample warning badge render block

## Test plan

- [ ] Home page (EN + KO): trust badge row shows "CoinGecko Data" / "CoinGecko 데이터" instead of Binance
- [ ] Ranking page (EN + KO): strategy cards with `total_trades < 100` show ⚠️ badge with correct trade count
- [ ] Ranking page: cards with `total_trades >= 100` show NO warning badge
- [ ] No visual regression on cards without `low_sample=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)