### PR TITLE
ux: add bottom CTA to coin detail pages (EN + KO)

### DIFF
--- a/src/pages/coins/[symbol].astro
+++ b/src/pages/coins/[symbol].astro
@@ -148,6 +148,22 @@ const canonicalOverride = symbol.endsWith('usdt') ? undefined : `/coins/${symbol
           </details>
         </div>
       </div>
+
+      <!-- Bottom CTA -->
+      <div class="mt-10 pt-8 border-t border-[--color-border] text-center">
+        <a href={`/simulate?coin=${symbolUpper}`}
+           class="inline-block bg-[--color-accent] text-[--color-bg] px-6 py-2.5 rounded font-semibold text-sm hover:bg-[--color-accent-dim] transition-colors">
+          {t('coin_detail.simulate_coin').replace('{coin}', coinName)} &rarr;
+        </a>
+        <div class="flex flex-wrap gap-3 justify-center mt-4">
+          <a href="/strategies/ranking" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+            {t('ranking.tag')} &rarr;
+          </a>
+          <a href="/coins" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+            {t('coin_detail.all_coins')} &rarr;
+          </a>
+        </div>
+      </div>
     </div>
   </section>
 

--- a/src/pages/ko/coins/[symbol].astro
+++ b/src/pages/ko/coins/[symbol].astro
@@ -149,6 +149,22 @@ const canonicalOverride = symbol.endsWith('usdt') ? undefined : `/ko/coins/${sym
           </details>
         </div>
       </div>
+
+      <!-- Bottom CTA -->
+      <div class="mt-10 pt-8 border-t border-[--color-border] text-center">
+        <a href={`/ko/simulate?coin=${symbolUpper}`}
+           class="inline-block bg-[--color-accent] text-[--color-bg] px-6 py-2.5 rounded font-semibold text-sm hover:bg-[--color-accent-dim] transition-colors">
+          {t('coin_detail.simulate_coin').replace('{coin}', coinName)} &rarr;
+        </a>
+        <div class="flex flex-wrap gap-3 justify-center mt-4">
+          <a href="/ko/strategies/ranking" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+            {t('ranking.tag')} &rarr;
+          </a>
+          <a href="/ko/coins" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+            {t('coin_detail.all_coins')} &rarr;
+          </a>
+        </div>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- Adds "Simulate {Coin}" primary CTA after FAQ section on both EN and KO coin detail pages
- Adds "Daily Rankings" and "All Coins" secondary links as navigation escape hatches
- Prevents dead-end: visitors who read through FAQ previously had no next action

## Why
Coin pages (`/coins/BTCUSDT`, etc.) are high-traffic SEO entry points. Users land on them from Google and read the FAQ — but previously there was no CTA below the FAQ, leaving the page with no conversion opportunity at the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)