### PR TITLE
ux: JSON-LD structured data for about and learn pages

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -6,6 +6,22 @@ const t = useTranslations('en');
 ---
 
 <Layout title={t('meta.about_title')} description={t('meta.about_desc')}>
+  <script type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "AboutPage",
+    "name": "About PRUVIQ",
+    "description": "PRUVIQ is an independent crypto backtesting research platform built by a solo developer and systematic trader.",
+    "url": "https://pruviq.com/about/",
+    "inLanguage": "en",
+    "publisher": {
+      "@type": "Organization",
+      "name": "PRUVIQ",
+      "url": "https://pruviq.com",
+      "foundingDate": "2025",
+      "email": "contact@pruviq.com",
+      "sameAs": ["https://github.com/pruviq", "https://x.com/pruviq"]
+    }
+  })} />
   <section class="py-12">
     <div class="max-w-3xl mx-auto px-4">
 

--- a/src/pages/ko/about.astro
+++ b/src/pages/ko/about.astro
@@ -6,6 +6,22 @@ const t = useTranslations('ko');
 ---
 
 <Layout title={t('meta.about_title')} description={t('meta.about_desc')}>
+  <script type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "AboutPage",
+    "name": "PRUVIQ 소개",
+    "description": "PRUVIQ는 1인 개발자이자 시스템 트레이더가 만든 독립 크립토 백테스팅 리서치 플랫폼입니다.",
+    "url": "https://pruviq.com/ko/about/",
+    "inLanguage": "ko",
+    "publisher": {
+      "@type": "Organization",
+      "name": "PRUVIQ",
+      "url": "https://pruviq.com",
+      "foundingDate": "2025",
+      "email": "contact@pruviq.com",
+      "sameAs": ["https://github.com/pruviq", "https://x.com/pruviq"]
+    }
+  })} />
   <section class="py-12">
     <div class="max-w-3xl mx-auto px-4">
 

--- a/src/pages/ko/learn/index.astro
+++ b/src/pages/ko/learn/index.astro
@@ -88,6 +88,22 @@ const levelConfig = [
 ---
 
 <Layout title={t('meta.learn_title')} description={t('meta.learn_desc')}>
+  <script type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "name": "크립토 트레이딩 학습 — PRUVIQ",
+    "description": "무료 크립토 트레이딩 교육: 백테스팅, 리스크 관리, 트레이딩 전략 초급·중급·고급 가이드.",
+    "url": "https://pruviq.com/ko/learn/",
+    "inLanguage": "ko",
+    "hasPart": allPosts.slice(0, 20).map(p => ({
+      "@type": "Article",
+      "name": p.data.title,
+      "description": p.data.description,
+      "url": p.isKorean ? `https://pruviq.com/ko/blog/${p.id}/` : `https://pruviq.com/blog/${p.id}/`,
+      "datePublished": p.data.date,
+      "publisher": { "@type": "Organization", "name": "PRUVIQ" }
+    }))
+  })} />
 
   <!-- HERO -->
   <section class="py-16">

--- a/src/pages/learn/index.astro
+++ b/src/pages/learn/index.astro
@@ -81,6 +81,22 @@ const levelConfig = [
 ---
 
 <Layout title={t('meta.learn_title')} description={t('meta.learn_desc')}>
+  <script type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "name": "Learn Crypto Trading — PRUVIQ",
+    "description": "Free crypto trading education: beginner, intermediate, and advanced guides on backtesting, risk management, and trading strategies.",
+    "url": "https://pruviq.com/learn/",
+    "inLanguage": "en",
+    "hasPart": posts.slice(0, 20).map(p => ({
+      "@type": "Article",
+      "name": p.data.title,
+      "description": p.data.description,
+      "url": `https://pruviq.com/blog/${p.id}/`,
+      "datePublished": p.data.date,
+      "publisher": { "@type": "Organization", "name": "PRUVIQ" }
+    }))
+  })} />
 
   <!-- HERO -->
   <section class="pt-16 pb-8">


### PR DESCRIPTION
## Summary
- `/about` (EN): `AboutPage` + `Organization` schema (name, url, foundingDate, email, sameAs)
- `/ko/about` (KO): same schema with Korean name, `inLanguage: ko`, `/ko/about/` URL
- `/learn` (EN): `CollectionPage` schema with `hasPart` array of top 20 articles
- `/ko/learn` (KO): same with KO URLs for translated posts, EN URLs for English-only posts

## Test plan
- [ ] Rich Results Test shows valid AboutPage schema on `/about`
- [ ] Rich Results Test shows valid CollectionPage schema on `/learn`
- [ ] KO variants have `inLanguage: ko` and correct `/ko/` URLs
- [ ] No build errors (Astro JSON-LD injection uses `set:html`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)