### PR TITLE
ux: show TopStrategyWidget on mobile home (EN+KO)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -109,8 +109,8 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
           Data powered by <span class="text-[--color-text-muted] opacity-80">Binance</span> &amp; <span class="text-[--color-text-muted] opacity-80">CoinGecko</span>
         </p>
       </div>
-      <!-- Right: Live strategy widget (desktop only) -->
-      <div class="hidden md:block">
+      <!-- Right: Live strategy widget -->
+      <div class="mt-6 md:mt-0">
         <TopStrategyWidget client:load lang="en" />
       </div>
       </div>

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -145,8 +145,8 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
           </div>
         </div>
       </div>
-      <!-- Right: Live strategy widget (desktop only) -->
-      <div class="hidden md:block">
+      <!-- Right: Live strategy widget -->
+      <div class="mt-6 md:mt-0">
         <TopStrategyWidget client:load lang="ko" />
       </div>
       </div>


### PR DESCRIPTION
## Summary
- Removed `hidden md:block` from TopStrategyWidget wrapper on home page
- Widget now visible on mobile — stacks below hero text (single column grid on mobile)
- `mt-6 md:mt-0` preserves desktop layout, adds spacing on mobile
- EN + KO home pages both updated

## Why
Mobile users saw no live data in the hero — 100% of the right-column value was invisible on ~50%+ of sessions. The widget loads the #1 strategy on demand (API call) and shows real-time data, which is a key differentiator vs competitors.

## Test plan
- [ ] Mobile: TopStrategyWidget renders below CTA buttons
- [ ] Desktop: Widget still appears in right hero column (no layout change)
- [ ] /ko/ same as English
- [ ] Widget loading skeleton shows correctly on mobile
- [ ] No regression on hero text/CTA layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)