### PR TITLE
fix: ranking SSR fallback group param mismatch (Market Cap Top 50 → top50)

### DIFF
--- a/src/pages/ko/strategies/ranking.astro
+++ b/src/pages/ko/strategies/ranking.astro
@@ -32,7 +32,7 @@ interface RankingData {
 
 let ssrRanking: RankingData | null = null;
 try {
-  const res = await fetch('https://api.pruviq.com/rankings/daily?period=30d&group=Market%20Cap%20Top%2050', {
+  const res = await fetch('https://api.pruviq.com/rankings/daily?period=30d&group=top50', {
     signal: AbortSignal.timeout(5000),
   });
   if (res.ok) ssrRanking = await res.json() as RankingData;

--- a/src/pages/strategies/ranking.astro
+++ b/src/pages/strategies/ranking.astro
@@ -42,7 +42,7 @@ interface RankingData {
 
 let ssrRanking: RankingData | null = null;
 try {
-  const res = await fetch('https://api.pruviq.com/rankings/daily?period=30d&group=Market%20Cap%20Top%2050', {
+  const res = await fetch('https://api.pruviq.com/rankings/daily?period=30d&group=top50', {
     signal: AbortSignal.timeout(5000),
   });
   if (res.ok) ssrRanking = await res.json() as RankingData;


### PR DESCRIPTION
## Summary

The SSR pre-render for both EN and KO ranking pages was calling:
```
/rankings/daily?period=30d&group=Market%20Cap%20Top%2050
```

The API no longer accepts the old human-readable group name. Current accepted values are `top30`, `top50`, `top100`, `btc` (as confirmed by the `available_groups` field in API responses and the `GROUP_LABELS` map in StrategyRanking.tsx).

**Impact**: The `ssrRanking` was always `null` at build time, so crawlers (Googlebot, social preview bots) saw an empty ranking page with no strategy data. The `allLowSampleWarning` SSR fallback section never rendered.

**Fix**: Change both ranking pages to use `group=top50`.

## Test plan

- [ ] Build-time fetch succeeds (`ssrRanking !== null`)
- [ ] Googlebot / noscript visitors see SSR ranking cards
- [ ] No regression in JS-loaded StrategyRanking component (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)