### PR TITLE
ux: add 'Popular' badge to Standard simulator tab

### DIFF
--- a/src/components/ModeSwitcher.tsx
+++ b/src/components/ModeSwitcher.tsx
@@ -36,6 +36,7 @@ const L = {
     expert: "Expert",
     expertSub: "Full control",
     bestStart: "Best Start",
+    mostPopular: "Popular",
     advanced: "advanced",
     ariaLabel: "Simulator mode",
   },
@@ -47,6 +48,7 @@ const L = {
     expert: "엑스퍼트",
     expertSub: "전체 제어",
     bestStart: "추천",
+    mostPopular: "인기",
     advanced: "고급",
     ariaLabel: "시뮬레이터 모드",
   },
@@ -74,7 +76,12 @@ export default function ModeSwitcher({
       sub: t.quickSub,
       badge: isFirstVisit ? t.bestStart : undefined,
     },
-    { key: "standard", label: t.standard, sub: t.standardSub },
+    {
+      key: "standard",
+      label: t.standard,
+      sub: t.standardSub,
+      badge: isFirstVisit ? undefined : t.mostPopular,
+    },
     { key: "expert", label: t.expert, sub: t.expertSub },
   ];
 


### PR DESCRIPTION
## Summary
- Standard tab now shows 'Popular' / '인기' badge on **return visits only**
- First visit: Quick='Best Start', Standard=no badge → guides new users to Quick
- Return visits: Quick=no badge, Standard='Popular' → anchors repeat users to Standard
- Exactly one badge visible at a time, no visual conflict

## Why
Standard tab had no social proof signal on return visits. Adding 'Popular' leverages social proof anchoring (people choose what others choose). EN + KO both covered via L dictionary.

## Test plan
- [ ] First visit: Quick tab has 'Best Start' badge, Standard has none
- [ ] Return visit: Quick tab has no badge, Standard shows 'Popular' badge (green/accent)
- [ ] /ko/simulate: Standard shows '인기' badge on return visits
- [ ] Expert tab unchanged (still has "advanced" corner text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)