### PR TITLE
fix: leaderboard SSR fallback + graceful error state (P0)

### DIFF
--- a/src/components/WeeklyLeaderboard.tsx
+++ b/src/components/WeeklyLeaderboard.tsx
@@ -24,7 +24,7 @@ const labels = {
     worstTitle: "Worst 3 This Week",
     worstSub: "Avoid these — bottom 3 by 7-day PF",
     loading: "Loading weekly rankings...",
-    error: "Failed to load weekly data",
+    error: "Weekly data is being refreshed — check back shortly.",
     simCta: "Test in Simulator",
     rankingLink: "See daily rankings →",
     noData: "Weekly data not available yet.",
@@ -43,7 +43,7 @@ const labels = {
     worstTitle: "이번 주 하위 3개",
     worstSub: "피해야 할 조합 — 7일 PF 하위 3개",
     loading: "주간 랭킹 로딩 중...",
-    error: "주간 데이터 로드 실패",
+    error: "주간 데이터를 불러오는 중입니다. 잠시 후 다시 확인해 주세요.",
     simCta: "시뮬레이터에서 확인",
     rankingLink: "일일 랭킹 보기 →",
     noData: "주간 데이터가 아직 없습니다.",
@@ -144,8 +144,16 @@ export default function WeeklyLeaderboard({ lang }: Props) {
           </p>
         </div>
         {error ? (
-          <div class="border border-[--color-red]/30 rounded-lg p-4 text-[--color-red] text-sm font-mono">
-            {error}
+          <div class="border border-[--color-border] rounded-lg p-5 bg-[--color-bg-card] text-center">
+            <p class="text-[--color-text-muted] text-sm font-mono mb-2">
+              {l.error}
+            </p>
+            <a
+              href={rankingPath}
+              class="inline-block text-[--color-accent] text-xs font-mono hover:underline"
+            >
+              {l.rankingLink}
+            </a>
           </div>
         ) : (
           <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">

--- a/src/pages/ko/leaderboard.astro
+++ b/src/pages/ko/leaderboard.astro
@@ -5,6 +5,26 @@ import WeeklyLeaderboard from '../../components/WeeklyLeaderboard';
 import ErrorBoundary from '../../components/ErrorBoundary';
 
 const t = useTranslations('ko');
+
+interface RankingEntry {
+  rank: number; name_en: string; strategy: string; direction: string;
+  win_rate: number; profit_factor: number; total_trades: number;
+  timeframe: string; low_sample: boolean;
+}
+interface WeeklySSR { date: string; weekly_best3: RankingEntry[]; top3: RankingEntry[]; }
+let ssrWeekly: WeeklySSR | null = null;
+try {
+  const res = await fetch('https://api.pruviq.com/rankings/daily?period=7d&group=top50', {
+    signal: AbortSignal.timeout(5000),
+  });
+  if (res.ok) ssrWeekly = await res.json() as WeeklySSR;
+} catch { /* API unavailable at build time */ }
+const ssrEntries = ssrWeekly?.weekly_best3?.filter(e => e.total_trades > 0 && e.profit_factor < 50) ?? [];
+const ssrTop3 = ssrEntries.length > 0 ? ssrEntries : (ssrWeekly?.top3 ?? []);
+function formatDate(iso: string) {
+  try { return new Date(iso + 'T00:00:00').toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'Asia/Seoul' }); }
+  catch { return iso; }
+}
 ---
 
 <Layout title={t('meta.leaderboard_title')} description={t('meta.leaderboard_desc')}>
@@ -30,6 +50,61 @@ const t = useTranslations('ko');
       <p class="text-[--color-text-muted] text-lg mb-10 max-w-2xl leading-relaxed">
         {t('leaderboard.desc')}
       </p>
+
+      {ssrTop3.length > 0 && (
+        <div id="leaderboard-ssr-fallback" class="mb-8">
+          <p class="font-mono text-[--color-accent] text-xs mb-3 tracking-wider">
+            이번 주 상위 — {ssrWeekly?.date ? formatDate(ssrWeekly.date) : ''} · 7일 · 상위 50
+          </p>
+          <div class="grid md:grid-cols-3 gap-4">
+            {ssrTop3.slice(0, 3).map((entry) => {
+              const medals = ['🥇','🥈','🥉'];
+              const medal = medals[entry.rank - 1] ?? `#${entry.rank}`;
+              const isLong = entry.direction === 'long';
+              const isBoth = entry.direction === 'both';
+              const dirLabel = isBoth ? 'BOTH↕' : isLong ? 'LONG↑' : 'SHORT↓';
+              const dirColor = isBoth ? 'text-[--color-yellow] border-[--color-yellow]/40' : isLong ? 'text-[--color-up] border-[--color-up]/40' : 'text-[--color-red] border-[--color-red]/40';
+              const wrColor = entry.win_rate >= 55 ? 'text-[--color-up]' : entry.win_rate >= 50 ? 'text-[--color-yellow]' : 'text-[--color-red]';
+              const pfColor = entry.profit_factor >= 1.5 ? 'text-[--color-up]' : entry.profit_factor >= 1.0 ? 'text-[--color-yellow]' : 'text-[--color-red]';
+              return (
+                <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card]">
+                  <div class="flex items-start justify-between gap-2 mb-3">
+                    <div class="flex items-center gap-2 min-w-0">
+                      <span class="text-xl shrink-0">{medal}</span>
+                      <div class="min-w-0">
+                        <p class="font-semibold text-[--color-text] text-sm leading-tight truncate">{entry.name_en}</p>
+                        <p class="text-[--color-text-muted] text-xs font-mono">{entry.timeframe} · {entry.direction}</p>
+                      </div>
+                    </div>
+                    <span class={`font-mono text-xs px-2 py-0.5 rounded border shrink-0 ${dirColor}`}>{dirLabel}</span>
+                  </div>
+                  <div class="grid grid-cols-3 gap-2 font-mono text-sm">
+                    <div>
+                      <p class="text-[--color-text-muted] text-xs mb-0.5">승률</p>
+                      <p class={`font-bold text-base ${wrColor}`}>{entry.win_rate.toFixed(1)}%</p>
+                    </div>
+                    <div>
+                      <p class="text-[--color-text-muted] text-xs mb-0.5">PF</p>
+                      <p class={`font-bold text-base ${pfColor}`}>{entry.profit_factor.toFixed(2)}</p>
+                    </div>
+                    <div>
+                      <p class="text-[--color-text-muted] text-xs mb-0.5">거래 수</p>
+                      <p class="font-bold text-base text-[--color-text]">{entry.total_trades}</p>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+      <script>
+        document.addEventListener('astro:page-load', () => {
+          const el = document.getElementById('leaderboard-ssr-fallback');
+          if (el) setTimeout(() => { el.style.display = 'none'; }, 1500);
+        });
+      </script>
+      <noscript><style>#leaderboard-ssr-fallback { display: block !important; }</style></noscript>
 
       <ErrorBoundary name="Weekly Leaderboard" lang="ko" client:load>
         <WeeklyLeaderboard lang="ko" client:load />

--- a/src/pages/leaderboard.astro
+++ b/src/pages/leaderboard.astro
@@ -5,6 +5,27 @@ import WeeklyLeaderboard from '../components/WeeklyLeaderboard';
 import ErrorBoundary from '../components/ErrorBoundary';
 
 const t = useTranslations('en');
+
+// SSR fallback: fetch weekly data at build time so crawlers + no-JS users see content
+interface RankingEntry {
+  rank: number; name_en: string; strategy: string; direction: string;
+  win_rate: number; profit_factor: number; total_trades: number;
+  timeframe: string; low_sample: boolean;
+}
+interface WeeklySSR { date: string; weekly_best3: RankingEntry[]; top3: RankingEntry[]; }
+let ssrWeekly: WeeklySSR | null = null;
+try {
+  const res = await fetch('https://api.pruviq.com/rankings/daily?period=7d&group=top50', {
+    signal: AbortSignal.timeout(5000),
+  });
+  if (res.ok) ssrWeekly = await res.json() as WeeklySSR;
+} catch { /* API unavailable at build time */ }
+const ssrEntries = ssrWeekly?.weekly_best3?.filter(e => e.total_trades > 0 && e.profit_factor < 50) ?? [];
+const ssrTop3 = ssrEntries.length > 0 ? ssrEntries : (ssrWeekly?.top3 ?? []);
+function formatDate(iso: string) {
+  try { return new Date(iso + 'T00:00:00').toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'Asia/Seoul' }); }
+  catch { return iso; }
+}
 ---
 
 <Layout title={t('meta.leaderboard_title')} description={t('meta.leaderboard_desc')}>
@@ -30,6 +51,62 @@ const t = useTranslations('en');
       <p class="text-[--color-text-muted] text-lg mb-10 max-w-2xl leading-relaxed">
         {t('leaderboard.desc')}
       </p>
+
+      <!-- SSR fallback: visible before JS loads or when API unavailable -->
+      {ssrTop3.length > 0 && (
+        <div id="leaderboard-ssr-fallback" class="mb-8">
+          <p class="font-mono text-[--color-accent] text-xs mb-3 tracking-wider">
+            THIS WEEK'S BEST — {ssrWeekly?.date ? formatDate(ssrWeekly.date) : ''} · 7d · Top 50
+          </p>
+          <div class="grid md:grid-cols-3 gap-4">
+            {ssrTop3.slice(0, 3).map((entry) => {
+              const medals = ['🥇','🥈','🥉'];
+              const medal = medals[entry.rank - 1] ?? `#${entry.rank}`;
+              const isLong = entry.direction === 'long';
+              const isBoth = entry.direction === 'both';
+              const dirLabel = isBoth ? 'BOTH↕' : isLong ? 'LONG↑' : 'SHORT↓';
+              const dirColor = isBoth ? 'text-[--color-yellow] border-[--color-yellow]/40' : isLong ? 'text-[--color-up] border-[--color-up]/40' : 'text-[--color-red] border-[--color-red]/40';
+              const wrColor = entry.win_rate >= 55 ? 'text-[--color-up]' : entry.win_rate >= 50 ? 'text-[--color-yellow]' : 'text-[--color-red]';
+              const pfColor = entry.profit_factor >= 1.5 ? 'text-[--color-up]' : entry.profit_factor >= 1.0 ? 'text-[--color-yellow]' : 'text-[--color-red]';
+              return (
+                <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card]">
+                  <div class="flex items-start justify-between gap-2 mb-3">
+                    <div class="flex items-center gap-2 min-w-0">
+                      <span class="text-xl shrink-0">{medal}</span>
+                      <div class="min-w-0">
+                        <p class="font-semibold text-[--color-text] text-sm leading-tight truncate">{entry.name_en}</p>
+                        <p class="text-[--color-text-muted] text-xs font-mono">{entry.timeframe} · {entry.direction}</p>
+                      </div>
+                    </div>
+                    <span class={`font-mono text-xs px-2 py-0.5 rounded border shrink-0 ${dirColor}`}>{dirLabel}</span>
+                  </div>
+                  <div class="grid grid-cols-3 gap-2 font-mono text-sm">
+                    <div>
+                      <p class="text-[--color-text-muted] text-xs mb-0.5">Win Rate</p>
+                      <p class={`font-bold text-base ${wrColor}`}>{entry.win_rate.toFixed(1)}%</p>
+                    </div>
+                    <div>
+                      <p class="text-[--color-text-muted] text-xs mb-0.5">PF</p>
+                      <p class={`font-bold text-base ${pfColor}`}>{entry.profit_factor.toFixed(2)}</p>
+                    </div>
+                    <div>
+                      <p class="text-[--color-text-muted] text-xs mb-0.5">Trades</p>
+                      <p class="font-bold text-base text-[--color-text]">{entry.total_trades}</p>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+      <script>
+        document.addEventListener('astro:page-load', () => {
+          const el = document.getElementById('leaderboard-ssr-fallback');
+          if (el) setTimeout(() => { el.style.display = 'none'; }, 1500);
+        });
+      </script>
+      <noscript><style>#leaderboard-ssr-fallback { display: block !important; }</style></noscript>
 
       <ErrorBoundary name="Weekly Leaderboard" client:load>
         <WeeklyLeaderboard lang="en" client:load />


### PR DESCRIPTION
## Problem
`/leaderboard` and `/ko/leaderboard` had no SSR fallback — unlike `/strategies/ranking` which fetches data at build time. When the API was unavailable (or slow), users saw a red **"Failed to load weekly data"** error box covering the entire content area.

## Changes

### `src/components/WeeklyLeaderboard.tsx`
- Error state: replace alarming red border/text box with neutral gray card + soft message
- EN: `"Weekly data is being refreshed — check back shortly."` + link to daily rankings
- KO: `"주간 데이터를 불러오는 중입니다. 잠시 후 다시 확인해 주세요."`

### `src/pages/leaderboard.astro` + `src/pages/ko/leaderboard.astro`
- Add SSR fetch at build time (`/rankings/daily?period=7d&group=top50`, 5s timeout)
- Shows `weekly_best3` entries (or fallback to `top3`) as static cards before JS loads
- Auto-hides after JS component renders (same 1.5s pattern as `/strategies/ranking`)
- `<noscript>` keeps SSR content visible when JS is disabled

## Test
- API available: SSR cards show → JS component renders → SSR hides after 1.5s ✅
- API down at build time: SSR block skipped, JS component shows soft gray message ✅
- No-JS: SSR cards remain visible via `<noscript>` style override ✅