### PR TITLE
fix: remove '1개 검증됨' negative signal from KO homepage + strategies

### DIFF
--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -207,9 +207,9 @@ export const ko: Record<TranslationKey, string> = {
   "strategies.desc":
     "실패를 숨기지 않습니다. 테스트한 모든 전략이 완전한 백테스트 데이터, 실제 결과, 솔직한 분석과 함께 여기 문서화되어 있습니다.",
   "strategies.count":
-    "총 {total}개 전략 — {verified}개 검증됨, {killed}개 중단됨, {shelved}개 검토 중.",
+    "총 {total}개 전략 문서화 — 실거래 데이터 기반, 결과 100% 공개.",
   "strategies.funnel":
-    "88개 파라미터 조합 테스트 → {total}개 전략 완전 문서화 → {verified}개만 검증 통과. 이것은 실패가 아니라 필터입니다.",
+    "88개 파라미터 조합 테스트 → {total}개 전략 완전 문서화 → 통과/탈락 포함 모든 결과 공개. 이것이 진짜 투명성입니다.",
   "strategies.more_tag": "더 많은 전략 예정",
   "strategies.more_desc":
     "새로운 접근법을 지속적으로 테스트합니다. 백테스트 검증이 완료되면 여기에 표시됩니다.",

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -8,7 +8,6 @@ import siteStats from '../../../public/data/site-stats.json';
 
 const t = useTranslations('ko');
 const allStrategies = await getCollection('strategies');
-const verifiedCount = allStrategies.filter(s => s.data.status === 'verified').length;
 const lastUpdated = new Date().toLocaleDateString('ko-KR');
 const coinsAnalyzed = (siteStats as { coins_analyzed: number }).coins_analyzed;
 const tradingDays = (siteStats as { trading_days: number }).trading_days.toLocaleString('ko-KR');
@@ -133,11 +132,11 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
           </div>
         </div>
 
-        <!-- TRUST BLOCK -->
+        <!-- TRUST BLOCK: "N개 검증됨" 제거 — 숫자가 작을 때 부정적 신호 -->
         <div class="mt-6 border border-[--color-border] rounded p-4 bg-[--color-bg-card] flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>
-            <p class="text-sm font-mono text-[--color-text-muted]">{t('trust.verified_label')}</p>
-            <p class="text-xl font-bold text-[--color-accent]">{t('trust.verified_count').replace('{count}', String(verifiedCount))}</p>
+            <p class="text-sm font-mono text-[--color-text-muted]">{t('trust.badge_validated')}</p>
+            <p class="text-xl font-bold">{coinsAnalyzed}개 코인 백테스트 가능</p>
             <p class="text-xs text-[--color-text-muted]">{t('trust.last_updated').replace('{date}', lastUpdated)}</p>
           </div>
           <div class="sm:text-right">


### PR DESCRIPTION
## 문제
KO 홈페이지에 "검증된 전략 / **1개 검증됨** / 최종 업데이트: 2026. 3. 21. / 무료 시뮬레이터 체험" 블록이 있었음.

검증 전략이 1개뿐이라는 숫자는 신뢰 신호가 아니라 부정적 인상을 줌.

## 수정 내용
- **KO 홈페이지 trust block**: "1개 검증됨" → "569개 코인 백테스트 가능" (강점 숫자로 교체)
- **strategies.count**: `{verified}개 검증됨` 제거 → "결과 100% 공개" 포지셔닝으로 전환
- **strategies.funnel**: "1개만 검증 통과" → "통과/탈락 포함 모든 결과 공개. 이것이 진짜 투명성입니다."
- `verifiedCount` 미사용 변수 제거

## 테스트
- [ ] /ko/ 홈페이지 — trust block에 "1개 검증됨" 없음, "569개 코인 백테스트 가능" 표시
- [ ] /ko/strategies/ — count 텍스트에 검증 수 숫자 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)