### PR TITLE
feat: Binance referral card below simulator results

### DIFF
--- a/src/components/ResultsPanel.tsx
+++ b/src/components/ResultsPanel.tsx
@@ -1329,6 +1329,15 @@ export default function ResultsPanel({
           </div>
         )
       )}
+      {result && result.total_trades > 0 && (
+        <div class="px-3 pb-3 md:px-4 md:pb-4">
+          <ExchangeCTA
+            mode="card"
+            lang={lang}
+            strategy={activePreset ?? undefined}
+          />
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add `ExchangeCTA` in card mode below the results tabs after any completed simulation (when `total_trades > 0`)
- Previously the exchange CTA was only shown inline within the stats tab and only for profitable results
- This gives Binance/Bitget referral links more visibility as a natural next step after viewing results

## Test plan
- [ ] Run a simulation → ExchangeCTA card appears below the tabs
- [ ] Binance and Bitget referral links render correctly
- [ ] Works in both EN and KO

🤖 Generated with [Claude Code](https://claude.com/claude-code)