### PR TITLE
fix: performance page date dynamic from performance.json (EN+KO)

### DIFF
--- a/src/pages/ko/performance/index.astro
+++ b/src/pages/ko/performance/index.astro
@@ -1,8 +1,12 @@
 ---
 import Layout from '../../../layouts/Layout.astro';
 import { useTranslations } from '../../../i18n/index';
+import perfData from '../../../../public/data/performance.json';
 
 const t = useTranslations('ko');
+const perfUpdated = new Date(
+  (perfData as { generated: string }).generated
+).toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' });
 ---
 
 <Layout title={t('meta.performance_title')} description={t('meta.performance_desc')}>
@@ -20,7 +24,7 @@ const t = useTranslations('ko');
       <h1 class="text-3xl md:text-4xl font-bold mb-4">{t('perf.title')}</h1>
       <p class="text-[--color-text-muted] text-lg mb-4 max-w-2xl">{t('perf.desc')}</p>
       <p class="font-mono text-xs text-[--color-text-muted] mb-6">
-        {t('perf.updated_label')}: <span class="text-[--color-text]">{t('perf.updated_val')}</span>
+        {t('perf.updated_label')}: <span class="text-[--color-text]">{perfUpdated}</span>
         &nbsp;&middot;&nbsp;
         {t('perf.period_label')}: <span class="text-[--color-text]">{t('perf.period_val')}</span>
       </p>

--- a/src/pages/performance/index.astro
+++ b/src/pages/performance/index.astro
@@ -1,8 +1,12 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import { useTranslations } from '../../i18n/index';
+import perfData from '../../../public/data/performance.json';
 
 const t = useTranslations('en');
+const perfUpdated = new Date(
+  (perfData as { generated: string }).generated
+).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
 ---
 
 <Layout title={t('meta.performance_title')} description={t('meta.performance_desc')}>
@@ -20,7 +24,7 @@ const t = useTranslations('en');
       <h1 class="text-3xl md:text-4xl font-bold mb-4">{t('perf.title')}</h1>
       <p class="text-[--color-text-muted] text-lg mb-4 max-w-2xl">{t('perf.desc')}</p>
       <p class="font-mono text-xs text-[--color-text-muted] mb-6">
-        {t('perf.updated_label')}: <span class="text-[--color-text]">{t('perf.updated_val')}</span>
+        {t('perf.updated_label')}: <span class="text-[--color-text]">{perfUpdated}</span>
         &nbsp;&middot;&nbsp;
         {t('perf.period_label')}: <span class="text-[--color-text]">{t('perf.period_val')}</span>
       </p>


### PR DESCRIPTION
## Summary
- Performance page date was hardcoded "Feb 28, 2026" in i18n
- Now reads `generated` field from `public/data/performance.json` at build time
- EN: formatted as "Mar 5, 2026" style; KO: formatted in Korean locale
- Auto-updates on next deploy when performance.json is refreshed

## Why
Audit WARN-1: performance page showed 20-day stale date, signaling abandonment. The page already has an ARCHIVED badge — but the date should still reflect actual data freshness.

## Test plan
- [ ] /performance shows correct date (Mar 5, 2026) from performance.json
- [ ] /ko/performance shows Korean locale date format
- [ ] Date auto-updates when performance.json is regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)