### PR TITLE
ux: KO about Solo Founder section + i18n hero stat labels

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -510,6 +510,21 @@ export const en = {
   "about.proof_commits": "Active development",
   "about.proof_since": "In development since 2025",
 
+  // About - Solo Founder section
+  "about.solo_tag": "SOLO FOUNDER",
+  "about.solo_headline":
+    "Built and maintained by a single developer and systematic trader.",
+  "about.solo_background":
+    "Background: algorithmic trading, quantitative research, crypto markets since 2021.",
+  "about.solo_why":
+    "Why PRUVIQ: After losing $4,000 on a backtested strategy that failed live — because every tool hid its failures — I built what I wished existed.",
+
+  // Home hero stat labels
+  "home.stat_coins": "Coins Tested",
+  "home.stat_trades": "Backtested Trades",
+  "home.stat_datapoints": "Data Points",
+  "home.stat_free": "Forever Free",
+
   // Performance page static fallback
   "perf.tag": "BACKTEST RESULTS",
   "perf.archived_badge": "ARCHIVED",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -511,6 +511,21 @@ export const ko: Record<TranslationKey, string> = {
   "about.proof_commits": "활발한 개발 진행 중",
   "about.proof_since": "2025년부터 개발 중",
 
+  // About - Solo Founder section
+  "about.solo_tag": "1인 창업자",
+  "about.solo_headline":
+    "개발자이자 시스템 트레이더 한 명이 만들고 유지합니다.",
+  "about.solo_background":
+    "배경: 2021년부터 알고리즘 트레이딩, 퀀트 리서치, 크립토 시장 연구.",
+  "about.solo_why":
+    "PRUVIQ를 만든 이유: 백테스트에서 검증된 전략으로 $4,000을 잃은 경험 — 모든 툴이 실패를 숨겼기 때문입니다. 그래서 내가 원했던 것을 직접 만들었습니다.",
+
+  // Home hero stat labels
+  "home.stat_coins": "테스트 코인",
+  "home.stat_trades": "백테스트 거래",
+  "home.stat_datapoints": "데이터 포인트",
+  "home.stat_free": "영원히 무료",
+
   // Performance page static fallback
   "perf.tag": "백테스트 결과",
   "perf.archived_badge": "보관됨",

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -40,14 +40,13 @@ const t = useTranslations('en');
 
       <!-- Solo Founder -->
       <div class="border border-[--color-accent]/30 rounded-lg p-6 bg-[--color-bg-card] mb-12">
-        <p class="font-mono text-[--color-accent] text-xs tracking-wider mb-3">SOLO FOUNDER</p>
-        <p class="font-bold text-base mb-3">Built and maintained by a single developer and systematic trader.</p>
+        <p class="font-mono text-[--color-accent] text-xs tracking-wider mb-3">{t('about.solo_tag')}</p>
+        <p class="font-bold text-base mb-3">{t('about.solo_headline')}</p>
         <p class="text-[--color-text-muted] text-sm leading-relaxed mb-3">
-          Background: algorithmic trading, quantitative research, crypto markets since 2021.
+          {t('about.solo_background')}
         </p>
         <p class="text-[--color-text-muted] text-sm leading-relaxed mb-4">
-          Why PRUVIQ: After losing $4,000 on a backtested strategy that failed live — because every tool
-          hid its failures — I built what I wished existed.
+          {t('about.solo_why')}
         </p>
         <div class="flex flex-wrap gap-3 text-sm">
           <a href="mailto:contact@pruviq.com" class="font-mono text-[--color-accent] hover:underline">contact@pruviq.com</a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -38,19 +38,19 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
         <div class="grid grid-cols-2 sm:grid-cols-4 gap-px border border-[--color-border] rounded-lg overflow-hidden mb-3 bg-[--color-border]">
           <div class="bg-[--color-bg-card] px-4 py-3 text-center">
             <p class="font-mono text-[--color-accent] text-xl font-bold">{coinsAnalyzed}+</p>
-            <p class="text-[--color-text-muted] text-xs mt-0.5">Coins Tested</p>
+            <p class="text-[--color-text-muted] text-xs mt-0.5">{t('home.stat_coins')}</p>
           </div>
           <div class="bg-[--color-bg-card] px-4 py-3 text-center">
             <p class="font-mono text-[--color-accent] text-xl font-bold">{tradingDays}+</p>
-            <p class="text-[--color-text-muted] text-xs mt-0.5">Backtested Trades</p>
+            <p class="text-[--color-text-muted] text-xs mt-0.5">{t('home.stat_trades')}</p>
           </div>
           <div class="bg-[--color-bg-card] px-4 py-3 text-center">
             <p class="font-mono text-[--color-accent] text-xl font-bold">{candlesProcessed}+</p>
-            <p class="text-[--color-text-muted] text-xs mt-0.5">Data Points</p>
+            <p class="text-[--color-text-muted] text-xs mt-0.5">{t('home.stat_datapoints')}</p>
           </div>
           <div class="bg-[--color-bg-card] px-4 py-3 text-center">
             <p class="font-mono text-[--color-up] text-xl font-bold">$0</p>
-            <p class="text-[--color-text-muted] text-xs mt-0.5">Forever Free</p>
+            <p class="text-[--color-text-muted] text-xs mt-0.5">{t('home.stat_free')}</p>
           </div>
         </div>
 

--- a/src/pages/ko/about.astro
+++ b/src/pages/ko/about.astro
@@ -38,6 +38,23 @@ const t = useTranslations('ko');
         </div>
       </div>
 
+      <!-- Solo Founder -->
+      <div class="border border-[--color-accent]/30 rounded-lg p-6 bg-[--color-bg-card] mb-12">
+        <p class="font-mono text-[--color-accent] text-xs tracking-wider mb-3">{t('about.solo_tag')}</p>
+        <p class="font-bold text-base mb-3">{t('about.solo_headline')}</p>
+        <p class="text-[--color-text-muted] text-sm leading-relaxed mb-3">
+          {t('about.solo_background')}
+        </p>
+        <p class="text-[--color-text-muted] text-sm leading-relaxed mb-4">
+          {t('about.solo_why')}
+        </p>
+        <div class="flex flex-wrap gap-3 text-sm">
+          <a href="mailto:contact@pruviq.com" class="font-mono text-[--color-accent] hover:underline">contact@pruviq.com</a>
+          <span class="text-[--color-border]">·</span>
+          <a href="https://github.com/pruviq" target="_blank" rel="noopener noreferrer" class="font-mono text-[--color-accent] hover:underline">github.com/pruviq</a>
+        </div>
+      </div>
+
       <!-- Philosophy -->
       <div class="mb-12">
         <p class="font-mono text-[--color-accent] text-xs tracking-wider mb-2">{t('about.philosophy_tag')}</p>


### PR DESCRIPTION
## Summary
- Added Solo Founder section to `/ko/about` (was missing vs EN version — 18-line gap)
- i18n-ified 4 hardcoded English solo-founder strings in EN `/about` → `about.solo_*` keys
- i18n-ified 4 hardcoded stat labels in `/` hero section → `home.stat_*` keys (Coins Tested, Backtested Trades, Data Points, Forever Free)
- KO translations added for all 8 new keys

## Test plan
- [ ] `/about` EN: Solo Founder section renders with i18n keys (no visible change)
- [ ] `/ko/about`: Solo Founder section now appears between Team Stats and Philosophy
- [ ] `/` hero stat grid labels render correctly in EN
- [ ] `/ko/` hero stat grid shows Korean labels (테스트 코인, 백테스트 거래, 데이터 포인트, 영원히 무료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)