### PR TITLE
ux: i18n-ify remaining hardcoded strings in index.astro

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1068,6 +1068,11 @@ export const en = {
   "home.trust_oos_label": "OOS-validated strategies",
   "home.cta_survives": "See What Survives",
   "home.cta_test_yourself": "Test It Yourself — Free",
+  "home.not_sure": "Not sure?",
+  "home.not_sure_cta": "See how it works in 30 seconds",
+  "home.community_feedback_tag": "COMMUNITY FEEDBACK",
+  "home.quotes_initials_note":
+    "Names shown as initials at community members' request.",
   "home.quotes_heading": "What Traders Say",
   "home.quotes_cta": "Join them — Try Simulator Free",
   "home.ranking_shortcut": "Today's top strategies",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -1047,6 +1047,11 @@ export const ko: Record<TranslationKey, string> = {
   "home.trust_oos_label": "OOS 검증 전략",
   "home.cta_survives": "살아남는 전략 보기",
   "home.cta_test_yourself": "직접 테스트 — 무료",
+  "home.not_sure": "확신이 없으신가요?",
+  "home.not_sure_cta": "30초 만에 작동 방식 확인하기",
+  "home.community_feedback_tag": "커뮤니티 피드백",
+  "home.quotes_initials_note":
+    "이름은 커뮤니티 회원 요청에 따라 이니셜로 표시합니다.",
   "home.quotes_heading": "트레이더들의 이야기",
   "home.quotes_cta": "함께 해보세요 — 무료 시뮬레이터 체험",
   "home.ranking_shortcut": "오늘의 상위 전략",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -89,7 +89,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
         </div>
         <!-- Soft CTA: see how it works -->
         <p class="text-sm text-[--color-text-muted] font-mono mb-4">
-          Not sure? <a href="#how-it-works" class="text-[--color-accent] hover:underline">&#9654; See how it works in 30 seconds</a>
+          {t('home.not_sure')} <a href="#how-it-works" class="text-[--color-accent] hover:underline">&#9654; {t('home.not_sure_cta')}</a>
         </p>
         <!-- Trust signals + Ranking shortcut -->
         <div class="flex flex-wrap gap-x-4 gap-y-1 text-sm text-[--color-text-muted] font-mono mb-3">
@@ -461,9 +461,9 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
   <!-- SOCIAL PROOF QUOTES -->
   <section class="py-16 border-t border-[--color-border] reveal" aria-labelledby="quotes-heading">
     <div class="max-w-6xl mx-auto px-4">
-      <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">COMMUNITY FEEDBACK</p>
+      <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('home.community_feedback_tag')}</p>
       <h2 id="quotes-heading" class="text-2xl font-bold mb-1">{t('home.quotes_heading')}</h2>
-      <p class="text-[--color-text-muted] text-xs font-mono mb-8 opacity-60">Names shown as initials at community members' request.</p>
+      <p class="text-[--color-text-muted] text-xs font-mono mb-8 opacity-60">{t('home.quotes_initials_note')}</p>
       <div class="grid md:grid-cols-3 gap-6">
         <blockquote class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card]">
           <p class="text-[--color-text-muted] text-sm leading-relaxed mb-4">"I tested 8 strategies on TradingView before finding PRUVIQ. Testing hundreds of coins at once saved me weeks of work. The killed strategies page convinced me this is legit."</p>


### PR DESCRIPTION
## Summary
3 hardcoded English strings in `/` (EN home page) replaced with i18n keys:
- `"Not sure? See how it works in 30 seconds"` → `home.not_sure` + `home.not_sure_cta`
- `"COMMUNITY FEEDBACK"` → `home.community_feedback_tag`
- `"Names shown as initials at community members' request."` → `home.quotes_initials_note`

KO translations added for all 4 new keys (`확신이 없으신가요?`, `커뮤니티 피드백`, etc.)

## Test plan
- [ ] `/` EN: Hero "Not sure?" soft CTA renders correctly
- [ ] `/` EN: "COMMUNITY FEEDBACK" section tag and initials note render
- [ ] Build passes (no missing i18n key errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)