### PR TITLE
ux: KO ranking translations + Expert badge fix

### DIFF
--- a/src/components/ModeSwitcher.tsx
+++ b/src/components/ModeSwitcher.tsx
@@ -93,7 +93,7 @@ export default function ModeSwitcher({ mode, setMode, lang, isFirstVisit }: Prop
             tabIndex={active ? 0 : -1}
             onClick={() => setMode(tab.key)}
             onKeyDown={(e: KeyboardEvent) => handleKeyDown(e, idx)}
-            class={`relative flex-1 min-h-[44px] py-2.5 px-2 rounded-lg border transition-all text-center
+            class={`relative flex-1 min-h-[44px] py-2.5 px-2 rounded-lg border transition-all text-center overflow-visible
               ${active
                 ? 'border-[--color-accent]'
                 : 'border-[--color-border] hover:border-[--color-text-muted]'
@@ -130,7 +130,7 @@ export default function ModeSwitcher({ mode, setMode, lang, isFirstVisit }: Prop
 
             {/* Expert "advanced" label */}
             {tab.key === 'expert' && !active && (
-              <span aria-hidden="true" class="absolute top-1 right-1.5 text-[8px] opacity-70 font-mono"
+              <span aria-hidden="true" class="absolute top-1 right-2 text-[8px] opacity-70 font-mono"
                 style={{ color: COLORS.accentDim }}>
                 {t.advanced}
               </span>

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -575,7 +575,7 @@ export const ko: Record<TranslationKey, string> = {
   "perf.tbl_safety": "안전 마진",
 
   // Daily Ranking page
-  "ranking.tag": "DAILY RANKING",
+  "ranking.tag": "데일리 랭킹",
   "ranking.title": "오늘의 전략 랭킹",
   "ranking.date_label": "{date} 기준 · PRUVIQ 시뮬레이터 백테스트 결과",
   "ranking.desc":

--- a/src/pages/ko/strategies/ranking.astro
+++ b/src/pages/ko/strategies/ranking.astro
@@ -98,7 +98,7 @@ if (!ssrRanking) {
         </a>
         <a
           href="/ko/leaderboard"
-          class="inline-flex items-center gap-2 border border-[--color-border] text-[--color-text-muted] px-5 py-2.5 rounded-lg font-semibold text-sm hover:border-[--color-accent] hover:text-[--color-accent] transition-colors"
+          class="hidden sm:inline-flex items-center gap-2 border border-[--color-border] text-[--color-text-muted] px-5 py-2.5 rounded-lg font-semibold text-sm hover:border-[--color-accent] hover:text-[--color-accent] transition-colors"
         >
           {t('ranking.leaderboard')}
         </a>
@@ -140,7 +140,7 @@ if (!ssrRanking) {
                   </div>
                   <div class="grid grid-cols-3 gap-2 font-mono text-sm">
                     <div>
-                      <p class="text-[--color-text-muted] text-xs mb-0.5">Win Rate</p>
+                      <p class="text-[--color-text-muted] text-xs mb-0.5">승률</p>
                       <p class={`font-bold text-base ${wrColor}`}>{entry.win_rate.toFixed(1)}%</p>
                     </div>
                     <div>
@@ -152,7 +152,7 @@ if (!ssrRanking) {
                       )}
                     </div>
                     <div>
-                      <p class="text-[--color-text-muted] text-xs mb-0.5">Trades</p>
+                      <p class="text-[--color-text-muted] text-xs mb-0.5">거래 수</p>
                       <p class="font-bold text-base text-[--color-text]">{entry.total_trades}</p>
                     </div>
                   </div>
@@ -177,9 +177,9 @@ if (!ssrRanking) {
                     </div>
                   </div>
                   <div class="grid grid-cols-3 gap-2 font-mono text-sm">
-                    <div><p class="text-[--color-text-muted] text-xs mb-0.5">Win Rate</p><p class={`font-bold ${wrColor}`}>{entry.win_rate.toFixed(1)}%</p></div>
+                    <div><p class="text-[--color-text-muted] text-xs mb-0.5">승률</p><p class={`font-bold ${wrColor}`}>{entry.win_rate.toFixed(1)}%</p></div>
                     <div><p class="text-[--color-text-muted] text-xs mb-0.5">PF</p>{entry.profit_factor >= 50 ? (<p class={`font-bold ${pfColor} cursor-help underline decoration-dotted`} title="PF 99.99로 제한됨 (거래 샘플 부족)">{entry.profit_factor.toFixed(2)} <span class="text-[0.6rem] font-normal text-[--color-text-muted]">(cap)</span></p>) : (<p class={`font-bold ${pfColor}`}>{entry.profit_factor.toFixed(2)}</p>)}</div>
-                    <div><p class="text-[--color-text-muted] text-xs mb-0.5">Trades</p><p class="font-bold text-[--color-text]">{entry.total_trades}</p></div>
+                    <div><p class="text-[--color-text-muted] text-xs mb-0.5">거래 수</p><p class="font-bold text-[--color-text]">{entry.total_trades}</p></div>
                   </div>
                 </div>
               );


### PR DESCRIPTION
## Changes

- **KO ranking.tag**: "DAILY RANKING" → "데일리 랭킹" (section label + desktop tab)
- **KO ranking SSR metric labels**: "Win Rate" → "승률", "Trades" → "거래 수" (PF stays as PF — universal term)
- **KO ranking mobile**: hide 리더보드 button on mobile — prevents awkward 3rd-button-alone wrap layout
- **ModeSwitcher Expert badge**: `overflow-visible` + `right-2` — fixes "고급" badge clipping on rightmost tab (was showing only "고")

## Detected by
Vision QA report (35 ATF screenshots, 2026-03-20)

## Test plan
- [ ] `/ko/strategies/ranking` desktop: section tag shows "데일리 랭킹", metrics show 승률/PF/거래 수
- [ ] `/ko/strategies/ranking` mobile: only 2 buttons visible (시뮬레이터 열기, 전략 라이브러리)
- [ ] `/ko/simulate` Expert tab: "고급" badge fully visible, not clipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)