### PR TITLE
refactor: i18n labels migration — remove 52 inline lang ternaries

### DIFF
--- a/src/components/BuilderPanel.tsx
+++ b/src/components/BuilderPanel.tsx
@@ -1,20 +1,25 @@
 /**
  * BuilderPanel.tsx - Strategy builder panel (compact layout, no internal scroll)
  */
-import { useState, useEffect } from 'preact/hooks';
-import type { Condition, IndicatorInfo, PresetItem, CoinOption } from './simulator-types';
-import { COLORS } from './simulator-types';
-import PresetBar from './PresetBar';
-import ConditionRow from './ConditionRow';
+import { useState, useEffect } from "preact/hooks";
+import type {
+  Condition,
+  IndicatorInfo,
+  PresetItem,
+  CoinOption,
+} from "./simulator-types";
+import { COLORS } from "./simulator-types";
+import PresetBar from "./PresetBar";
+import ConditionRow from "./ConditionRow";
 
 interface Props {
   // i18n
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- i18n dict has mixed value types (string, string[], Record<string,string>)
   t: Record<string, any>;
-  lang: 'en' | 'ko';
+  lang: "en" | "ko";
   // API state
   coinsLoaded: number;
-  totalCoins: number;  // total available coins from /health API
+  totalCoins: number; // total available coins from /health API
   demoMode: boolean;
   // Indicators
   availableIndicators: IndicatorInfo[];
@@ -24,26 +29,41 @@ interface Props {
   // Conditions
   conditions: Condition[];
   addCondition: () => void;
-  updateCondition: (id: string, key: string, val: string | number | boolean) => void;
+  updateCondition: (
+    id: string,
+    key: string,
+    val: string | number | boolean,
+  ) => void;
   removeCondition: (id: string) => void;
   // Params
-  direction: 'short' | 'long' | 'both';
-  setDirection: (d: 'short' | 'long' | 'both') => void;
-  slPct: number; setSlPct: (n: number) => void;
-  tpPct: number; setTpPct: (n: number) => void;
-  maxBars: number; setMaxBars: (n: number) => void;
-  perCoinUsdt: number; setPerCoinUsdt: (n: number) => void;
-  leverage: number; setLeverage: (n: number) => void;
-  compounding: boolean; setCompounding: (b: boolean) => void;
+  direction: "short" | "long" | "both";
+  setDirection: (d: "short" | "long" | "both") => void;
+  slPct: number;
+  setSlPct: (n: number) => void;
+  tpPct: number;
+  setTpPct: (n: number) => void;
+  maxBars: number;
+  setMaxBars: (n: number) => void;
+  perCoinUsdt: number;
+  setPerCoinUsdt: (n: number) => void;
+  leverage: number;
+  setLeverage: (n: number) => void;
+  compounding: boolean;
+  setCompounding: (b: boolean) => void;
   // Date range
-  startDate: string; setStartDate: (s: string) => void;
-  endDate: string; setEndDate: (s: string) => void;
+  startDate: string;
+  setStartDate: (s: string) => void;
+  endDate: string;
+  setEndDate: (s: string) => void;
   // Coins
-  coinMode: 'all' | 'top' | 'select';
-  setCoinMode: (m: 'all' | 'top' | 'select') => void;
-  topN: number; setTopN: (n: number) => void;
-  selectedCoins: string[]; setSelectedCoins: (fn: (prev: string[]) => string[]) => void;
-  coinSearch: string; setCoinSearch: (s: string) => void;
+  coinMode: "all" | "top" | "select";
+  setCoinMode: (m: "all" | "top" | "select") => void;
+  topN: number;
+  setTopN: (n: number) => void;
+  selectedCoins: string[];
+  setSelectedCoins: (fn: (prev: string[]) => string[]) => void;
+  coinSearch: string;
+  setCoinSearch: (s: string) => void;
   filteredCoins: CoinOption[];
   allCoinsCount: number;
   // Avoid hours
@@ -67,14 +87,52 @@ interface Props {
   onRun: () => void;
 }
 
-const indicatorActiveStyle = { background: COLORS.accent, color: '#fff', borderColor: COLORS.accent, boxShadow: `0 0 8px ${COLORS.accentGlow}` };
-const coinActiveStyle = { background: COLORS.accent, color: '#fff', borderColor: COLORS.accent, boxShadow: `0 0 8px ${COLORS.accentGlow}` };
-const shortActiveStyle = { background: COLORS.red, color: '#fff', borderColor: COLORS.red, boxShadow: `0 0 12px ${COLORS.redGlowStrong}` };
-const longActiveStyle = { background: COLORS.green, color: '#fff', borderColor: COLORS.green, boxShadow: `0 0 12px ${COLORS.greenGlow}` };
-const avoidActiveStyle = { background: COLORS.red, color: '#fff', borderColor: COLORS.red, boxShadow: `0 0 6px ${COLORS.redGlow}` };
-const tfActiveStyle = { background: COLORS.accent, color: '#fff', borderColor: COLORS.accent, boxShadow: `0 0 8px ${COLORS.accentGlow}`, fontWeight: 'bold' as const };
-const runStyle = { background: COLORS.accent, color: '#fff', boxShadow: `0 0 20px ${COLORS.accentGlow}` };
-const runDisabledStyle = { background: COLORS.disabled, color: COLORS.disabledText };
+const indicatorActiveStyle = {
+  background: COLORS.accent,
+  color: "#fff",
+  borderColor: COLORS.accent,
+  boxShadow: `0 0 8px ${COLORS.accentGlow}`,
+};
+const coinActiveStyle = {
+  background: COLORS.accent,
+  color: "#fff",
+  borderColor: COLORS.accent,
+  boxShadow: `0 0 8px ${COLORS.accentGlow}`,
+};
+const shortActiveStyle = {
+  background: COLORS.red,
+  color: "#fff",
+  borderColor: COLORS.red,
+  boxShadow: `0 0 12px ${COLORS.redGlowStrong}`,
+};
+const longActiveStyle = {
+  background: COLORS.green,
+  color: "#fff",
+  borderColor: COLORS.green,
+  boxShadow: `0 0 12px ${COLORS.greenGlow}`,
+};
+const avoidActiveStyle = {
+  background: COLORS.red,
+  color: "#fff",
+  borderColor: COLORS.red,
+  boxShadow: `0 0 6px ${COLORS.redGlow}`,
+};
+const tfActiveStyle = {
+  background: COLORS.accent,
+  color: "#fff",
+  borderColor: COLORS.accent,
+  boxShadow: `0 0 8px ${COLORS.accentGlow}`,
+  fontWeight: "bold" as const,
+};
+const runStyle = {
+  background: COLORS.accent,
+  color: "#fff",
+  boxShadow: `0 0 20px ${COLORS.accentGlow}`,
+};
+const runDisabledStyle = {
+  background: COLORS.disabled,
+  color: COLORS.disabledText,
+};
 
 export default function BuilderPanel(props: Props) {
   const { t } = props;
@@ -89,21 +147,37 @@ export default function BuilderPanel(props: Props) {
   const [localTopN, setLocalTopN] = useState(String(props.topN));
 
   // Sync local state when props change (e.g., preset load)
-  useEffect(() => { setLocalSl(String(props.slPct)); }, [props.slPct]);
-  useEffect(() => { setLocalTp(String(props.tpPct)); }, [props.tpPct]);
-  useEffect(() => { setLocalMaxBars(String(props.maxBars)); }, [props.maxBars]);
-  useEffect(() => { setLocalPerCoin(String(props.perCoinUsdt)); }, [props.perCoinUsdt]);
-  useEffect(() => { setLocalLeverage(String(props.leverage)); }, [props.leverage]);
-  useEffect(() => { setLocalTopN(String(props.topN)); }, [props.topN]);
+  useEffect(() => {
+    setLocalSl(String(props.slPct));
+  }, [props.slPct]);
+  useEffect(() => {
+    setLocalTp(String(props.tpPct));
+  }, [props.tpPct]);
+  useEffect(() => {
+    setLocalMaxBars(String(props.maxBars));
+  }, [props.maxBars]);
+  useEffect(() => {
+    setLocalPerCoin(String(props.perCoinUsdt));
+  }, [props.perCoinUsdt]);
+  useEffect(() => {
+    setLocalLeverage(String(props.leverage));
+  }, [props.leverage]);
+  useEffect(() => {
+    setLocalTopN(String(props.topN));
+  }, [props.topN]);
 
   return (
     <div class="border border-[--color-border] rounded-lg bg-[--color-bg-card] overflow-hidden flex flex-col">
       {/* Panel header */}
       <div class="px-4 py-2 border-b border-[--color-border] flex-shrink-0">
         <div class="flex items-center justify-between">
-          <span class="font-mono text-sm text-[--color-accent] tracking-wider font-bold">{t.strategyBuilder}</span>
+          <span class="font-mono text-sm text-[--color-accent] tracking-wider font-bold">
+            {t.strategyBuilder}
+          </span>
           {props.coinsLoaded > 0 && (
-            <span class="text-[--color-text-muted] text-xs font-mono">{props.coinsLoaded} coins</span>
+            <span class="text-[--color-text-muted] text-xs font-mono">
+              {props.coinsLoaded} coins
+            </span>
           )}
         </div>
       </div>
@@ -119,14 +193,21 @@ export default function BuilderPanel(props: Props) {
           loading={props.presetLoading}
         />
         {props.presetError && (
-          <div class="mx-4 mt-1 mb-0 px-2.5 py-1 rounded bg-[--color-red]/10 border border-[--color-red]/20" role="alert">
-            <span class="text-[10px] font-mono text-[--color-red]">{props.presetError}</span>
+          <div
+            class="mx-4 mt-1 mb-0 px-2.5 py-1 rounded bg-[--color-red]/10 border border-[--color-red]/20"
+            role="alert"
+          >
+            <span class="text-[10px] font-mono text-[--color-red]">
+              {props.presetError}
+            </span>
           </div>
         )}
 
         {/* Indicators */}
         <div class="px-4 py-2 border-b border-[--color-border]">
-          <div class="text-xs font-mono text-[--color-text-muted] uppercase mb-1">{t.indicators}</div>
+          <div class="text-xs font-mono text-[--color-text-muted] uppercase mb-1">
+            {t.indicators}
+          </div>
           <div class="flex flex-wrap gap-1">
             {props.availableIndicators.map((ind) => (
               <button
@@ -140,10 +221,16 @@ export default function BuilderPanel(props: Props) {
                   });
                 }}
                 class={`px-2.5 py-0.5 text-xs font-mono rounded transition-colors border
-                  ${props.selectedIndicators.has(ind.id)
-                    ? 'font-bold'
-                    : 'bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-accent]/20'}`}
-                style={props.selectedIndicators.has(ind.id) ? indicatorActiveStyle : undefined}
+                  ${
+                    props.selectedIndicators.has(ind.id)
+                      ? "font-bold"
+                      : "bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-accent]/20"
+                  }`}
+                style={
+                  props.selectedIndicators.has(ind.id)
+                    ? indicatorActiveStyle
+                    : undefined
+                }
               >
                 {ind.name}
               </button>
@@ -154,8 +241,13 @@ export default function BuilderPanel(props: Props) {
         {/* Entry Conditions */}
         <div class="px-4 py-2 border-b border-[--color-border]">
           <div class="flex items-center justify-between mb-1">
-            <span class="text-xs font-mono text-[--color-text-muted] uppercase">{t.conditions}</span>
-            <button onClick={props.addCondition} class="text-xs font-mono text-[--color-accent] hover:underline">
+            <span class="text-xs font-mono text-[--color-text-muted] uppercase">
+              {t.conditions}
+            </span>
+            <button
+              onClick={props.addCondition}
+              class="text-xs font-mono text-[--color-accent] hover:underline"
+            >
               {t.addCondition}
             </button>
           </div>
@@ -177,7 +269,8 @@ export default function BuilderPanel(props: Props) {
           {hasLookAhead && (
             <div class="mt-1.5 px-2.5 py-1 rounded bg-[--color-yellow]/10 border border-[--color-yellow]/20">
               <span class="text-[10px] font-mono text-[--color-yellow]">
-                {t.lookAheadWarn || 'C = current candle (incomplete in live). P = previous candle (confirmed). Using C may cause look-ahead bias.'}
+                {t.lookAheadWarn ||
+                  "C = current candle (incomplete in live). P = previous candle (confirmed). Using C may cause look-ahead bias."}
               </span>
             </div>
           )}
@@ -185,20 +278,26 @@ export default function BuilderPanel(props: Props) {
 
         {/* Parameters + Date Range (merged 3-column grid) */}
         <div class="px-4 py-2 border-b border-[--color-border]">
-          <div class="text-xs font-mono text-[--color-text-muted] uppercase mb-1">{t.parameters}</div>
+          <div class="text-xs font-mono text-[--color-text-muted] uppercase mb-1">
+            {t.parameters}
+          </div>
           <div class="grid grid-cols-3 gap-x-2 gap-y-1.5">
             {/* Timeframe - spans full width */}
             <div class="col-span-3 mb-1">
-              <label class="text-[10px] text-[--color-text-muted]">Timeframe</label>
+              <label class="text-[10px] text-[--color-text-muted]">
+                Timeframe
+              </label>
               <div class="flex gap-1 mt-0.5">
-                {['1H', '2H', '4H', '6H', '12H', '1D', '1W'].map((tf) => (
+                {["1H", "2H", "4H", "6H", "12H", "1D", "1W"].map((tf) => (
                   <button
                     key={tf}
                     onClick={() => props.setTimeframe(tf)}
                     class={`flex-1 py-1 text-xs font-mono rounded border transition-colors cursor-pointer
-                      ${props.timeframe === tf
-                        ? ''
-                        : 'bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:text-[--color-text]'}`}
+                      ${
+                        props.timeframe === tf
+                          ? ""
+                          : "bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:text-[--color-text]"
+                      }`}
                     style={props.timeframe === tf ? tfActiveStyle : undefined}
                   >
                     {tf}
@@ -208,53 +307,120 @@ export default function BuilderPanel(props: Props) {
             </div>
             {/* Direction */}
             <div>
-              <label class="text-[10px] text-[--color-text-muted]">{t.direction}</label>
+              <label class="text-[10px] text-[--color-text-muted]">
+                {t.direction}
+              </label>
               <div class="flex gap-1 mt-0.5">
                 <button
-                  onClick={() => props.setDirection('short')}
-                  class={`flex-1 py-1 text-xs font-mono rounded transition-colors border ${props.direction === 'short' ? 'font-bold' : 'bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-red]/30'}`}
-                  style={props.direction === 'short' ? shortActiveStyle : undefined}
-                >{t.short}</button>
+                  onClick={() => props.setDirection("short")}
+                  class={`flex-1 py-1 text-xs font-mono rounded transition-colors border ${props.direction === "short" ? "font-bold" : "bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-red]/30"}`}
+                  style={
+                    props.direction === "short" ? shortActiveStyle : undefined
+                  }
+                >
+                  {t.short}
+                </button>
                 <button
-                  onClick={() => props.setDirection('long')}
-                  class={`flex-1 py-1 text-xs font-mono rounded transition-colors border ${props.direction === 'long' ? 'font-bold' : 'bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-accent]/30'}`}
-                  style={props.direction === 'long' ? longActiveStyle : undefined}
-                >{t.long}</button>
+                  onClick={() => props.setDirection("long")}
+                  class={`flex-1 py-1 text-xs font-mono rounded transition-colors border ${props.direction === "long" ? "font-bold" : "bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-accent]/30"}`}
+                  style={
+                    props.direction === "long" ? longActiveStyle : undefined
+                  }
+                >
+                  {t.long}
+                </button>
                 <button
-                  onClick={() => props.setDirection('both')}
-                  class={`flex-1 py-1 text-xs font-mono rounded transition-colors border ${props.direction === 'both' ? 'font-bold' : 'bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-accent]/30'}`}
-                  style={props.direction === 'both' ? { background: 'linear-gradient(90deg, rgba(239,68,68,0.15), rgba(0,255,136,0.15))', borderColor: '#888', color: '#fff' } : undefined}
-                >BOTH</button>
+                  onClick={() => props.setDirection("both")}
+                  class={`flex-1 py-1 text-xs font-mono rounded transition-colors border ${props.direction === "both" ? "font-bold" : "bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-accent]/30"}`}
+                  style={
+                    props.direction === "both"
+                      ? {
+                          background:
+                            "linear-gradient(90deg, rgba(239,68,68,0.15), rgba(0,255,136,0.15))",
+                          borderColor: "#888",
+                          color: "#fff",
+                        }
+                      : undefined
+                  }
+                >
+                  BOTH
+                </button>
               </div>
               <p class="text-[9px] text-[--color-text-muted] mt-0.5 font-mono">
-                {props.direction === 'short' ? (props.lang === 'ko' ? '하락 시 수익' : 'Profit when price falls') :
-                 props.direction === 'long' ? (props.lang === 'ko' ? '상승 시 수익' : 'Profit when price rises') :
-                 (props.lang === 'ko' ? 'SHORT + LONG 동시 테스트' : 'Test SHORT + LONG simultaneously')}
+                {props.direction === "short"
+                  ? t.dirShortDesc
+                  : props.direction === "long"
+                    ? t.dirLongDesc
+                    : t.dirBothDesc}
               </p>
             </div>
             {/* SL */}
             <div>
-              <label class="text-[10px] text-[--color-text-muted]">{t.sl} <span class="cursor-help opacity-60 hover:opacity-100" title={t.slTip || ''}>&#9432;</span></label>
-              <input type="number" value={localSl} min={1} max={50} step={0.5}
-                onChange={(e: Event) => setLocalSl((e.target as HTMLInputElement).value)}
+              <label class="text-[10px] text-[--color-text-muted]">
+                {t.sl}{" "}
+                <span
+                  class="cursor-help opacity-60 hover:opacity-100"
+                  title={t.slTip || ""}
+                >
+                  &#9432;
+                </span>
+              </label>
+              <input
+                type="number"
+                value={localSl}
+                min={1}
+                max={50}
+                step={0.5}
+                onChange={(e: Event) =>
+                  setLocalSl((e.target as HTMLInputElement).value)
+                }
                 onBlur={() => props.setSlPct(parseFloat(localSl) || 10)}
                 class="w-full mt-0.5 px-2 py-1 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
               />
             </div>
             {/* TP */}
             <div>
-              <label class="text-[10px] text-[--color-text-muted]">{t.tp} <span class="cursor-help opacity-60 hover:opacity-100" title={t.tpTip || ''}>&#9432;</span></label>
-              <input type="number" value={localTp} min={1} max={50} step={0.5}
-                onChange={(e: Event) => setLocalTp((e.target as HTMLInputElement).value)}
+              <label class="text-[10px] text-[--color-text-muted]">
+                {t.tp}{" "}
+                <span
+                  class="cursor-help opacity-60 hover:opacity-100"
+                  title={t.tpTip || ""}
+                >
+                  &#9432;
+                </span>
+              </label>
+              <input
+                type="number"
+                value={localTp}
+                min={1}
+                max={50}
+                step={0.5}
+                onChange={(e: Event) =>
+                  setLocalTp((e.target as HTMLInputElement).value)
+                }
                 onBlur={() => props.setTpPct(parseFloat(localTp) || 8)}
                 class="w-full mt-0.5 px-2 py-1 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
               />
             </div>
             {/* Max bars */}
             <div>
-              <label class="text-[10px] text-[--color-text-muted]">{t.maxBars} <span class="cursor-help opacity-60 hover:opacity-100" title={t.maxBarsTip || ''}>&#9432;</span></label>
-              <input type="number" value={localMaxBars} min={1} max={168}
-                onChange={(e: Event) => setLocalMaxBars((e.target as HTMLInputElement).value)}
+              <label class="text-[10px] text-[--color-text-muted]">
+                {t.maxBars}{" "}
+                <span
+                  class="cursor-help opacity-60 hover:opacity-100"
+                  title={t.maxBarsTip || ""}
+                >
+                  &#9432;
+                </span>
+              </label>
+              <input
+                type="number"
+                value={localMaxBars}
+                min={1}
+                max={168}
+                onChange={(e: Event) =>
+                  setLocalMaxBars((e.target as HTMLInputElement).value)
+                }
                 onBlur={() => props.setMaxBars(parseInt(localMaxBars) || 48)}
                 class="w-full mt-0.5 px-2 py-1 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
               />
@@ -263,23 +429,40 @@ export default function BuilderPanel(props: Props) {
             <div>
               <label class="text-[10px] text-[--color-text-muted]">
                 {props.compounding
-                  ? (props.lang === 'ko' ? '투자 원금 $' : 'Capital $')
-                  : (t.perCoinUsdt || 'Per Coin $')}
+                  ? t.capitalLabel
+                  : t.perCoinUsdt || "Per Coin $"}
               </label>
-              <input type="number" value={localPerCoin}
+              <input
+                type="number"
+                value={localPerCoin}
                 min={props.compounding ? 100 : 1}
                 max={props.compounding ? 1000000 : 10000}
                 step={props.compounding ? 100 : 10}
-                onChange={(e: Event) => setLocalPerCoin((e.target as HTMLInputElement).value)}
-                onBlur={() => props.setPerCoinUsdt(parseFloat(localPerCoin) || (props.compounding ? 1000 : 60))}
+                onChange={(e: Event) =>
+                  setLocalPerCoin((e.target as HTMLInputElement).value)
+                }
+                onBlur={() =>
+                  props.setPerCoinUsdt(
+                    parseFloat(localPerCoin) || (props.compounding ? 1000 : 60),
+                  )
+                }
                 class="w-full mt-0.5 px-2 py-1 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
               />
             </div>
             {/* Leverage */}
             <div>
-              <label class="text-[10px] text-[--color-text-muted]">{t.leverage || 'Leverage'}</label>
-              <input type="number" value={localLeverage} min={1} max={125} step={1}
-                onChange={(e: Event) => setLocalLeverage((e.target as HTMLInputElement).value)}
+              <label class="text-[10px] text-[--color-text-muted]">
+                {t.leverage || "Leverage"}
+              </label>
+              <input
+                type="number"
+                value={localLeverage}
+                min={1}
+                max={125}
+                step={1}
+                onChange={(e: Event) =>
+                  setLocalLeverage((e.target as HTMLInputElement).value)
+                }
                 onBlur={() => props.setLeverage(parseInt(localLeverage) || 5)}
                 class="w-full mt-0.5 px-2 py-1 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
               />
@@ -290,20 +473,34 @@ export default function BuilderPanel(props: Props) {
                 <button
                   onClick={() => props.setCompounding(!props.compounding)}
                   class="relative w-8 h-[18px] rounded-full transition-colors duration-200 shrink-0"
-                  style={{ background: props.compounding ? '#3182f6' : '#3a3a42' }}
-                  aria-label={props.compounding ? 'Switch to Simple mode' : 'Switch to Compound mode'}
+                  style={{
+                    background: props.compounding ? "#3182f6" : "#3a3a42",
+                  }}
+                  aria-label={
+                    props.compounding
+                      ? "Switch to Simple mode"
+                      : "Switch to Compound mode"
+                  }
                 >
                   <span
                     class="absolute top-[2px] left-[2px] w-[14px] h-[14px] rounded-full bg-white transition-transform duration-200"
-                    style={{ transform: props.compounding ? 'translateX(14px)' : 'translateX(0)' }}
+                    style={{
+                      transform: props.compounding
+                        ? "translateX(14px)"
+                        : "translateX(0)",
+                    }}
                   />
                 </button>
-                <label class="text-[10px] font-bold cursor-pointer select-none whitespace-nowrap"
+                <label
+                  class="text-[10px] font-bold cursor-pointer select-none whitespace-nowrap"
                   onClick={() => props.setCompounding(!props.compounding)}
-                  style={{ color: props.compounding ? '#3182f6' : 'var(--color-text-muted)' }}>
-                  {props.compounding
-                    ? (props.lang === 'ko' ? '복리' : 'Compound')
-                    : (props.lang === 'ko' ? '단리' : 'Simple')}
+                  style={{
+                    color: props.compounding
+                      ? "#3182f6"
+                      : "var(--color-text-muted)",
+                  }}
+                >
+                  {props.compounding ? t.compoundLabel : t.simpleLabel}
                 </label>
               </div>
             </div>
@@ -314,31 +511,47 @@ export default function BuilderPanel(props: Props) {
                   const capital = parseFloat(localPerCoin) || 1000;
                   const lev = parseInt(localLeverage) || 5;
                   const exposure = capital * lev;
-                  const isSingle = props.coinMode === 'select' && props.selectedCoins.length === 1;
-                  const coinLabel = isSingle ? props.selectedCoins[0] : (
-                    props.coinMode === 'all' ? (props.lang === 'ko' ? '전체 코인' : 'All Coins') :
-                    props.coinMode === 'top' ? `Top ${props.topN}` :
-                    props.selectedCoins.length > 0 ? `${props.selectedCoins.length} coins` : '?'
-                  );
-                  return props.lang === 'ko'
-                    ? `${coinLabel} — $${capital.toLocaleString()} × ${lev}x = $${exposure.toLocaleString()} 포지션, 수익이 다음 거래 원금에 누적`
-                    : `${coinLabel} — $${capital.toLocaleString()} × ${lev}x = $${exposure.toLocaleString()} position, profits compound into next trade`;
+                  const isSingle =
+                    props.coinMode === "select" &&
+                    props.selectedCoins.length === 1;
+                  const coinLabel = isSingle
+                    ? props.selectedCoins[0]
+                    : props.coinMode === "all"
+                      ? t.allCoinsLabel
+                      : props.coinMode === "top"
+                        ? `Top ${props.topN}`
+                        : props.selectedCoins.length > 0
+                          ? `${props.selectedCoins.length} coins`
+                          : "?";
+                  return t.compoundInfoTpl(coinLabel, capital, lev, exposure);
                 })()}
               </div>
             )}
             {/* Start Date */}
             <div>
-              <label class="text-[10px] text-[--color-text-muted]">{t.startDate}</label>
-              <input type="date" value={props.startDate}
-                onChange={(e: Event) => props.setStartDate((e.target as HTMLInputElement).value)}
+              <label class="text-[10px] text-[--color-text-muted]">
+                {t.startDate}
+              </label>
+              <input
+                type="date"
+                value={props.startDate}
+                onChange={(e: Event) =>
+                  props.setStartDate((e.target as HTMLInputElement).value)
+                }
                 class="w-full mt-0.5 px-2 py-1 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
               />
             </div>
             {/* End Date */}
             <div>
-              <label class="text-[10px] text-[--color-text-muted]">{t.endDate}</label>
-              <input type="date" value={props.endDate}
-                onChange={(e: Event) => props.setEndDate((e.target as HTMLInputElement).value)}
+              <label class="text-[10px] text-[--color-text-muted]">
+                {t.endDate}
+              </label>
+              <input
+                type="date"
+                value={props.endDate}
+                onChange={(e: Event) =>
+                  props.setEndDate((e.target as HTMLInputElement).value)
+                }
                 class="w-full mt-0.5 px-2 py-1 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
               />
             </div>
@@ -347,44 +560,65 @@ export default function BuilderPanel(props: Props) {
 
         {/* Coin Selection */}
         <div class="px-4 py-2 border-b border-[--color-border]">
-          <div class="text-xs font-mono text-[--color-text-muted] uppercase mb-1">{t.coins}</div>
+          <div class="text-xs font-mono text-[--color-text-muted] uppercase mb-1">
+            {t.coins}
+          </div>
           <div class="flex gap-1 mb-1.5">
             {[
-              { mode: 'all' as const, label: t.allCoins },
-              { mode: 'top' as const, label: `${t.topN} N` },
-              { mode: 'select' as const, label: props.coinMode === 'select' && props.selectedCoins.length > 0 ? `${t.selectCoins} (${props.selectedCoins.length})` : t.selectCoins },
+              { mode: "all" as const, label: t.allCoins },
+              { mode: "top" as const, label: `${t.topN} N` },
+              {
+                mode: "select" as const,
+                label:
+                  props.coinMode === "select" && props.selectedCoins.length > 0
+                    ? `${t.selectCoins} (${props.selectedCoins.length})`
+                    : t.selectCoins,
+              },
             ].map(({ mode, label }) => (
               <button
                 key={mode}
                 onClick={() => props.setCoinMode(mode)}
                 class={`px-2.5 py-0.5 text-xs font-mono rounded transition-colors border
-                  ${props.coinMode === mode
-                    ? 'font-bold'
-                    : 'bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-accent]/20'}`}
+                  ${
+                    props.coinMode === mode
+                      ? "font-bold"
+                      : "bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-accent]/20"
+                  }`}
                 style={props.coinMode === mode ? coinActiveStyle : undefined}
               >
                 {label}
               </button>
             ))}
           </div>
-          {props.coinMode === 'top' && (
+          {props.coinMode === "top" && (
             <div>
-              <input type="number" value={localTopN} min={1} max={props.totalCoins || 999}
-                onChange={(e: Event) => setLocalTopN((e.target as HTMLInputElement).value)}
+              <input
+                type="number"
+                value={localTopN}
+                min={1}
+                max={props.totalCoins || 999}
+                onChange={(e: Event) =>
+                  setLocalTopN((e.target as HTMLInputElement).value)
+                }
                 onBlur={() => props.setTopN(parseInt(localTopN) || 50)}
                 class="w-full px-2 py-1 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
                 placeholder={t.topCoinsPlaceholder || "Number of top coins"}
               />
-              <p class="text-[10px] text-[--color-text-muted] mt-0.5 font-mono">{props.t.topNCoinsHint || `Top ${localTopN} coins by data availability`}</p>
+              <p class="text-[10px] text-[--color-text-muted] mt-0.5 font-mono">
+                {props.t.topNCoinsHint ||
+                  `Top ${localTopN} coins by data availability`}
+              </p>
             </div>
           )}
-          {props.coinMode === 'select' && (
+          {props.coinMode === "select" && (
             <div>
               <div class="flex items-center gap-1 mb-1">
                 <input
                   type="text"
                   value={props.coinSearch}
-                  onInput={(e: Event) => props.setCoinSearch((e.target as HTMLInputElement).value)}
+                  onInput={(e: Event) =>
+                    props.setCoinSearch((e.target as HTMLInputElement).value)
+                  }
                   placeholder={t.searchCoinsPlaceholder || "Search coins..."}
                   class="flex-1 px-2 py-1 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs outline-none"
                 />
@@ -413,9 +647,22 @@ export default function BuilderPanel(props: Props) {
               {props.selectedCoins.length > 0 && (
                 <div class="flex flex-wrap gap-1 mb-1">
                   {props.selectedCoins.map((s) => (
-                    <span key={s} class="px-2 py-0.5 text-[10px] font-mono bg-[--color-accent]/10 text-[--color-accent] rounded flex items-center gap-1">
-                      {s.replace('USDT', '')}
-                      <button onClick={() => props.setSelectedCoins((p) => p.filter((x) => x !== s))} class="hover:text-[--color-red]" aria-label={`Remove ${s}`}>x</button>
+                    <span
+                      key={s}
+                      class="px-2 py-0.5 text-[10px] font-mono bg-[--color-accent]/10 text-[--color-accent] rounded flex items-center gap-1"
+                    >
+                      {s.replace("USDT", "")}
+                      <button
+                        onClick={() =>
+                          props.setSelectedCoins((p) =>
+                            p.filter((x) => x !== s),
+                          )
+                        }
+                        class="hover:text-[--color-red]"
+                        aria-label={`Remove ${s}`}
+                      >
+                        x
+                      </button>
                     </span>
                   ))}
                 </div>
@@ -426,13 +673,16 @@ export default function BuilderPanel(props: Props) {
                     key={c.symbol}
                     onClick={() => {
                       props.setSelectedCoins((prev) =>
-                        prev.includes(c.symbol) ? prev.filter((x) => x !== c.symbol) : [...prev, c.symbol]
+                        prev.includes(c.symbol)
+                          ? prev.filter((x) => x !== c.symbol)
+                          : [...prev, c.symbol],
                       );
                     }}
                     class={`block w-full text-left px-2 py-0.5 text-xs font-mono rounded hover:bg-[--color-bg-hover]
-                      ${props.selectedCoins.includes(c.symbol) ? 'text-[--color-accent]' : 'text-[--color-text-muted]'}`}
+                      ${props.selectedCoins.includes(c.symbol) ? "text-[--color-accent]" : "text-[--color-text-muted]"}`}
                   >
-                    {props.selectedCoins.includes(c.symbol) ? '\u2713 ' : ''}{c.symbol}
+                    {props.selectedCoins.includes(c.symbol) ? "\u2713 " : ""}
+                    {c.symbol}
                   </button>
                 ))}
               </div>
@@ -444,7 +694,11 @@ export default function BuilderPanel(props: Props) {
         <details class="border-b border-[--color-border]" open>
           <summary class="px-4 py-2 text-xs font-mono text-[--color-text-muted] uppercase cursor-pointer select-none hover:text-[--color-text] transition-colors list-none flex items-center justify-between">
             <span>{t.avoidHours}</span>
-            <span class="text-[10px] opacity-50">{props.avoidHours.size > 0 ? `${props.avoidHours.size}h selected` : 'none'}</span>
+            <span class="text-[10px] opacity-50">
+              {props.avoidHours.size > 0
+                ? `${props.avoidHours.size}h selected`
+                : "none"}
+            </span>
           </summary>
           <div class="px-4 pb-2">
             <div class="flex flex-wrap gap-1 sm:gap-0.5">
@@ -460,9 +714,11 @@ export default function BuilderPanel(props: Props) {
                     });
                   }}
                   class={`w-8 h-8 sm:w-[26px] sm:h-[22px] text-xs sm:text-[10px] font-mono rounded transition-colors border
-                    ${props.avoidHours.has(i)
-                      ? ''
-                      : 'bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-red]/20'}`}
+                    ${
+                      props.avoidHours.has(i)
+                        ? ""
+                        : "bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-red]/20"
+                    }`}
                   style={props.avoidHours.has(i) ? avoidActiveStyle : undefined}
                 >
                   {i}
@@ -483,20 +739,30 @@ export default function BuilderPanel(props: Props) {
             onClick={props.onRun}
             disabled={props.isRunning || props.conditions.length === 0}
             class={`w-full py-2 rounded-lg font-mono text-sm font-bold transition-colors
-              ${props.isRunning || props.conditions.length === 0 ? 'cursor-not-allowed' : 'hover:opacity-90'}`}
-            style={props.isRunning || props.conditions.length === 0 ? runDisabledStyle : runStyle}
+              ${props.isRunning || props.conditions.length === 0 ? "cursor-not-allowed" : "hover:opacity-90"}`}
+            style={
+              props.isRunning || props.conditions.length === 0
+                ? runDisabledStyle
+                : runStyle
+            }
           >
             {props.isRunning ? (
               <span class="flex items-center justify-center gap-2">
                 <span class="spinner" />
                 {props.progressLabels[props.progressStep] || t.running}
                 {(props.elapsedSec ?? 0) > 0 && (
-                  <span class="text-[10px] opacity-70 font-normal">{props.elapsedSec}s</span>
+                  <span class="text-[10px] opacity-70 font-normal">
+                    {props.elapsedSec}s
+                  </span>
                 )}
               </span>
             ) : props.conditions.length === 0 ? (
               <span class="text-xs">{t.addCondition}</span>
-            ) : props.coinsLoaded > 0 ? t.runWithCoins?.replace('{n}', String(props.coinsLoaded)) || t.run : t.run}
+            ) : props.coinsLoaded > 0 ? (
+              t.runWithCoins?.replace("{n}", String(props.coinsLoaded)) || t.run
+            ) : (
+              t.run
+            )}
           </button>
         </div>
       </div>

--- a/src/components/CoinChart.tsx
+++ b/src/components/CoinChart.tsx
@@ -6,7 +6,14 @@ import {
   getCssVar,
 } from "../utils/format";
 import { API_BASE_URL as API_URL } from "../config/api";
-import type { MouseEventParams, Time, IChartApi, ISeriesApi, SeriesType, UTCTimestamp } from "lightweight-charts";
+import type {
+  MouseEventParams,
+  Time,
+  IChartApi,
+  ISeriesApi,
+  SeriesType,
+  UTCTimestamp,
+} from "lightweight-charts";
 
 interface OhlcvBar {
   t: number;
@@ -473,7 +480,7 @@ export default function CoinChart({
           }}
           class="px-4 py-2 rounded-lg border border-[--color-border] bg-[--color-bg-card] text-[--color-text] font-mono text-sm cursor-pointer hover:border-[--color-accent] transition-colors min-h-[44px]"
         >
-          {lang === "ko" ? "다시 시도" : "Retry"}
+          {t.retry}
         </button>
       </div>
     );

--- a/src/components/LiveStats.tsx
+++ b/src/components/LiveStats.tsx
@@ -28,12 +28,14 @@ const L = {
     coins: "Coins Tested",
     strategies: "Variations Tested",
     history: "Historical Data",
+    yrs: "yrs",
   },
   ko: {
     trades: "백테스트 거래",
     coins: "테스트 코인",
     strategies: "테스트 조합",
     history: "과거 데이터",
+    yrs: "년",
   },
 };
 
@@ -80,7 +82,7 @@ function AnimatedNumber({
 }
 
 export default function LiveStats({ lang = "en" }: Props) {
-  const t = L[lang] || L.en;
+  const t = L[lang] ?? L.en;
   const [stats, setStats] = useState<SiteStats>(DEFAULTS);
 
   useEffect(() => {
@@ -122,7 +124,7 @@ export default function LiveStats({ lang = "en" }: Props) {
       <div class="text-center p-4">
         <p class="font-mono text-[--color-accent] text-3xl md:text-4xl font-bold">
           <AnimatedNumber value={2} suffix="+" />
-          <span class="text-xl ml-1">{lang === "ko" ? "년" : "yrs"}</span>
+          <span class="text-xl ml-1">{t.yrs}</span>
         </p>
         <p class="text-[--color-text-muted] text-sm mt-1">{t.history}</p>
       </div>

--- a/src/components/MarketDashboard.tsx
+++ b/src/components/MarketDashboard.tsx
@@ -45,6 +45,7 @@ const labels = {
     showMoreNews: "Show more news",
     showLessNews: "Show less",
     retry: "Retry",
+    noResults: "No results found.",
   },
   ko: {
     tag: "시장 현황",
@@ -85,6 +86,7 @@ const labels = {
     showMoreNews: "더 보기",
     showLessNews: "접기",
     retry: "다시 시도",
+    noResults: "검색 결과가 없습니다.",
   },
 };
 
@@ -783,7 +785,7 @@ export default function MarketDashboard({
             )}
             {news && filteredNews.length === 0 && (
               <div class="text-center py-8 text-[--color-text-muted] text-[13px]">
-                {lang === "ko" ? "검색 결과가 없습니다." : "No results found."}
+                {l.noResults}
               </div>
             )}
           </div>

--- a/src/components/OnboardingTour.tsx
+++ b/src/components/OnboardingTour.tsx
@@ -59,8 +59,20 @@ const STEPS: Record<"en" | "ko", Step[]> = {
 };
 
 const L = {
-  en: { next: "Next", done: "Done", skip: "Skip tour", step: "Step" },
-  ko: { next: "다음", done: "완료", skip: "건너뛰기", step: "단계" },
+  en: {
+    next: "Next",
+    done: "Done",
+    skip: "Skip tour",
+    step: "Step",
+    ariaLabel: "Onboarding guide",
+  },
+  ko: {
+    next: "다음",
+    done: "완료",
+    skip: "건너뛰기",
+    step: "단계",
+    ariaLabel: "온보딩 가이드",
+  },
 };
 
 interface Props {
@@ -115,7 +127,7 @@ export default function OnboardingTour({ lang = "en" }: Props) {
     <div
       role="dialog"
       aria-modal="true"
-      aria-label={lang === "ko" ? "온보딩 가이드" : "Onboarding guide"}
+      aria-label={t.ariaLabel}
       style={{
         position: "fixed",
         inset: 0,

--- a/src/components/ReproBadge.tsx
+++ b/src/components/ReproBadge.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'preact/hooks';
+import { useState, useEffect } from "preact/hooks";
 
 interface ReproMeta {
   data_version?: string;
@@ -10,10 +10,22 @@ interface ReproMeta {
 
 interface Props {
   strategy: string;
-  lang?: 'en' | 'ko';
+  lang?: "en" | "ko";
 }
 
-export default function ReproBadge({ strategy, lang = 'en' }: Props) {
+const labels = {
+  en: {
+    packageLabel: "Reproducible Package",
+    download: "Download package",
+  },
+  ko: {
+    packageLabel: "재현 가능 패키지",
+    download: "패키지 다운로드",
+  },
+};
+
+export default function ReproBadge({ strategy, lang = "en" }: Props) {
+  const t = labels[lang] ?? labels.en;
   const [meta, setMeta] = useState<ReproMeta | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -23,7 +35,7 @@ export default function ReproBadge({ strategy, lang = 'en' }: Props) {
     const url = `/data/reproducible/${strategy}.json`;
     fetch(url)
       .then((res) => {
-        if (!res.ok) throw new Error('no-repro-data');
+        if (!res.ok) throw new Error("no-repro-data");
         return res.json();
       })
       .then((json: ReproMeta) => {
@@ -34,31 +46,50 @@ export default function ReproBadge({ strategy, lang = 'en' }: Props) {
       .catch(() => {
         if (!mounted) return;
         setLoading(false);
-        setError('not found');
+        setError("not found");
       });
-    return () => { mounted = false; };
+    return () => {
+      mounted = false;
+    };
   }, [strategy]);
 
   if (loading) return null;
-  if (!meta) return null; // no reproducible package available
-
-  const label = lang === 'ko' ? '재현 가능 패키지' : 'Reproducible Package';
+  if (error || !meta) return null; // no reproducible package available
 
   return (
     <div class="mt-3 mb-3 flex items-center gap-3">
       <div class="px-2 py-1 rounded border border-[--color-border] bg-[--color-bg-card] text-sm flex items-center gap-3">
-        <span class="font-mono text-xs text-[--color-accent] border border-[--color-accent] px-2 py-0.5 rounded">VERIFIED</span>
+        <span class="font-mono text-xs text-[--color-accent] border border-[--color-accent] px-2 py-0.5 rounded">
+          VERIFIED
+        </span>
         <div class="text-sm text-[--color-text-muted]">
-          <div class="font-semibold text-[--color-text]">{label}</div>
-          <div class="text-[--color-text-muted] text-[12px]">Data v{meta.data_version || 'N/A'} • Engine {meta.engine_version || 'N/A'}</div>
+          <div class="font-semibold text-[--color-text]">{t.packageLabel}</div>
+          <div class="text-[--color-text-muted] text-[12px]">
+            Data v{meta.data_version || "N/A"} • Engine{" "}
+            {meta.engine_version || "N/A"}
+          </div>
         </div>
       </div>
 
       <div class="ml-auto flex items-center gap-3">
         {meta.package_url ? (
-          <a href={meta.package_url} class="inline-block border border-[--color-border] text-[--color-text] px-3 py-2 rounded font-mono text-sm hover:border-[--color-accent]" target="_blank" rel="noopener noreferrer">{lang === 'ko' ? '패키지 다운로드' : 'Download package'}</a>
+          <a
+            href={meta.package_url}
+            class="inline-block border border-[--color-border] text-[--color-text] px-3 py-2 rounded font-mono text-sm hover:border-[--color-accent]"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {t.download}
+          </a>
         ) : (
-          <a href={`/data/reproducible/${strategy}.zip`} class="inline-block border border-[--color-border] text-[--color-text] px-3 py-2 rounded font-mono text-sm hover:border-[--color-accent]" target="_blank" rel="noopener noreferrer">{lang === 'ko' ? '패키지 다운로드' : 'Download package'}</a>
+          <a
+            href={`/data/reproducible/${strategy}.zip`}
+            class="inline-block border border-[--color-border] text-[--color-text] px-3 py-2 rounded font-mono text-sm hover:border-[--color-accent]"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {t.download}
+          </a>
         )}
       </div>
     </div>

--- a/src/components/ResultsCard.tsx
+++ b/src/components/ResultsCard.tsx
@@ -183,6 +183,13 @@ const labels = {
     feeConsumeOf: "% of returns",
     showDetails: "Show details",
     hideDetails: "Hide details",
+    showAdvanced: "Show advanced metrics \u25BE",
+    hideAdvanced: "Hide advanced metrics \u25B2",
+    gradePrefix: "Grade",
+    mcBeats: (pct: number) => `Beats ${pct}% of random strategies`,
+    referralCta: "Ready to trade this strategy? Save up to 20% on trading fees",
+    survivorshipNote:
+      "Results based on currently listed assets only. Delisted coins excluded (survivorship bias).",
   },
   ko: {
     live: "기본 설정",
@@ -246,6 +253,13 @@ const labels = {
     feeConsumeOf: "%를 차지합니다",
     showDetails: "상세 보기",
     hideDetails: "접기",
+    showAdvanced: "고급 지표 보기 \u25BE",
+    hideAdvanced: "접기 \u25B2",
+    gradePrefix: "등급",
+    mcBeats: (pct: number) => `랜덤 전략 중 상위 ${(100 - pct).toFixed(0)}%`,
+    referralCta: "이 전략으로 거래 준비됐나요? 거래 수수료 최대 20% 절약",
+    survivorshipNote:
+      "현재 상장된 자산만 테스트됩니다. 상폐 코인 제외 (생존 편향).",
   },
 };
 
@@ -459,9 +473,7 @@ export default function ResultsCard({
                       : "text-[--color-red]"
               }`}
             >
-              {lang === "ko"
-                ? `등급 ${data.strategy_grade}`
-                : `Grade ${data.strategy_grade}`}
+              {`${t.gradePrefix} ${data.strategy_grade}`}
             </span>
             {data.grade_details && (
               <span class="font-mono text-[10px] text-[--color-text-muted]">
@@ -583,7 +595,7 @@ export default function ResultsCard({
           onClick={() => setShowAllMetrics(true)}
           class="w-full py-2 mb-3 rounded-lg border border-[--color-border] font-mono text-xs text-[--color-text-muted] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors"
         >
-          {lang === "ko" ? "고급 지표 보기 ▾" : "Show advanced metrics ▾"}
+          {t.showAdvanced}
         </button>
       )}
 
@@ -854,11 +866,7 @@ export default function ResultsCard({
             {data.mc_percentile != null && (
               <div class="mt-2 mb-1">
                 <div class="flex items-center justify-between font-mono text-[10px] text-[--color-text-muted] mb-1">
-                  <span>
-                    {lang === "ko"
-                      ? `랜덤 전략 중 상위 ${(100 - data.mc_percentile).toFixed(0)}%`
-                      : `Beats ${data.mc_percentile}% of random strategies`}
-                  </span>
+                  <span>{t.mcBeats(data.mc_percentile)}</span>
                   <span
                     style={{
                       color:
@@ -1003,7 +1011,7 @@ export default function ResultsCard({
           onClick={() => setShowAllMetrics(false)}
           class="w-full py-2 mb-3 rounded-lg border border-[--color-border] font-mono text-xs text-[--color-text-muted] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors"
         >
-          {lang === "ko" ? "접기 ▲" : "Hide advanced metrics ▲"}
+          {t.hideAdvanced}
         </button>
       )}
 
@@ -1053,9 +1061,7 @@ export default function ResultsCard({
         class="mt-3 flex items-center justify-between gap-2 px-3 py-2.5 rounded-lg border border-[--color-yellow]/40 bg-[--color-yellow]/5 hover:border-[--color-yellow]/70 hover:bg-[--color-yellow]/10 transition-colors no-underline group"
       >
         <span class="font-mono text-[11px] text-[--color-yellow] group-hover:text-[--color-yellow]">
-          {lang === "ko"
-            ? "이 전략으로 거래 준비됐나요? 거래 수수료 최대 20% 절약"
-            : "Ready to trade this strategy? Save up to 20% on trading fees"}
+          {t.referralCta}
         </span>
         <span class="font-mono text-[11px] text-[--color-yellow] shrink-0">
           &rarr;
@@ -1066,9 +1072,7 @@ export default function ResultsCard({
         class="text-[9px] mt-2"
         style={{ color: "var(--color-text-muted)", opacity: 0.6 }}
       >
-        {lang === "ko"
-          ? "현재 상장된 자산만 테스트됩니다. 상폐 코인 제외 (생존 편향)."
-          : "Results based on currently listed assets only. Delisted coins excluded (survivorship bias)."}
+        {t.survivorshipNote}
       </p>
     </div>
   );

--- a/src/components/ResultsPanel.tsx
+++ b/src/components/ResultsPanel.tsx
@@ -112,8 +112,7 @@ export default function ResultsPanel({
     const presetName = activePreset
       ? activePreset.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())
       : `Custom ${dir}`;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- timeframe not in type but may be present in API response
-    const tf = (result as any).timeframe ?? "1H";
+    const tf = result.timeframe ?? "1H";
     const lines = [
       `Strategy: ${presetName}`,
       `Direction: ${dir} | SL: ${result.sl_pct ?? slPct}% | TP: ${result.tp_pct ?? tpPct}%`,
@@ -586,53 +585,39 @@ export default function ResultsPanel({
                   let gradeColor: string;
                   let reason: string;
                   if (pf >= 2.0 && wr >= 55 && mdd <= 20) {
-                    grade = lang === "ko" ? "강력함" : "STRONG";
+                    grade = t.gradeStrong;
                     gradeColor = "#22c55e";
-                    reason =
-                      lang === "ko"
-                        ? `PF ${formatPF(pf)}, 승률 ${wr.toFixed(1)}%, MDD ${mdd.toFixed(1)}% — 세 지표 모두 우수`
-                        : `PF ${formatPF(pf)}, WR ${wr.toFixed(1)}%, MDD ${mdd.toFixed(1)}% — all three metrics strong`;
+                    reason = t.reasonStrong(
+                      formatPF(pf),
+                      wr.toFixed(1),
+                      mdd.toFixed(1),
+                    );
                   } else if (pf >= 1.5 && wr >= 50 && mdd <= 30) {
-                    grade = lang === "ko" ? "양호함" : "GOOD";
+                    grade = t.gradeGood;
                     gradeColor = "#86efac";
-                    reason =
-                      lang === "ko"
-                        ? `PF ${formatPF(pf)}, 승률 ${wr.toFixed(1)}%, MDD ${mdd.toFixed(1)}% — 실사용 가능 수준`
-                        : `PF ${formatPF(pf)}, WR ${wr.toFixed(1)}%, MDD ${mdd.toFixed(1)}% — viable for live use`;
+                    reason = t.reasonGood(
+                      formatPF(pf),
+                      wr.toFixed(1),
+                      mdd.toFixed(1),
+                    );
                   } else if (pf >= 1.2 && mdd <= 40) {
-                    grade = lang === "ko" ? "보통" : "FAIR";
+                    grade = t.gradeFair;
                     gradeColor = "#facc15";
                     const weak =
                       pf < 1.5
-                        ? lang === "ko"
-                          ? `PF ${formatPF(pf)} (목표: 1.5 이상)`
-                          : `PF ${formatPF(pf)} (target: ≥1.5)`
-                        : lang === "ko"
-                          ? `승률 ${wr.toFixed(1)}% (목표: 50% 이상)`
-                          : `WR ${wr.toFixed(1)}% (target: ≥50%)`;
-                    reason =
-                      lang === "ko"
-                        ? `${weak} — 파라미터 조정 권장`
-                        : `${weak} — consider parameter tuning`;
+                        ? t.reasonFairPf(formatPF(pf))
+                        : t.reasonFairWr(wr.toFixed(1));
+                    reason = t.reasonFairSuffix(weak);
                   } else {
-                    grade = lang === "ko" ? "위험" : "WEAK";
+                    grade = t.gradeWeak;
                     gradeColor = "#f87171";
                     const mainIssue =
                       pf < 1.0
-                        ? lang === "ko"
-                          ? `PF ${formatPF(pf)} (손익 역전)`
-                          : `PF ${formatPF(pf)} (net loss)`
+                        ? t.reasonWeakPf(formatPF(pf))
                         : mdd > 40
-                          ? lang === "ko"
-                            ? `MDD ${mdd.toFixed(1)}% (과도한 낙폭)`
-                            : `MDD ${mdd.toFixed(1)}% (excessive drawdown)`
-                          : lang === "ko"
-                            ? `승률 ${wr.toFixed(1)}% (50% 미만)`
-                            : `WR ${wr.toFixed(1)}% (below 50%)`;
-                    reason =
-                      lang === "ko"
-                        ? `${mainIssue} — 실거래 비권장`
-                        : `${mainIssue} — not recommended for live trading`;
+                          ? t.reasonWeakMdd(mdd.toFixed(1))
+                          : t.reasonWeakWr(wr.toFixed(1));
+                    reason = t.reasonWeakSuffix(mainIssue);
                   }
                   return (
                     <div
@@ -646,7 +631,7 @@ export default function ResultsPanel({
                         class="font-bold shrink-0"
                         style={{ color: gradeColor }}
                       >
-                        {lang === "ko" ? "전략 등급:" : "Strategy:"}{" "}
+                        {t.strategyLabel}{" "}
                         <span style={{ color: gradeColor }}>{grade}</span>
                       </span>
                       <span class="text-[--color-text-muted]">—</span>
@@ -823,7 +808,7 @@ export default function ResultsPanel({
                 )}
               <div class="mt-3 flex flex-wrap gap-3 text-[10px] text-[--color-text-muted] font-mono">
                 <span>
-                  {result.coins_used} {lang === "ko" ? "코인" : "coins"}
+                  {result.coins_used} {t.coinsUnit}
                 </span>
                 <span>{result.data_range}</span>
                 <span>{result.compute_time_ms}ms</span>
@@ -871,10 +856,7 @@ export default function ResultsPanel({
                       <polyline points="16 6 12 2 8 6" />
                       <line x1="12" y1="2" x2="12" y2="15" />
                     </svg>
-                    {linkCopied
-                      ? t.linkCopied || (lang === "ko" ? "복사됨!" : "Copied!")
-                      : t.shareResults ||
-                        (lang === "ko" ? "결과 공유하기" : "Share Results")}
+                    {linkCopied ? t.linkCopied : t.shareResults}
                   </button>
                 )}
                 {/* Fix 2: Copy Strategy Settings button */}
@@ -907,22 +889,13 @@ export default function ResultsPanel({
                     <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
                     <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
                   </svg>
-                  {settingsCopied
-                    ? lang === "ko"
-                      ? "복사됨!"
-                      : "Copied!"
-                    : t.copySettings ||
-                      (lang === "ko" ? "설정 복사" : "Copy Strategy Settings")}
+                  {settingsCopied ? t.settingsCopied : t.copySettings}
                 </button>
                 <a
                   href="/fees"
                   class="flex items-center gap-1.5 px-4 py-2 text-xs font-mono rounded border border-[--color-border] text-[--color-text-muted] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors"
                 >
-                  {t.saveOnFees ||
-                    (lang === "ko"
-                      ? "거래소 수수료 절약하기"
-                      : "Save on exchange fees")}{" "}
-                  &rarr;
+                  {t.saveOnFees} &rarr;
                 </a>
               </div>
               {/* Fix 1: ExchangeCTA — shown when result is profitable */}
@@ -955,11 +928,7 @@ export default function ResultsPanel({
                   </span>
                   {result.max_drawdown_pct > 100 && (
                     <span class="ml-1.5 text-[10px] opacity-70">
-                      (
-                      {lang === "ko"
-                        ? "누적 % — 개별 코인 합산"
-                        : "cumulative % — sum of per-coin trades"}
-                      )
+                      ({t.cumulativePct})
                     </span>
                   )}
                 </div>
@@ -1119,19 +1088,18 @@ export default function ResultsPanel({
                 <div class="p-2">
                   <div class="flex flex-wrap gap-3 mb-3 px-2 text-[10px] font-mono text-[--color-text-muted]">
                     <span style={{ color: COLORS.green }}>
-                      {profitable} {lang === "ko" ? "수익" : "profitable"}
+                      {profitable} {t.profitableUnit}
                     </span>
                     <span style={{ color: COLORS.red }}>
-                      {losing} {lang === "ko" ? "손실" : "losing"}
+                      {losing} {t.losingUnit}
                     </span>
                     {neutral > 0 && (
                       <span>
-                        {neutral} {lang === "ko" ? "보합" : "flat"}
+                        {neutral} {t.flatUnit}
                       </span>
                     )}
                     <span>
-                      {profitPct.toFixed(0)}%{" "}
-                      {lang === "ko" ? "수익 코인" : "profitable"}
+                      {profitPct.toFixed(0)}% {t.profitableCoinsUnit}
                     </span>
                   </div>
                   <div class="overflow-x-auto -webkit-overflow-scrolling-touch">
@@ -1145,21 +1113,21 @@ export default function ResultsPanel({
                             class="py-2 px-2 text-left cursor-pointer select-none hover:text-[--color-text]"
                             onClick={() => toggleSort("symbol")}
                           >
-                            {lang === "ko" ? "코인" : "Coin"}
+                            {t.coinHeader}
                             {arrow("symbol")}
                           </th>
                           <th
                             class="py-2 px-2 text-right cursor-pointer select-none hover:text-[--color-text]"
                             onClick={() => toggleSort("trades")}
                           >
-                            {lang === "ko" ? "거래" : "Trades"}
+                            {t.tradesHeader}
                             {arrow("trades")}
                           </th>
                           <th
                             class="py-2 px-2 text-right cursor-pointer select-none hover:text-[--color-text]"
                             onClick={() => toggleSort("win_rate")}
                           >
-                            {lang === "ko" ? "승률" : "Win%"}
+                            {t.winRateHeader}
                             {arrow("win_rate")}
                           </th>
                           <th
@@ -1172,7 +1140,7 @@ export default function ResultsPanel({
                             class="py-2 px-2 text-right cursor-pointer select-none hover:text-[--color-text]"
                             onClick={() => toggleSort("total_return_pct")}
                           >
-                            {lang === "ko" ? "수익률" : "Return"}
+                            {t.returnHeader}
                             {arrow("total_return_pct")}
                           </th>
                           <th class="py-2 px-2 text-center hidden sm:table-cell">

--- a/src/components/SimulatorPage.tsx
+++ b/src/components/SimulatorPage.tsx
@@ -159,6 +159,55 @@ const L = {
     retryingIn: "Retrying in {n}s...",
     elapsed: "{n}s",
     estimatedTime: "~{n}s for {c} coins",
+    // BuilderPanel direction descriptions
+    dirShortDesc: "Profit when price falls",
+    dirLongDesc: "Profit when price rises",
+    dirBothDesc: "Test SHORT + LONG simultaneously",
+    // BuilderPanel capital/compound labels
+    capitalLabel: "Capital $",
+    compoundLabel: "Compound",
+    simpleLabel: "Simple",
+    // BuilderPanel compound info (coinLabel injected at render)
+    allCoinsLabel: "All Coins",
+    compoundInfoTpl: (
+      coinLabel: string,
+      capital: number,
+      lev: number,
+      exposure: number,
+    ) =>
+      `${coinLabel} — $${capital.toLocaleString()} × ${lev}x = $${exposure.toLocaleString()} position, profits compound into next trade`,
+    // ResultsPanel strategy verdict
+    gradeStrong: "STRONG",
+    gradeGood: "GOOD",
+    gradeFair: "FAIR",
+    gradeWeak: "WEAK",
+    strategyLabel: "Strategy:",
+    reasonStrong: (pf: string, wr: string, mdd: string) =>
+      `PF ${pf}, WR ${wr}%, MDD ${mdd}% — all three metrics strong`,
+    reasonGood: (pf: string, wr: string, mdd: string) =>
+      `PF ${pf}, WR ${wr}%, MDD ${mdd}% — viable for live use`,
+    reasonFairPf: (pf: string) => `PF ${pf} (target: ≥1.5)`,
+    reasonFairWr: (wr: string) => `WR ${wr}% (target: ≥50%)`,
+    reasonFairSuffix: (weak: string) => `${weak} — consider parameter tuning`,
+    reasonWeakPf: (pf: string) => `PF ${pf} (net loss)`,
+    reasonWeakMdd: (mdd: string) => `MDD ${mdd}% (excessive drawdown)`,
+    reasonWeakWr: (wr: string) => `WR ${wr}% (below 50%)`,
+    reasonWeakSuffix: (issue: string) =>
+      `${issue} — not recommended for live trading`,
+    // ResultsPanel coins used / shared buttons
+    coinsUnit: "coins",
+    cumulativePct: "cumulative % — sum of per-coin trades",
+    settingsCopied: "Copied!",
+    copySettings: "Copy Strategy Settings",
+    // ResultsPanel coins tab headers + stats
+    coinHeader: "Coin",
+    tradesHeader: "Trades",
+    winRateHeader: "Win%",
+    returnHeader: "Return",
+    profitableUnit: "profitable",
+    losingUnit: "losing",
+    flatUnit: "flat",
+    profitableCoinsUnit: "profitable",
   },
   ko: {
     title: "전략 시뮬레이터",
@@ -283,6 +332,54 @@ const L = {
     retryingIn: "{n}초 후 재시도...",
     elapsed: "{n}초",
     estimatedTime: "~{n}초 ({c}개 코인)",
+    // BuilderPanel direction descriptions
+    dirShortDesc: "하락 시 수익",
+    dirLongDesc: "상승 시 수익",
+    dirBothDesc: "SHORT + LONG 동시 테스트",
+    // BuilderPanel capital/compound labels
+    capitalLabel: "투자 원금 $",
+    compoundLabel: "복리",
+    simpleLabel: "단리",
+    // BuilderPanel compound info
+    allCoinsLabel: "전체 코인",
+    compoundInfoTpl: (
+      coinLabel: string,
+      capital: number,
+      lev: number,
+      exposure: number,
+    ) =>
+      `${coinLabel} — $${capital.toLocaleString()} × ${lev}x = $${exposure.toLocaleString()} 포지션, 수익이 다음 거래 원금에 누적`,
+    // ResultsPanel strategy verdict
+    gradeStrong: "강력함",
+    gradeGood: "양호함",
+    gradeFair: "보통",
+    gradeWeak: "위험",
+    strategyLabel: "전략 등급:",
+    reasonStrong: (pf: string, wr: string, mdd: string) =>
+      `PF ${pf}, 승률 ${wr}%, MDD ${mdd}% — 세 지표 모두 우수`,
+    reasonGood: (pf: string, wr: string, mdd: string) =>
+      `PF ${pf}, 승률 ${wr}%, MDD ${mdd}% — 실사용 가능 수준`,
+    reasonFairPf: (pf: string) => `PF ${pf} (목표: 1.5 이상)`,
+    reasonFairWr: (wr: string) => `승률 ${wr}% (목표: 50% 이상)`,
+    reasonFairSuffix: (weak: string) => `${weak} — 파라미터 조정 권장`,
+    reasonWeakPf: (pf: string) => `PF ${pf} (손익 역전)`,
+    reasonWeakMdd: (mdd: string) => `MDD ${mdd}% (과도한 낙폭)`,
+    reasonWeakWr: (wr: string) => `승률 ${wr}% (50% 미만)`,
+    reasonWeakSuffix: (issue: string) => `${issue} — 실거래 비권장`,
+    // ResultsPanel coins used / shared buttons
+    coinsUnit: "코인",
+    cumulativePct: "누적 % — 개별 코인 합산",
+    settingsCopied: "복사됨!",
+    copySettings: "설정 복사",
+    // ResultsPanel coins tab headers + stats
+    coinHeader: "코인",
+    tradesHeader: "거래",
+    winRateHeader: "승률",
+    returnHeader: "수익률",
+    profitableUnit: "수익",
+    losingUnit: "손실",
+    flatUnit: "보합",
+    profitableCoinsUnit: "수익 코인",
   },
 };
 

--- a/src/components/WeeklyLeaderboard.tsx
+++ b/src/components/WeeklyLeaderboard.tsx
@@ -33,6 +33,8 @@ const labels = {
     weeklyNote: "Updated daily · 7-day rolling window",
     pfTip:
       "Profit Factor = avg win ÷ avg loss. 1.0 = breakeven, 2.0+ = strong.",
+    allLowSampleWarning:
+      "All strategies have < 100 weekly trades. Results have low statistical reliability — check daily rankings for more data.",
   },
   ko: {
     weeklyBest: "이번 주 Best 3",
@@ -47,6 +49,8 @@ const labels = {
     noDataWeekly: "이번 주 거래 샘플이 부족합니다. 일일 랭킹을 확인하세요.",
     weeklyNote: "매일 업데이트 · 7일 롤링",
     pfTip: "PF(수익팩터) = 평균 수익 ÷ 평균 손실. 1.0 = 손익분기, 2.0+ = 우수.",
+    allLowSampleWarning:
+      "이번 주 모든 전략의 거래 샘플이 부족합니다(< 100건). 통계적 신뢰도가 낮을 수 있습니다.",
   },
 };
 
@@ -124,10 +128,7 @@ export default function WeeklyLeaderboard({ lang }: Props) {
       {!loading && !error && allLowSample && (
         <div class="border border-[--color-yellow]/40 rounded-lg px-4 py-3 bg-[--color-yellow]/5">
           <p class="text-[--color-yellow] text-xs font-mono">
-            ⚠️{" "}
-            {lang === "ko"
-              ? "이번 주 모든 전략의 거래 샘플이 부족합니다(< 100건). 통계적 신뢰도가 낮을 수 있습니다."
-              : "All strategies have < 100 weekly trades. Results have low statistical reliability — check daily rankings for more data."}
+            ⚠️ {l.allLowSampleWarning}
           </p>
         </div>
       )}

--- a/src/components/simulator-types.ts
+++ b/src/components/simulator-types.ts
@@ -2,60 +2,117 @@
  * simulator-types.ts - Shared types for Simulator components
  */
 
-export { getCssVar } from '../utils/format';
+export { getCssVar } from "../utils/format";
 
 export interface OhlcvBar {
-  t: number; o: number; h: number; l: number; c: number; v: number;
-  bb_upper: number | null; bb_lower: number | null; bb_mid: number | null;
-  ema20: number | null; ema50: number | null; vol_ratio: number | null;
+  t: number;
+  o: number;
+  h: number;
+  l: number;
+  c: number;
+  v: number;
+  bb_upper: number | null;
+  bb_lower: number | null;
+  bb_mid: number | null;
+  ema20: number | null;
+  ema50: number | null;
+  vol_ratio: number | null;
 }
 
 export interface IndicatorInfo {
-  id: string; name: string; fields: string[]; default_params: Record<string, number>;
+  id: string;
+  name: string;
+  fields: string[];
+  default_params: Record<string, number>;
 }
 
 export interface Condition {
-  id: string; field: string; op: string; value?: number | boolean;
-  field2?: string; shift: number;
+  id: string;
+  field: string;
+  op: string;
+  value?: number | boolean;
+  field2?: string;
+  shift: number;
 }
 
 export interface TradeItem {
-  symbol: string; direction: string; entry_time: string; exit_time: string;
-  entry_price: number; exit_price: number; pnl_pct: number;
-  pnl_usd: number; exit_reason: string; bars_held: number;
+  symbol: string;
+  direction: string;
+  entry_time: string;
+  exit_time: string;
+  entry_price: number;
+  exit_price: number;
+  pnl_pct: number;
+  pnl_usd: number;
+  exit_reason: string;
+  bars_held: number;
 }
 
 export interface MonthlyStat {
-  month: string; trades: number; wins: number; win_rate: number;
-  total_return_pct: number; profit_factor: number;
+  month: string;
+  trades: number;
+  wins: number;
+  win_rate: number;
+  total_return_pct: number;
+  profit_factor: number;
 }
 
 export interface YearlyStat {
-  year: number; trades: number; wins: number; win_rate: number;
-  total_return_pct: number; profit_factor: number;
+  year: number;
+  trades: number;
+  wins: number;
+  win_rate: number;
+  total_return_pct: number;
+  profit_factor: number;
 }
 
 export interface CoinResult {
-  symbol: string; trades: number; wins: number; losses: number;
-  win_rate: number; profit_factor: number; total_return_pct: number;
-  avg_pnl_pct: number; tp_count: number; sl_count: number; timeout_count: number;
+  symbol: string;
+  trades: number;
+  wins: number;
+  losses: number;
+  win_rate: number;
+  profit_factor: number;
+  total_return_pct: number;
+  avg_pnl_pct: number;
+  tp_count: number;
+  sl_count: number;
+  timeout_count: number;
 }
 
 export interface BacktestResult {
-  name: string; direction: string; total_trades: number; wins: number; losses: number;
-  win_rate: number; profit_factor: number; total_return_pct: number;
-  max_drawdown_pct: number; avg_win_pct: number; avg_loss_pct: number;
-  max_consecutive_losses: number; tp_count: number; sl_count: number; timeout_count: number;
-  sl_pct: number; tp_pct: number; max_bars: number;
+  name: string;
+  direction: string;
+  total_trades: number;
+  wins: number;
+  losses: number;
+  win_rate: number;
+  profit_factor: number;
+  total_return_pct: number;
+  max_drawdown_pct: number;
+  avg_win_pct: number;
+  avg_loss_pct: number;
+  max_consecutive_losses: number;
+  tp_count: number;
+  sl_count: number;
+  timeout_count: number;
+  sl_pct: number;
+  tp_pct: number;
+  max_bars: number;
   compounding?: boolean;
   equity_curve: { time: string; value: number }[];
   yearly_stats?: YearlyStat[];
-  indicators_used: string[]; conditions_count: number; coins_used: number;
-  data_range: string; is_valid: boolean; validation_errors: string[];
+  indicators_used: string[];
+  conditions_count: number;
+  coins_used: number;
+  data_range: string;
+  is_valid: boolean;
+  validation_errors: string[];
   total_fees_pct?: number;
   total_funding_pct?: number;
   coin_results?: CoinResult[];
-  compute_time_ms: number; _isDemo?: boolean;
+  compute_time_ms: number;
+  _isDemo?: boolean;
   export_hash?: string;
   trades?: TradeItem[];
   per_coin_usd?: number;
@@ -91,50 +148,73 @@ export interface BacktestResult {
   mc_p_value?: number;
   mc_percentile?: number;
   jensens_alpha?: number;
+  timeframe?: string;
 }
 
 export interface PresetItem {
-  id: string; name: string; direction: string;
-  indicators: string[]; conditions_count: number; sl_pct: number; tp_pct: number;
+  id: string;
+  name: string;
+  direction: string;
+  indicators: string[];
+  conditions_count: number;
+  sl_pct: number;
+  tp_pct: number;
 }
 
-export interface CoinOption { symbol: string; name?: string; }
+export interface CoinOption {
+  symbol: string;
+  name?: string;
+}
 
 // ─── Helpers ───
 let _condId = 0;
-export function nextCondId() { return `c_${++_condId}`; }
+export function nextCondId() {
+  return `c_${++_condId}`;
+}
 
 export const OPS = [
-  { value: '>=', label: '>=' },
-  { value: '<=', label: '<=' },
-  { value: '>', label: '>' },
-  { value: '<', label: '<' },
-  { value: '==', label: '==' },
+  { value: ">=", label: ">=" },
+  { value: "<=", label: "<=" },
+  { value: ">", label: ">" },
+  { value: "<", label: "<" },
+  { value: "==", label: "==" },
 ];
 
 export const booleanFields = new Set([
-  'is_squeeze', 'uptrend', 'downtrend', 'bullish', 'bearish', 'doji',
-  'hv_squeeze', 'rsi_oversold', 'rsi_overbought', 'macd_crossover',
-  'stoch_oversold', 'stoch_overbought', 'strong_trend', 'breakout_up', 'breakout_down',
+  "is_squeeze",
+  "uptrend",
+  "downtrend",
+  "bullish",
+  "bearish",
+  "doji",
+  "hv_squeeze",
+  "rsi_oversold",
+  "rsi_overbought",
+  "macd_crossover",
+  "stoch_oversold",
+  "stoch_overbought",
+  "strong_trend",
+  "breakout_up",
+  "breakout_down",
 ]);
 
 // Color constants (Toss Securities style)
 export const COLORS = {
-  accent: '#3182f6',
-  accentDim: '#1b6cf2',
-  accentGlow: 'rgba(49,130,246,0.2)',
-  accentGlowStrong: 'rgba(49,130,246,0.3)',
-  accentBg: 'rgba(49,130,246,0.12)',
-  green: '#00c073',
-  greenGlow: 'rgba(0,192,115,0.3)',
-  greenBg: 'rgba(0,192,115,0.12)',
-  greenFill: 'rgba(0,192,115,0.15)',
-  red: '#f04251',
-  redGlow: 'rgba(240,66,81,0.2)',
-  redGlowStrong: 'rgba(240,66,81,0.3)',
-  redBg: 'rgba(240,66,81,0.12)',
-  redFill: 'rgba(240,66,81,0.15)',
-  dark: '#17171c',
-  disabled: '#252529',
-  disabledText: '#56565f',
+  accent: "#3182f6",
+  accentDim: "#1b6cf2",
+  accentGlow: "rgba(49,130,246,0.2)",
+  accentGlowStrong: "rgba(49,130,246,0.3)",
+  accentBg: "rgba(49,130,246,0.12)",
+  green: "#00c073",
+  greenGlow: "rgba(0,192,115,0.3)",
+  greenBg: "rgba(0,192,115,0.12)",
+  greenFill: "rgba(0,192,115,0.15)",
+  red: "#f04251",
+  redGlow: "rgba(240,66,81,0.2)",
+  redGlowStrong: "rgba(240,66,81,0.3)",
+  redBg: "rgba(240,66,81,0.12)",
+  redFill: "rgba(240,66,81,0.15)",
+  dark: "#17171c",
+  disabled: "#252529",
+  disabledText: "#56565f",
 } as const;


### PR DESCRIPTION
## Summary
- Replace all `lang === 'ko' ? ... : ...` UI string ternaries with structured `labels`/`t` objects
- 11 components updated, 52 ternaries migrated (URL routing and data-field selectors untouched)
- Adds `timeframe` to `BacktestResult` interface (removes `as any` cast)

## Changes
| Component | Instances |
|-----------|-----------|
| ResultsPanel | 29 |
| BuilderPanel | 8 |
| SimulatorPage (+40 new keys) | — |
| ResultsCard | 7 |
| ReproBadge | 3 |
| OnboardingTour, LiveStats, WeeklyLeaderboard, CoinChart, MarketDashboard | 1 each |

## Test plan
- [ ] Simulator renders correctly in EN and KO modes
- [ ] Grade verdicts (A+, B, etc.) display correct language strings
- [ ] Share buttons, direction labels, coin table headers all localized
- [ ] No TypeScript errors (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)