### PR TITLE
fix: og/twitter image:alt → description (resolves #479 #480)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -166,7 +166,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <meta property="og:site_name" content="PRUVIQ" />
     <meta property="og:locale" content={lang === 'ko' ? 'ko_KR' : 'en_US'} />
     <meta property="og:image" content={ogImage} />
-    <meta property="og:image:alt" content={title} />
+    <meta property="og:image:alt" content={description} />
     <link rel="preload" href={ogImageAvif} as="image" type="image/avif" />
     <link rel="preload" href={ogImageWebp} as="image" type="image/webp" />
     <meta property="og:image:width" content="1200" />
@@ -176,7 +176,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImage} />
-    <meta name="twitter:image:alt" content={title} />
+    <meta name="twitter:image:alt" content={description} />
     <meta name="twitter:site" content="@pruviq" />
     <title>{title}</title>
     <!-- JSON-LD Organization -->


### PR DESCRIPTION
## Summary
- `og:image:alt` and `twitter:image:alt`: `{title}` → `{description}`
- Title is already in `og:title`/`twitter:title` — alt duplication reduces SEO quality
- Clean rebase of PR #495 (which was CONFLICTING after #499 merged)

## Root cause fix
PR #495 has been stuck in deploy loop (9 retries) due to merge conflict with main.
This PR replaces it with a clean commit directly on current main.

Closes #479 Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)