### PR TITLE
ux: about page stats dynamic from site-stats.json (EN+KO)

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -477,7 +477,7 @@ export const en = {
   "about.team_stat1_val": "88+",
   "about.team_stat2_label": "Coins Covered",
   "about.team_stat2_val": "569",
-  "about.team_stat3_label": "Simulated Trades",
+  "about.team_stat3_label": "Simulator Sessions",
   "about.team_stat3_val": "1M+",
   "about.philosophy_tag": "OUR PHILOSOPHY",
   "about.philosophy_title": "Prove It or Kill It.",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -478,7 +478,7 @@ export const ko: Record<TranslationKey, string> = {
   "about.team_stat1_val": "88+",
   "about.team_stat2_label": "커버 코인",
   "about.team_stat2_val": "569",
-  "about.team_stat3_label": "시뮬레이션 거래",
+  "about.team_stat3_label": "시뮬레이터 실행 수",
   "about.team_stat3_val": "100만+",
   "about.philosophy_tag": "우리의 철학",
   "about.philosophy_title": "증명하거나, 제거하거나.",

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,8 +1,11 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import { useTranslations } from '../i18n/index';
+import siteStats from '../../public/data/site-stats.json';
 
 const t = useTranslations('en');
+const coinsAnalyzed = (siteStats as { coins_analyzed: number }).coins_analyzed;
+const simulationsRun = (siteStats as { simulations_run: number }).simulations_run.toLocaleString('en-US');
 ---
 
 <Layout title={t('meta.about_title')} description={t('meta.about_desc')}>
@@ -44,11 +47,11 @@ const t = useTranslations('en');
             <p class="text-[--color-text-muted] text-xs">{t('about.team_stat1_label')}</p>
           </div>
           <div class="text-center">
-            <p class="font-mono text-[--color-accent] text-xl font-bold">{t('about.team_stat2_val')}</p>
+            <p class="font-mono text-[--color-accent] text-xl font-bold">{coinsAnalyzed}+</p>
             <p class="text-[--color-text-muted] text-xs">{t('about.team_stat2_label')}</p>
           </div>
           <div class="text-center">
-            <p class="font-mono text-[--color-accent] text-xl font-bold">{t('about.team_stat3_val')}</p>
+            <p class="font-mono text-[--color-accent] text-xl font-bold">{simulationsRun}</p>
             <p class="text-[--color-text-muted] text-xs">{t('about.team_stat3_label')}</p>
           </div>
         </div>

--- a/src/pages/ko/about.astro
+++ b/src/pages/ko/about.astro
@@ -1,8 +1,11 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import { useTranslations } from '../../i18n/index';
+import siteStats from '../../../public/data/site-stats.json';
 
 const t = useTranslations('ko');
+const coinsAnalyzed = (siteStats as { coins_analyzed: number }).coins_analyzed;
+const simulationsRun = (siteStats as { simulations_run: number }).simulations_run.toLocaleString('ko-KR');
 ---
 
 <Layout title={t('meta.about_title')} description={t('meta.about_desc')}>
@@ -44,11 +47,11 @@ const t = useTranslations('ko');
             <p class="text-[--color-text-muted] text-xs">{t('about.team_stat1_label')}</p>
           </div>
           <div class="text-center">
-            <p class="font-mono text-[--color-accent] text-xl font-bold">{t('about.team_stat2_val')}</p>
+            <p class="font-mono text-[--color-accent] text-xl font-bold">{coinsAnalyzed}+</p>
             <p class="text-[--color-text-muted] text-xs">{t('about.team_stat2_label')}</p>
           </div>
           <div class="text-center">
-            <p class="font-mono text-[--color-accent] text-xl font-bold">{t('about.team_stat3_val')}</p>
+            <p class="font-mono text-[--color-accent] text-xl font-bold">{simulationsRun}</p>
             <p class="text-[--color-text-muted] text-xs">{t('about.team_stat3_label')}</p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- stat2 (Coins Covered): hardcoded "569" → `siteStats.coins_analyzed` (auto-updates on build)
- stat3 (Simulator Sessions): hardcoded "1M+" → `siteStats.simulations_run` (12,847 live count)
- stat3 label updated: "Simulated Trades" → "Simulator Sessions" (KO: "시뮬레이터 실행 수")
- EN + KO about pages both updated

## Why
About page stats were stale hardcoded strings. Coins count and simulation count grow over time and should reflect real platform activity (builds credibility with users).

## Test plan
- [ ] /about shows "569+" for Coins Covered
- [ ] /about shows "12,847" (or updated count) for Simulator Sessions
- [ ] /ko/about shows same values with Korean locale formatting
- [ ] Stats auto-update when site-stats.json is refreshed

🤖 Generated with [Claude Code](https://claude.com/claude-code)