### PR TITLE
feat: reading time on learn cards

### DIFF
--- a/src/components/LearnCard.tsx
+++ b/src/components/LearnCard.tsx
@@ -11,6 +11,7 @@ interface Props {
   levelLabel?: string;
   levelColor?: string;
   readTime?: number;
+  readTimeLabel?: string;
 }
 
 const STORAGE_KEY = "pruviq_learn_read";
@@ -41,6 +42,7 @@ export default function LearnCard({
   levelLabel,
   levelColor,
   readTime,
+  readTimeLabel,
 }: Props) {
   const [read, setRead] = useState(false);
 
@@ -77,9 +79,9 @@ export default function LearnCard({
             {levelLabel}
           </span>
         )}
-        {readTime && readTime > 0 && (
+        {readTime != null && readTime > 0 && (
           <span class="text-[10px] font-mono text-[--color-text-muted]">
-            {readTime} min read
+            {readTime} {readTimeLabel || "min read"}
           </span>
         )}
       </div>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -706,6 +706,7 @@ export const en = {
   "learn.level_advanced_title": "Quant & Strategy",
   "learn.level_advanced_desc":
     "Backtesting, position sizing, and real decision-making.",
+  "learn.min_read": "min read",
   "learn.cta_title": "Ready to test what you've learned?",
   "learn.cta_desc":
     "Build a strategy and run it on 569+ coins — free, no account needed.",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -704,6 +704,7 @@ export const ko: Record<TranslationKey, string> = {
   "learn.level_advanced": "고급",
   "learn.level_advanced_title": "퀀트 & 전략",
   "learn.level_advanced_desc": "백테스팅, 포지션 사이징, 실제 의사결정 과정.",
+  "learn.min_read": "분 소요",
   "learn.cta_title": "배운 것을 테스트할 준비가 되셨나요?",
   "learn.cta_desc":
     "전략을 만들고 569개 이상의 코인에서 실행하세요 — 무료, 계정 불필요.",

--- a/src/pages/ko/learn/index.astro
+++ b/src/pages/ko/learn/index.astro
@@ -4,6 +4,7 @@ import { getCollection } from 'astro:content';
 import { useTranslations } from '../../../i18n/index';
 import LearnProgress from '../../../components/LearnProgress.tsx';
 import LearnCard from '../../../components/LearnCard.tsx';
+import { getReadTime } from '../../../utils/readTime';
 
 const t = useTranslations('ko');
 
@@ -79,11 +80,6 @@ const levelColorMap: Record<string, string> = {
   yellow: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
   red: 'bg-red-500/10 text-red-400 border-red-500/20',
 };
-
-function getReadTime(body: string): number {
-  const words = body.trim().split(/\s+/).length;
-  return Math.max(1, Math.ceil(words / 200));
-}
 
 const levelConfig = [
   { level: 'beginner', label: t('learn.level_beginner'), title: t('learn.level_beginner_title'), desc: t('learn.level_beginner_desc'), color: 'green', posts: beginner },
@@ -169,6 +165,7 @@ const levelConfig = [
                 levelLabel={label}
                 levelColor={color}
                 readTime={getReadTime(post.body)}
+                readTimeLabel={t('learn.min_read')}
               />
             </div>
           ))}

--- a/src/pages/learn/index.astro
+++ b/src/pages/learn/index.astro
@@ -4,6 +4,7 @@ import { getCollection } from 'astro:content';
 import { useTranslations } from '../../i18n/index';
 import LearnProgress from '../../components/LearnProgress.tsx';
 import LearnCard from '../../components/LearnCard.tsx';
+import { getReadTime } from '../../utils/readTime';
 
 const t = useTranslations('en');
 
@@ -72,11 +73,6 @@ const levelColorMap: Record<string, string> = {
   yellow: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
   red: 'bg-red-500/10 text-red-400 border-red-500/20',
 };
-
-function getReadTime(body: string): number {
-  const words = body.trim().split(/\s+/).length;
-  return Math.max(1, Math.ceil(words / 200));
-}
 
 const levelConfig = [
   { level: 'beginner', label: t('learn.level_beginner'), title: t('learn.level_beginner_title'), desc: t('learn.level_beginner_desc'), color: 'green', posts: beginner },
@@ -161,6 +157,7 @@ const levelConfig = [
                 levelLabel={label}
                 levelColor={color}
                 readTime={getReadTime(post.body)}
+                readTimeLabel={t('learn.min_read')}
               />
             </div>
           ))}

--- a/src/utils/readTime.ts
+++ b/src/utils/readTime.ts
@@ -1,0 +1,4 @@
+export function getReadTime(body: string): number {
+  const words = body.trim().split(/\s+/).length;
+  return Math.max(1, Math.ceil(words / 200));
+}


### PR DESCRIPTION
## Summary
- Compute reading time from article word count at build time (word count ÷ 200 wpm, min 1 min)
- Display "N min read" alongside the difficulty level badge on each LearnCard
- Level badge + reading time now in a flex row for cleaner layout

## Test plan
- [ ] `/learn` and `/ko/learn` — each card shows reading time below badge
- [ ] Reading times look reasonable (5-15 min for most articles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)