### PR TITLE
fix: auto-fix #479 (+1 related)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -170,11 +170,13 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <link rel="preload" href={ogImageWebp} as="image" type="image/webp" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content={description} />
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImage} />
+    <meta name="twitter:image:alt" content={description} />
     <meta name="twitter:site" content="@pruviq" />
     <title>{title}</title>
     <!-- JSON-LD Organization -->
@@ -334,7 +336,13 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
           }
         },
         "mainEntityOfPage": canonicalURL.href,
-        "articleSection": category || "education"
+        "articleSection": category || "education",
+        "image": {
+          "@type": "ImageObject",
+          "url": ogImage,
+          "width": 1200,
+          "height": 630
+        }
       })} />
     )}
     <!-- JSON-LD BreadcrumbList (skip for 404 pages) -->


### PR DESCRIPTION
## Auto-fix for 2 issue(s)

#479: [claude-auto][P2] Article JSON-LD missing `image` — 34 blog posts ineligible for rich results
#480: [claude-auto][P2] `og:image:alt` and `twitter:image:alt` absent — social share accessibility & p

### Changes
```
 src/layouts/Layout.astro | 10 +++++++++-
 1 file changed, 9 insertions(+), 1 deletion(-)
```

### Safety Checks
- Files changed: **1** (limit: 20)
- Lines changed: **10** (limit: 1500)

---
*Auto-generated by JEPO auto-fix agent. Requires auto-test pass before merge.*