### PR TITLE
fix: negative limit bypass + rate-limit IP extraction (#471, #472)

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -286,12 +286,12 @@ def get_client_ip(request: Request) -> str:
     """Extract real client IP, only trusting proxy headers from trusted sources."""
     direct_ip = request.client.host if request.client else "unknown"
 
-    if direct_ip not in TRUSTED_PROXIES:
-        return direct_ip
-
     cf_ip = request.headers.get("cf-connecting-ip")
     if cf_ip:
         return cf_ip.strip()
+
+    if direct_ip not in TRUSTED_PROXIES:
+        return direct_ip
 
     forwarded = request.headers.get("x-forwarded-for")
     if forwarded:
@@ -1034,7 +1034,9 @@ async def get_ohlcv(symbol: str, limit: int = 1000, offset: int = 0, timeframe: 
     timeframe = _validate_timeframe(timeframe)
 
     # Cap limit at 5000 to prevent excessive response sizes
-    if limit > 5000:
+    if limit < 0:
+        limit = 1000
+    elif limit > 5000:
         limit = 5000
 
     if _is_resampled(timeframe):


### PR DESCRIPTION
## Summary
- **#471**: Negative `limit` on `/ohlcv` bypassed 5,000-row cap → now resets to default 1000
- **#472**: `cf-connecting-ip` was never read in production (Cloudflare edge IPs aren't in `TRUSTED_PROXIES`) → moved CF header check before proxy gate so rate limiting uses real client IPs

## Test plan
- [ ] `GET /ohlcv/BTC?limit=-1` returns default 1000 rows (not all data)
- [ ] `GET /ohlcv/BTC?limit=0` still returns all data (unchanged)
- [ ] Rate limiting uses distinct client IPs behind Cloudflare

Fixes #471, Fixes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)