### PR TITLE
ux: final polish — CSV export, cookie shadow, strategies copy

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -207,9 +207,9 @@ export const en = {
   "strategies.desc":
     "We don't hide failures. Every strategy we've tested is documented here with full backtest data, real results, and honest analysis of what worked and what didn't.",
   "strategies.count":
-    "{total} strategies documented — {verified} active, {killed} retired, {shelved} under review.",
+    "{total} strategies documented — real market data, 100% results published.",
   "strategies.funnel":
-    "88 parameter combinations tested → {total} strategies fully documented → {verified} survived validation. This is the filter, not the failure.",
+    "88 parameter combinations tested → {total} strategies fully documented → pass and fail results all published. That's real transparency.",
   "strategies.more_tag": "MORE STRATEGIES COMING",
   "strategies.more_desc":
     "We continuously test new approaches. Documented strategies will appear here as they complete backtesting validation.",
@@ -557,6 +557,7 @@ export const en = {
   "perf.equity_title": "Live Trading Equity Curve",
   "perf.equity_desc":
     "Cumulative PnL from live trading (Jan 13 – Mar 5, 2026). Strategy paused after MDD exceeded the 20% risk limit.",
+  "perf.download_csv": "Download CSV",
   "perf.download_json": "Download JSON",
   "perf.verify_title": "Verify It Yourself",
   "perf.verify_desc":

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -559,6 +559,7 @@ export const ko: Record<TranslationKey, string> = {
   "perf.equity_desc":
     "실거래 누적 PnL (2026년 1월 13일 – 3월 5일). MDD가 20% 리스크 한도를 초과하여 전략이 중단되었습니다.",
   "perf.download_json": "JSON 다운로드",
+  "perf.download_csv": "CSV 다운로드",
   "perf.verify_title": "직접 확인하세요",
   "perf.verify_desc":
     "저희를 믿지 마세요. 시뮬레이터에서 SL/TP를 조정하여 결과가 실시간으로 변하는 것을 직접 확인하세요.",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -566,7 +566,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
       })();
     </script>
     <!-- Cookie Notice (GDPR essential notice) -->
-    <div id="cookie-notice" class="fixed bottom-0 max-sm:bottom-auto max-sm:top-16 left-0 right-0 z-40 bg-[--color-bg-card] border-t border-[--color-border] max-sm:border-t-0 max-sm:border-b px-4 py-3 flex items-center justify-between gap-4 text-sm" style="display:none" aria-live="polite">
+    <div id="cookie-notice" class="fixed bottom-0 max-sm:bottom-auto max-sm:top-16 left-0 right-0 z-40 bg-[--color-bg-card] shadow-[0_-2px_12px_rgba(0,0,0,0.35)] max-sm:shadow-none max-sm:border-b border-[--color-border] px-4 py-3 flex items-center justify-between gap-4 text-sm" style="display:none" aria-live="polite">
       <p class="text-[--color-text-muted] text-xs max-w-xl">{t('cookie.notice')}</p>
       <button id="cookie-ok" class="shrink-0 font-mono text-xs px-3 py-1.5 rounded border border-[--color-border] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
         {t('cookie.ok')}

--- a/src/pages/ko/performance/index.astro
+++ b/src/pages/ko/performance/index.astro
@@ -207,14 +207,19 @@ const xLast = daily[daily.length - 1]?.date ?? '';
           </span></span>
           <span class="text-[--color-text-muted]">MDD: <span class="text-[--color-red]">{(perfData as any).summary?.max_drawdown_pct ?? '—'}%</span></span>
           <span class="text-[--color-text-muted]">거래 수: <span class="text-[--color-text]">{(perfData as any).summary?.total_trades ?? '—'}</span></span>
-          <a
-            href="/data/performance.json"
-            download="pruviq-performance.json"
-            class="ml-auto border border-[--color-border] px-3 py-1.5 rounded text-[--color-text-muted] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors no-underline"
-            title="JSON 형식으로 퍼포먼스 데이터 다운로드"
-          >
-            &#8595; {t('perf.download_json')}
-          </a>
+          <div class="ml-auto flex gap-2">
+            <button id="dl-csv-btn" class="border border-[--color-border] px-3 py-1.5 rounded text-[--color-text-muted] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors cursor-pointer bg-transparent font-mono text-xs" title="CSV 형식으로 일별 PnL 데이터 다운로드">
+              &#8595; {t('perf.download_csv')}
+            </button>
+            <a
+              href="/data/performance.json"
+              download="pruviq-performance.json"
+              class="border border-[--color-border] px-3 py-1.5 rounded text-[--color-text-muted] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors no-underline"
+              title="JSON 형식으로 퍼포먼스 데이터 다운로드"
+            >
+              &#8595; {t('perf.download_json')}
+            </a>
+          </div>
         </div>
       </div>
     </section>
@@ -356,3 +361,19 @@ const xLast = daily[daily.length - 1]?.date ?? '';
   </section>
 
 </Layout>
+
+<script>
+  document.getElementById('dl-csv-btn')?.addEventListener('click', async () => {
+    const r = await fetch('/data/performance.json');
+    const d = await r.json();
+    const rows = [['date','pnl','cum_pnl','trades']];
+    (d.daily || []).forEach((e: {date:string;pnl:number;cum_pnl:number;trades:number}) => {
+      rows.push([e.date, String(e.pnl), String(e.cum_pnl), String(e.trades)]);
+    });
+    const csv = rows.map((r: string[]) => r.join(',')).join('\n');
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(new Blob([csv], {type:'text/csv'}));
+    a.download = 'pruviq-performance-daily.csv';
+    a.click();
+  });
+</script>

--- a/src/pages/performance/index.astro
+++ b/src/pages/performance/index.astro
@@ -249,16 +249,40 @@ const xLast = daily[daily.length - 1]?.date ?? '';
           <span class="text-[--color-text-muted]">
             Trades: <span class="text-[--color-text]">{(perfData as any).summary?.total_trades ?? '—'}</span>
           </span>
-          <a
-            href="/data/performance.json"
-            download="pruviq-performance.json"
-            class="ml-auto border border-[--color-border] px-3 py-1.5 rounded text-[--color-text-muted] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors no-underline"
-            title="Download raw performance data as JSON"
-          >
-            &#8595; {t('perf.download_json')}
-          </a>
+          <div class="ml-auto flex gap-2">
+            <button
+              id="dl-csv-btn"
+              class="border border-[--color-border] px-3 py-1.5 rounded text-[--color-text-muted] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors cursor-pointer bg-transparent font-mono text-xs"
+              title="Download daily PnL data as CSV"
+            >
+              &#8595; {t('perf.download_csv')}
+            </button>
+            <a
+              href="/data/performance.json"
+              download="pruviq-performance.json"
+              class="border border-[--color-border] px-3 py-1.5 rounded text-[--color-text-muted] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors no-underline"
+              title="Download raw performance data as JSON"
+            >
+              &#8595; {t('perf.download_json')}
+            </a>
+          </div>
         </div>
       </div>
+      <script>
+        document.getElementById('dl-csv-btn')?.addEventListener('click', async () => {
+          const r = await fetch('/data/performance.json');
+          const d = await r.json();
+          const rows = [['date','pnl','cum_pnl','trades']];
+          (d.daily || []).forEach((e: {date:string;pnl:number;cum_pnl:number;trades:number}) => {
+            rows.push([e.date, String(e.pnl), String(e.cum_pnl), String(e.trades)]);
+          });
+          const csv = rows.map(r => r.join(',')).join('\n');
+          const a = document.createElement('a');
+          a.href = URL.createObjectURL(new Blob([csv], {type:'text/csv'}));
+          a.download = 'pruviq-performance-daily.csv';
+          a.click();
+        });
+      </script>
     </section>
   )}
 


### PR DESCRIPTION
## Summary

- **CSV export** (EN + KO `/performance`): Add "Download CSV" button next to existing JSON button — client-side generation from `/data/performance.json`
- **i18n**: Add `perf.download_csv` key to both `en.ts` and `ko.ts`
- **Strategies copy** (`en.ts`): Remove "1 survived validation" negative signal from `strategies.count` and `strategies.funnel` — reframe around transparency and total count
- **Cookie banner** (`Layout.astro`): Replace `border-t` with `shadow-[0_-2px_12px_rgba(0,0,0,0.35)]` for softer visual separation on desktop

## Test plan
- [ ] `/performance` EN: CSV button visible, downloads valid CSV
- [ ] `/ko/performance` KO: CSV button visible with Korean label, downloads valid CSV
- [ ] `/` EN strategies section: no "1 survived" text, copy focuses on total count + transparency
- [ ] Cookie banner desktop: no double border line at bottom, soft shadow instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)