### PR TITLE
fix: complete ghost button migration — 47 pages

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -167,7 +167,7 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
           <a href="/simulate" class="btn btn-primary btn-md">
             {t('cross.simulate_cta')} &rarr;
           </a>
-          <a href="/strategies" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+          <a href="/strategies" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
             {t('cross.strategies_cta')} &rarr;
           </a>
         </div>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -65,13 +65,13 @@ const categoryColors: Record<string, string> = {
           <div class="mt-8 pt-6 border-t border-[--color-border] text-center">
             <p class="text-[--color-text-muted] text-sm mb-4">While we prepare more content:</p>
             <div class="flex flex-wrap gap-3 justify-center">
-              <a href="/learn" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+              <a href="/learn" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
                 {t('blog.learn_cta')} &rarr;
               </a>
-              <a href="/strategies" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+              <a href="/strategies" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
                 {t('blog.strategies_cta')} &rarr;
               </a>
-              <a href="/simulate" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+              <a href="/simulate" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
                 {t('blog.simulate_cta')} &rarr;
               </a>
             </div>
@@ -103,10 +103,10 @@ const categoryColors: Record<string, string> = {
               {t('blog.simulate_cta')} &rarr;
             </a>
             <div class="flex flex-wrap gap-3 justify-center mt-4">
-              <a href="/strategies/ranking" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+              <a href="/strategies/ranking" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
                 {t('ranking.tag')} &rarr;
               </a>
-              <a href="/learn" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+              <a href="/learn" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
                 {t('blog.learn_cta')} &rarr;
               </a>
             </div>

--- a/src/pages/coins/[symbol].astro
+++ b/src/pages/coins/[symbol].astro
@@ -156,10 +156,10 @@ const canonicalOverride = symbol.endsWith('usdt') ? undefined : `/coins/${symbol
           {t('coin_detail.simulate_coin').replace('{coin}', coinName)} &rarr;
         </a>
         <div class="flex flex-wrap gap-3 justify-center mt-4">
-          <a href="/strategies/ranking" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+          <a href="/strategies/ranking" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
             {t('ranking.tag')} &rarr;
           </a>
-          <a href="/coins" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+          <a href="/coins" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
             {t('coin_detail.all_coins')} &rarr;
           </a>
         </div>

--- a/src/pages/coins/index.astro
+++ b/src/pages/coins/index.astro
@@ -75,7 +75,7 @@ const TOP_COINS = [
           <a href="/simulate" class="btn btn-primary btn-md">
             {t('cross.simulate_cta')} &rarr;
           </a>
-          <a href="/learn" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+          <a href="/learn" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
             {t('cross.learn_cta')} &rarr;
           </a>
         </div>

--- a/src/pages/compare/3commas.astro
+++ b/src/pages/compare/3commas.astro
@@ -133,7 +133,7 @@ const rows = [
           {t('cta.button1')} &rarr;
         </a>
         <a href="/strategies"
-           class="inline-block border border-[--color-border] text-[--color-text] px-8 py-3 rounded font-semibold text-lg hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
+           class="btn btn-ghost btn-lg hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
           {t('hero.cta1')}
         </a>
       </div>

--- a/src/pages/compare/coinrule.astro
+++ b/src/pages/compare/coinrule.astro
@@ -133,7 +133,7 @@ const rows = [
           {t('cta.button1')} &rarr;
         </a>
         <a href="/strategies"
-           class="inline-block border border-[--color-border] text-[--color-text] px-8 py-3 rounded font-semibold text-lg hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
+           class="btn btn-ghost btn-lg hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
           {t('hero.cta1')}
         </a>
       </div>

--- a/src/pages/compare/cryptohopper.astro
+++ b/src/pages/compare/cryptohopper.astro
@@ -133,7 +133,7 @@ const rows = [
           {t('cta.button1')} &rarr;
         </a>
         <a href="/strategies"
-           class="inline-block border border-[--color-border] text-[--color-text] px-8 py-3 rounded font-semibold text-lg hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
+           class="btn btn-ghost btn-lg hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
           {t('hero.cta1')}
         </a>
       </div>

--- a/src/pages/compare/gainium.astro
+++ b/src/pages/compare/gainium.astro
@@ -133,7 +133,7 @@ const rows = [
           {t('cta.button1')} &rarr;
         </a>
         <a href="/strategies"
-           class="inline-block border border-[--color-border] text-[--color-text] px-8 py-3 rounded font-semibold text-lg hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
+           class="btn btn-ghost btn-lg hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
           {t('hero.cta1')}
         </a>
       </div>

--- a/src/pages/compare/streak.astro
+++ b/src/pages/compare/streak.astro
@@ -133,7 +133,7 @@ const rows = [
           {t('cta.button1')} &rarr;
         </a>
         <a href="/strategies"
-           class="inline-block border border-[--color-border] text-[--color-text] px-8 py-3 rounded font-semibold text-lg hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
+           class="btn btn-ghost btn-lg hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
           {t('hero.cta1')}
         </a>
       </div>

--- a/src/pages/compare/tradingview.astro
+++ b/src/pages/compare/tradingview.astro
@@ -172,7 +172,7 @@ const rows = [
           {t('cta.button1')} &rarr;
         </a>
         <a href="/strategies"
-           class="inline-block border border-[--color-border] text-[--color-text] px-8 py-3 rounded font-semibold text-lg hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
+           class="btn btn-ghost btn-lg hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
           {t('hero.cta1')}
         </a>
       </div>

--- a/src/pages/demo.astro
+++ b/src/pages/demo.astro
@@ -26,10 +26,10 @@ const t = useTranslations('en');
         <a href="/simulate" class="btn btn-primary btn-md">
           {t('demo.open_simulator')} &rarr;
         </a>
-        <a href="/strategies" class="inline-block border border-[--color-border] px-6 py-2.5 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+        <a href="/strategies" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
           {t('demo.view_strategies')}
         </a>
-        <a href="/fees" class="inline-block border border-[--color-border] px-6 py-2.5 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+        <a href="/fees" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
           {t('demo.fees_cta')} &rarr;
         </a>
       </div>

--- a/src/pages/fees.astro
+++ b/src/pages/fees.astro
@@ -170,7 +170,7 @@ const exchangeCards: Record<string, { tagLabel: string; description: string }> =
   </section>
 
   <div class="text-center mt-8">
-    <a href="/simulate" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+    <a href="/simulate" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
       {t('cross.simulate_cta')} &rarr;
     </a>
   </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -445,7 +445,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
           {t('cta.button1')} →
         </a>
         <a href="/strategies"
-           class="inline-block border border-[--color-border] text-[--color-text] px-8 py-3 rounded font-semibold text-lg hover:border-[--color-accent] hover:text-[--color-accent] hover:bg-[--color-accent]/5 transition-colors">
+           class="btn btn-ghost btn-lg hover:border-[--color-accent] hover:text-[--color-accent] hover:bg-[--color-accent]/5 transition-colors">
           {t('hero.cta_secondary')}
         </a>
       </div>

--- a/src/pages/ko/about.astro
+++ b/src/pages/ko/about.astro
@@ -167,7 +167,7 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
           <a href="/ko/simulate" class="btn btn-primary btn-md">
             {t('cross.simulate_cta')} &rarr;
           </a>
-          <a href="/ko/strategies" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+          <a href="/ko/strategies" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
             {t('cross.strategies_cta')} &rarr;
           </a>
         </div>

--- a/src/pages/ko/blog/[id].astro
+++ b/src/pages/ko/blog/[id].astro
@@ -78,7 +78,7 @@ const categoryLabels: Record<string, string> = {
               {t('blog.cta_button')} &rarr;
             </a>
             <a href="/ko/fees"
-               class="inline-block border border-[--color-border] text-[--color-text] px-6 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors">
+               class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors">
               {t('blog.cta_fees')}
             </a>
           </div>

--- a/src/pages/ko/blog/index.astro
+++ b/src/pages/ko/blog/index.astro
@@ -73,13 +73,13 @@ const categoryColors: Record<string, string> = {
           <div class="mt-8 pt-6 border-t border-[--color-border] text-center">
             <p class="text-[--color-text-muted] text-sm mb-4">While we prepare more content:</p>
             <div class="flex flex-wrap gap-3 justify-center">
-              <a href="/ko/learn" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+              <a href="/ko/learn" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
                 {t('blog.learn_cta')} &rarr;
               </a>
-              <a href="/ko/strategies" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+              <a href="/ko/strategies" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
                 {t('blog.strategies_cta')} &rarr;
               </a>
-              <a href="/ko/simulate" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+              <a href="/ko/simulate" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
                 {t('blog.simulate_cta')} &rarr;
               </a>
             </div>
@@ -114,10 +114,10 @@ const categoryColors: Record<string, string> = {
               {t('blog.simulate_cta')} &rarr;
             </a>
             <div class="flex flex-wrap gap-3 justify-center mt-4">
-              <a href="/ko/strategies/ranking" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+              <a href="/ko/strategies/ranking" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
                 {t('ranking.tag')} &rarr;
               </a>
-              <a href="/ko/learn" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+              <a href="/ko/learn" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
                 {t('blog.learn_cta')} &rarr;
               </a>
             </div>

--- a/src/pages/ko/coins/[symbol].astro
+++ b/src/pages/ko/coins/[symbol].astro
@@ -157,10 +157,10 @@ const canonicalOverride = symbol.endsWith('usdt') ? undefined : `/ko/coins/${sym
           {t('coin_detail.simulate_coin').replace('{coin}', coinName)} &rarr;
         </a>
         <div class="flex flex-wrap gap-3 justify-center mt-4">
-          <a href="/ko/strategies/ranking" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+          <a href="/ko/strategies/ranking" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
             {t('ranking.tag')} &rarr;
           </a>
-          <a href="/ko/coins" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+          <a href="/ko/coins" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
             {t('coin_detail.all_coins')} &rarr;
           </a>
         </div>

--- a/src/pages/ko/coins/index.astro
+++ b/src/pages/ko/coins/index.astro
@@ -75,7 +75,7 @@ const TOP_COINS = [
           <a href="/ko/simulate" class="btn btn-primary btn-md">
             {t('cross.simulate_cta')} &rarr;
           </a>
-          <a href="/ko/learn" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+          <a href="/ko/learn" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
             {t('cross.learn_cta')} &rarr;
           </a>
         </div>

--- a/src/pages/ko/compare/3commas.astro
+++ b/src/pages/ko/compare/3commas.astro
@@ -133,7 +133,7 @@ const rows = [
           {t('cta.button1')} &rarr;
         </a>
         <a href="/ko/strategies"
-           class="inline-block border border-[--color-border] text-[--color-text] px-8 py-3 rounded font-semibold text-lg hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
+           class="btn btn-ghost btn-lg hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
           {t('hero.cta1')}
         </a>
       </div>

--- a/src/pages/ko/compare/coinrule.astro
+++ b/src/pages/ko/compare/coinrule.astro
@@ -133,7 +133,7 @@ const rows = [
           {t('cta.button1')} &rarr;
         </a>
         <a href="/ko/strategies"
-           class="inline-block border border-[--color-border] text-[--color-text] px-8 py-3 rounded font-semibold text-lg hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
+           class="btn btn-ghost btn-lg hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
           {t('hero.cta1')}
         </a>
       </div>

--- a/src/pages/ko/compare/cryptohopper.astro
+++ b/src/pages/ko/compare/cryptohopper.astro
@@ -133,7 +133,7 @@ const rows = [
           {t('cta.button1')} &rarr;
         </a>
         <a href="/ko/strategies"
-           class="inline-block border border-[--color-border] text-[--color-text] px-8 py-3 rounded font-semibold text-lg hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
+           class="btn btn-ghost btn-lg hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
           {t('hero.cta1')}
         </a>
       </div>

--- a/src/pages/ko/compare/gainium.astro
+++ b/src/pages/ko/compare/gainium.astro
@@ -133,7 +133,7 @@ const rows = [
           {t('cta.button1')} &rarr;
         </a>
         <a href="/ko/strategies"
-           class="inline-block border border-[--color-border] text-[--color-text] px-8 py-3 rounded font-semibold text-lg hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
+           class="btn btn-ghost btn-lg hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
           {t('hero.cta1')}
         </a>
       </div>

--- a/src/pages/ko/compare/streak.astro
+++ b/src/pages/ko/compare/streak.astro
@@ -133,7 +133,7 @@ const rows = [
           {t('cta.button1')} &rarr;
         </a>
         <a href="/ko/strategies"
-           class="inline-block border border-[--color-border] text-[--color-text] px-8 py-3 rounded font-semibold text-lg hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
+           class="btn btn-ghost btn-lg hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
           {t('hero.cta1')}
         </a>
       </div>

--- a/src/pages/ko/compare/tradingview.astro
+++ b/src/pages/ko/compare/tradingview.astro
@@ -172,7 +172,7 @@ const rows = [
           {t('cta.button1')} &rarr;
         </a>
         <a href="/ko/strategies"
-           class="inline-block border border-[--color-border] text-[--color-text] px-8 py-3 rounded font-semibold text-lg hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
+           class="btn btn-ghost btn-lg hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
           {t('hero.cta1')}
         </a>
       </div>

--- a/src/pages/ko/demo.astro
+++ b/src/pages/ko/demo.astro
@@ -26,10 +26,10 @@ const t = useTranslations('ko');
         <a href="/ko/simulate" class="btn btn-primary btn-md">
           {t('demo.open_simulator')} &rarr;
         </a>
-        <a href="/ko/strategies" class="inline-block border border-[--color-border] px-6 py-2.5 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+        <a href="/ko/strategies" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
           {t('demo.view_strategies')}
         </a>
-        <a href="/ko/fees" class="inline-block border border-[--color-border] px-6 py-2.5 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+        <a href="/ko/fees" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
           {t('demo.fees_cta')} &rarr;
         </a>
       </div>

--- a/src/pages/ko/fees.astro
+++ b/src/pages/ko/fees.astro
@@ -169,7 +169,7 @@ const exchangeCards: Record<string, { tagLabel: string; description: string }> =
   </section>
 
   <div class="text-center mt-8">
-    <a href="/ko/simulate" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+    <a href="/ko/simulate" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
       {t('cross.simulate_cta')} &rarr;
     </a>
   </div>

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -561,7 +561,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
           {t('cta.button1')} &rarr;
         </a>
         <a href="/ko/strategies"
-           class="inline-block border border-[--color-border] text-[--color-text] px-8 py-3 rounded font-semibold text-lg hover:border-[--color-accent] hover:text-[--color-accent] hover:bg-[--color-accent]/5 transition-colors">
+           class="btn btn-ghost btn-lg hover:border-[--color-accent] hover:text-[--color-accent] hover:bg-[--color-accent]/5 transition-colors">
           {t('hero.cta1')}
         </a>
       </div>

--- a/src/pages/ko/leaderboard.astro
+++ b/src/pages/ko/leaderboard.astro
@@ -144,7 +144,7 @@ function formatDate(iso: string) {
         <a href="/ko/simulate" class="btn btn-primary btn-md">
           {t('cross.simulate_cta')} &rarr;
         </a>
-        <a href="/ko/strategies" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+        <a href="/ko/strategies" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
           {t('cross.strategies_cta')} &rarr;
         </a>
       </div>

--- a/src/pages/ko/learn/index.astro
+++ b/src/pages/ko/learn/index.astro
@@ -180,10 +180,10 @@ const levelConfig = [
         {t('learn.cta_button')} →
       </a>
       <div class="flex flex-wrap gap-3 justify-center mt-4">
-        <a href="/ko/demo" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+        <a href="/ko/demo" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
           {t('cross.demo_cta')} &rarr;
         </a>
-        <a href="/ko/strategies" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+        <a href="/ko/strategies" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
           {t('cross.strategies_cta')} &rarr;
         </a>
       </div>

--- a/src/pages/ko/market/index.astro
+++ b/src/pages/ko/market/index.astro
@@ -42,7 +42,7 @@ const marketDataJson = JSON.stringify(marketDataRaw);
         <a href="/ko/simulate" class="btn btn-primary btn-md">
           {t('cross.simulate_cta')} &rarr;
         </a>
-        <a href="/ko/strategies" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+        <a href="/ko/strategies" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
           {t('cross.strategies_cta')} &rarr;
         </a>
       </div>

--- a/src/pages/ko/methodology.astro
+++ b/src/pages/ko/methodology.astro
@@ -182,10 +182,10 @@ const t = useTranslations('ko');
         {t('methodology.cta_button')} &rarr;
       </a>
       <div class="flex flex-wrap gap-3 justify-center mt-4">
-        <a href="/ko/performance" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+        <a href="/ko/performance" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
           {t('methodology.performance_cta')} &rarr;
         </a>
-        <a href="/ko/strategies" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+        <a href="/ko/strategies" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
           {t('methodology.strategies_cta')} &rarr;
         </a>
       </div>

--- a/src/pages/ko/performance/index.astro
+++ b/src/pages/ko/performance/index.astro
@@ -336,15 +336,15 @@ const xLast = daily[daily.length - 1]?.date ?? '';
         <a href="/ko/simulate" class="btn btn-primary btn-md">
           {t('perf.verify_cta')} &rarr;
         </a>
-        <a href="/ko/methodology" class="inline-block border border-[--color-border] text-[--color-text] px-6 py-2.5 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors">
+        <a href="/ko/methodology" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors">
           {t('perf.methodology_cta')}
         </a>
       </div>
       <div class="flex flex-wrap gap-3 mt-6">
-        <a href="/ko/strategies" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+        <a href="/ko/strategies" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
           {t('perf.strategies_cta')} &rarr;
         </a>
-        <a href="/ko/fees" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+        <a href="/ko/fees" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
           {t('perf.fees_cta')} &rarr;
         </a>
       </div>

--- a/src/pages/ko/simulate/index.astro
+++ b/src/pages/ko/simulate/index.astro
@@ -79,10 +79,10 @@ const coinsAnalyzed = (siteStats as { coins_analyzed: number }).coins_analyzed;
       {t('simulate.risk_disclaimer')}
     </p>
     <div class="flex flex-wrap gap-2 mt-2">
-      <a href="/ko/fees" class="inline-block border border-[--color-border] px-4 py-1.5 rounded text-xs hover:border-[--color-accent] transition-colors no-underline">
+      <a href="/ko/fees" class="btn btn-ghost btn-sm no-underline">
         {t('simulate.fees_cta')} &rarr;
       </a>
-      <a href="/ko/methodology" class="inline-block border border-[--color-border] px-4 py-1.5 rounded text-xs hover:border-[--color-accent] transition-colors no-underline text-[--color-text-muted]">
+      <a href="/ko/methodology" class="btn btn-ghost btn-sm no-underline text-[--color-text-muted]">
         계산 방법론 &rarr;
       </a>
     </div>

--- a/src/pages/ko/strategies/[id].astro
+++ b/src/pages/ko/strategies/[id].astro
@@ -202,7 +202,7 @@ const statusLabels: Record<string, string> = {
             {t('strategies.explore')} &rarr;
           </a>
           <a href="/ko/fees"
-             class="inline-block border border-[--color-border] text-[--color-text] px-6 py-2 rounded font-semibold text-sm hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
+             class="btn btn-ghost btn-md hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
             {t('cta.button3')}
           </a>
         </div>

--- a/src/pages/ko/strategies/compare.astro
+++ b/src/pages/ko/strategies/compare.astro
@@ -37,7 +37,7 @@ const t = useTranslations('ko');
         <a href="/ko/simulate" class="btn btn-primary btn-md">
           {t('cross.simulate_cta')} &rarr;
         </a>
-        <a href="/ko/strategies" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+        <a href="/ko/strategies" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
           {t('cross.strategies_cta')} &rarr;
         </a>
       </div>

--- a/src/pages/ko/strategies/index.astro
+++ b/src/pages/ko/strategies/index.astro
@@ -289,10 +289,10 @@ const isKorean = (id: string) => koIds.has(id);
           {t('strategies.more_desc')}
         </p>
         <div class="flex flex-wrap gap-3 justify-center">
-          <a href="/ko/performance" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+          <a href="/ko/performance" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
             {t('strategies.performance_cta')} &rarr;
           </a>
-          <a href="/ko/fees" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+          <a href="/ko/fees" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
             {t('strategies.fees_cta')} &rarr;
           </a>
         </div>

--- a/src/pages/ko/strategies/ranking.astro
+++ b/src/pages/ko/strategies/ranking.astro
@@ -231,13 +231,13 @@ if (!ssrRanking) {
         </a>
         <a
           href="/ko/strategies"
-          class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline"
+          class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline"
         >
           {t('ranking.strategy_lib')} &rarr;
         </a>
         <a
           href="/ko/performance"
-          class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline"
+          class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline"
         >
           {t('ranking.live_perf')} &rarr;
         </a>

--- a/src/pages/leaderboard.astro
+++ b/src/pages/leaderboard.astro
@@ -146,7 +146,7 @@ function formatDate(iso: string) {
         <a href="/simulate" class="btn btn-primary btn-md">
           {t('cross.simulate_cta')} &rarr;
         </a>
-        <a href="/strategies" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+        <a href="/strategies" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
           {t('cross.strategies_cta')} &rarr;
         </a>
       </div>

--- a/src/pages/learn/index.astro
+++ b/src/pages/learn/index.astro
@@ -172,10 +172,10 @@ const levelConfig = [
         {t('learn.cta_button')} →
       </a>
       <div class="flex flex-wrap gap-3 justify-center mt-4">
-        <a href="/demo" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+        <a href="/demo" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
           {t('cross.demo_cta')} &rarr;
         </a>
-        <a href="/strategies" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+        <a href="/strategies" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
           {t('cross.strategies_cta')} &rarr;
         </a>
       </div>

--- a/src/pages/market/index.astro
+++ b/src/pages/market/index.astro
@@ -42,7 +42,7 @@ const marketDataJson = JSON.stringify(marketDataRaw);
         <a href="/simulate" class="btn btn-primary btn-md">
           {t('cross.simulate_cta')} &rarr;
         </a>
-        <a href="/strategies" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+        <a href="/strategies" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
           {t('cross.strategies_cta')} &rarr;
         </a>
       </div>

--- a/src/pages/methodology.astro
+++ b/src/pages/methodology.astro
@@ -182,10 +182,10 @@ const t = useTranslations('en');
         {t('methodology.cta_button')} &rarr;
       </a>
       <div class="flex flex-wrap gap-3 justify-center mt-4">
-        <a href="/performance" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+        <a href="/performance" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
           {t('methodology.performance_cta')} &rarr;
         </a>
-        <a href="/strategies" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+        <a href="/strategies" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
           {t('methodology.strategies_cta')} &rarr;
         </a>
       </div>

--- a/src/pages/performance/index.astro
+++ b/src/pages/performance/index.astro
@@ -397,15 +397,15 @@ const xLast = daily[daily.length - 1]?.date ?? '';
         <a href="/simulate" class="btn btn-primary btn-md">
           {t('perf.verify_cta')} &rarr;
         </a>
-        <a href="/methodology" class="inline-block border border-[--color-border] text-[--color-text] px-6 py-2.5 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors">
+        <a href="/methodology" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors">
           {t('perf.methodology_cta')}
         </a>
       </div>
       <div class="flex flex-wrap gap-3 mt-6">
-        <a href="/strategies" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+        <a href="/strategies" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
           {t('perf.strategies_cta')} &rarr;
         </a>
-        <a href="/fees" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+        <a href="/fees" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
           {t('perf.fees_cta')} &rarr;
         </a>
       </div>

--- a/src/pages/simulate/index.astro
+++ b/src/pages/simulate/index.astro
@@ -79,10 +79,10 @@ const coinsAnalyzed = (siteStats as { coins_analyzed: number }).coins_analyzed;
       {t('simulate.risk_disclaimer')}
     </p>
     <div class="flex flex-wrap gap-2 mt-2">
-      <a href="/fees" class="inline-block border border-[--color-border] px-4 py-1.5 rounded text-xs hover:border-[--color-accent] transition-colors no-underline">
+      <a href="/fees" class="btn btn-ghost btn-sm no-underline">
         {t('simulate.fees_cta')} &rarr;
       </a>
-      <a href="/methodology" class="inline-block border border-[--color-border] px-4 py-1.5 rounded text-xs hover:border-[--color-accent] transition-colors no-underline text-[--color-text-muted]">
+      <a href="/methodology" class="btn btn-ghost btn-sm no-underline text-[--color-text-muted]">
         How we calculate &rarr;
       </a>
     </div>

--- a/src/pages/strategies/[id].astro
+++ b/src/pages/strategies/[id].astro
@@ -182,7 +182,7 @@ const statusLabels: Record<string, string> = {
             {t('strategies.explore')} &rarr;
           </a>
           <a href="/fees"
-             class="inline-block border border-[--color-border] text-[--color-text] px-6 py-2 rounded font-semibold text-sm hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
+             class="btn btn-ghost btn-md hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
             {t('cta.button3')}
           </a>
         </div>

--- a/src/pages/strategies/compare.astro
+++ b/src/pages/strategies/compare.astro
@@ -37,7 +37,7 @@ const t = useTranslations('en');
         <a href="/simulate" class="btn btn-primary btn-md">
           {t('cross.simulate_cta')} &rarr;
         </a>
-        <a href="/strategies" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+        <a href="/strategies" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
           {t('cross.strategies_cta')} &rarr;
         </a>
       </div>

--- a/src/pages/strategies/index.astro
+++ b/src/pages/strategies/index.astro
@@ -311,10 +311,10 @@ const difficultyColors: Record<string, string> = {
           {t('strategies.more_desc')}
         </p>
         <div class="flex flex-wrap gap-3 justify-center">
-          <a href="/performance" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+          <a href="/performance" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
             {t('strategies.performance_cta')} &rarr;
           </a>
-          <a href="/fees" class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline">
+          <a href="/fees" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
             {t('strategies.fees_cta')} &rarr;
           </a>
         </div>

--- a/src/pages/strategies/ranking.astro
+++ b/src/pages/strategies/ranking.astro
@@ -249,7 +249,7 @@ if (!ssrRanking) {
         </a>
         <a
           href="/strategies"
-          class="inline-block border border-[--color-border] px-5 py-2 rounded font-semibold text-sm hover:border-[--color-accent] transition-colors no-underline"
+          class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline"
         >
           {t('ranking.strategy_lib')} &rarr;
         </a>


### PR DESCRIPTION
## Summary
Converts all remaining inline ghost (secondary) button styles to the btn system:

**Before:** `inline-block border border-[--color-border] px-N py-N rounded font-semibold text-sm hover:border-[--color-accent] transition-colors`

**After:** `btn btn-ghost btn-md` (or `btn-lg` / `btn-sm` based on original size)

47 pages fixed (EN + KO pairs):
- about, fees, leaderboard, methodology, demo, learn
- strategies/index, strategies/[id], strategies/compare, strategies/ranking
- coins/index, coins/[symbol], blog/index, blog/[id]
- compare/* (5 pages), simulate, market, performance

Zero inline border-button styles remaining across all `.astro` pages.

## Test plan
- [ ] Secondary CTA buttons still render with border + hover accent color
- [ ] No visual regressions — ghost buttons look consistent
- [ ] Sizing correct: lg on hero CTAs, md on section CTAs, sm on small inline links

🤖 Generated with [Claude Code](https://claude.com/claude-code)