### PR TITLE
fix(P1): leaderboard Best 3 shows only 1 card — weekly trades aggregation

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -3441,7 +3441,7 @@ def _get_daily_rankings_sync(
         weekly_agg.sort(key=lambda x: (x["avg_pf"], x["avg_wr"]), reverse=True)
         for i, item in enumerate(weekly_agg[:3]):
             meta = item["meta"]
-            trades = meta.get("total_trades", 0)
+            trades = sum(e.get("total_trades", 0) for e in item["entries"])
             weekly_best3.append({
                 "rank": i + 1,
                 "name_ko": meta.get("category_ko", meta.get("strategy", "")),


### PR DESCRIPTION
## Bug
Vision QA P1: Leaderboard "This Week's Best 3" section shows only 1 card instead of 3 across all 3 viewports (desktop, KO desktop, tablet).

## Root Cause
`weekly_best3` calculation in `backend/api/main.py` took `total_trades` from the **first day's metadata only** (`meta = data["meta"]`).

**The failure sequence:**
1. Strategy X appears in rankings for 7 days, but day 1 (the `meta` entry) has `total_trades: 0` (new entry, or sentinel value from placeholder)
2. Average PF/WR across all 7 days is excellent → strategy ranks in top 3
3. But `total_trades = meta.get("total_trades", 0)` = 0 from day 1
4. Frontend `hasValidTrades = (e) => e.total_trades > 0` filters it out
5. 2 of 3 entries removed → only 1 card renders in the 3-column grid

**Evidence from visual QA:**
- 3 Win Rates present on page (73.6, 19.0, 27.8%) confirming 3 API entries exist
- Only 1 RankingCard component rendered
- Consistent across EN desktop, KO desktop, and tablet

## Fix
Aggregate `total_trades` across all 7 daily entries:

```python
# Before — uses first day's metadata only
trades = meta.get("total_trades", 0)

# After — sums across all 7 days
trades = sum(e.get("total_trades", 0) for e in item["entries"])
```

True weekly trade count is always ≥ any single day's count, so strategies with valid data across most of the week will never filter as 0.

## Test plan
- [ ] `/rankings/weekly` endpoint returns 3 entries, all with `total_trades > 0`
- [ ] Leaderboard desktop: "This Week's Best 3" shows 3 cards
- [ ] Leaderboard KO desktop: "이번 주 Best 3" shows 3 cards
- [ ] Leaderboard tablet: 3 cards render in 3-column grid
- [ ] `low_sample` flag correctly set based on aggregated trades (< 100 = low)

🤖 Generated with [Claude Code](https://claude.com/claude-code)