### PR TITLE
fix: WCAG AA accessibility — simulator form control labels

### DIFF
--- a/src/components/ConditionRow.tsx
+++ b/src/components/ConditionRow.tsx
@@ -1,9 +1,9 @@
 /**
  * ConditionRow.tsx - Single entry condition row
  */
-import { useState } from 'preact/hooks';
-import type { Condition } from './simulator-types';
-import { OPS, booleanFields } from './simulator-types';
+import { useState } from "preact/hooks";
+import type { Condition } from "./simulator-types";
+import { OPS, booleanFields } from "./simulator-types";
 
 interface Props {
   condition: Condition;
@@ -16,67 +16,76 @@ interface Props {
   currLabel?: string;
 }
 
-export default function ConditionRow({ condition: c, availableFields, onUpdate, onRemove, removeLabel, lookAheadWarning = 'Using current (incomplete) candle data may cause look-ahead bias in live trading', prevLabel = 'Prev', currLabel = 'Curr' }: Props) {
+export default function ConditionRow({
+  condition: c,
+  availableFields,
+  onUpdate,
+  onRemove,
+  removeLabel,
+  lookAheadWarning = "Using current (incomplete) candle data may cause look-ahead bias in live trading",
+  prevLabel = "Prev",
+  currLabel = "Curr",
+}: Props) {
   const fieldDescriptions: Record<string, string> = {
-    'is_squeeze': 'Bollinger Band Squeeze detected',
-    'bb_width_change': 'BB width expansion rate (%)',
-    'vol_ratio': 'Volume ratio vs average',
-    'bearish': 'Bearish candle pattern',
-    'bullish': 'Bullish candle pattern',
-    'ema_fast': 'Fast EMA value',
-    'ema_slow': 'Slow EMA value',
-    'rsi': 'RSI (Relative Strength Index)',
-    'macd_hist': 'MACD Histogram',
-    'stoch_k': 'Stochastic %K',
-    'stoch_d': 'Stochastic %D',
-    'adx': 'ADX (Average Directional Index)',
-    'atr': 'ATR (Average True Range)',
-    'hv': 'Historical Volatility',
-    'price_change': 'Price change (%)',
-    'close': 'Close price',
-    'open': 'Open price',
-    'high': 'High price',
-    'low': 'Low price',
-    'volume': 'Trading volume',
-    'bb_upper': 'Bollinger Band upper',
-    'bb_lower': 'Bollinger Band lower',
-    'bb_mid': 'Bollinger Band middle',
-    'ema20': 'EMA 20-period',
-    'ema50': 'EMA 50-period',
-    'uptrend': 'Uptrend detected',
-    'downtrend': 'Downtrend detected',
-    'doji': 'Doji candle pattern',
+    is_squeeze: "Bollinger Band Squeeze detected",
+    bb_width_change: "BB width expansion rate (%)",
+    vol_ratio: "Volume ratio vs average",
+    bearish: "Bearish candle pattern",
+    bullish: "Bullish candle pattern",
+    ema_fast: "Fast EMA value",
+    ema_slow: "Slow EMA value",
+    rsi: "RSI (Relative Strength Index)",
+    macd_hist: "MACD Histogram",
+    stoch_k: "Stochastic %K",
+    stoch_d: "Stochastic %D",
+    adx: "ADX (Average Directional Index)",
+    atr: "ATR (Average True Range)",
+    hv: "Historical Volatility",
+    price_change: "Price change (%)",
+    close: "Close price",
+    open: "Open price",
+    high: "High price",
+    low: "Low price",
+    volume: "Trading volume",
+    bb_upper: "Bollinger Band upper",
+    bb_lower: "Bollinger Band lower",
+    bb_mid: "Bollinger Band middle",
+    ema20: "EMA 20-period",
+    ema50: "EMA 50-period",
+    uptrend: "Uptrend detected",
+    downtrend: "Downtrend detected",
+    doji: "Doji candle pattern",
   };
 
   const fieldLabels: Record<string, string> = {
-    'is_squeeze': 'BB Squeeze (is_squeeze)',
-    'bb_width_change': 'BB Width \u0394% (bb_width_change)',
-    'vol_ratio': 'Volume Ratio (vol_ratio)',
-    'bearish': 'Bearish Pattern (bearish)',
-    'bullish': 'Bullish Pattern (bullish)',
-    'ema_fast': 'EMA Fast (ema_fast)',
-    'ema_slow': 'EMA Slow (ema_slow)',
-    'rsi': 'RSI (rsi)',
-    'macd_hist': 'MACD Histogram (macd_hist)',
-    'stoch_k': 'Stochastic %K (stoch_k)',
-    'stoch_d': 'Stochastic %D (stoch_d)',
-    'adx': 'ADX (adx)',
-    'atr': 'ATR (atr)',
-    'hv': 'Hist. Volatility (hv)',
-    'price_change': 'Price Change % (price_change)',
-    'close': 'Close (close)',
-    'open': 'Open (open)',
-    'high': 'High (high)',
-    'low': 'Low (low)',
-    'volume': 'Volume (volume)',
-    'bb_upper': 'BB Upper (bb_upper)',
-    'bb_lower': 'BB Lower (bb_lower)',
-    'bb_mid': 'BB Mid (bb_mid)',
-    'ema20': 'EMA 20 (ema20)',
-    'ema50': 'EMA 50 (ema50)',
-    'uptrend': 'Uptrend (uptrend)',
-    'downtrend': 'Downtrend (downtrend)',
-    'doji': 'Doji (doji)',
+    is_squeeze: "BB Squeeze (is_squeeze)",
+    bb_width_change: "BB Width \u0394% (bb_width_change)",
+    vol_ratio: "Volume Ratio (vol_ratio)",
+    bearish: "Bearish Pattern (bearish)",
+    bullish: "Bullish Pattern (bullish)",
+    ema_fast: "EMA Fast (ema_fast)",
+    ema_slow: "EMA Slow (ema_slow)",
+    rsi: "RSI (rsi)",
+    macd_hist: "MACD Histogram (macd_hist)",
+    stoch_k: "Stochastic %K (stoch_k)",
+    stoch_d: "Stochastic %D (stoch_d)",
+    adx: "ADX (adx)",
+    atr: "ATR (atr)",
+    hv: "Hist. Volatility (hv)",
+    price_change: "Price Change % (price_change)",
+    close: "Close (close)",
+    open: "Open (open)",
+    high: "High (high)",
+    low: "Low (low)",
+    volume: "Volume (volume)",
+    bb_upper: "BB Upper (bb_upper)",
+    bb_lower: "BB Lower (bb_lower)",
+    bb_mid: "BB Mid (bb_mid)",
+    ema20: "EMA 20 (ema20)",
+    ema50: "EMA 50 (ema50)",
+    uptrend: "Uptrend (uptrend)",
+    downtrend: "Downtrend (downtrend)",
+    doji: "Doji (doji)",
   };
 
   const [showInfo, setShowInfo] = useState(false);
@@ -89,17 +98,22 @@ export default function ConditionRow({ condition: c, availableFields, onUpdate, 
           value={c.field}
           onChange={(e: Event) => {
             const newField = (e.target as HTMLSelectElement).value;
-            onUpdate(c.id, 'field', newField);
+            onUpdate(c.id, "field", newField);
             if (booleanFields.has(newField)) {
-              onUpdate(c.id, 'op', '==');
-              onUpdate(c.id, 'value', true);
+              onUpdate(c.id, "op", "==");
+              onUpdate(c.id, "value", true);
             }
             setShowInfo(false);
           }}
           class="flex-1 min-w-0 px-1.5 py-1.5 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
           title={fieldDescriptions[c.field] || c.field}
+          aria-label="Indicator field"
         >
-          {availableFields.map((f) => <option key={f} value={f} title={fieldDescriptions[f] || f}>{fieldLabels[f] || f}</option>)}
+          {availableFields.map((f) => (
+            <option key={f} value={f} title={fieldDescriptions[f] || f}>
+              {fieldLabels[f] || f}
+            </option>
+          ))}
         </select>
         {/* Info toggle */}
         <button
@@ -111,59 +125,102 @@ export default function ConditionRow({ condition: c, availableFields, onUpdate, 
         >
           i
         </button>
-      {/* Op */}
-      <select
-        value={c.op}
-        onChange={(e: Event) => onUpdate(c.id, 'op', (e.target as HTMLSelectElement).value)}
-        class="w-12 px-1 py-1.5 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
-      >
-        {OPS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
-      </select>
-      {/* Value */}
-      {booleanFields.has(c.field) ? (
+        {/* Op */}
         <select
-          value={String(c.value)}
-          onChange={(e: Event) => onUpdate(c.id, 'value', (e.target as HTMLSelectElement).value === 'true')}
-          class="w-14 px-1 py-1.5 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
+          value={c.op}
+          onChange={(e: Event) =>
+            onUpdate(c.id, "op", (e.target as HTMLSelectElement).value)
+          }
+          class="w-12 px-1 py-1.5 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
+          aria-label="Comparison operator"
         >
-          <option value="true">true</option>
-          <option value="false">false</option>
+          {OPS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
         </select>
-      ) : (
-        <input
-          type="number"
-          step="any"
-          value={c.value as number}
-          onChange={(e: Event) => onUpdate(c.id, 'value', parseFloat((e.target as HTMLInputElement).value))}
-          class="w-16 px-1.5 py-1.5 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
-        />
-      )}
-      {/* Shift */}
-      <select
-        value={c.shift}
-        onChange={(e: Event) => onUpdate(c.id, 'shift', parseInt((e.target as HTMLSelectElement).value))}
-        class={`w-12 px-1 py-1.5 bg-[--color-bg-tooltip] border rounded font-mono text-xs outline-none focus:border-[--color-accent] ${
-          c.shift === 0
-            ? 'border-[--color-yellow] text-[--color-yellow] font-bold'
-            : 'border-[--color-border] text-[--color-text]'
-        }`}
-        title={c.shift === 1 ? 'Previous candle (confirmed/safe for live trading)' : 'Current candle (incomplete in live) — look-ahead bias risk!'}
-      >
-        <option value="1">{prevLabel}</option>
-        <option value="0">{currLabel}</option>
-      </select>
-      {c.shift === 0 && (
-        <span class="text-[--color-yellow] text-[9px] font-mono shrink-0" title={lookAheadWarning} role="img" aria-label={lookAheadWarning}>!</span>
-      )}
-      {/* Remove */}
-      <button
-        onClick={() => onRemove(c.id)}
-        class="text-[--color-text-muted] hover:text-[--color-red] px-1"
-        title={removeLabel}
-        aria-label={removeLabel}
-      >
-        x
-      </button>
+        {/* Value */}
+        {booleanFields.has(c.field) ? (
+          <select
+            value={String(c.value)}
+            onChange={(e: Event) =>
+              onUpdate(
+                c.id,
+                "value",
+                (e.target as HTMLSelectElement).value === "true",
+              )
+            }
+            class="w-14 px-1 py-1.5 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
+            aria-label="Boolean value"
+          >
+            <option value="true">true</option>
+            <option value="false">false</option>
+          </select>
+        ) : (
+          <input
+            type="number"
+            step="any"
+            value={c.value as number}
+            onChange={(e: Event) =>
+              onUpdate(
+                c.id,
+                "value",
+                parseFloat((e.target as HTMLInputElement).value),
+              )
+            }
+            class="w-16 px-1.5 py-1.5 bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
+            aria-label="Comparison value"
+          />
+        )}
+        {/* Shift */}
+        <select
+          value={c.shift}
+          onChange={(e: Event) =>
+            onUpdate(
+              c.id,
+              "shift",
+              parseInt((e.target as HTMLSelectElement).value),
+            )
+          }
+          class={`w-12 px-1 py-1.5 bg-[--color-bg-tooltip] border rounded font-mono text-xs outline-none focus:border-[--color-accent] ${
+            c.shift === 0
+              ? "border-[--color-yellow] text-[--color-yellow] font-bold"
+              : "border-[--color-border] text-[--color-text]"
+          }`}
+          title={
+            c.shift === 1
+              ? "Previous candle (confirmed/safe for live trading)"
+              : "Current candle (incomplete in live) — look-ahead bias risk!"
+          }
+          aria-label={
+            c.shift === 1
+              ? "Candle: previous (confirmed)"
+              : "Candle: current (look-ahead bias risk)"
+          }
+        >
+          <option value="1">{prevLabel}</option>
+          <option value="0">{currLabel}</option>
+        </select>
+        {c.shift === 0 && (
+          <span
+            class="text-[--color-yellow] text-[9px] font-mono shrink-0"
+            title={lookAheadWarning}
+            role="img"
+            aria-label={lookAheadWarning}
+          >
+            !
+          </span>
+        )}
+        {/* Remove */}
+        <button
+          onClick={() => onRemove(c.id)}
+          class="text-[--color-text-muted] hover:text-[--color-red] px-1"
+          title={removeLabel}
+          aria-label={removeLabel}
+        >
+          x
+        </button>
       </div>
       {/* Info panel */}
       {showInfo && fieldDescriptions[c.field] && (

--- a/src/components/ResultsPanel.tsx
+++ b/src/components/ResultsPanel.tsx
@@ -405,6 +405,7 @@ export default function ResultsPanel({
                       setQaSl(parseFloat((e.target as HTMLInputElement).value))
                     }
                     class="slider-range mt-1"
+                    aria-label={`Stop Loss ${qaSl}%`}
                     style={{
                       background: `linear-gradient(to right, ${COLORS.red} 0%, ${COLORS.red} ${((qaSl - 1) / 49) * 100}%, var(--color-border) ${((qaSl - 1) / 49) * 100}%, var(--color-border) 100%)`,
                     }}
@@ -425,6 +426,7 @@ export default function ResultsPanel({
                       setQaTp(parseFloat((e.target as HTMLInputElement).value))
                     }
                     class="slider-range mt-1"
+                    aria-label={`Take Profit ${qaTp}%`}
                     style={{
                       background: `linear-gradient(to right, ${COLORS.green} 0%, ${COLORS.green} ${((qaTp - 1) / 49) * 100}%, var(--color-border) ${((qaTp - 1) / 49) * 100}%, var(--color-border) 100%)`,
                     }}
@@ -445,6 +447,7 @@ export default function ResultsPanel({
                       setQaCoins(parseInt((e.target as HTMLInputElement).value))
                     }
                     class="slider-range mt-1"
+                    aria-label={`Coins ${qaCoins}`}
                     style={{
                       background: `linear-gradient(to right, ${COLORS.accent} 0%, ${COLORS.accent} ${((qaCoins - 1) / 568) * 100}%, var(--color-border) ${((qaCoins - 1) / 568) * 100}%, var(--color-border) 100%)`,
                     }}


### PR DESCRIPTION
## Summary
- **ConditionRow.tsx**: Added `aria-label` to all 4 `<select>` elements (indicator field, comparison operator, boolean value, candle shift) and the numeric comparison value `<input type="number">`. Previously these only had `title` attributes which screen readers may ignore.
- **ResultsPanel.tsx**: Added `aria-label` to 3 `<input type="range">` sliders (Stop Loss, Take Profit, Coins) — the existing `<label>` elements lack `htmlFor`/`id` pairing so explicit association was missing.

## Already compliant (no changes needed)
- Skip nav link at top of Layout.astro ✅
- Mobile menu `aria-hidden` toggle in layout-client.js ✅
- Global `focus-visible` ring in global.css ✅
- `aria-expanded` / `aria-controls` on hamburger button ✅
- `aria-label` on hamburger, lang switcher, and remove buttons ✅

## Test plan
- [ ] Screen reader (VoiceOver/NVDA): ConditionRow selects announce their purpose
- [ ] Screen reader: Range sliders in Quick Adjust panel announced correctly
- [ ] `npm run build` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)