### PR TITLE
fix: auto-fix #549 (+1 related)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -66,9 +66,6 @@ export default defineConfig({
           item.priority = 0.5; item.changefreq = /** @type {any} */ ('monthly');
         }
 
-        // Freshness signal for search engines
-        item.lastmod = new Date().toISOString().split('T')[0];
-
         return item;
       }
     }),

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -38,7 +38,9 @@ const categoryColors: Record<string, string> = {
       "headline": p.data.title,
       "description": p.data.description,
       "datePublished": p.data.date,
-      "url": `https://pruviq.com/blog/${p.id}`
+      "url": `https://pruviq.com/blog/${p.id}`,
+      "author": { "@type": "Organization", "name": "PRUVIQ" },
+      "mainEntityOfPage": { "@type": "WebPage", "@id": `https://pruviq.com/blog/${p.id}` }
     }))
   })} />
   <section class="py-12">

--- a/src/pages/ko/blog/index.astro
+++ b/src/pages/ko/blog/index.astro
@@ -46,7 +46,9 @@ const categoryColors: Record<string, string> = {
       "headline": p.data.title,
       "description": p.data.description,
       "datePublished": p.data.date,
-      "url": `https://pruviq.com/ko/blog/${p.id}`
+      "url": p.isKorean ? `https://pruviq.com/ko/blog/${p.id}` : `https://pruviq.com/blog/${p.id}`,
+      "author": { "@type": "Organization", "name": "PRUVIQ" },
+      "mainEntityOfPage": { "@type": "WebPage", "@id": p.isKorean ? `https://pruviq.com/ko/blog/${p.id}` : `https://pruviq.com/blog/${p.id}` }
     }))
   })} />
   <section class="py-12">


### PR DESCRIPTION
## Auto-fix for 2 issue(s)

#549: [claude-auto][P2] `sitemap lastmod` stamped to current build date on every deploy
#550: [claude-auto][P2] `BlogPosting` items in blog index JSON-LD missing `author` and `mainEntityOfPage

### Changes
```
 astro.config.mjs              | 3 ---
 src/pages/blog/index.astro    | 4 +++-
 src/pages/ko/blog/index.astro | 4 +++-
 3 files changed, 6 insertions(+), 5 deletions(-)
```

### Safety Checks
- Files changed: **3** (limit: 20)
- Lines changed: **11** (limit: 1500)

---
*Auto-generated by JEPO auto-fix agent. Requires auto-test pass before merge.*