### PR TITLE
fix: rankings/daily 500 — KeyError 'entries' in weekly_best3

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -3440,7 +3440,7 @@ def _get_daily_rankings_sync(
         weekly_agg.sort(key=lambda x: (x["avg_pf"], x["avg_wr"]), reverse=True)
         for i, item in enumerate(weekly_agg[:3]):
             meta = item["meta"]
-            trades = sum(e.get("total_trades", 0) for e in item["entries"])
+            trades = meta.get("total_trades", 0)
             weekly_best3.append({
                 "rank": i + 1,
                 "name_ko": meta.get("category_ko", meta.get("strategy", "")),


### PR DESCRIPTION
## Summary
- `weekly_agg` items were never given an `"entries"` key, causing `item["entries"]` to raise `KeyError` on every `/rankings/daily` request
- Root cause: `weekly_best3` loop tried to sum entries from `item["entries"]`, but `weekly_agg` only stored `key/avg_pf/avg_wr/days/meta`
- Fix: use `meta.get("total_trades", 0)` — `meta` is the latest-day entry and already has the correct `total_trades` value
- Impact: 100% of `/rankings/daily` requests returned HTTP 500 since the weekly_best3 block was added

## Test plan
- [x] Verified `curl http://localhost:8080/rankings/daily?period=30d&group=top50` returns 200 with today's data after fix
- [x] `top3`, `weekly_best3`, `summary` fields all populated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)