### PR TITLE
ux: comprehensive site review — fees, homepage, performance

### DIFF
--- a/src/config/exchanges.ts
+++ b/src/config/exchanges.ts
@@ -50,24 +50,4 @@ export const EXCHANGES: ExchangeFeeConfig[] = [
     url: "https://www.binance.com",
     referralUrl: "https://accounts.binance.com/register?ref=PRUVIQ",
   },
-  {
-    id: "bitget",
-    name: "Bitget",
-    standardMakerFee: 0.02, // futures maker: 0.020%
-    standardTakerFee: 0.06, // futures taker: 0.060%
-    referralDiscountPct: 20,
-    marketingLabel: "20% off",
-    url: "https://www.bitget.com",
-    referralUrl: "https://partner.bitget.com/bg/71KRCS",
-  },
-  {
-    id: "okx",
-    name: "OKX",
-    standardMakerFee: 0.02, // futures maker: 0.020%
-    standardTakerFee: 0.05, // futures taker: 0.050%
-    referralDiscountPct: 20,
-    marketingLabel: "20% off",
-    url: "https://www.okx.com",
-    referralUrl: "#",
-  },
 ];

--- a/src/data/exchanges.ts
+++ b/src/data/exchanges.ts
@@ -1,5 +1,5 @@
 export interface FeeRate {
-  maker: number;  // decimal, e.g. 0.001 = 0.10%
+  maker: number; // decimal, e.g. 0.001 = 0.10%
   taker: number;
 }
 
@@ -8,76 +8,54 @@ export interface Exchange {
   name: string;
   spot: FeeRate;
   futures: FeeRate;
-  discount: number;       // decimal, e.g. 0.10 = 10%
-  discountLabel: string;  // display string, e.g. "10%"
+  discount: number; // decimal, e.g. 0.10 = 10%
+  discountLabel: string; // display string, e.g. "10%"
   referralUrl: string;
   available: boolean;
-  tag: string;            // English tag, e.g. "#1 Volume"
-  spotOnly?: boolean;     // true for exchanges without futures (e.g. Korean exchanges)
-  infoOnly?: boolean;     // true for non-affiliate info-only exchanges
+  tag: string; // English tag, e.g. "#1 Volume"
+  spotOnly?: boolean; // true for exchanges without futures (e.g. Korean exchanges)
+  infoOnly?: boolean; // true for non-affiliate info-only exchanges
 }
 
 export const exchanges: Exchange[] = [
   {
-    id: 'binance',
-    name: 'Binance',
+    id: "binance",
+    name: "Binance",
     spot: { maker: 0.001, taker: 0.001 },
     futures: { maker: 0.0002, taker: 0.0005 },
-    discount: 0.10,
-    discountLabel: '10%',
-    referralUrl: 'https://accounts.binance.com/register?ref=PRUVIQ',
+    discount: 0.1,
+    discountLabel: "10%",
+    referralUrl: "https://accounts.binance.com/register?ref=PRUVIQ",
     available: true,
-    tag: '#1 Volume',
-  },
-  {
-    id: 'bitget',
-    name: 'Bitget',
-    spot: { maker: 0.001, taker: 0.001 },
-    futures: { maker: 0.0002, taker: 0.0006 },
-    discount: 0.20,
-    discountLabel: '20%',
-    referralUrl: 'https://partner.bitget.com/bg/71KRCS',
-    available: true,
-    tag: 'Copy Trading',
-  },
-  {
-    id: 'okx',
-    name: 'OKX',
-    spot: { maker: 0.0008, taker: 0.001 },
-    futures: { maker: 0.0002, taker: 0.0005 },
-    discount: 0.20,
-    discountLabel: '20%',
-    referralUrl: '#',
-    available: false,
-    tag: '120+ Countries',
+    tag: "#1 Volume",
   },
 ];
 
 /** Korean exchanges — info-only, no referral */
 export const koreanExchanges: Exchange[] = [
   {
-    id: 'upbit',
-    name: 'Upbit (업비트)',
+    id: "upbit",
+    name: "Upbit (업비트)",
     spot: { maker: 0.0005, taker: 0.0005 },
     futures: { maker: 0, taker: 0 },
     discount: 0,
-    discountLabel: '—',
-    referralUrl: 'https://upbit.com',
+    discountLabel: "—",
+    referralUrl: "https://upbit.com",
     available: true,
-    tag: '#1 Korea',
+    tag: "#1 Korea",
     spotOnly: true,
     infoOnly: true,
   },
   {
-    id: 'bithumb',
-    name: 'Bithumb (빗썸)',
+    id: "bithumb",
+    name: "Bithumb (빗썸)",
     spot: { maker: 0.0004, taker: 0.0004 },
     futures: { maker: 0, taker: 0 },
     discount: 0,
-    discountLabel: '—',
-    referralUrl: 'https://www.bithumb.com',
+    discountLabel: "—",
+    referralUrl: "https://www.bithumb.com",
     available: true,
-    tag: '#2 Korea',
+    tag: "#2 Korea",
     spotOnly: true,
     infoOnly: true,
   },
@@ -94,7 +72,7 @@ export function formatFee(rate: number, decimals: 2 | 3 = 2): string {
 }
 
 /** Format maker/taker as "0.10% / 0.10%" (spot) or "0.020% / 0.050%" (futures) */
-export function formatFeeRange(fee: FeeRate, type: 'spot' | 'futures'): string {
-  const d = type === 'futures' ? 3 : 2;
+export function formatFeeRange(fee: FeeRate, type: "spot" | "futures"): string {
+  const d = type === "futures" ? 3 : 2;
   return `${formatFee(fee.maker, d)} / ${formatFee(fee.taker, d)}`;
 }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -574,6 +574,26 @@ export const en = {
   "perf.results_title": "Backtest Results",
   "perf.results_desc":
     "2+ years, 569 coins, 2,898 trades. Includes 0.08%/side fees.",
+  "perf.gap_title": "Backtest vs Reality",
+  "perf.gap_desc":
+    "Every backtest has a gap with live trading. We experienced it firsthand — and stopped trading when it exceeded our limits.",
+  "perf.gap_backtest": "Backtest (2yr, 569 coins)",
+  "perf.gap_live": "Live Trading (52 days)",
+  "perf.gap_pnl_label": "Total PnL",
+  "perf.gap_mdd_label": "Max Drawdown",
+  "perf.gap_status_label": "Status",
+  "perf.gap_status_stopped": "Stopped at MDD limit",
+  "perf.gap_why_title": "Why the gap?",
+  "perf.gap_why1": "Market impact: live orders move prices, backtests don't",
+  "perf.gap_why2": "Timing: backtests assume instant fills, live has latency",
+  "perf.gap_why3":
+    "Regime shifts: 2024-2025 data didn't predict 2026 conditions",
+  "perf.gap_why4": "Sample size: 52 days of live vs 2+ years of backtest",
+  "perf.gap_action_title": "What we did about it",
+  "perf.gap_action_desc":
+    "We enforced a 20% MDD hard stop. When live trading hit this limit, we killed the strategy immediately — no exceptions. This is the same discipline we recommend for all traders.",
+  "perf.gap_lesson":
+    "A profitable backtest is necessary but not sufficient. Always verify with out-of-sample testing and strict risk limits.",
   "perf.killed_title": "Killed Strategies",
   "perf.killed_desc":
     "Strategies we tested and rejected. We show failures because they're just as important as successes.",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -574,6 +574,28 @@ export const ko: Record<TranslationKey, string> = {
   "perf.results_title": "백테스트 결과",
   "perf.results_desc":
     "2년+, 569개 코인, 2,898건 거래. 0.08%/side 수수료 포함.",
+  "perf.gap_title": "백테스트 vs 현실",
+  "perf.gap_desc":
+    "모든 백테스트에는 실거래와의 괴리가 있습니다. 직접 경험했고 — 한계를 초과했을 때 즉시 중단했습니다.",
+  "perf.gap_backtest": "백테스트 (2년, 569개 코인)",
+  "perf.gap_live": "실거래 (52일)",
+  "perf.gap_pnl_label": "총 손익",
+  "perf.gap_mdd_label": "최대 낙폭",
+  "perf.gap_status_label": "상태",
+  "perf.gap_status_stopped": "MDD 한도 도달로 중단",
+  "perf.gap_why_title": "왜 괴리가 발생하나?",
+  "perf.gap_why1":
+    "시장 충격: 실제 주문은 가격을 움직이지만, 백테스트는 그렇지 않음",
+  "perf.gap_why2":
+    "체결 시간: 백테스트는 즉시 체결을 가정하지만, 실제로는 지연 발생",
+  "perf.gap_why3":
+    "시장 체제 변화: 2024-2025 데이터가 2026 상황을 예측하지 못함",
+  "perf.gap_why4": "샘플 크기: 52일 실거래 vs 2년+ 백테스트",
+  "perf.gap_action_title": "어떻게 대응했나",
+  "perf.gap_action_desc":
+    "MDD 20% 하드 스톱을 적용했습니다. 실거래에서 이 한계에 도달하자 전략을 즉시 중단했습니다 — 예외 없이. 모든 트레이더에게 동일한 규율을 권장합니다.",
+  "perf.gap_lesson":
+    "수익성 있는 백테스트는 필요조건이지 충분조건이 아닙니다. 항상 표본외 검증과 엄격한 리스크 한도로 확인하세요.",
   "perf.killed_title": "기각된 전략",
   "perf.killed_desc":
     "테스트 후 기각한 전략들입니다. 실패도 성공만큼 중요하기에 공개합니다.",

--- a/src/pages/fees.astro
+++ b/src/pages/fees.astro
@@ -5,35 +5,17 @@ import { useTranslations } from '../i18n/index';
 import { exchanges, formatFeeRange } from '../data/exchanges';
 import { EXCHANGES, discountTooltip } from '../config/exchanges';
 
-// Build a lookup map for tooltip data keyed by exchange id
-const exchangeTooltips = Object.fromEntries(EXCHANGES.map((ex) => [ex.id, discountTooltip(ex)]));
+// Get Binance config (single exchange focus)
+const binanceConfig = EXCHANGES[0];
+const binanceDisplay = exchanges[0];
+const binanceTooltip = discountTooltip(binanceConfig);
 
-// Compute annual savings badge per exchange based on $10k/month volume (2 sides)
-// savings = discountPct% × standardTakerFee × $120k/year × 2 sides
-const savingsBadge = Object.fromEntries(
-  EXCHANGES.map((ex) => {
-    const annualVolume = 10_000 * 12; // $120,000/year
-    const saved = (ex.referralDiscountPct / 100) * (ex.standardTakerFee / 100) * annualVolume * 2;
-    return [ex.id, saved >= 1 ? `Save $${Math.round(saved)}/yr` : null];
-  })
-);
+// Compute annual savings at $10k/month volume (2 sides)
+const annualVolume = 10_000 * 12;
+const annualSavings = (binanceConfig.referralDiscountPct / 100) * (binanceConfig.standardTakerFee / 100) * annualVolume * 2;
+const savingsBadge = annualSavings >= 1 ? `Save $${Math.round(annualSavings)}/yr` : null;
 
 const t = useTranslations('en');
-
-const exchangeCards: Record<string, { tagLabel: string; description: string }> = {
-  binance: {
-    tagLabel: t('fees.card_binance_tag'),
-    description: t('fees.card_binance_desc'),
-  },
-  bitget: {
-    tagLabel: t('fees.card_bitget_tag'),
-    description: t('fees.card_bitget_desc'),
-  },
-  okx: {
-    tagLabel: t('fees.card_okx_tag'),
-    description: t('fees.card_okx_desc'),
-  },
-};
 ---
 
 <Layout title={t('meta.fees_title')} description={t('meta.fees_desc')}>
@@ -66,58 +48,56 @@ const exchangeCards: Record<string, { tagLabel: string; description: string }> =
     </div>
   </section>
 
-  <!-- 3 EXCHANGE CARDS -->
+  <!-- BINANCE FEATURED CARD -->
   <section class="pb-12 border-t border-[--color-border] pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-2">{t('fees.compare_title')}</h2>
       <p class="text-[--color-text-muted] text-sm mb-6">{t('fees.compare_desc')}</p>
 
-      <div class="grid md:grid-cols-3 gap-6">
-        {exchanges.map((ex) => {
-          const card = exchangeCards[ex.id];
-          return (
-            <div class={`border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] flex flex-col${!ex.available ? ' opacity-50' : ''}`}>
-              <div class="font-mono text-[--color-accent] text-xs font-bold mb-1">{card.tagLabel}</div>
-              <h3 class="text-xl font-bold mb-3">{ex.name}</h3>
-              <div class="space-y-2 text-sm mb-4 flex-grow">
-                <div class="flex justify-between">
-                  <span class="text-[--color-text-muted]">{t('fees.label_spot')}</span>
-                  <span class="font-mono">{formatFeeRange(ex.spot, 'spot')}</span>
-                </div>
-                <div class="flex justify-between">
-                  <span class="text-[--color-text-muted]">{t('fees.label_futures')}</span>
-                  <span class="font-mono">{formatFeeRange(ex.futures, 'futures')}</span>
-                </div>
-                <div class="flex justify-between border-t border-[--color-border] pt-2 mt-2">
-                  <span class="text-[--color-accent] font-medium">{t('fees.pruviq_discount')}</span>
-                  <span
-                    class="font-mono font-bold text-[--color-accent] cursor-help underline decoration-dotted"
-                    title={exchangeTooltips[ex.id]}
-                  >{ex.discountLabel} {t('fees.discount_off')}</span>
-                </div>
+      <div class="max-w-3xl mx-auto">
+        <div class="border border-[--color-accent]/30 rounded-xl p-8">
+          <div class="flex items-center gap-3 mb-6">
+            <h3 class="text-2xl font-bold">{binanceDisplay.name}</h3>
+            <span class="font-mono text-[--color-accent] text-xs font-bold px-2 py-0.5 rounded border border-[--color-accent]/30 bg-[--color-accent]/5">{binanceDisplay.tag}</span>
+          </div>
+
+          <div class="grid md:grid-cols-2 gap-8">
+            <!-- Left: fee rates -->
+            <div class="space-y-3 text-sm">
+              <div class="flex justify-between">
+                <span class="text-[--color-text-muted]">{t('fees.label_spot')}</span>
+                <span class="font-mono">{formatFeeRange(binanceDisplay.spot, 'spot')}</span>
               </div>
-              <p class="text-[--color-text-muted] text-xs mb-4">{card.description}</p>
-              {savingsBadge[ex.id] && ex.available && (
-                <div class="mb-3">
+              <div class="flex justify-between">
+                <span class="text-[--color-text-muted]">{t('fees.label_futures')}</span>
+                <span class="font-mono">{formatFeeRange(binanceDisplay.futures, 'futures')}</span>
+              </div>
+              <div class="flex justify-between border-t border-[--color-border] pt-3 mt-3">
+                <span class="text-[--color-accent] font-medium">{t('fees.pruviq_discount')}</span>
+                <span
+                  class="font-mono font-bold text-[--color-accent] cursor-help underline decoration-dotted"
+                  title={binanceTooltip}
+                >{binanceDisplay.discountLabel} {t('fees.discount_off')}</span>
+              </div>
+            </div>
+
+            <!-- Right: savings + CTA -->
+            <div class="flex flex-col justify-between">
+              {savingsBadge && (
+                <div class="mb-4">
                   <span class="inline-flex items-center gap-1 text-xs font-mono px-2 py-1 rounded border border-[--color-up]/40 bg-[--color-up]/5 text-[--color-up] font-semibold">
-                    &#9650; {savingsBadge[ex.id]}
+                    &#9650; {savingsBadge}
                     <span class="font-normal text-[--color-text-muted]">at $10k/mo</span>
                   </span>
                 </div>
               )}
-              {ex.available ? (
-                <a href={ex.referralUrl} target="_blank" rel="noopener noreferrer"
-                   class="block text-center bg-[--color-accent] text-[--color-bg] px-4 py-3 min-h-[48px] flex items-center justify-center rounded text-sm font-bold hover:opacity-90 transition-opacity shadow-sm">
-                  {t('fees.signup')} &rarr;
-                </a>
-              ) : (
-                <span class="block text-center bg-[--color-border] text-[--color-text-muted] px-4 py-2 min-h-[44px] flex items-center justify-center rounded text-sm font-semibold cursor-default">
-                  {t('fees.coming_soon')}
-                </span>
-              )}
+              <a href={binanceDisplay.referralUrl} target="_blank" rel="noopener noreferrer"
+                 class="block text-center bg-[--color-accent] text-[--color-bg] px-4 py-3 min-h-[48px] flex items-center justify-center rounded text-sm font-bold hover:opacity-90 transition-opacity shadow-sm">
+                {t('fees.signup')} &rarr;
+              </a>
             </div>
-          );
-        })}
+          </div>
+        </div>
       </div>
 
       <p class="text-[--color-text-muted] text-xs mt-4">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -86,88 +86,6 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
     </div>
   </section>
 
-  <!-- WHY PRUVIQ (Merged Problem + Evidence) -->
-  <hr class="section-divider" />
-  <section class="py-20 bg-[--color-bg-subtle] reveal" aria-labelledby="why-heading">
-    <div class="max-w-6xl mx-auto px-4">
-      <p class="font-mono text-[--color-down] text-sm mb-2 tracking-wider">{t('problem.tag')}</p>
-      <h2 id="why-heading" class="text-3xl md:text-4xl font-bold mb-4">{t('problem.title')}</h2>
-      <p class="text-[--color-text-muted] text-lg mb-12 max-w-3xl">{t('evidence.desc')}</p>
-
-      <!-- Case Studies: Problem cards -->
-      <div class="grid md:grid-cols-3 gap-8 mb-12 reveal-child">
-        <div class="border border-[--color-down]/30 rounded-lg p-6 bg-[--color-bg-card]">
-          <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
-            <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
-            {t('problem.case1_label')}
-          </div>
-          <h3 class="font-bold text-lg mb-2">{t('problem.card1_title')}</h3>
-          <p class="text-[--color-text-muted] text-sm leading-relaxed mb-3">{t('problem.card1_desc')}</p>
-          <p class="text-xs text-[--color-text-muted] opacity-60 italic">{t('problem.card1_source')}</p>
-        </div>
-        <div class="border border-[--color-down]/30 rounded-lg p-6 bg-[--color-bg-card]">
-          <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
-            <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
-            {t('problem.case2_label')}
-          </div>
-          <h3 class="font-bold text-lg mb-2">{t('problem.card2_title')}</h3>
-          <p class="text-[--color-text-muted] text-sm leading-relaxed mb-3">{t('problem.card2_desc')}</p>
-          <p class="text-xs text-[--color-text-muted] opacity-60 italic">{t('problem.card2_source')}</p>
-        </div>
-        <div class="border border-[--color-down]/30 rounded-lg p-6 bg-[--color-bg-card]">
-          <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
-            <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
-            {t('problem.case3_label')}
-          </div>
-          <h3 class="font-bold text-lg mb-2">{t('problem.card3_title')}</h3>
-          <p class="text-[--color-text-muted] text-sm leading-relaxed mb-3">{t('problem.card3_desc')}</p>
-          <p class="text-xs text-[--color-text-muted] opacity-60 italic">{t('problem.card3_source')}</p>
-        </div>
-      </div>
-
-      <!-- The Elimination Process (evidence highlight) -->
-      <div class="border border-[--color-accent]/30 rounded-lg p-8 bg-[--color-bg-card] max-w-3xl mx-auto mb-12">
-        <p class="font-mono text-[--color-accent] text-xs font-bold mb-4">{t('evidence.lesson_tag')}</p>
-        <p class="text-[--color-text-muted] leading-relaxed mb-3">
-          {t('evidence.lesson1')} <span class="text-[--color-accent] font-bold text-lg">{t('evidence.lesson_loss')}</span> <span class="text-[--color-up] font-bold text-lg">{t('evidence.lesson1_end')}</span>
-        </p>
-        <p class="text-[--color-text-muted] leading-relaxed mb-4">{t('evidence.lesson3')}</p>
-        <p class="text-[--color-accent] font-bold text-lg italic">{t('evidence.lesson_rule')}</p>
-      </div>
-
-      <!-- What we publish vs don't promise -->
-      <div class="grid md:grid-cols-2 gap-8 mb-12">
-        <div class="border border-[--color-up]/30 rounded-lg p-6 bg-[--color-bg-card]">
-          <p class="font-mono text-[--color-up] text-xs font-bold mb-4">{t('evidence.publish_tag')}</p>
-          <ul class="space-y-2 text-sm text-[--color-text-muted]">
-            <li class="flex items-start gap-2"><span class="text-[--color-up] shrink-0 mt-0.5">&#10003;</span> {t('evidence.publish1')}</li>
-            <li class="flex items-start gap-2"><span class="text-[--color-up] shrink-0 mt-0.5">&#10003;</span> {t('evidence.publish2')}</li>
-            <li class="flex items-start gap-2"><span class="text-[--color-up] shrink-0 mt-0.5">&#10003;</span> {t('evidence.publish3')}</li>
-            <li class="flex items-start gap-2"><span class="text-[--color-up] shrink-0 mt-0.5">&#10003;</span> {t('evidence.publish4')}</li>
-          </ul>
-        </div>
-        <div class="border border-[--color-down]/30 rounded-lg p-6 bg-[--color-bg-card]">
-          <p class="font-mono text-[--color-down] text-xs font-bold mb-4">{t('evidence.nopromise_tag')}</p>
-          <ul class="space-y-2 text-sm text-[--color-text-muted]">
-            <li class="flex items-start gap-2"><span class="text-[--color-down] shrink-0 mt-0.5">&#10007;</span> {t('evidence.nopromise1')}</li>
-            <li class="flex items-start gap-2"><span class="text-[--color-down] shrink-0 mt-0.5">&#10007;</span> {t('evidence.nopromise2')}</li>
-            <li class="flex items-start gap-2"><span class="text-[--color-down] shrink-0 mt-0.5">&#10007;</span> {t('evidence.nopromise3')}</li>
-            <li class="flex items-start gap-2"><span class="text-[--color-down] shrink-0 mt-0.5">&#10007;</span> {t('evidence.nopromise4')}</li>
-          </ul>
-        </div>
-      </div>
-
-      <div class="text-center">
-        <p class="text-xl md:text-2xl font-bold mb-6">
-          {t('problem.hook')} <span class="text-[--color-accent]">{t('problem.hook_accent')}</span>
-        </p>
-        <a href="/simulate" class="btn btn-primary btn-lg">
-          {t('home.cta_survives')} →
-        </a>
-      </div>
-    </div>
-  </section>
-
   <!-- COMPARISON TABLE (vs Competitors) -->
   <hr class="section-divider" />
   <section class="py-20 reveal" aria-labelledby="compare-heading">
@@ -242,6 +160,53 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
     </div>
   </section>
 
+  <!-- WHY PRUVIQ (Merged Problem + Evidence) -->
+  <hr class="section-divider" />
+  <section class="py-20 bg-[--color-bg-subtle] reveal" aria-labelledby="why-heading">
+    <div class="max-w-6xl mx-auto px-4">
+      <p class="font-mono text-[--color-down] text-sm mb-2 tracking-wider">{t('problem.tag')}</p>
+      <h2 id="why-heading" class="text-3xl md:text-4xl font-bold mb-4">{t('problem.title')}</h2>
+      <p class="text-[--color-text-muted] text-lg mb-12 max-w-3xl">{t('evidence.desc')}</p>
+
+      <!-- Case Studies: Problem cards -->
+      <div class="grid md:grid-cols-3 gap-8 mb-12 reveal-child">
+        <div class="border border-[--color-down]/30 rounded-lg p-6 bg-[--color-bg-card]">
+          <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
+            <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
+            {t('problem.case1_label')}
+          </div>
+          <h3 class="font-bold text-lg mb-2">{t('problem.card1_title')}</h3>
+          <p class="text-[--color-text-muted] text-sm leading-relaxed mb-3">{t('problem.card1_desc')}</p>
+          <p class="text-xs text-[--color-text-muted] opacity-60 italic">{t('problem.card1_source')}</p>
+        </div>
+        <div class="border border-[--color-down]/30 rounded-lg p-6 bg-[--color-bg-card]">
+          <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
+            <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
+            {t('problem.case2_label')}
+          </div>
+          <h3 class="font-bold text-lg mb-2">{t('problem.card2_title')}</h3>
+          <p class="text-[--color-text-muted] text-sm leading-relaxed mb-3">{t('problem.card2_desc')}</p>
+          <p class="text-xs text-[--color-text-muted] opacity-60 italic">{t('problem.card2_source')}</p>
+        </div>
+        <div class="border border-[--color-down]/30 rounded-lg p-6 bg-[--color-bg-card]">
+          <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
+            <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
+            {t('problem.case3_label')}
+          </div>
+          <h3 class="font-bold text-lg mb-2">{t('problem.card3_title')}</h3>
+          <p class="text-[--color-text-muted] text-sm leading-relaxed mb-3">{t('problem.card3_desc')}</p>
+          <p class="text-xs text-[--color-text-muted] opacity-60 italic">{t('problem.card3_source')}</p>
+        </div>
+      </div>
+
+      <div class="text-center">
+        <p class="text-xl md:text-2xl font-bold">
+          {t('problem.hook')} <span class="text-[--color-accent]">{t('problem.hook_accent')}</span>
+        </p>
+      </div>
+    </div>
+  </section>
+
   <!-- FEATURES & TRUST (Merged) -->
   <hr class="section-divider" />
   <section class="py-20 bg-[--color-bg-subtle] reveal" aria-labelledby="features-heading">
@@ -311,11 +276,6 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
           <p class="text-[--color-text-muted] text-sm">{t('trust.badge_open_desc')}</p>
         </a>
       </div>
-      <div class="mt-10 text-center">
-        <a href="/simulate" class="btn btn-primary btn-md
-          {t('hero.cta_primary')} →
-        </a>
-      </div>
     </div>
   </section>
 
@@ -360,12 +320,6 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
             </div>
           </footer>
         </blockquote>
-      </div>
-      <!-- CTA after social proof quotes -->
-      <div class="mt-8 text-center">
-        <a href="/simulate" class="btn btn-primary btn-md
-          {t('home.quotes_cta')} →
-        </a>
       </div>
     </div>
   </section>
@@ -412,12 +366,6 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
           </summary>
           <div class="faq-body"><div><p class="px-6 pb-4 text-[--color-text-muted] text-sm leading-relaxed">{t('faq.a5')}</p></div></div>
         </details>
-      </div>
-      <!-- CTA after FAQ -->
-      <div class="mt-8 text-center">
-        <a href="/simulate" class="btn btn-primary btn-md
-          {t('hero.cta_primary')} →
-        </a>
       </div>
     </div>
   </section>

--- a/src/pages/ko/fees.astro
+++ b/src/pages/ko/fees.astro
@@ -5,34 +5,17 @@ import { useTranslations } from '../../i18n/index';
 import { exchanges, formatFeeRange } from '../../data/exchanges';
 import { EXCHANGES, discountTooltip } from '../../config/exchanges';
 
-// Build a lookup map for tooltip data keyed by exchange id
-const exchangeTooltips = Object.fromEntries(EXCHANGES.map((ex) => [ex.id, discountTooltip(ex)]));
+// Get Binance config (single exchange focus)
+const binanceConfig = EXCHANGES[0];
+const binanceDisplay = exchanges[0];
+const binanceTooltip = discountTooltip(binanceConfig);
 
-// Compute annual savings badge per exchange based on $10k/month volume (2 sides)
-const savingsBadge = Object.fromEntries(
-  EXCHANGES.map((ex) => {
-    const annualVolume = 10_000 * 12;
-    const saved = (ex.referralDiscountPct / 100) * (ex.standardTakerFee / 100) * annualVolume * 2;
-    return [ex.id, saved >= 1 ? `연 $${Math.round(saved)} 절약` : null];
-  })
-);
+// Compute annual savings at $10k/month volume (2 sides)
+const annualVolume = 10_000 * 12;
+const annualSavings = (binanceConfig.referralDiscountPct / 100) * (binanceConfig.standardTakerFee / 100) * annualVolume * 2;
+const savingsBadge = annualSavings >= 1 ? `연 $${Math.round(annualSavings)} 절약` : null;
 
 const t = useTranslations('ko');
-
-const exchangeCards: Record<string, { tagLabel: string; description: string }> = {
-  binance: {
-    tagLabel: t('fees.card_binance_tag'),
-    description: t('fees.card_binance_desc'),
-  },
-  bitget: {
-    tagLabel: t('fees.card_bitget_tag'),
-    description: t('fees.card_bitget_desc'),
-  },
-  okx: {
-    tagLabel: t('fees.card_okx_tag'),
-    description: t('fees.card_okx_desc'),
-  },
-};
 ---
 
 <Layout title={t('meta.fees_title')} description={t('meta.fees_desc')}>
@@ -65,58 +48,56 @@ const exchangeCards: Record<string, { tagLabel: string; description: string }> =
     </div>
   </section>
 
-  <!-- 3개 거래소 카드 -->
+  <!-- 바이낸스 추천 카드 -->
   <section class="pb-12 border-t border-[--color-border] pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-2">{t('fees.compare_title')}</h2>
       <p class="text-[--color-text-muted] text-sm mb-6">{t('fees.compare_desc')}</p>
 
-      <div class="grid md:grid-cols-3 gap-6">
-        {exchanges.map((ex) => {
-          const card = exchangeCards[ex.id];
-          return (
-            <div class={`border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] flex flex-col${!ex.available ? ' opacity-50' : ''}`}>
-              <div class="font-mono text-[--color-accent] text-xs font-bold mb-1">{card.tagLabel}</div>
-              <h3 class="text-xl font-bold mb-3">{ex.name}</h3>
-              <div class="space-y-2 text-sm mb-4 flex-grow">
-                <div class="flex justify-between">
-                  <span class="text-[--color-text-muted]">{t('fees.label_spot')}</span>
-                  <span class="font-mono">{formatFeeRange(ex.spot, 'spot')}</span>
-                </div>
-                <div class="flex justify-between">
-                  <span class="text-[--color-text-muted]">{t('fees.label_futures')}</span>
-                  <span class="font-mono">{formatFeeRange(ex.futures, 'futures')}</span>
-                </div>
-                <div class="flex justify-between border-t border-[--color-border] pt-2 mt-2">
-                  <span class="text-[--color-accent] font-medium">{t('fees.pruviq_discount')}</span>
-                  <span
-                    class="font-mono font-bold text-[--color-accent] cursor-help underline decoration-dotted"
-                    title={exchangeTooltips[ex.id]}
-                  >{ex.discountLabel} {t('fees.discount_off')}</span>
-                </div>
+      <div class="max-w-3xl mx-auto">
+        <div class="border border-[--color-accent]/30 rounded-xl p-8">
+          <div class="flex items-center gap-3 mb-6">
+            <h3 class="text-2xl font-bold">{binanceDisplay.name}</h3>
+            <span class="font-mono text-[--color-accent] text-xs font-bold px-2 py-0.5 rounded border border-[--color-accent]/30 bg-[--color-accent]/5">{binanceDisplay.tag}</span>
+          </div>
+
+          <div class="grid md:grid-cols-2 gap-8">
+            <!-- 왼쪽: 수수료율 -->
+            <div class="space-y-3 text-sm">
+              <div class="flex justify-between">
+                <span class="text-[--color-text-muted]">{t('fees.label_spot')}</span>
+                <span class="font-mono">{formatFeeRange(binanceDisplay.spot, 'spot')}</span>
               </div>
-              <p class="text-[--color-text-muted] text-xs mb-4">{card.description}</p>
-              {savingsBadge[ex.id] && ex.available && (
-                <div class="mb-3">
+              <div class="flex justify-between">
+                <span class="text-[--color-text-muted]">{t('fees.label_futures')}</span>
+                <span class="font-mono">{formatFeeRange(binanceDisplay.futures, 'futures')}</span>
+              </div>
+              <div class="flex justify-between border-t border-[--color-border] pt-3 mt-3">
+                <span class="text-[--color-accent] font-medium">{t('fees.pruviq_discount')}</span>
+                <span
+                  class="font-mono font-bold text-[--color-accent] cursor-help underline decoration-dotted"
+                  title={binanceTooltip}
+                >{binanceDisplay.discountLabel} {t('fees.discount_off')}</span>
+              </div>
+            </div>
+
+            <!-- 오른쪽: 절약 + CTA -->
+            <div class="flex flex-col justify-between">
+              {savingsBadge && (
+                <div class="mb-4">
                   <span class="inline-flex items-center gap-1 text-xs font-mono px-2 py-1 rounded border border-[--color-up]/40 bg-[--color-up]/5 text-[--color-up] font-semibold">
-                    &#9650; {savingsBadge[ex.id]}
+                    &#9650; {savingsBadge}
                     <span class="font-normal text-[--color-text-muted]">($10k/월 기준)</span>
                   </span>
                 </div>
               )}
-              {ex.available ? (
-                <a href={ex.referralUrl} target="_blank" rel="noopener noreferrer"
-                   class="block text-center bg-[--color-accent] text-[--color-bg] px-4 py-3 min-h-[48px] flex items-center justify-center rounded text-sm font-bold hover:opacity-90 transition-opacity shadow-sm">
-                  {t('fees.signup')} &rarr;
-                </a>
-              ) : (
-                <span class="block text-center bg-[--color-border] text-[--color-text-muted] px-4 py-2 min-h-[44px] flex items-center justify-center rounded text-sm font-semibold cursor-default">
-                  {t('fees.coming_soon')}
-                </span>
-              )}
+              <a href={binanceDisplay.referralUrl} target="_blank" rel="noopener noreferrer"
+                 class="block text-center bg-[--color-accent] text-[--color-bg] px-4 py-3 min-h-[48px] flex items-center justify-center rounded text-sm font-bold hover:opacity-90 transition-opacity shadow-sm">
+                {t('fees.signup')} &rarr;
+              </a>
             </div>
-          );
-        })}
+          </div>
+        </div>
       </div>
 
       <p class="text-[--color-text-muted] text-xs mt-4">

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -100,49 +100,6 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
         </div>
         <a href="/ko/compare/tradingview" class="text-xs text-[--color-accent] hover:underline font-mono mb-8 inline-block">{t('compare_table.detail_link_alt')} &rarr;</a>
 
-        <!-- Stats -->
-        <div class="grid grid-cols-2 sm:grid-cols-3 gap-4">
-          <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover" style="box-shadow: var(--shadow-card);">
-            <p class="font-mono text-[--color-accent] text-2xl font-bold">{coinsAnalyzed}</p>
-            <p class="text-[--color-text-muted] text-sm">{t('hero.stat1')}</p>
-            <p class="text-[--color-text-muted] text-xs mt-1 opacity-60">{t('hero.stat1_sub')}</p>
-          </div>
-          <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover" style="box-shadow: var(--shadow-card);">
-            <p class="font-mono text-[--color-accent] text-2xl font-bold">{tradingDays}+</p>
-            <p class="text-[--color-text-muted] text-sm">{t('hero.stat4')}</p>
-            <p class="text-[--color-text-muted] text-xs mt-1 opacity-60">{t('hero.stat4_sub')}</p>
-          </div>
-          <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover" style="box-shadow: var(--shadow-card);">
-            <p class="font-mono text-[--color-accent] text-2xl font-bold">{candlesProcessed}+</p>
-            <p class="text-[--color-text-muted] text-sm">{t('hero.stat5')}</p>
-            <p class="text-[--color-text-muted] text-xs mt-1 opacity-60">{t('hero.stat5_sub')}</p>
-          </div>
-          <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover" style="box-shadow: var(--shadow-card);">
-            <p class="font-mono text-[--color-accent] text-2xl font-bold">{t('hero.stat2_val')}</p>
-            <p class="text-[--color-text-muted] text-sm">{t('hero.stat2')}</p>
-          </div>
-          <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover" style="box-shadow: var(--shadow-card);">
-            <p class="font-mono text-[--color-accent] text-2xl font-bold">100%</p>
-            <p class="text-[--color-text-muted] text-sm">{t('hero.stat3')}</p>
-          </div>
-          <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover" style="box-shadow: var(--shadow-card);">
-            <p class="font-mono text-[--color-accent] text-2xl font-bold">$0</p>
-            <p class="text-[--color-text-muted] text-sm">{t('hero.stat6')}</p>
-            <p class="text-[--color-text-muted] text-xs mt-1 opacity-60">{t('hero.stat6_sub')}</p>
-          </div>
-        </div>
-
-        <!-- TRUST BLOCK: "N개 검증됨" 제거 — 숫자가 작을 때 부정적 신호 -->
-        <div class="mt-6 border border-[--color-border] rounded p-4 bg-[--color-bg-card] flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-          <div>
-            <p class="text-sm font-mono text-[--color-text-muted]">{t('trust.badge_validated')}</p>
-            <p class="text-xl font-bold">{coinsAnalyzed}개 코인 백테스트 가능</p>
-            <p class="text-xs text-[--color-text-muted]">{t('trust.last_updated').replace('{date}', lastUpdated)}</p>
-          </div>
-          <div class="sm:text-right">
-            <a href="/ko/simulate" class="btn btn-primary btn-md">{t('cta.button1')}</a>
-          </div>
-        </div>
       </div>
       <!-- Right: Live strategy widget -->
       <div class="mt-6 md:mt-0">
@@ -168,129 +125,6 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
         <div>
           <div class="font-mono text-[--color-accent] text-xs tracking-wider mb-1">③ {t('how.step3')}</div>
           <p class="text-xs text-[--color-text-muted]">{t('how.step3_desc')}</p>
-        </div>
-      </div>
-      <div class="mt-6 text-center">
-        <a href="/ko/simulate" class="btn btn-primary btn-md
-          {t('hero.cta_primary')} &rarr;
-        </a>
-      </div>
-    </div>
-  </section>
-
-  <!-- WHY PRUVIQ (Merged Problem + Evidence) -->
-  <hr class="section-divider" />
-  <section class="py-20 bg-[--color-bg-subtle]" aria-labelledby="why-heading-ko">
-    <div class="max-w-6xl mx-auto px-4">
-      <p class="font-mono text-[--color-down] text-sm mb-2 tracking-wider">{t('problem.tag')}</p>
-      <h2 id="why-heading-ko" class="text-3xl md:text-4xl font-bold mb-4">{t('problem.title')}</h2>
-      <p class="text-[--color-text-muted] text-lg mb-12 max-w-3xl">{t('evidence.desc')}</p>
-
-      <!-- Case Studies -->
-      <div class="grid md:grid-cols-3 gap-8 mb-12">
-        <div class="border border-[--color-down]/30 rounded-lg p-6 bg-[--color-bg-card]">
-          <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
-            <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
-            {t('problem.case1_label')}
-          </div>
-          <h3 class="font-bold text-lg mb-2">{t('problem.card1_title')}</h3>
-          <p class="text-[--color-text-muted] text-sm leading-relaxed mb-3">{t('problem.card1_desc')}</p>
-          <p class="text-xs text-[--color-text-muted] opacity-60 italic">{t('problem.card1_source')}</p>
-        </div>
-        <div class="border border-[--color-down]/30 rounded-lg p-6 bg-[--color-bg-card]">
-          <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
-            <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
-            {t('problem.case2_label')}
-          </div>
-          <h3 class="font-bold text-lg mb-2">{t('problem.card2_title')}</h3>
-          <p class="text-[--color-text-muted] text-sm leading-relaxed mb-3">{t('problem.card2_desc')}</p>
-          <p class="text-xs text-[--color-text-muted] opacity-60 italic">{t('problem.card2_source')}</p>
-        </div>
-        <div class="border border-[--color-down]/30 rounded-lg p-6 bg-[--color-bg-card]">
-          <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
-            <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
-            {t('problem.case3_label')}
-          </div>
-          <h3 class="font-bold text-lg mb-2">{t('problem.card3_title')}</h3>
-          <p class="text-[--color-text-muted] text-sm leading-relaxed mb-3">{t('problem.card3_desc')}</p>
-          <p class="text-xs text-[--color-text-muted] opacity-60 italic">{t('problem.card3_source')}</p>
-        </div>
-      </div>
-
-      <!-- The Elimination Process -->
-      <div class="border border-[--color-accent]/30 rounded-lg p-8 bg-[--color-bg-card] max-w-3xl mx-auto mb-12">
-        <p class="font-mono text-[--color-accent] text-xs font-bold mb-4">{t('evidence.lesson_tag')}</p>
-        <p class="text-[--color-text-muted] leading-relaxed mb-3">
-          {t('evidence.lesson1')} <span class="text-[--color-accent] font-bold text-lg">{t('evidence.lesson_loss')}</span> <span class="text-[--color-up] font-bold text-lg">{t('evidence.lesson1_end')}</span>
-        </p>
-        <p class="text-[--color-text-muted] leading-relaxed mb-4">{t('evidence.lesson3')}</p>
-        <p class="text-[--color-accent] font-bold text-lg italic">{t('evidence.lesson_rule')}</p>
-      </div>
-
-      <!-- What we publish vs don't promise -->
-      <div class="grid md:grid-cols-2 gap-8 mb-12">
-        <div class="border border-[--color-up]/30 rounded-lg p-6 bg-[--color-bg-card]">
-          <p class="font-mono text-[--color-up] text-xs font-bold mb-4">{t('evidence.publish_tag')}</p>
-          <ul class="space-y-2 text-sm text-[--color-text-muted]">
-            <li class="flex items-start gap-2"><span class="text-[--color-up] shrink-0 mt-0.5">&#10003;</span> {t('evidence.publish1')}</li>
-            <li class="flex items-start gap-2"><span class="text-[--color-up] shrink-0 mt-0.5">&#10003;</span> {t('evidence.publish2')}</li>
-            <li class="flex items-start gap-2"><span class="text-[--color-up] shrink-0 mt-0.5">&#10003;</span> {t('evidence.publish3')}</li>
-            <li class="flex items-start gap-2"><span class="text-[--color-up] shrink-0 mt-0.5">&#10003;</span> {t('evidence.publish4')}</li>
-          </ul>
-        </div>
-        <div class="border border-[--color-down]/30 rounded-lg p-6 bg-[--color-bg-card]">
-          <p class="font-mono text-[--color-down] text-xs font-bold mb-4">{t('evidence.nopromise_tag')}</p>
-          <ul class="space-y-2 text-sm text-[--color-text-muted]">
-            <li class="flex items-start gap-2"><span class="text-[--color-down] shrink-0 mt-0.5">&#10007;</span> {t('evidence.nopromise1')}</li>
-            <li class="flex items-start gap-2"><span class="text-[--color-down] shrink-0 mt-0.5">&#10007;</span> {t('evidence.nopromise2')}</li>
-            <li class="flex items-start gap-2"><span class="text-[--color-down] shrink-0 mt-0.5">&#10007;</span> {t('evidence.nopromise3')}</li>
-            <li class="flex items-start gap-2"><span class="text-[--color-down] shrink-0 mt-0.5">&#10007;</span> {t('evidence.nopromise4')}</li>
-          </ul>
-        </div>
-      </div>
-
-      <div class="text-center">
-        <p class="text-xl md:text-2xl font-bold mb-6">
-          {t('problem.hook')} <span class="text-[--color-accent]">{t('problem.hook_accent')}</span>
-        </p>
-        <a href="/ko/simulate" class="btn btn-primary btn-lg">
-          {t('hero.cta_primary')} &rarr;
-        </a>
-      </div>
-    </div>
-  </section>
-
-  <!-- SYSTEM (How It Works - Visual) -->
-  <hr class="section-divider" />
-  <section class="py-20 bg-[--color-bg-subtle]" aria-labelledby="system-heading-ko">
-    <div class="max-w-6xl mx-auto px-4">
-      <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('system.tag')}</p>
-      <h2 id="system-heading-ko" class="text-3xl md:text-4xl font-bold mb-4">{t('system.title')}</h2>
-      <p class="text-[--color-text-muted] text-lg mb-12 max-w-2xl">{t('system.desc')}</p>
-
-      <div class="grid md:grid-cols-3 gap-8 mb-12">
-        <div class="relative">
-          <div class="font-mono text-[--color-accent] text-5xl font-bold opacity-20 absolute -top-4 -left-2">1</div>
-          <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] relative">
-            <h3 class="font-mono text-[--color-accent] font-bold mb-2">{t('system.step1')}</h3>
-            <p class="text-[--color-text-muted] text-sm leading-relaxed">{t('system.step1_desc')}</p>
-          </div>
-          <div class="hidden md:block absolute top-1/2 -right-4 text-[--color-text-muted] text-2xl">&rarr;</div>
-        </div>
-        <div class="relative">
-          <div class="font-mono text-[--color-accent] text-5xl font-bold opacity-20 absolute -top-4 -left-2">2</div>
-          <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] relative">
-            <h3 class="font-mono text-[--color-accent] font-bold mb-2">{t('system.step2')}</h3>
-            <p class="text-[--color-text-muted] text-sm leading-relaxed">{t('system.step2_desc')}</p>
-          </div>
-          <div class="hidden md:block absolute top-1/2 -right-4 text-[--color-text-muted] text-2xl">&rarr;</div>
-        </div>
-        <div class="relative">
-          <div class="font-mono text-[--color-accent] text-5xl font-bold opacity-20 absolute -top-4 -left-2">3</div>
-          <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] relative">
-            <h3 class="font-mono text-[--color-accent] font-bold mb-2">{t('system.step3')}</h3>
-            <p class="text-[--color-text-muted] text-sm leading-relaxed">{t('system.step3_desc')}</p>
-          </div>
         </div>
       </div>
     </div>
@@ -367,6 +201,53 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
     </div>
   </section>
 
+  <!-- WHY PRUVIQ (Merged Problem + Evidence) -->
+  <hr class="section-divider" />
+  <section class="py-20 bg-[--color-bg-subtle]" aria-labelledby="why-heading-ko">
+    <div class="max-w-6xl mx-auto px-4">
+      <p class="font-mono text-[--color-down] text-sm mb-2 tracking-wider">{t('problem.tag')}</p>
+      <h2 id="why-heading-ko" class="text-3xl md:text-4xl font-bold mb-4">{t('problem.title')}</h2>
+      <p class="text-[--color-text-muted] text-lg mb-12 max-w-3xl">{t('evidence.desc')}</p>
+
+      <!-- Case Studies -->
+      <div class="grid md:grid-cols-3 gap-8 mb-12">
+        <div class="border border-[--color-down]/30 rounded-lg p-6 bg-[--color-bg-card]">
+          <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
+            <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
+            {t('problem.case1_label')}
+          </div>
+          <h3 class="font-bold text-lg mb-2">{t('problem.card1_title')}</h3>
+          <p class="text-[--color-text-muted] text-sm leading-relaxed mb-3">{t('problem.card1_desc')}</p>
+          <p class="text-xs text-[--color-text-muted] opacity-60 italic">{t('problem.card1_source')}</p>
+        </div>
+        <div class="border border-[--color-down]/30 rounded-lg p-6 bg-[--color-bg-card]">
+          <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
+            <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
+            {t('problem.case2_label')}
+          </div>
+          <h3 class="font-bold text-lg mb-2">{t('problem.card2_title')}</h3>
+          <p class="text-[--color-text-muted] text-sm leading-relaxed mb-3">{t('problem.card2_desc')}</p>
+          <p class="text-xs text-[--color-text-muted] opacity-60 italic">{t('problem.card2_source')}</p>
+        </div>
+        <div class="border border-[--color-down]/30 rounded-lg p-6 bg-[--color-bg-card]">
+          <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
+            <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
+            {t('problem.case3_label')}
+          </div>
+          <h3 class="font-bold text-lg mb-2">{t('problem.card3_title')}</h3>
+          <p class="text-[--color-text-muted] text-sm leading-relaxed mb-3">{t('problem.card3_desc')}</p>
+          <p class="text-xs text-[--color-text-muted] opacity-60 italic">{t('problem.card3_source')}</p>
+        </div>
+      </div>
+
+      <div class="text-center">
+        <p class="text-xl md:text-2xl font-bold">
+          {t('problem.hook')} <span class="text-[--color-accent]">{t('problem.hook_accent')}</span>
+        </p>
+      </div>
+    </div>
+  </section>
+
   <!-- FEATURES & TRUST (Merged) -->
   <hr class="section-divider" />
   <section class="py-20 bg-[--color-bg-subtle]" aria-labelledby="features-heading-ko">
@@ -436,11 +317,6 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
           <p class="text-[--color-text-muted] text-sm">{t('trust.badge_open_desc')}</p>
         </a>
       </div>
-      <div class="mt-10 text-center">
-        <a href="/ko/simulate" class="btn btn-primary btn-md
-          {t('hero.cta_primary')} &rarr;
-        </a>
-      </div>
     </div>
   </section>
 
@@ -482,11 +358,6 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
             </div>
           </footer>
         </blockquote>
-      </div>
-      <div class="mt-8 text-center">
-        <a href="/ko/simulate" class="btn btn-primary btn-md
-          {t('home.quotes_cta')} &rarr;
-        </a>
       </div>
     </div>
   </section>
@@ -533,11 +404,6 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
           </summary>
           <p class="px-6 pb-4 text-[--color-text-muted] text-sm leading-relaxed">{t('faq.a5')}</p>
         </details>
-      </div>
-      <div class="mt-8 text-center">
-        <a href="/ko/simulate" class="btn btn-primary btn-md
-          {t('hero.cta_primary')} &rarr;
-        </a>
       </div>
     </div>
   </section>

--- a/src/pages/ko/performance/index.astro
+++ b/src/pages/ko/performance/index.astro
@@ -225,6 +225,74 @@ const xLast = daily[daily.length - 1]?.date ?? '';
     </section>
   )}
 
+  <!-- 백테스트 VS 현실 -->
+  <section class="pb-12 border-t border-[--color-border] pt-8">
+    <div class="max-w-5xl mx-auto px-4">
+      <h2 class="text-2xl font-bold mb-2">{t('perf.gap_title')}</h2>
+      <p class="text-[--color-text-muted] text-sm mb-8">{t('perf.gap_desc')}</p>
+
+      <!-- 비교 카드 -->
+      <div class="grid md:grid-cols-2 gap-6 mb-8">
+        <div class="border border-[--color-up]/30 rounded-lg p-6 bg-[--color-up]/5">
+          <p class="font-mono text-[--color-up] text-xs font-bold mb-4">{t('perf.gap_backtest')}</p>
+          <div class="space-y-3">
+            <div class="flex justify-between text-sm">
+              <span class="text-[--color-text-muted]">{t('perf.gap_pnl_label')}</span>
+              <span class="font-mono font-bold text-[--color-up]">+$794</span>
+            </div>
+            <div class="flex justify-between text-sm">
+              <span class="text-[--color-text-muted]">{t('perf.gap_mdd_label')}</span>
+              <span class="font-mono">33%</span>
+            </div>
+            <div class="flex justify-between text-sm">
+              <span class="text-[--color-text-muted]">{t('compare.trades')}</span>
+              <span class="font-mono">2,898</span>
+            </div>
+          </div>
+        </div>
+        <div class="border border-[--color-down]/30 rounded-lg p-6 bg-[--color-down]/5">
+          <p class="font-mono text-[--color-down] text-xs font-bold mb-4">{t('perf.gap_live')}</p>
+          <div class="space-y-3">
+            <div class="flex justify-between text-sm">
+              <span class="text-[--color-text-muted]">{t('perf.gap_pnl_label')}</span>
+              <span class="font-mono font-bold text-[--color-down]">-$275</span>
+            </div>
+            <div class="flex justify-between text-sm">
+              <span class="text-[--color-text-muted]">{t('perf.gap_mdd_label')}</span>
+              <span class="font-mono">15.7%</span>
+            </div>
+            <div class="flex justify-between text-sm">
+              <span class="text-[--color-text-muted]">{t('perf.gap_status_label')}</span>
+              <span class="font-mono text-[--color-down]">{t('perf.gap_status_stopped')}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 왜 괴리가 발생하나 -->
+      <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] mb-6">
+        <h3 class="font-bold mb-3">{t('perf.gap_why_title')}</h3>
+        <ol class="list-decimal pl-5 space-y-2 text-sm text-[--color-text-muted]">
+          <li>{t('perf.gap_why1')}</li>
+          <li>{t('perf.gap_why2')}</li>
+          <li>{t('perf.gap_why3')}</li>
+          <li>{t('perf.gap_why4')}</li>
+        </ol>
+      </div>
+
+      <!-- 대응 조치 -->
+      <div class="border border-[--color-accent]/30 rounded-lg p-6 bg-[--color-accent]/5 mb-6">
+        <h3 class="font-bold mb-2">{t('perf.gap_action_title')}</h3>
+        <p class="text-sm text-[--color-text-muted] leading-relaxed">{t('perf.gap_action_desc')}</p>
+      </div>
+
+      <!-- 핵심 교훈 -->
+      <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card]">
+        <p class="text-sm text-[--color-text-muted] italic">{t('perf.gap_lesson')}</p>
+      </div>
+    </div>
+  </section>
+
   <!-- KILLED STRATEGIES -->
   <section class="pb-12 border-t border-[--color-border] pt-8">
     <div class="max-w-5xl mx-auto px-4">

--- a/src/pages/ko/privacy.astro
+++ b/src/pages/ko/privacy.astro
@@ -55,7 +55,7 @@ const t = useTranslations('ko');
             <li><strong class="text-[--color-text]">Cloudflare Web Analytics:</strong> 익명 트래픽 분석 (쿠키 미사용, GDPR 준수)</li>
             <li><strong class="text-[--color-text]">자체 호스팅 폰트:</strong> 모든 웹 폰트(Inter, JetBrains Mono)는 자체 도메인에서 직접 제공됩니다. 외부 폰트 서비스를 사용하지 않습니다.</li>
           </ul>
-          <p class="mt-3">제휴 링크를 통해 암호화폐 거래소(바이낸스, 바이비트, OKX, 비트겟 등)로 이동하면 해당 플랫폼의 개인정보처리방침이 적용됩니다.</p>
+          <p class="mt-3">제휴 링크를 통해 암호화폐 거래소(바이낸스 등)로 이동하면 해당 플랫폼의 개인정보처리방침이 적용됩니다.</p>
         </div>
 
         <div>

--- a/src/pages/performance/index.astro
+++ b/src/pages/performance/index.astro
@@ -286,6 +286,74 @@ const xLast = daily[daily.length - 1]?.date ?? '';
     </section>
   )}
 
+  <!-- BACKTEST VS REALITY -->
+  <section class="pb-12 border-t border-[--color-border] pt-8">
+    <div class="max-w-5xl mx-auto px-4">
+      <h2 class="text-2xl font-bold mb-2">{t('perf.gap_title')}</h2>
+      <p class="text-[--color-text-muted] text-sm mb-8">{t('perf.gap_desc')}</p>
+
+      <!-- Side-by-side comparison -->
+      <div class="grid md:grid-cols-2 gap-6 mb-8">
+        <div class="border border-[--color-up]/30 rounded-lg p-6 bg-[--color-up]/5">
+          <p class="font-mono text-[--color-up] text-xs font-bold mb-4">{t('perf.gap_backtest')}</p>
+          <div class="space-y-3">
+            <div class="flex justify-between text-sm">
+              <span class="text-[--color-text-muted]">{t('perf.gap_pnl_label')}</span>
+              <span class="font-mono font-bold text-[--color-up]">+$794</span>
+            </div>
+            <div class="flex justify-between text-sm">
+              <span class="text-[--color-text-muted]">{t('perf.gap_mdd_label')}</span>
+              <span class="font-mono">33%</span>
+            </div>
+            <div class="flex justify-between text-sm">
+              <span class="text-[--color-text-muted]">Trades</span>
+              <span class="font-mono">2,898</span>
+            </div>
+          </div>
+        </div>
+        <div class="border border-[--color-down]/30 rounded-lg p-6 bg-[--color-down]/5">
+          <p class="font-mono text-[--color-down] text-xs font-bold mb-4">{t('perf.gap_live')}</p>
+          <div class="space-y-3">
+            <div class="flex justify-between text-sm">
+              <span class="text-[--color-text-muted]">{t('perf.gap_pnl_label')}</span>
+              <span class="font-mono font-bold text-[--color-down]">-$275</span>
+            </div>
+            <div class="flex justify-between text-sm">
+              <span class="text-[--color-text-muted]">{t('perf.gap_mdd_label')}</span>
+              <span class="font-mono">15.7%</span>
+            </div>
+            <div class="flex justify-between text-sm">
+              <span class="text-[--color-text-muted]">{t('perf.gap_status_label')}</span>
+              <span class="font-mono text-[--color-down]">{t('perf.gap_status_stopped')}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Why the gap -->
+      <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] mb-6">
+        <h3 class="font-bold mb-3">{t('perf.gap_why_title')}</h3>
+        <ol class="list-decimal pl-5 space-y-2 text-sm text-[--color-text-muted]">
+          <li>{t('perf.gap_why1')}</li>
+          <li>{t('perf.gap_why2')}</li>
+          <li>{t('perf.gap_why3')}</li>
+          <li>{t('perf.gap_why4')}</li>
+        </ol>
+      </div>
+
+      <!-- What we did -->
+      <div class="border border-[--color-accent]/30 rounded-lg p-6 bg-[--color-accent]/5 mb-6">
+        <h3 class="font-bold mb-2">{t('perf.gap_action_title')}</h3>
+        <p class="text-sm text-[--color-text-muted] leading-relaxed">{t('perf.gap_action_desc')}</p>
+      </div>
+
+      <!-- Key lesson -->
+      <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card]">
+        <p class="text-sm text-[--color-text-muted] italic">{t('perf.gap_lesson')}</p>
+      </div>
+    </div>
+  </section>
+
   <!-- KILLED STRATEGIES -->
   <section class="pb-12 border-t border-[--color-border] pt-8">
     <div class="max-w-5xl mx-auto px-4">

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -62,7 +62,7 @@ const t = useTranslations('en');
             <li><strong class="text-[--color-text]">Cloudflare Web Analytics:</strong> Anonymous traffic analytics. Cookie-free, GDPR-compliant. <a href="https://www.cloudflare.com/trust-hub/gdpr/" class="text-[--color-accent] hover:underline" target="_blank" rel="noopener noreferrer">Cloudflare GDPR Compliance</a></li>
             <li><strong class="text-[--color-text]">Self-hosted Fonts:</strong> All web fonts (Inter, JetBrains Mono) are served directly from our domain. No third-party font services are used.</li>
           </ul>
-          <p class="mt-3">When you click affiliate links to cryptocurrency exchanges (e.g., Binance, Bybit, OKX, Bitget), you leave PRUVIQ and are subject to those platforms' privacy policies. We recommend reviewing their policies before creating accounts.</p>
+          <p class="mt-3">When you click affiliate links to cryptocurrency exchanges (e.g., Binance), you leave PRUVIQ and are subject to those platforms' privacy policies. We recommend reviewing their policies before creating accounts.</p>
         </div>
 
         <!-- 5. Affiliate Links -->


### PR DESCRIPTION
## Summary
Full UX audit 결과물 (closed #601-603 통합, 충돌 해결):

### 1. Fees — Binance 단독 집중
- Bitget/OKX SSoT 제거, 3-col → Binance featured card
- Privacy 거래소 목록 업데이트

### 2. Homepage — 플로우 최적화
- 중복 섹션 제거 (Stats, SYSTEM)
- THE PROBLEM 축소 (case study만 유지)
- Comparison Table 위치 상향
- CTA 9개 → 3개

### 3. Performance — 백테스트 vs 실거래
- +$794 vs -$275 괴리 투명 설명
- 원인 4가지 + MDD 20% 대응
- i18n 15키 추가

**12 files, EN/KO 동시, Build: 2478 pages 0 errors**

## Test plan
- [ ] /fees Binance 카드만 표시
- [ ] / 홈페이지 순서: Hero → How → Comparison → Why → Features → Social → FAQ → CTA
- [ ] /performance Backtest vs Reality 섹션
- [ ] /ko/* 동일 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)