### PR TITLE
fix: remove duplicate hero.desc paragraph from KO home (P0)

### DIFF
--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -33,9 +33,6 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
         <p class="text-lg md:text-xl text-[--color-up] font-semibold mb-3 max-w-2xl">
           {t('hero.subcopy')}
         </p>
-        <p class="text-lg md:text-xl text-[--color-text-muted] mb-4 max-w-2xl">
-          {t('hero.desc')}
-        </p>
         <!-- 히어로 스탯 그리드 -->
         <div class="grid grid-cols-2 sm:grid-cols-4 gap-px border border-[--color-border] rounded-lg overflow-hidden mb-3 bg-[--color-border]">
           <div class="bg-[--color-bg-card] px-4 py-3 text-center">


### PR DESCRIPTION
## Problem
`/ko/index.astro` was rendering **two** paragraphs in the hero that conveyed conflicting failure counts:

1. `hero.subcopy` → "88가지 전략 조합을 검증했습니다. **4개가 실패했고** — 전부 공개했습니다."
2. `hero.desc` → "569개 이상의 코인에서 **5개의 전략**을 테스트했습니다. **4개는 손실을 기록했습니다.**"

The EN home (`/index.astro`) only renders `hero.subcopy` — `hero.desc` is never shown in the ATF. KO had an extra paragraph that:
- Repeated "4개 실패" twice
- Implied **80% failure rate** (5 tested, 4 failed) immediately after the 88-combination framing
- Created confusion: "88개 조합" then "5개 전략" — two different numbers for the same thing

## Change
Remove the `hero.desc` paragraph from `ko/index.astro` to match EN structure.

`hero.desc` key is retained in `ko.ts` — it is used in other pages (about, performance, etc.).

## Before / After
| Before (KO ATF) | After (KO ATF) |
|---|---|
| subcopy: 88개 조합, 4개 실패 | subcopy: 88개 조합, 4개 실패 |
| desc: **5개 전략, 4개 손실** (extra) | *(removed)* |