### PR TITLE
ux: hero differentiator + fees CTA + preset RECOMMENDED + PF tooltip

### DIFF
--- a/src/components/FeeCalculator.tsx
+++ b/src/components/FeeCalculator.tsx
@@ -1,42 +1,44 @@
-import { useState } from 'preact/hooks';
-import { exchanges, type Exchange } from '../data/exchanges';
+import { useState } from "preact/hooks";
+import { exchanges, type Exchange } from "../data/exchanges";
 
 const labels = {
   en: {
-    tag: 'FEE CALCULATOR',
-    title: 'How Much Can You Save?',
-    desc: 'Enter your monthly trading volume. See the real cost — and how much PRUVIQ saves you.',
-    volume: 'Monthly Volume (USD)',
-    spot: 'Spot',
-    futures: 'Futures',
-    market: 'Market',
-    exchange: 'Exchange',
-    standard: 'Standard Fee',
-    withPruviq: 'With PRUVIQ',
-    savings: 'You Save / Year',
-    signup: 'Sign Up',
-    coming: 'Coming Soon',
-    disclaimer: 'Based on VIP 0 (base tier) taker fees. Actual fees may vary with VIP level.',
-    spotTab: 'Spot Trading',
-    futuresTab: 'Futures Trading',
+    tag: "FEE CALCULATOR",
+    title: "How Much Can You Save?",
+    desc: "Enter your monthly trading volume. See the real cost — and how much PRUVIQ saves you.",
+    volume: "Monthly Volume (USD)",
+    spot: "Spot",
+    futures: "Futures",
+    market: "Market",
+    exchange: "Exchange",
+    standard: "Standard Fee",
+    withPruviq: "With PRUVIQ",
+    savings: "You Save / Year",
+    signup: "Sign Up",
+    coming: "Coming Soon",
+    disclaimer:
+      "Based on VIP 0 (base tier) taker fees. Actual fees may vary with VIP level.",
+    spotTab: "Spot Trading",
+    futuresTab: "Futures Trading",
   },
   ko: {
-    tag: '수수료 계산기',
-    title: '얼마나 절약할 수 있을까요?',
-    desc: '월 거래량을 입력하세요. 실제 비용과 PRUVIQ로 절약할 수 있는 금액을 확인하세요.',
-    volume: '월 거래량 (USD)',
-    spot: '현물',
-    futures: '선물',
-    market: '시장',
-    exchange: '거래소',
-    standard: '기본 수수료',
-    withPruviq: 'PRUVIQ 적용',
-    savings: '연간 절약액',
-    signup: '가입하기',
-    coming: '준비 중',
-    disclaimer: 'VIP 0 (기본 등급) 테이커 수수료 기준. 실제 수수료는 VIP 등급에 따라 다를 수 있습니다. 원화 환산은 약 1,450원/달러 기준 참고값입니다.',
-    spotTab: '현물 거래',
-    futuresTab: '선물 거래',
+    tag: "수수료 계산기",
+    title: "얼마나 절약할 수 있을까요?",
+    desc: "월 거래량을 입력하세요. 실제 비용과 PRUVIQ로 절약할 수 있는 금액을 확인하세요.",
+    volume: "월 거래량 (USD)",
+    spot: "현물",
+    futures: "선물",
+    market: "시장",
+    exchange: "거래소",
+    standard: "기본 수수료",
+    withPruviq: "PRUVIQ 적용",
+    savings: "연간 절약액",
+    signup: "가입하기",
+    coming: "준비 중",
+    disclaimer:
+      "VIP 0 (기본 등급) 테이커 수수료 기준. 실제 수수료는 VIP 등급에 따라 다를 수 있습니다. 원화 환산은 약 1,450원/달러 기준 참고값입니다.",
+    spotTab: "현물 거래",
+    futuresTab: "선물 거래",
   },
 };
 
@@ -46,29 +48,29 @@ function fmt(n: number): string {
 }
 
 function fmtFull(n: number): string {
-  return `$${n.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
+  return `$${n.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
 }
 
 const KRW_RATE = 1450;
 function fmtKrw(n: number): string {
   const krw = Math.round(n * KRW_RATE);
   if (krw >= 10000) return `${(krw / 10000).toFixed(0)}만원`;
-  return `${krw.toLocaleString('ko-KR')}원`;
+  return `${krw.toLocaleString("ko-KR")}원`;
 }
 
 interface Props {
-  lang?: 'en' | 'ko';
+  lang?: "en" | "ko";
 }
 
-export default function FeeCalculator({ lang = 'en' }: Props) {
+export default function FeeCalculator({ lang = "en" }: Props) {
   const t = labels[lang] || labels.en;
-  const [volume, setVolume] = useState(100000);
-  const [market, setMarket] = useState<'futures' | 'spot'>('futures');
+  const [volume, setVolume] = useState(10000);
+  const [market, setMarket] = useState<"futures" | "spot">("futures");
 
   const volumeSteps = [10000, 25000, 50000, 100000, 250000, 500000, 1000000];
 
   function calcFees(ex: Exchange) {
-    const rates = market === 'futures' ? ex.futures : ex.spot;
+    const rates = market === "futures" ? ex.futures : ex.spot;
     const standard = volume * rates.taker;
     const discounted = standard * (1 - ex.discount);
     const savingsYear = (standard - discounted) * 12;
@@ -79,7 +81,9 @@ export default function FeeCalculator({ lang = 'en' }: Props) {
 
   return (
     <div class="border border-[--color-border] rounded-lg bg-[--color-bg-card] p-6">
-      <div class="font-mono text-[--color-accent] text-xs tracking-wider mb-2">{t.tag}</div>
+      <div class="font-mono text-[--color-accent] text-xs tracking-wider mb-2">
+        {t.tag}
+      </div>
       <h3 class="text-xl font-bold mb-1">{t.title}</h3>
       <p class="text-[--color-text-muted] text-sm mb-6">{t.desc}</p>
 
@@ -87,27 +91,37 @@ export default function FeeCalculator({ lang = 'en' }: Props) {
       <div class="flex flex-col sm:flex-row gap-4 mb-6">
         {/* Spot / Futures Toggle */}
         <div class="flex-shrink-0">
-          <label class="block font-mono text-xs text-[--color-text-muted] mb-2">{t.market}</label>
+          <label class="block font-mono text-xs text-[--color-text-muted] mb-2">
+            {t.market}
+          </label>
           <div class="flex rounded-lg overflow-hidden border border-[--color-border]">
             <button
-              onClick={() => setMarket('spot')}
+              onClick={() => setMarket("spot")}
               class={`px-4 py-2 min-h-[44px] text-sm font-semibold transition-colors ${
-                market === 'spot'
-                  ? ''
-                  : 'bg-[--color-bg-card] text-[--color-text-muted] hover:text-[--color-text]'
+                market === "spot"
+                  ? ""
+                  : "bg-[--color-bg-card] text-[--color-text-muted] hover:text-[--color-text]"
               }`}
-              style={market === 'spot' ? { background: 'var(--color-accent)', color: '#fff' } : undefined}
+              style={
+                market === "spot"
+                  ? { background: "var(--color-accent)", color: "#fff" }
+                  : undefined
+              }
             >
               {t.spotTab}
             </button>
             <button
-              onClick={() => setMarket('futures')}
+              onClick={() => setMarket("futures")}
               class={`px-4 py-2 min-h-[44px] text-sm font-semibold transition-colors ${
-                market === 'futures'
-                  ? ''
-                  : 'bg-[--color-bg-card] text-[--color-text-muted] hover:text-[--color-text]'
+                market === "futures"
+                  ? ""
+                  : "bg-[--color-bg-card] text-[--color-text-muted] hover:text-[--color-text]"
               }`}
-              style={market === 'futures' ? { background: 'var(--color-accent)', color: '#fff' } : undefined}
+              style={
+                market === "futures"
+                  ? { background: "var(--color-accent)", color: "#fff" }
+                  : undefined
+              }
             >
               {t.futuresTab}
             </button>
@@ -116,13 +130,21 @@ export default function FeeCalculator({ lang = 'en' }: Props) {
 
         {/* Volume Slider */}
         <div class="flex-1">
-          <label class="block font-mono text-xs text-[--color-text-muted] mb-2">{t.volume}</label>
+          <label class="block font-mono text-xs text-[--color-text-muted] mb-2">
+            {t.volume}
+          </label>
           <input
             type="range"
             min={0}
             max={volumeSteps.length - 1}
-            value={volumeSteps.indexOf(volume) >= 0 ? volumeSteps.indexOf(volume) : 3}
-            onInput={(e: Event) => setVolume(volumeSteps[Number((e.target as HTMLInputElement).value)])}
+            value={
+              volumeSteps.indexOf(volume) >= 0 ? volumeSteps.indexOf(volume) : 3
+            }
+            onInput={(e: Event) =>
+              setVolume(
+                volumeSteps[Number((e.target as HTMLInputElement).value)],
+              )
+            }
             class="w-full accent-[--color-accent]"
             aria-label={t.volume}
             aria-valuemin={volumeSteps[0]}
@@ -132,7 +154,11 @@ export default function FeeCalculator({ lang = 'en' }: Props) {
           />
           <div class="font-mono text-lg font-bold mt-1">
             {fmtFull(volume)}
-            {lang === 'ko' && <span class="text-sm text-[--color-text-muted] ml-2">({fmtKrw(volume)})</span>}
+            {lang === "ko" && (
+              <span class="text-sm text-[--color-text-muted] ml-2">
+                ({fmtKrw(volume)})
+              </span>
+            )}
           </div>
         </div>
       </div>
@@ -152,18 +178,34 @@ export default function FeeCalculator({ lang = 'en' }: Props) {
             {/* Fees */}
             <div class="flex-1 grid grid-cols-1 sm:grid-cols-3 gap-2 text-center">
               <div>
-                <div class="font-mono text-[0.625rem] sm:text-xs text-[--color-text-muted] mb-1">{t.standard}</div>
-                <div class="font-mono text-xs sm:text-sm line-through text-[--color-text-muted]">{fmt(standard)}<span class="text-[0.6rem]">/mo</span></div>
+                <div class="font-mono text-[0.625rem] sm:text-xs text-[--color-text-muted] mb-1">
+                  {t.standard}
+                </div>
+                <div class="font-mono text-xs sm:text-sm line-through text-[--color-text-muted]">
+                  {fmt(standard)}
+                  <span class="text-[0.6rem]">/mo</span>
+                </div>
               </div>
               <div>
-                <div class="font-mono text-[0.625rem] sm:text-xs text-[--color-accent] mb-1">{t.withPruviq} ({ex.discountLabel})</div>
-                <div class="font-mono text-xs sm:text-sm font-bold text-[--color-accent]">{fmt(discounted)}<span class="text-[0.6rem]">/mo</span></div>
+                <div class="font-mono text-[0.625rem] sm:text-xs text-[--color-accent] mb-1">
+                  {t.withPruviq} ({ex.discountLabel})
+                </div>
+                <div class="font-mono text-xs sm:text-sm font-bold text-[--color-accent]">
+                  {fmt(discounted)}
+                  <span class="text-[0.6rem]">/mo</span>
+                </div>
               </div>
               <div>
-                <div class="font-mono text-[0.625rem] sm:text-xs text-[--color-text-muted] mb-1">{t.savings}</div>
+                <div class="font-mono text-[0.625rem] sm:text-xs text-[--color-text-muted] mb-1">
+                  {t.savings}
+                </div>
                 <div class="font-mono text-xs sm:text-sm font-bold text-[--color-accent]">
                   {fmtFull(Math.round(savingsYear))}
-                  {lang === 'ko' && <div class="text-[0.6rem] text-[--color-text-muted]">({fmtKrw(savingsYear)})</div>}
+                  {lang === "ko" && (
+                    <div class="text-[0.6rem] text-[--color-text-muted]">
+                      ({fmtKrw(savingsYear)})
+                    </div>
+                  )}
                 </div>
               </div>
             </div>
@@ -175,9 +217,15 @@ export default function FeeCalculator({ lang = 'en' }: Props) {
                   href={ex.referralUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="inline-block w-full px-4 py-2 min-h-[44px] flex items-center justify-center rounded text-xs font-semibold hover:opacity-90 transition-opacity" style="background:var(--color-accent);color:#fff"
+                  class="inline-block w-full px-4 py-2 min-h-[44px] flex flex-col items-center justify-center rounded text-xs font-semibold hover:opacity-90 transition-opacity"
+                  style="background:var(--color-accent);color:#fff"
                 >
-                  {t.signup} &rarr;
+                  <span>{t.signup} &rarr;</span>
+                  {savingsYear > 0 && (
+                    <span class="text-[0.6rem] opacity-80 font-normal mt-0.5">
+                      Save {fmt(savingsYear)}/yr
+                    </span>
+                  )}
                 </a>
               ) : (
                 <span class="inline-block w-full bg-[--color-border] text-[--color-text-muted] px-4 py-2 min-h-[44px] flex items-center justify-center rounded text-xs font-semibold cursor-default">

--- a/src/components/MarketDashboard.tsx
+++ b/src/components/MarketDashboard.tsx
@@ -604,12 +604,21 @@ export default function MarketDashboard({
                 {l.calendarNote}
               </span>
             </div>
-            <div class="w-full h-[300px] md:h-[400px]">
+            <div class="w-full h-[300px] md:h-[400px] relative">
+              {/* Loading placeholder — shown until iframe paints */}
+              <div
+                class="absolute inset-0 flex flex-col items-center justify-center gap-2 text-[--color-text-muted] text-xs font-mono pointer-events-none"
+                id="cal-placeholder"
+              >
+                <span class="animate-spin inline-block w-5 h-5 border-2 border-[--color-accent] border-t-transparent rounded-full" />
+                Loading economic calendar...
+              </div>
               <iframe
                 src={`https://s.tradingview.com/embed-widget/events/?locale=${lang === "ko" ? "kr" : "en"}#%7B%22colorTheme%22%3A%22dark%22%2C%22isTransparent%22%3Atrue%2C%22width%22%3A%22100%25%22%2C%22height%22%3A%22100%25%22%2C%22importanceFilter%22%3A%220%2C1%22%7D`}
                 title={l.economicCalendar}
-                class="w-full h-full border-0"
+                class="w-full h-full border-0 relative z-10"
                 loading="lazy"
+                onLoad="document.getElementById('cal-placeholder')?.remove()"
               />
             </div>
           </div>

--- a/src/components/PresetBar.tsx
+++ b/src/components/PresetBar.tsx
@@ -1,8 +1,10 @@
 /**
  * PresetBar.tsx - Preset strategy buttons (compact)
+ * Shows top 5 as RECOMMENDED, rest collapsible.
  */
-import type { PresetItem } from './simulator-types';
-import { COLORS } from './simulator-types';
+import { useState } from "preact/hooks";
+import type { PresetItem } from "./simulator-types";
+import { COLORS } from "./simulator-types";
 
 interface Props {
   presets: PresetItem[];
@@ -12,42 +14,131 @@ interface Props {
   loading?: boolean;
 }
 
-const activeStyle = { background: COLORS.accent, color: '#fff', borderColor: COLORS.accent, boxShadow: `0 0 12px ${COLORS.accentGlowStrong}` };
+const RECOMMENDED_COUNT = 5;
 
-export default function PresetBar({ presets, activePreset, onSelectPreset, label, loading }: Props) {
+const activeStyle = {
+  background: COLORS.accent,
+  color: "#fff",
+  borderColor: COLORS.accent,
+  boxShadow: `0 0 12px ${COLORS.accentGlowStrong}`,
+};
+
+function PresetButton({
+  p,
+  activePreset,
+  onSelectPreset,
+}: {
+  p: PresetItem;
+  activePreset: string | null;
+  onSelectPreset: (id: string | null) => void;
+}) {
+  const isActive = activePreset === p.id;
+  return (
+    <button
+      key={p.id}
+      onClick={() => onSelectPreset(p.id)}
+      class={`px-2.5 py-1 text-xs font-mono rounded transition-colors border
+        ${
+          isActive
+            ? "font-bold"
+            : "bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-accent]/30 hover:text-[--color-text]"
+        }`}
+      style={isActive ? activeStyle : undefined}
+    >
+      {p.name}
+    </button>
+  );
+}
+
+export default function PresetBar({
+  presets,
+  activePreset,
+  onSelectPreset,
+  label,
+  loading,
+}: Props) {
+  const [showAll, setShowAll] = useState(false);
+
   if (presets.length === 0) return null;
 
+  const recommended = presets.slice(0, RECOMMENDED_COUNT);
+  const rest = presets.slice(RECOMMENDED_COUNT);
+  const hasMore = rest.length > 0;
+  // If active preset is in "rest", auto-expand
+  const activeInRest = hasMore && rest.some((p) => p.id === activePreset);
+
   return (
-    <div class="px-4 py-2 border-b border-[--color-border]" style={{ background: `linear-gradient(135deg, ${COLORS.accentBg}, transparent)` }}>
-      <div class="text-xs font-mono uppercase mb-1 flex items-center gap-1.5" style={{ color: COLORS.accent }}>
-        {label}
-        {loading && <span class="spinner" style={{ width: '10px', height: '10px' }} />}
+    <div
+      class="px-4 py-2 border-b border-[--color-border]"
+      style={{
+        background: `linear-gradient(135deg, ${COLORS.accentBg}, transparent)`,
+      }}
+    >
+      {/* RECOMMENDED row */}
+      <div
+        class="text-xs font-mono uppercase mb-1 flex items-center gap-1.5"
+        style={{ color: COLORS.accent }}
+      >
+        ★ Recommended
+        {loading && (
+          <span class="spinner" style={{ width: "10px", height: "10px" }} />
+        )}
       </div>
-      <div class="flex flex-wrap gap-1">
+      <div class="flex flex-wrap gap-1 mb-1.5">
         <button
           onClick={() => onSelectPreset(null)}
           class={`px-2.5 py-1 text-xs font-mono rounded transition-colors border
-            ${activePreset === null
-              ? 'font-bold'
-              : 'bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-accent]/30 hover:text-[--color-text]'}`}
+            ${
+              activePreset === null
+                ? "font-bold"
+                : "bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-accent]/30 hover:text-[--color-text]"
+            }`}
           style={activePreset === null ? activeStyle : undefined}
         >
           Custom
         </button>
-        {presets.map((p) => (
-          <button
+        {recommended.map((p) => (
+          <PresetButton
             key={p.id}
-            onClick={() => onSelectPreset(p.id)}
-            class={`px-2.5 py-1 text-xs font-mono rounded transition-colors border
-              ${activePreset === p.id
-                ? 'font-bold'
-                : 'bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-accent]/30 hover:text-[--color-text]'}`}
-            style={activePreset === p.id ? activeStyle : undefined}
-          >
-            {p.name}
-          </button>
+            p={p}
+            activePreset={activePreset}
+            onSelectPreset={onSelectPreset}
+          />
         ))}
       </div>
+
+      {/* Collapsible "All presets" */}
+      {hasMore && (
+        <>
+          <button
+            onClick={() => setShowAll((v) => !v)}
+            class="text-[0.65rem] font-mono text-[--color-text-muted] hover:text-[--color-accent] transition-colors flex items-center gap-1 mb-1"
+          >
+            <span
+              style={{
+                display: "inline-block",
+                transform: showAll || activeInRest ? "rotate(90deg)" : "none",
+                transition: "transform 0.15s",
+              }}
+            >
+              ▶
+            </span>
+            {showAll || activeInRest ? "Hide" : `All ${presets.length} presets`}
+          </button>
+          {(showAll || activeInRest) && (
+            <div class="flex flex-wrap gap-1">
+              {rest.map((p) => (
+                <PresetButton
+                  key={p.id}
+                  p={p}
+                  activePreset={activePreset}
+                  onSelectPreset={onSelectPreset}
+                />
+              ))}
+            </div>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/RankingCard.tsx
+++ b/src/components/RankingCard.tsx
@@ -128,7 +128,12 @@ export function RankingCard({
           </p>
         </div>
         <div>
-          <p class="text-[--color-text-muted] text-xs mb-0.5">PF</p>
+          <p
+            class="text-[--color-text-muted] text-xs mb-0.5 cursor-help"
+            title="Profit Factor = avg win ÷ avg loss. 1.0 = breakeven, 1.5+ = good, 2.0+ = strong. Capped at 99.99 for low-sample results."
+          >
+            PF <span class="opacity-50 text-[0.6rem]">?</span>
+          </p>
           {entry.profit_factor >= 50 ? (
             <p
               class={`font-bold text-base ${pfColor(entry.profit_factor)} cursor-help underline decoration-dotted`}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -40,7 +40,8 @@ export const en = {
   "hero.tool_strategies": "88+ Variations Backtested",
   "hero.tool_data": "2+ Years Historical Data",
   "hero.tool_free": "100% Free, No Signup",
-  "hero.subcopy": "No signup required. Free forever. Get results in 3 seconds.",
+  "hero.subcopy":
+    "We tested 88 strategy combinations. 4 failed — and we published every one.",
   "hero.cta_secondary": "See Backtest Results",
   "hero.stat1_sub": "Including BTC, ETH, and altcoins",
   "hero.stat4_sub": "Across all verified strategies",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -41,7 +41,8 @@ export const ko: Record<TranslationKey, string> = {
   "hero.tool_strategies": "88+ 조합 백테스트",
   "hero.tool_data": "2년+ 과거 데이터",
   "hero.tool_free": "100% 무료, 가입 불필요",
-  "hero.subcopy": "가입 불필요. 영원히 무료. 3초 만에 결과 확인.",
+  "hero.subcopy":
+    "88가지 전략 조합을 검증했습니다. 4개가 실패했고 — 전부 공개했습니다.",
   "hero.cta_secondary": "백테스트 결과 보기",
   "hero.stat1_sub": "BTC, ETH 포함 알트코인",
   "hero.stat4_sub": "검증된 전략 전체",


### PR DESCRIPTION
## UX 감사 기반 5개 핵심 개선 (6.7/10 → 7.5+ 목표)

3개 에이전트 교차검증 + TradingView/3Commas/Coinrule/QuantConnect 벤치마크 결과 적용.

## 변경 사항

### 홈 Hero 차별화 메시지 (`en.ts`, `ko.ts`)
- **Before**: "No signup required. Free forever. Get results in 3 seconds." (subtitle과 중복)
- **After**: "We tested 88 strategy combinations. 4 failed — and we published every one."
- **Why**: hero.subtitle이 이미 "No signup. No cost." 커버 → subcopy는 유일한 차별점(투명성) 강조

### Fees 계산기 기본값 (`FeeCalculator.tsx`)
- 기본 거래량 $100,000 → **$10,000** (일반 트레이더 현실적 금액)
- Sign Up CTA 버튼에 **"Save $X/yr"** 절약 금액 직접 표시 (레퍼럴 전환 개선)

### 시뮬레이터 프리셋 구조화 (`PresetBar.tsx`)
- **Before**: 36개 버튼 평면 나열 → 선택 장애 (Casey 페르소나 이탈 원인)
- **After**: ★ Recommended (상위 5개) + "All 36 presets" 접기/펼치기
- 활성 프리셋이 나머지 목록에 있으면 자동 펼침

### Ranking PF 툴팁 (`RankingCard.tsx`)
- PF 헤더에 `?` 아이콘 + hover 툴팁: "Profit Factor = avg win ÷ avg loss. 1.0 = breakeven, 1.5+ = good..."
- PF 99.99 (cap) 설명은 기존 유지

### Market 경제 캘린더 로딩 상태 (`MarketDashboard.tsx`)
- TradingView iframe 로딩 중 빈 박스 → 스피너 + "Loading economic calendar..." 플레이스홀더
- iframe `onLoad` 시 플레이스홀더 자동 제거

## 검증
- `npm run build` → 2478 pages, 오류 없음

## 출처
- Persona audit (site_ux_audit_10pages_20260319.md): 전체 6.7/10
- Benchmark: TradingView, 3Commas, Coinrule, QuantConnect 실제 방문 분석

🤖 Generated with [Claude Code](https://claude.com/claude-code)