### PR TITLE
feat: difficulty badge on each Learn article card

### DIFF
--- a/src/components/LearnCard.tsx
+++ b/src/components/LearnCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'preact/hooks';
+import { useState, useEffect } from "preact/hooks";
 
 interface Props {
   postId: string;
@@ -8,9 +8,11 @@ interface Props {
   tags?: string[];
   tagMap?: Record<string, string>;
   isEnglish?: boolean;
+  levelLabel?: string;
+  levelColor?: string;
 }
 
-const STORAGE_KEY = 'pruviq_learn_read';
+const STORAGE_KEY = "pruviq_learn_read";
 
 function isRead(id: string): boolean {
   try {
@@ -21,7 +23,23 @@ function isRead(id: string): boolean {
   }
 }
 
-export default function LearnCard({ postId, href, title, description, tags, tagMap, isEnglish }: Props) {
+const levelColorMap: Record<string, string> = {
+  green: "bg-green-500/10 text-green-400 border-green-500/20",
+  yellow: "bg-yellow-500/10 text-yellow-400 border-yellow-500/20",
+  red: "bg-red-500/10 text-red-400 border-red-500/20",
+};
+
+export default function LearnCard({
+  postId,
+  href,
+  title,
+  description,
+  tags,
+  tagMap,
+  isEnglish,
+  levelLabel,
+  levelColor,
+}: Props) {
   const [read, setRead] = useState(false);
 
   useEffect(() => {
@@ -36,11 +54,24 @@ export default function LearnCard({ postId, href, title, description, tags, tagM
       {read && (
         <span
           class="absolute top-3 right-3 w-5 h-5 rounded-full bg-[--color-accent]/20 flex items-center justify-center"
-          title={isEnglish !== false ? 'Read' : '읽음'}
+          title={isEnglish !== false ? "Read" : "읽음"}
         >
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-            <path d="M2.5 6L5 8.5L9.5 3.5" stroke="var(--color-accent)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+            <path
+              d="M2.5 6L5 8.5L9.5 3.5"
+              stroke="var(--color-accent)"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
           </svg>
+        </span>
+      )}
+      {levelLabel && levelColor && (
+        <span
+          class={`inline-block text-[10px] font-mono px-1.5 py-0.5 rounded border mb-2 ${levelColorMap[levelColor] ?? ""}`}
+        >
+          {levelLabel}
         </span>
       )}
       <div class="flex items-center gap-2 mb-1 pr-6">
@@ -48,13 +79,17 @@ export default function LearnCard({ postId, href, title, description, tags, tagM
           {title}
         </h3>
         {isEnglish && (
-          <span class="font-mono text-[10px] px-1.5 py-0.5 rounded bg-[--color-border] text-[--color-text-muted] shrink-0">EN</span>
+          <span class="font-mono text-[10px] px-1.5 py-0.5 rounded bg-[--color-border] text-[--color-text-muted] shrink-0">
+            EN
+          </span>
         )}
       </div>
-      <p class="text-[--color-text-muted] text-xs line-clamp-2">{description}</p>
+      <p class="text-[--color-text-muted] text-xs line-clamp-2">
+        {description}
+      </p>
       {tags && tags.length > 0 && (
         <div class="flex flex-wrap gap-1 mt-2">
-          {tags.slice(0, 3).map(tag => (
+          {tags.slice(0, 3).map((tag) => (
             <span class="text-[10px] font-mono text-[--color-text-muted] bg-[--color-border]/50 px-1.5 py-0.5 rounded">
               {tagMap?.[tag] || tag}
             </span>

--- a/src/pages/ko/learn/index.astro
+++ b/src/pages/ko/learn/index.astro
@@ -161,6 +161,8 @@ const levelConfig = [
                 tags={post.data.tags}
                 tagMap={tagMap}
                 isEnglish={!post.isKorean}
+                levelLabel={label}
+                levelColor={color}
               />
             </div>
           ))}
@@ -174,8 +176,8 @@ const levelConfig = [
     <div class="max-w-5xl mx-auto px-4 text-center">
       <h2 class="text-xl font-bold mb-3">{t('learn.cta_title')}</h2>
       <p class="text-[--color-text-muted] text-sm mb-6">{t('learn.cta_desc')}</p>
-      <a href="/ko/simulate" class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-6 py-2.5 rounded font-semibold text-sm hover:bg-[--color-accent-dim]">
-        {t('learn.cta_button')} &rarr;
+      <a href="/ko/simulate" class="btn btn-primary btn-md">
+        {t('learn.cta_button')} →
       </a>
       <div class="flex flex-wrap gap-3 justify-center mt-4">
         <a href="/ko/demo" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">

--- a/src/pages/learn/index.astro
+++ b/src/pages/learn/index.astro
@@ -153,6 +153,8 @@ const levelConfig = [
                 description={post.data.description}
                 tags={post.data.tags}
                 tagMap={tagMap}
+                levelLabel={label}
+                levelColor={color}
               />
             </div>
           ))}
@@ -166,8 +168,8 @@ const levelConfig = [
     <div class="max-w-5xl mx-auto px-4 text-center">
       <h2 class="text-xl font-bold mb-3">{t('learn.cta_title')}</h2>
       <p class="text-[--color-text-muted] text-sm mb-6">{t('learn.cta_desc')}</p>
-      <a href="/simulate" class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-6 py-2.5 rounded font-semibold text-sm hover:bg-[--color-accent-dim]">
-        {t('learn.cta_button')} &rarr;
+      <a href="/simulate" class="btn btn-primary btn-md">
+        {t('learn.cta_button')} →
       </a>
       <div class="flex flex-wrap gap-3 justify-center mt-4">
         <a href="/demo" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">


### PR DESCRIPTION
## Summary
- Each `LearnCard` now shows a color-coded difficulty pill (Beginner=green, Intermediate=yellow, Advanced=red) matching the section header badge
- Passes `levelLabel` + `levelColor` from both EN and KO learn index pages to `LearnCard`
- Fixes inline-style CTA buttons in learn pages → `btn btn-primary btn-md`

## Visual
- Beginner articles: green `BEGINNER` pill at top of card
- Intermediate: yellow `INTERMEDIATE` pill
- Advanced: red `ADVANCED` pill
- Badge disappears if level info not provided (backwards compatible)

## Test plan
- [ ] `/learn` — cards show green/yellow/red badges per section
- [ ] `/ko/learn` — same badges in Korean labels
- [ ] Read checkmark (✓) still shows at top-right when article is read
- [ ] Search still filters cards correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)