### PR TITLE
fix: raise WORST 3 minimum trades threshold 10 → 30

### DIFF
--- a/src/components/StrategyRanking.tsx
+++ b/src/components/StrategyRanking.tsx
@@ -350,7 +350,7 @@ export function StrategyRanking({ lang = "en" }: { lang?: Lang }) {
           {isFirstLoad
             ? [0, 1, 2].map((i) => <SkeletonCard key={i} />)
             : (data?.worst3 ?? [])
-                .filter((e) => e.total_trades >= 10)
+                .filter((e) => e.total_trades >= 30)
                 .map((entry) => (
                   <RankingCard
                     key={`worst-${entry.rank}`}

--- a/src/components/WeeklyLeaderboard.tsx
+++ b/src/components/WeeklyLeaderboard.tsx
@@ -119,8 +119,8 @@ export default function WeeklyLeaderboard({ lang }: Props) {
       ? data.weekly_best3
       : (data?.top3 ?? []);
   const weeklyEntries = rawWeekly.filter(hasValidTrades);
-  // worst3: require at least 10 trades to avoid statistical noise (matches daily ranking threshold)
-  const worstEntries = (data?.worst3 ?? []).filter((e) => e.total_trades >= 10);
+  // worst3: require at least 30 trades for statistical reliability
+  const worstEntries = (data?.worst3 ?? []).filter((e) => e.total_trades >= 30);
   // Detect when all valid entries are low_sample (INFO-2)
   const allLowSample =
     weeklyEntries.length > 0 && weeklyEntries.every((e) => e.low_sample);

--- a/src/pages/ko/strategies/ranking.astro
+++ b/src/pages/ko/strategies/ranking.astro
@@ -162,7 +162,7 @@ if (!ssrRanking) {
           </div>
           <p class="font-mono text-[--color-red] text-xs mb-3 tracking-wider">하위 3개</p>
           <div class="grid md:grid-cols-3 gap-4 mb-2">
-            {ssrRanking.worst3.filter(e => e.total_trades >= 10).map((entry) => {
+            {ssrRanking.worst3.filter(e => e.total_trades >= 30).map((entry) => {
               const medals = ['🥇','🥈','🥉'];
               const medal = medals[entry.rank - 1] ?? `#${entry.rank}`;
               const wrColor = entry.win_rate >= 55 ? 'text-[--color-up]' : entry.win_rate >= 50 ? 'text-[--color-yellow]' : 'text-[--color-red]';

--- a/src/pages/strategies/ranking.astro
+++ b/src/pages/strategies/ranking.astro
@@ -172,7 +172,7 @@ if (!ssrRanking) {
           </div>
           <p class="font-mono text-[--color-red] text-xs mb-3 tracking-wider">WORST 3</p>
           <div class="grid md:grid-cols-3 gap-4 mb-2">
-            {ssrRanking.worst3.filter(e => e.total_trades >= 10).map((entry) => {
+            {ssrRanking.worst3.filter(e => e.total_trades >= 30).map((entry) => {
               const medals = ['🥇','🥈','🥉'];
               const medal = medals[entry.rank - 1] ?? `#${entry.rank}`;
               const wrColor = entry.win_rate >= 55 ? 'text-[--color-up]' : entry.win_rate >= 50 ? 'text-[--color-yellow]' : 'text-[--color-red]';


### PR DESCRIPTION
## Summary
- Raised minimum trades for WORST 3 inclusion from 10 → 30
- 4 places updated: StrategyRanking.tsx, WeeklyLeaderboard.tsx, ranking.astro (EN+KO) SSR
- Strategies with <30 weekly/daily trades excluded from WORST 3

## Why
Audit WARN-6: 5-trade strategy labeled as "worst" is statistically meaningless. 30 trades provides basic reliability for win rate estimates (±14% margin at 95% CI). Below 30 = noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)