### PR TITLE
fix(ux): performance page archived context — trading paused Mar 2026

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -512,6 +512,9 @@ export const en = {
 
   // Performance page static fallback
   "perf.tag": "BACKTEST RESULTS",
+  "perf.archived_badge": "ARCHIVED",
+  "perf.archived_notice":
+    "Trading paused Mar 2026. Data below covers Jan 2024 – Feb 2026 backtests.",
   "perf.title": "Every Trade Published. Including Losses.",
   "perf.desc":
     "Backtest results for BB Squeeze SHORT strategy on 569 coins. 2+ years of historical data. No cherry-picking.",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -513,6 +513,9 @@ export const ko: Record<TranslationKey, string> = {
 
   // Performance page static fallback
   "perf.tag": "백테스트 결과",
+  "perf.archived_badge": "보관됨",
+  "perf.archived_notice":
+    "2026년 3월 실거래 중단. 아래 데이터는 2024년 1월 – 2026년 2월 백테스트 결과입니다.",
   "perf.title": "모든 거래 공개. 손실 포함.",
   "perf.desc":
     "BB Squeeze SHORT 전략 백테스트 결과. 569개 코인, 2년 이상 과거 데이터. 체리피킹 없음.",

--- a/src/pages/ko/performance/index.astro
+++ b/src/pages/ko/performance/index.astro
@@ -10,7 +10,13 @@ const t = useTranslations('ko');
   <!-- HERO -->
   <section class="py-12 md:py-16">
     <div class="max-w-5xl mx-auto px-4">
-      <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('perf.tag')}</p>
+      <div class="flex items-center gap-2 mb-3">
+        <p class="font-mono text-[--color-accent] text-sm tracking-wider">{t('perf.tag')}</p>
+        <span class="font-mono text-xs px-2 py-0.5 rounded border border-[--color-yellow]/40 text-[--color-yellow] bg-[--color-yellow]/5">{t('perf.archived_badge')}</span>
+      </div>
+      <div class="mb-4 border border-[--color-yellow]/30 rounded-lg px-4 py-2.5 bg-[--color-yellow]/5">
+        <p class="text-[--color-yellow] text-xs font-mono">⚠️ {t('perf.archived_notice')}</p>
+      </div>
       <h1 class="text-3xl md:text-4xl font-bold mb-4">{t('perf.title')}</h1>
       <p class="text-[--color-text-muted] text-lg mb-4 max-w-2xl">{t('perf.desc')}</p>
       <p class="font-mono text-xs text-[--color-text-muted] mb-6">

--- a/src/pages/performance/index.astro
+++ b/src/pages/performance/index.astro
@@ -10,7 +10,13 @@ const t = useTranslations('en');
   <!-- HERO -->
   <section class="pt-12 pb-6 md:pt-16 md:pb-8">
     <div class="max-w-5xl mx-auto px-4">
-      <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('perf.tag')}</p>
+      <div class="flex items-center gap-2 mb-3">
+        <p class="font-mono text-[--color-accent] text-sm tracking-wider">{t('perf.tag')}</p>
+        <span class="font-mono text-xs px-2 py-0.5 rounded border border-[--color-yellow]/40 text-[--color-yellow] bg-[--color-yellow]/5">{t('perf.archived_badge')}</span>
+      </div>
+      <div class="mb-4 border border-[--color-yellow]/30 rounded-lg px-4 py-2.5 bg-[--color-yellow]/5">
+        <p class="text-[--color-yellow] text-xs font-mono">⚠️ {t('perf.archived_notice')}</p>
+      </div>
       <h1 class="text-3xl md:text-4xl font-bold mb-4">{t('perf.title')}</h1>
       <p class="text-[--color-text-muted] text-lg mb-4 max-w-2xl">{t('perf.desc')}</p>
       <p class="font-mono text-xs text-[--color-text-muted] mb-6">


### PR DESCRIPTION
## Summary
- Adds ARCHIVED badge next to the BACKTEST RESULTS tag on both EN and KO performance pages
- Adds yellow notice banner: "Trading paused Mar 2026. Data covers Jan 2024 – Feb 2026 backtests."
- Prevents visitors from confusing stale data (Feb 28, 2026 last updated) with a bug

## Why
Audit WARN-1: performance data shows Feb 28, 2026 with no explanation — visitors can't tell if the system is broken or if trading genuinely stopped.

## Test plan
- [ ] `/performance` shows yellow ARCHIVED badge + notice banner at top
- [ ] `/ko/performance` shows Korean badge + notice banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)