### PR TITLE
ux: Ranking/Leaderboard mobile tab labels — Daily/Weekly short form

### DIFF
--- a/src/pages/ko/strategies/ranking.astro
+++ b/src/pages/ko/strategies/ranking.astro
@@ -63,10 +63,10 @@ if (!ssrRanking) {
           {t('nav.strategies')}
         </a>
         <a href="/ko/strategies/ranking" aria-current="page" class="px-4 py-2.5 font-mono text-sm font-semibold text-[--color-accent] border-b-2 border-[--color-accent] -mb-px bg-[--color-accent-bg] transition-colors">
-          {t('ranking.tag')}
+          <span class="sm:hidden">데일리</span><span class="hidden sm:inline">{t('ranking.tag')}</span>
         </a>
         <a href="/ko/leaderboard" class="px-4 py-2.5 font-mono text-sm text-[--color-text-muted] border-b-2 border-transparent -mb-px hover:text-[--color-text] hover:border-[--color-border] transition-colors">
-          {t('leaderboard.tag')}
+          <span class="sm:hidden">주간</span><span class="hidden sm:inline">{t('leaderboard.tag')}</span>
         </a>
       </nav>
 

--- a/src/pages/leaderboard.astro
+++ b/src/pages/leaderboard.astro
@@ -17,10 +17,10 @@ const t = useTranslations('en');
           {t('nav.strategies')}
         </a>
         <a href="/strategies/ranking" class="px-4 py-2.5 font-mono text-sm text-[--color-text-muted] border-b-2 border-transparent -mb-px hover:text-[--color-text] hover:border-[--color-border] transition-colors">
-          {t('ranking.tag')}
+          <span class="sm:hidden">Daily</span><span class="hidden sm:inline">{t('ranking.tag')}</span>
         </a>
         <a href="/leaderboard" aria-current="page" class="px-4 py-2.5 font-mono text-sm font-semibold text-[--color-accent] border-b-2 border-[--color-accent] -mb-px bg-[--color-accent-bg] transition-colors">
-          {t('leaderboard.tag')}
+          <span class="sm:hidden">Weekly</span><span class="hidden sm:inline">{t('leaderboard.tag')}</span>
         </a>
       </nav>
 

--- a/src/pages/strategies/ranking.astro
+++ b/src/pages/strategies/ranking.astro
@@ -73,10 +73,10 @@ if (!ssrRanking) {
           {t('nav.strategies')}
         </a>
         <a href="/strategies/ranking" aria-current="page" class="px-4 py-2.5 font-mono text-sm font-semibold text-[--color-accent] border-b-2 border-[--color-accent] -mb-px bg-[--color-accent-bg] transition-colors">
-          {t('ranking.tag')}
+          <span class="sm:hidden">Daily</span><span class="hidden sm:inline">{t('ranking.tag')}</span>
         </a>
         <a href="/leaderboard" class="px-4 py-2.5 font-mono text-sm text-[--color-text-muted] border-b-2 border-transparent -mb-px hover:text-[--color-text] hover:border-[--color-border] transition-colors">
-          {t('leaderboard.tag')}
+          <span class="sm:hidden">Weekly</span><span class="hidden sm:inline">{t('leaderboard.tag')}</span>
         </a>
       </nav>
 


### PR DESCRIPTION
## Summary
- Tab nav on ranking and leaderboard pages: "DAILY RANKING" (13ch) and "WEEKLY RANKINGS" (15ch) wrap to 2 lines at mobile viewport (375px), making the tab bar unnecessarily tall
- Add `sm:hidden` short labels: **Daily / Weekly** (EN) and **데일리 / 주간** (KO) visible only on mobile
- Desktop (sm+) continues to show full "DAILY RANKING" / "WEEKLY RANKINGS" text

## Files changed
- `src/pages/strategies/ranking.astro`
- `src/pages/leaderboard.astro`
- `src/pages/ko/strategies/ranking.astro`

## Test plan
- [ ] Mobile 375px: all 3 tabs fit on one line (Strategies · Daily · Weekly)
- [ ] Desktop/tablet: shows full "DAILY RANKING" / "WEEKLY RANKINGS"
- [ ] KO mobile: "전략 · 데일리 · 주간 순위" on one line

🤖 Generated with [Claude Code](https://claude.com/claude-code)