### PR TITLE
fix: complete btn system migration — 24 remaining pages

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -10,7 +10,7 @@ import Layout from '../layouts/Layout.astro';
       The page you're looking for doesn't exist or has been moved.
     </p>
     <div class="flex flex-wrap gap-4 justify-center mb-8">
-      <a href="/" class="btn-primary bg-[--color-accent] text-[--color-bg] px-6 py-2 rounded font-semibold text-sm hover:bg-[--color-accent-dim]">
+      <a href="/" class="btn btn-primary btn-md">
         Home
       </a>
       <a href="/simulate" class="border border-[--color-border] px-6 py-2 rounded text-sm hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -154,7 +154,7 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
         <p class="text-[--color-text-muted] text-sm mb-4">{t('about.contact_desc')}</p>
         <div class="flex flex-col sm:flex-row gap-3 justify-center">
           <a href="mailto:contact@pruviq.com"
-             class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-6 py-2 rounded font-semibold text-sm hover:bg-[--color-accent-dim]">
+             class="btn btn-primary btn-md">
             {t('about.contact_email')}
           </a>
         </div>

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -214,7 +214,7 @@ const t = useTranslations('en');
       </p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
         <a href="/strategies"
-           class="btn-primary bg-[--color-accent] text-[--color-bg] px-6 py-3 rounded font-semibold hover:bg-[--color-accent-dim]">
+           class="btn btn-primary btn-lg">
           {t('strategies.explore')} &rarr;
         </a>
       </div>

--- a/src/pages/compare/3commas.astro
+++ b/src/pages/compare/3commas.astro
@@ -129,7 +129,7 @@ const rows = [
       <p class="text-[--color-text-muted] text-lg mb-8 max-w-xl mx-auto">{t('vs_3commas.cta_desc')}</p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center mb-4">
         <a href="/simulate"
-           class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-8 py-3 rounded font-semibold text-lg hover:bg-[--color-accent-dim]">
+           class="btn btn-primary btn-lg">
           {t('cta.button1')} &rarr;
         </a>
         <a href="/strategies"

--- a/src/pages/compare/coinrule.astro
+++ b/src/pages/compare/coinrule.astro
@@ -129,7 +129,7 @@ const rows = [
       <p class="text-[--color-text-muted] text-lg mb-8 max-w-xl mx-auto">{t('vs_coinrule.cta_desc')}</p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center mb-4">
         <a href="/simulate"
-           class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-8 py-3 rounded font-semibold text-lg hover:bg-[--color-accent-dim]">
+           class="btn btn-primary btn-lg">
           {t('cta.button1')} &rarr;
         </a>
         <a href="/strategies"

--- a/src/pages/compare/cryptohopper.astro
+++ b/src/pages/compare/cryptohopper.astro
@@ -129,7 +129,7 @@ const rows = [
       <p class="text-[--color-text-muted] text-lg mb-8 max-w-xl mx-auto">{t('vs_cryptohopper.cta_desc')}</p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center mb-4">
         <a href="/simulate"
-           class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-8 py-3 rounded font-semibold text-lg hover:bg-[--color-accent-dim]">
+           class="btn btn-primary btn-lg">
           {t('cta.button1')} &rarr;
         </a>
         <a href="/strategies"

--- a/src/pages/compare/gainium.astro
+++ b/src/pages/compare/gainium.astro
@@ -129,7 +129,7 @@ const rows = [
       <p class="text-[--color-text-muted] text-lg mb-8 max-w-xl mx-auto">{t('vs_gainium.cta_desc')}</p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center mb-4">
         <a href="/simulate"
-           class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-8 py-3 rounded font-semibold text-lg hover:bg-[--color-accent-dim]">
+           class="btn btn-primary btn-lg">
           {t('cta.button1')} &rarr;
         </a>
         <a href="/strategies"

--- a/src/pages/compare/streak.astro
+++ b/src/pages/compare/streak.astro
@@ -129,7 +129,7 @@ const rows = [
       <p class="text-[--color-text-muted] text-lg mb-8 max-w-xl mx-auto">{t('vs_streak.cta_desc')}</p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center mb-4">
         <a href="/simulate"
-           class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-8 py-3 rounded font-semibold text-lg hover:bg-[--color-accent-dim]">
+           class="btn btn-primary btn-lg">
           {t('cta.button1')} &rarr;
         </a>
         <a href="/strategies"

--- a/src/pages/compare/tradingview.astro
+++ b/src/pages/compare/tradingview.astro
@@ -171,7 +171,7 @@ const rows = [
       <p class="text-[--color-text-muted] text-lg mb-8 max-w-xl mx-auto">{t('vs.cta_desc')}</p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center mb-4">
         <a href="/simulate"
-           class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-8 py-3 rounded font-semibold text-lg hover:bg-[--color-accent-dim]">
+           class="btn btn-primary btn-lg">
           {t('cta.button1')} &rarr;
         </a>
         <a href="/strategies"

--- a/src/pages/ko/404/index.astro
+++ b/src/pages/ko/404/index.astro
@@ -12,7 +12,7 @@ const t = useTranslations('ko');
       <h1 class="text-3xl md:text-4xl font-bold mb-4">페이지를 찾을 수 없습니다</h1>
       <p class="text-[--color-text-muted] mb-8">요청하신 페이지를 찾을 수 없습니다. URL을 확인하거나 아래 링크를 이용하세요.</p>
       <div class="flex flex-wrap items-center justify-center gap-4 mb-8">
-        <a href="/ko/" class="inline-block bg-[--color-accent] text-[--color-bg] px-6 py-2 rounded font-semibold text-sm hover:bg-[--color-accent-dim]">홈으로</a>
+        <a href="/ko/" class="btn btn-primary btn-md">홈으로</a>
         <a href="/ko/simulate" class="border border-[--color-border] px-6 py-2 rounded text-sm hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">전략 시뮬레이터</a>
         <a href="/ko/strategies" class="border border-[--color-border] px-6 py-2 rounded text-sm hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">전략 라이브러리</a>
       </div>

--- a/src/pages/ko/about.astro
+++ b/src/pages/ko/about.astro
@@ -154,7 +154,7 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
         <p class="text-[--color-text-muted] text-sm mb-4">{t('about.contact_desc')}</p>
         <div class="flex flex-col sm:flex-row gap-3 justify-center">
           <a href="mailto:contact@pruviq.com"
-             class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-6 py-2 rounded font-semibold text-sm hover:bg-[--color-accent-dim]">
+             class="btn btn-primary btn-md">
             {t('about.contact_email')}
           </a>
         </div>

--- a/src/pages/ko/blog/[id].astro
+++ b/src/pages/ko/blog/[id].astro
@@ -74,7 +74,7 @@ const categoryLabels: Record<string, string> = {
           <p class="text-[--color-text-muted] text-sm mb-4">{t('blog.cta_desc')}</p>
           <div class="flex flex-col sm:flex-row gap-3 justify-center">
             <a href="/ko/simulate"
-               class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-6 py-2 rounded font-semibold text-sm hover:bg-[--color-accent-dim]">
+               class="btn btn-primary btn-md">
               {t('blog.cta_button')} &rarr;
             </a>
             <a href="/ko/fees"

--- a/src/pages/ko/changelog.astro
+++ b/src/pages/ko/changelog.astro
@@ -214,7 +214,7 @@ const t = useTranslations('ko');
       </p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
         <a href="/ko/strategies"
-           class="btn-primary bg-[--color-accent] text-[--color-bg] px-6 py-3 rounded font-semibold hover:bg-[--color-accent-dim]">
+           class="btn btn-primary btn-lg">
           {t('strategies.explore')} &rarr;
         </a>
       </div>

--- a/src/pages/ko/compare/3commas.astro
+++ b/src/pages/ko/compare/3commas.astro
@@ -129,7 +129,7 @@ const rows = [
       <p class="text-[--color-text-muted] text-lg mb-8 max-w-xl mx-auto">{t('vs_3commas.cta_desc')}</p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center mb-4">
         <a href="/ko/simulate"
-           class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-8 py-3 rounded font-semibold text-lg hover:bg-[--color-accent-dim]">
+           class="btn btn-primary btn-lg">
           {t('cta.button1')} &rarr;
         </a>
         <a href="/ko/strategies"

--- a/src/pages/ko/compare/coinrule.astro
+++ b/src/pages/ko/compare/coinrule.astro
@@ -129,7 +129,7 @@ const rows = [
       <p class="text-[--color-text-muted] text-lg mb-8 max-w-xl mx-auto">{t('vs_coinrule.cta_desc')}</p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center mb-4">
         <a href="/ko/simulate"
-           class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-8 py-3 rounded font-semibold text-lg hover:bg-[--color-accent-dim]">
+           class="btn btn-primary btn-lg">
           {t('cta.button1')} &rarr;
         </a>
         <a href="/ko/strategies"

--- a/src/pages/ko/compare/cryptohopper.astro
+++ b/src/pages/ko/compare/cryptohopper.astro
@@ -129,7 +129,7 @@ const rows = [
       <p class="text-[--color-text-muted] text-lg mb-8 max-w-xl mx-auto">{t('vs_cryptohopper.cta_desc')}</p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center mb-4">
         <a href="/ko/simulate"
-           class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-8 py-3 rounded font-semibold text-lg hover:bg-[--color-accent-dim]">
+           class="btn btn-primary btn-lg">
           {t('cta.button1')} &rarr;
         </a>
         <a href="/ko/strategies"

--- a/src/pages/ko/compare/gainium.astro
+++ b/src/pages/ko/compare/gainium.astro
@@ -129,7 +129,7 @@ const rows = [
       <p class="text-[--color-text-muted] text-lg mb-8 max-w-xl mx-auto">{t('vs_gainium.cta_desc')}</p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center mb-4">
         <a href="/ko/simulate"
-           class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-8 py-3 rounded font-semibold text-lg hover:bg-[--color-accent-dim]">
+           class="btn btn-primary btn-lg">
           {t('cta.button1')} &rarr;
         </a>
         <a href="/ko/strategies"

--- a/src/pages/ko/compare/streak.astro
+++ b/src/pages/ko/compare/streak.astro
@@ -129,7 +129,7 @@ const rows = [
       <p class="text-[--color-text-muted] text-lg mb-8 max-w-xl mx-auto">{t('vs_streak.cta_desc')}</p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center mb-4">
         <a href="/ko/simulate"
-           class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-8 py-3 rounded font-semibold text-lg hover:bg-[--color-accent-dim]">
+           class="btn btn-primary btn-lg">
           {t('cta.button1')} &rarr;
         </a>
         <a href="/ko/strategies"

--- a/src/pages/ko/compare/tradingview.astro
+++ b/src/pages/ko/compare/tradingview.astro
@@ -171,7 +171,7 @@ const rows = [
       <p class="text-[--color-text-muted] text-lg mb-8 max-w-xl mx-auto">{t('vs.cta_desc')}</p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center mb-4">
         <a href="/ko/simulate"
-           class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-8 py-3 rounded font-semibold text-lg hover:bg-[--color-accent-dim]">
+           class="btn btn-primary btn-lg">
           {t('cta.button1')} &rarr;
         </a>
         <a href="/ko/strategies"

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -565,7 +565,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
 
       <div class="flex flex-col sm:flex-row gap-4 justify-center mb-4">
         <a href="/ko/simulate"
-           class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-8 py-3 rounded font-semibold text-lg hover:bg-[--color-accent-dim]">
+           class="btn btn-primary btn-lg">
           {t('cta.button1')} &rarr;
         </a>
         <a href="/ko/strategies"

--- a/src/pages/ko/strategies/[id].astro
+++ b/src/pages/ko/strategies/[id].astro
@@ -193,7 +193,7 @@ const statusLabels: Record<string, string> = {
         <div class="flex flex-col sm:flex-row gap-3 justify-center">
           {strategy.data.status === 'verified' && (
             <a href={`/ko/simulate?preset=${strategy.id}`}
-               class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-6 py-2 rounded font-semibold text-sm hover:bg-[--color-accent-dim]">
+               class="btn btn-primary btn-md">
               {t('strategy_detail.simulate_this')} &rarr;
             </a>
           )}

--- a/src/pages/ko/strategies/index.astro
+++ b/src/pages/ko/strategies/index.astro
@@ -130,7 +130,7 @@ const isKorean = (id: string) => koIds.has(id);
 
       <div class="mb-6 flex flex-col sm:flex-row gap-3">
         <a href="/ko/simulate"
-           class="btn-primary inline-flex items-center gap-2 bg-[--color-accent] text-[--color-bg] px-5 py-2.5 rounded-lg font-semibold text-sm hover:bg-[--color-accent-dim]">
+           class="btn btn-primary btn-md inline-flex items-center gap-2">
           {t('hero.cta_builder')} &rarr;
         </a>
         <a href="/ko/strategies/ranking"

--- a/src/pages/strategies/[id].astro
+++ b/src/pages/strategies/[id].astro
@@ -173,7 +173,7 @@ const statusLabels: Record<string, string> = {
         <div class="flex flex-col sm:flex-row gap-3 justify-center">
           {strategy.data.status === 'verified' && (
             <a href={`/simulate?preset=${strategy.id}`}
-               class="btn-primary inline-block bg-[--color-accent] text-[--color-bg] px-6 py-2 rounded font-semibold text-sm hover:bg-[--color-accent-dim]">
+               class="btn btn-primary btn-md">
               {t('strategy_detail.simulate_this')} &rarr;
             </a>
           )}

--- a/src/pages/strategies/index.astro
+++ b/src/pages/strategies/index.astro
@@ -113,7 +113,7 @@ const difficultyColors: Record<string, string> = {
 
       <div class="mb-6 flex flex-col sm:flex-row gap-3">
         <a href="/simulate"
-           class="btn-primary inline-flex items-center gap-2 bg-[--color-accent] text-[--color-bg] px-5 py-2.5 rounded-lg font-semibold text-sm hover:bg-[--color-accent-dim]">
+           class="btn btn-primary btn-md inline-flex items-center gap-2">
           {t('hero.cta_builder')} &rarr;
         </a>
         <a href="/strategies/ranking"


### PR DESCRIPTION
## Summary
- Final batch cleanup catching `btn-primary inline-block bg-[--color-accent]...` pattern (had prefix but still old inline styles)
- Fixed 24 pages: 404, about, changelog, strategies/[id], strategies/index, compare/3commas/coinrule/streak/gainium/cryptohopper/tradingview, and all KO equivalents
- All primary CTAs now use `.btn .btn-primary .btn-md/.btn-lg` system

## Test plan
- [ ] 404 page — btn style consistent with rest of site
- [ ] `/about`, `/changelog` — CTAs use btn system
- [ ] `/strategies` and `/strategies/[id]` — CTAs consistent
- [ ] Compare pages — hero CTAs use btn-lg

🤖 Generated with [Claude Code](https://claude.com/claude-code)