### PR TITLE
design: Phase 2 — component shadow depth + hover lift

### DIFF
--- a/src/components/RankingCard.tsx
+++ b/src/components/RankingCard.tsx
@@ -86,7 +86,8 @@ export function RankingCard({
 
   return (
     <div
-      class={`border rounded-lg p-4 bg-[--color-bg-card] transition-colors ${lowSampleBest ? "border-[--color-yellow]/50 hover:border-[--color-yellow]" : "border-[--color-border] hover:border-[--color-accent]/40"}`}
+      class={`rounded-lg p-4 bg-[--color-bg-card] card-hover ${lowSampleBest ? "border border-[--color-yellow]/50 hover:border-[--color-yellow]" : "border border-[--color-border]"}`}
+      style="box-shadow: var(--shadow-card);"
     >
       {/* Header row */}
       <div class="flex items-start justify-between gap-2 mb-3">

--- a/src/components/ResultsCard.tsx
+++ b/src/components/ResultsCard.tsx
@@ -275,7 +275,10 @@ function MetricBox({
   description?: string;
 }) {
   return (
-    <div class="p-3 rounded-lg bg-[--color-bg-tooltip] border border-[--color-border] relative">
+    <div
+      class="p-3 rounded-lg bg-[--color-bg-card] relative"
+      style="box-shadow: var(--shadow-card);"
+    >
       <div class="font-mono text-[0.625rem] text-[--color-text-muted] uppercase tracking-wider mb-1 flex items-center gap-1">
         {label}
         {description && (

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -403,7 +403,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
                 <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.5" class="opacity-50 transition-transform group-hover:rotate-180" aria-hidden="true"><path d="M2 3.5l3 3 3-3"/></svg>
               </a>
               <div class="absolute top-full left-1/2 -translate-x-1/2 pt-3 hidden group-hover:block z-50">
-                <div class="bg-[--color-bg] border border-[--color-border] rounded-lg shadow-xl py-1.5 min-w-[160px]">
+                <div class="bg-[--color-bg-card] border border-[--color-border] rounded-lg py-1.5 min-w-[160px]" style="box-shadow: var(--shadow-elevated);">
                   <a href={rankingPath} class="flex items-center gap-2.5 px-4 py-2.5 text-sm text-[--color-text-muted] hover:text-[--color-accent] hover:bg-[--color-bg-subtle] transition-colors">
                     <span class="w-1.5 h-1.5 rounded-full bg-[--color-accent] animate-pulse shrink-0"></span>
                     {t('nav.ranking')}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,7 +24,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
     <div class="max-w-6xl mx-auto px-4 py-20">
       <div class="max-w-3xl">
         <p class="font-mono text-[--color-accent] text-sm mb-4 tracking-wider">{t('hero.tag')}</p>
-        <h1 id="hero-heading" class="text-4xl md:text-6xl font-bold leading-tight mb-6">
+        <h1 id="hero-heading" class="text-4xl md:text-6xl font-bold leading-tight mb-6" style="letter-spacing: -0.03em;">
           {t('hero.title1')}<br/>
           <span class="text-[--color-accent]">{t('hero.title2').replace('{coins}', String(coinsAnalyzed))}</span>
         </h1>
@@ -141,30 +141,30 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
       <div>
         <!-- Stats -->
         <div class="grid grid-cols-2 sm:grid-cols-3 gap-4">
-          <div class="border border-[--color-border] rounded p-4 bg-[--color-bg-card] card-hover">
+          <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover" style="box-shadow: var(--shadow-card);">
             <p class="font-mono text-[--color-accent] text-2xl font-bold">{coinsAnalyzed}</p>
             <p class="text-[--color-text-muted] text-sm">{t('hero.stat1')}</p>
             <p class="text-[--color-text-muted] text-xs mt-1 opacity-60">{t('hero.stat1_sub')}</p>
           </div>
-          <div class="border border-[--color-border] rounded p-4 bg-[--color-bg-card] card-hover">
+          <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover" style="box-shadow: var(--shadow-card);">
             <p class="font-mono text-[--color-accent] text-2xl font-bold">{tradingDays}+</p>
             <p class="text-[--color-text-muted] text-sm">{t('hero.stat4')}</p>
             <p class="text-[--color-text-muted] text-xs mt-1 opacity-60">{t('hero.stat4_sub')}</p>
           </div>
-          <div class="border border-[--color-border] rounded p-4 bg-[--color-bg-card] card-hover">
+          <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover" style="box-shadow: var(--shadow-card);">
             <p class="font-mono text-[--color-accent] text-2xl font-bold">{candlesProcessed}+</p>
             <p class="text-[--color-text-muted] text-sm">{t('hero.stat5')}</p>
             <p class="text-[--color-text-muted] text-xs mt-1 opacity-60">{t('hero.stat5_sub')}</p>
           </div>
-          <div class="border border-[--color-border] rounded p-4 bg-[--color-bg-card] card-hover">
+          <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover" style="box-shadow: var(--shadow-card);">
             <p class="font-mono text-[--color-accent] text-2xl font-bold">{t('hero.stat2_val')}</p>
             <p class="text-[--color-text-muted] text-sm">{t('hero.stat2')}</p>
           </div>
-          <div class="border border-[--color-border] rounded p-4 bg-[--color-bg-card] card-hover">
+          <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover" style="box-shadow: var(--shadow-card);">
             <p class="font-mono text-[--color-accent] text-2xl font-bold">100%</p>
             <p class="text-[--color-text-muted] text-sm">{t('hero.stat3')}</p>
           </div>
-          <div class="border border-[--color-border] rounded p-4 bg-[--color-bg-card] card-hover">
+          <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover" style="box-shadow: var(--shadow-card);">
             <p class="font-mono text-[--color-accent] text-2xl font-bold">$0</p>
             <p class="text-[--color-text-muted] text-sm">{t('hero.stat6')}</p>
             <p class="text-[--color-text-muted] text-xs mt-1 opacity-60">{t('hero.stat6_sub')}</p>

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -104,30 +104,30 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
 
         <!-- Stats -->
         <div class="grid grid-cols-2 sm:grid-cols-3 gap-4">
-          <div class="border border-[--color-border] rounded p-4 bg-[--color-bg-card] card-hover">
+          <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover" style="box-shadow: var(--shadow-card);">
             <p class="font-mono text-[--color-accent] text-2xl font-bold">{coinsAnalyzed}</p>
             <p class="text-[--color-text-muted] text-sm">{t('hero.stat1')}</p>
             <p class="text-[--color-text-muted] text-xs mt-1 opacity-60">{t('hero.stat1_sub')}</p>
           </div>
-          <div class="border border-[--color-border] rounded p-4 bg-[--color-bg-card] card-hover">
+          <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover" style="box-shadow: var(--shadow-card);">
             <p class="font-mono text-[--color-accent] text-2xl font-bold">{tradingDays}+</p>
             <p class="text-[--color-text-muted] text-sm">{t('hero.stat4')}</p>
             <p class="text-[--color-text-muted] text-xs mt-1 opacity-60">{t('hero.stat4_sub')}</p>
           </div>
-          <div class="border border-[--color-border] rounded p-4 bg-[--color-bg-card] card-hover">
+          <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover" style="box-shadow: var(--shadow-card);">
             <p class="font-mono text-[--color-accent] text-2xl font-bold">{candlesProcessed}+</p>
             <p class="text-[--color-text-muted] text-sm">{t('hero.stat5')}</p>
             <p class="text-[--color-text-muted] text-xs mt-1 opacity-60">{t('hero.stat5_sub')}</p>
           </div>
-          <div class="border border-[--color-border] rounded p-4 bg-[--color-bg-card] card-hover">
+          <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover" style="box-shadow: var(--shadow-card);">
             <p class="font-mono text-[--color-accent] text-2xl font-bold">{t('hero.stat2_val')}</p>
             <p class="text-[--color-text-muted] text-sm">{t('hero.stat2')}</p>
           </div>
-          <div class="border border-[--color-border] rounded p-4 bg-[--color-bg-card] card-hover">
+          <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover" style="box-shadow: var(--shadow-card);">
             <p class="font-mono text-[--color-accent] text-2xl font-bold">100%</p>
             <p class="text-[--color-text-muted] text-sm">{t('hero.stat3')}</p>
           </div>
-          <div class="border border-[--color-border] rounded p-4 bg-[--color-bg-card] card-hover">
+          <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover" style="box-shadow: var(--shadow-card);">
             <p class="font-mono text-[--color-accent] text-2xl font-bold">$0</p>
             <p class="text-[--color-text-muted] text-sm">{t('hero.stat6')}</p>
             <p class="text-[--color-text-muted] text-xs mt-1 opacity-60">{t('hero.stat6_sub')}</p>


### PR DESCRIPTION
## Summary

Component-level upgrades using Phase 1 shadow/motion tokens (already merged in #552):

- **RankingCard**: `shadow-card` depth + `card-hover` (translateY(-2px) lift on hover)
- **MetricBox** (ResultsCard): flat border → `shadow-card` system (layered depth)
- **Nav dropdown**: `shadow-elevated` + `bg-card` (distinct layer from `bg`)
- **Hero h1**: letter-spacing `-0.03em` (tighter, more premium)
- **Homepage stat cards**: `shadow-card` + `rounded-lg` (12px radius)

## Test plan
- [ ] RankingCard: hover shows lift animation (translateY -2px)
- [ ] MetricBox: visible depth/shadow on simulator results
- [ ] Nav dropdown: appears elevated above page content
- [ ] Hero heading: tighter letter spacing visible on desktop
- [ ] Build passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)