### PR TITLE
fix: red tint on killed strategy cards in /performance

### DIFF
--- a/src/pages/ko/performance/index.astro
+++ b/src/pages/ko/performance/index.astro
@@ -234,7 +234,7 @@ const xLast = daily[daily.length - 1]?.date ?? '';
       </p>
 
       <div class="grid md:grid-cols-2 gap-4">
-        <div class="border border-[--color-border] rounded-lg p-5 bg-[--color-bg-card] opacity-60">
+        <div class="border border-[--color-red]/30 rounded-lg p-5 bg-[--color-red]/5 opacity-70">
           <div class="flex items-center gap-2 mb-3">
             <span class="text-xs font-mono px-2 py-0.5 rounded bg-[--color-red]/10 text-[--color-text] border border-[--color-red]/20">{t('strategy.killed')}</span>
           </div>
@@ -256,7 +256,7 @@ const xLast = daily[daily.length - 1]?.date ?? '';
           </div>
         </div>
 
-        <div class="border border-[--color-border] rounded-lg p-5 bg-[--color-bg-card] opacity-60">
+        <div class="border border-[--color-red]/30 rounded-lg p-5 bg-[--color-red]/5 opacity-70">
           <div class="flex items-center gap-2 mb-3">
             <span class="text-xs font-mono px-2 py-0.5 rounded bg-[--color-red]/10 text-[--color-text] border border-[--color-red]/20">{t('strategy.killed')}</span>
           </div>
@@ -278,7 +278,7 @@ const xLast = daily[daily.length - 1]?.date ?? '';
           </div>
         </div>
 
-        <div class="border border-[--color-border] rounded-lg p-5 bg-[--color-bg-card] opacity-60">
+        <div class="border border-[--color-red]/30 rounded-lg p-5 bg-[--color-red]/5 opacity-70">
           <div class="flex items-center gap-2 mb-3">
             <span class="text-xs font-mono px-2 py-0.5 rounded bg-[--color-yellow]/10 text-[--color-yellow] border border-[--color-yellow]/20">88+ 변형</span>
           </div>
@@ -300,7 +300,7 @@ const xLast = daily[daily.length - 1]?.date ?? '';
           </div>
         </div>
 
-        <div class="border border-[--color-border] rounded-lg p-5 bg-[--color-bg-card] opacity-60">
+        <div class="border border-[--color-red]/30 rounded-lg p-5 bg-[--color-red]/5 opacity-70">
           <div class="flex items-center gap-2 mb-3">
             <span class="text-xs font-mono px-2 py-0.5 rounded bg-[--color-yellow]/10 text-[--color-yellow] border border-[--color-yellow]/20">기각된 필터</span>
           </div>

--- a/src/pages/performance/index.astro
+++ b/src/pages/performance/index.astro
@@ -295,7 +295,7 @@ const xLast = daily[daily.length - 1]?.date ?? '';
       </p>
 
       <div class="grid md:grid-cols-2 gap-4">
-        <div class="border border-[--color-border] rounded-lg p-5 bg-[--color-bg-card] opacity-60">
+        <div class="border border-[--color-red]/30 rounded-lg p-5 bg-[--color-red]/5 opacity-70">
           <div class="flex items-center gap-2 mb-3">
             <span class="text-xs font-mono px-2 py-0.5 rounded bg-[--color-red]/10 text-[--color-text] border border-[--color-red]/20">{t('strategy.killed')}</span>
           </div>
@@ -317,7 +317,7 @@ const xLast = daily[daily.length - 1]?.date ?? '';
           </div>
         </div>
 
-        <div class="border border-[--color-border] rounded-lg p-5 bg-[--color-bg-card] opacity-60">
+        <div class="border border-[--color-red]/30 rounded-lg p-5 bg-[--color-red]/5 opacity-70">
           <div class="flex items-center gap-2 mb-3">
             <span class="text-xs font-mono px-2 py-0.5 rounded bg-[--color-red]/10 text-[--color-text] border border-[--color-red]/20">{t('strategy.killed')}</span>
           </div>
@@ -339,7 +339,7 @@ const xLast = daily[daily.length - 1]?.date ?? '';
           </div>
         </div>
 
-        <div class="border border-[--color-border] rounded-lg p-5 bg-[--color-bg-card] opacity-60">
+        <div class="border border-[--color-red]/30 rounded-lg p-5 bg-[--color-red]/5 opacity-70">
           <div class="flex items-center gap-2 mb-3">
             <span class="text-xs font-mono px-2 py-0.5 rounded bg-[--color-yellow]/10 text-[--color-yellow] border border-[--color-yellow]/20">88+ Variations</span>
           </div>
@@ -361,7 +361,7 @@ const xLast = daily[daily.length - 1]?.date ?? '';
           </div>
         </div>
 
-        <div class="border border-[--color-border] rounded-lg p-5 bg-[--color-bg-card] opacity-60">
+        <div class="border border-[--color-red]/30 rounded-lg p-5 bg-[--color-red]/5 opacity-70">
           <div class="flex items-center gap-2 mb-3">
             <span class="text-xs font-mono px-2 py-0.5 rounded bg-[--color-yellow]/10 text-[--color-yellow] border border-[--color-yellow]/20">Rejected Filter</span>
           </div>


### PR DESCRIPTION
## Summary
- Changed `border-[--color-border]` → `border-[--color-red]/30` on all 4 killed strategy cards
- Added `bg-[--color-red]/5` background tint for stronger visual distinction
- Killed cards are now clearly differentiated from active strategies at a glance
- Applied to both EN `/performance` and KO `/ko/performance`

## Test plan
- [ ] `/performance` killed strategies section — cards have reddish border/bg tint

🤖 Generated with [Claude Code](https://claude.com/claude-code)