### PR TITLE
fix: kill orphaned port 4321 before E2E (self-hosted runner)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,6 +58,9 @@ jobs:
         BASE_URL: https://api.pruviq.com
       timeout-minutes: 3
 
+    - name: Kill orphaned dev server on port 4321
+      run: lsof -ti:4321 | xargs kill -9 2>/dev/null || true
+
     - name: Run E2E tests
       id: e2e
       run: |


### PR DESCRIPTION
## Summary
- self-hosted Mac Mini runner에서 이전 `npm run preview` 프로세스가 port 4321에 남아있어 모든 E2E 실패
- playwright.config.ts에 `reuseExistingServer: true`가 있어도 특정 상황에서 "already used" 에러 발생
- E2E 시작 전 port 4321 프로세스를 먼저 정리하는 1줄 step 추가

## Root Cause
self-hosted runner는 매 실행마다 cleanup이 보장되지 않음 → 이전 run의 `npm run preview` orphan → 포트 점유 → 신규 E2E 실행 불가

## Impact
- PR #501, #503, #506, #507 모두 이 이유로 E2E fail → tests-passed 라벨 못 받음 → 배포 블록

## Fix
```yaml
- name: Kill orphaned dev server on port 4321
  run: lsof -ti:4321 | xargs kill -9 2>/dev/null || true
```
`|| true` — 아무것도 없을 때도 exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)