### PR TITLE
fix: market dashboard cached fallback — no error page on API failure (CRIT-1)

### DIFF
--- a/src/components/MarketDashboard.tsx
+++ b/src/components/MarketDashboard.tsx
@@ -241,10 +241,25 @@ function getFGSegment(value: number) {
   return FG_SCALE.find((s) => value >= s.min && value < s.max) || FG_SCALE[0];
 }
 
+interface MarketDataShape {
+  btc_price: number;
+  btc_change_24h: number;
+  eth_price: number;
+  eth_change_24h: number;
+  fear_greed_index: number;
+  fear_greed_label: string;
+  total_market_cap_b: number;
+  btc_dominance: number;
+  total_volume_24h_b: number;
+  generated: string;
+}
+
 export default function MarketDashboard({
   lang = "en",
+  initialMarket = null,
 }: {
   lang?: "en" | "ko";
+  initialMarket?: MarketDataShape | null;
 }) {
   const l = labels[lang] || labels.en;
   const [coinsCount, setCoinsCount] = useState("569");
@@ -304,9 +319,13 @@ export default function MarketDashboard({
     return () => clearInterval(id);
   }, [generated]);
 
+  // Effective market: live hook data first, then SSR-injected cached fallback
+  const effectiveMarket = market || initialMarket;
+
   // Determine if we have enough data to render (either live prices or market overview)
-  const hasData = btcPrice > 0 || market;
-  const hasError = liveErr && marketErr;
+  const hasData = btcPrice > 0 || effectiveMarket;
+  // Only show error if we have no data at all (cached fallback prevents error state)
+  const hasError = liveErr && marketErr && !effectiveMarket;
 
   const activeNewsSources =
     newsTab === "crypto" ? CRYPTO_SOURCES : MACRO_SOURCES;
@@ -328,30 +347,36 @@ export default function MarketDashboard({
       return true;
     }) ?? [];
 
-  // Use live prices (30s) with fallback to market overview (5min)
-  const displayBtcPrice = btcPrice || market?.btc_price || 0;
-  const displayBtcChange = btcPrice ? btcChange : (market?.btc_change_24h ?? 0);
-  const displayEthPrice = ethPrice || market?.eth_price || 0;
-  const displayEthChange = ethPrice ? ethChange : (market?.eth_change_24h ?? 0);
+  // Use live prices (30s) with fallback to market overview (5min) or cached initial data
+  const displayBtcPrice = btcPrice || effectiveMarket?.btc_price || 0;
+  const displayBtcChange = btcPrice
+    ? btcChange
+    : (effectiveMarket?.btc_change_24h ?? 0);
+  const displayEthPrice = ethPrice || effectiveMarket?.eth_price || 0;
+  const displayEthChange = ethPrice
+    ? ethChange
+    : (effectiveMarket?.eth_change_24h ?? 0);
 
   // Display helpers
   const totalMcapDisplay =
-    market && market.total_market_cap_b
-      ? `$${market.total_market_cap_b.toFixed(0)}B`
+    effectiveMarket && effectiveMarket.total_market_cap_b
+      ? `$${effectiveMarket.total_market_cap_b.toFixed(0)}B`
       : "—";
   const btcDomDisplay =
-    market && market.btc_dominance ? `${market.btc_dominance}%` : "—";
+    effectiveMarket && effectiveMarket.btc_dominance
+      ? `${effectiveMarket.btc_dominance}%`
+      : "—";
   const volume24hDisplay =
-    market && market.total_volume_24h_b
-      ? `$${market.total_volume_24h_b.toFixed(0)}B`
+    effectiveMarket && effectiveMarket.total_volume_24h_b
+      ? `$${effectiveMarket.total_volume_24h_b.toFixed(0)}B`
       : "—";
 
   // Fear & Greed gauge
-  const fgSegment = market
-    ? getFGSegment(market.fear_greed_index)
+  const fgSegment = effectiveMarket
+    ? getFGSegment(effectiveMarket.fear_greed_index)
     : FG_SCALE[0];
-  const fgPct = market
-    ? Math.max(0, Math.min(100, market.fear_greed_index))
+  const fgPct = effectiveMarket
+    ? Math.max(0, Math.min(100, effectiveMarket.fear_greed_index))
     : 0;
 
   return (
@@ -441,7 +466,7 @@ export default function MarketDashboard({
           {/* Stat Cards — 5min market overview refresh */}
           <div class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
             {/* Fear & Greed with enhanced gauge */}
-            {market ? (
+            {effectiveMarket ? (
               <div
                 class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover"
                 style={{ backgroundColor: `${fgSegment.color}10` }}
@@ -454,7 +479,7 @@ export default function MarketDashboard({
                     class="text-2xl font-bold font-mono"
                     style={{ color: fgSegment.color }}
                   >
-                    {market.fear_greed_index}
+                    {effectiveMarket.fear_greed_index}
                   </span>
                   <span class="text-sm font-mono text-[--color-text-muted]">
                     / 100
@@ -467,7 +492,7 @@ export default function MarketDashboard({
                     class="w-full bg-[--color-bg-hover] rounded-full overflow-hidden"
                     style={{ height: "8px" }}
                     role="img"
-                    aria-label={`Fear and Greed gauge ${market.fear_greed_index} out of 100`}
+                    aria-label={`Fear and Greed gauge ${effectiveMarket.fear_greed_index} out of 100`}
                   >
                     <div
                       style={{
@@ -502,7 +527,9 @@ export default function MarketDashboard({
                   class="text-xs font-semibold"
                   style={{ color: fgSegment.color }}
                 >
-                  {lang === "ko" ? fgSegment.labelKo : market.fear_greed_label}
+                  {lang === "ko"
+                    ? fgSegment.labelKo
+                    : effectiveMarket.fear_greed_label}
                 </div>
               </div>
             ) : (

--- a/src/pages/ko/market/index.astro
+++ b/src/pages/ko/market/index.astro
@@ -1,8 +1,10 @@
 ---
 import Layout from '../../../layouts/Layout.astro';
 import { useTranslations } from '../../../i18n/index';
+import marketDataRaw from '../../../../public/data/market.json';
 
 const t = useTranslations('ko');
+const marketDataJson = JSON.stringify(marketDataRaw);
 ---
 
 <Layout title={t('meta.market_title')} description={t('meta.market_desc')}>
@@ -13,7 +15,7 @@ const t = useTranslations('ko');
       <p class="text-[--color-text-muted] text-lg mb-8 max-w-2xl">
         {t('market.desc')}
       </p>
-      <div id="market-mount">
+      <div id="market-mount" data-initial-market={marketDataJson}>
         <div class="animate-pulse space-y-4">
           <div class="flex gap-4 flex-wrap">
             <div class="flex-1 min-w-[200px] h-16 bg-[--color-bg-hover] rounded-lg"></div>
@@ -54,7 +56,8 @@ const t = useTranslations('ko');
 
     const mount = document.getElementById('market-mount');
     if (mount) {
-      render(h(ErrorBoundary, { name: 'Market Dashboard', lang: 'ko' }, h(MarketDashboard, { lang: 'ko' })), mount);
+      const initialMarket = JSON.parse(mount.dataset.initialMarket || 'null');
+      render(h(ErrorBoundary, { name: 'Market Dashboard', lang: 'ko' }, h(MarketDashboard, { lang: 'ko', initialMarket })), mount);
     }
   </script>
 </Layout>

--- a/src/pages/market/index.astro
+++ b/src/pages/market/index.astro
@@ -1,8 +1,10 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import { useTranslations } from '../../i18n/index';
+import marketDataRaw from '../../../public/data/market.json';
 
 const t = useTranslations('en');
+const marketDataJson = JSON.stringify(marketDataRaw);
 ---
 
 <Layout title={t('meta.market_title')} description={t('meta.market_desc')}>
@@ -13,7 +15,7 @@ const t = useTranslations('en');
       <p class="text-[--color-text-muted] text-lg mb-8 max-w-2xl">
         {t('market.desc')}
       </p>
-      <div id="market-mount">
+      <div id="market-mount" data-initial-market={marketDataJson}>
         <div class="animate-pulse space-y-4">
           <div class="flex gap-4 flex-wrap">
             <div class="flex-1 min-w-[200px] h-16 bg-[--color-bg-hover] rounded-lg"></div>
@@ -54,7 +56,8 @@ const t = useTranslations('en');
 
     const mount = document.getElementById('market-mount');
     if (mount) {
-      render(h(ErrorBoundary, { name: 'Market Dashboard' }, h(MarketDashboard, { lang: 'en' })), mount);
+      const initialMarket = JSON.parse(mount.dataset.initialMarket || 'null');
+      render(h(ErrorBoundary, { name: 'Market Dashboard' }, h(MarketDashboard, { lang: 'en', initialMarket })), mount);
     }
   </script>
 </Layout>


### PR DESCRIPTION
## Problem
Market page showed "Something went wrong loading Market Dashboard" when the live API was unreachable (e.g., CoinGecko 429 rate limiting). First-time visitors landing on /market saw a full error state, creating immediate distrust.

## Fix
- **`MarketDashboard.tsx`**: Accepts new `initialMarket` prop (build-time cached data). Introduces `effectiveMarket = market || initialMarket` so the component always has data to render.
  - `hasData = btcPrice > 0 || effectiveMarket` — cached data counts as valid
  - `hasError` only shown if both live hooks fail AND no cached fallback exists
  - All display vars (BTC price, ETH price, F&G, Market Cap, BTC Dom, Volume) use `effectiveMarket`
- **`market/index.astro` + `ko/market/index.astro`**: Import `market.json` at build time, serialize to `data-initial-market` attribute on the mount div. Client script reads and parses it, passes as `initialMarket` prop.

## Behavior after fix
- **Normal case**: Live API works → live data renders as before
- **API failure case**: `initialMarket` (last cron refresh, ≤20 min old) renders immediately. Existing staleness banner (`staleWarning` / `staleWarningSevere`) shows if data is >30 min old.
- **Total failure** (API down + market.json missing): Only then shows error/retry UI

## Test plan
- [ ] `npm run build` passes ✅
- [ ] `/market` renders BTC/ETH prices and F&G gauge on first load
- [ ] Error state no longer shown when `api.pruviq.com` is unreachable (test with DevTools → block api.pruviq.com)
- [ ] KO market page `/ko/market` works identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)