### PR TITLE
ux: About roadmap + Market contextual CTA

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -431,6 +431,9 @@ export const en = {
   "market.title": "Market Dashboard",
   "market.desc":
     "Real-time crypto market data. Fear & Greed Index, top movers, economic calendar, and aggregated news from major crypto outlets.",
+  "market.context_tip":
+    "See something interesting? Test how a strategy would perform.",
+  "market.context_cta": "Open Simulator",
   "market.fear_greed": "Fear & Greed",
   "market.total_mcap": "Total Market Cap",
   "market.btc_dom": "BTC Dominance",
@@ -525,6 +528,20 @@ export const en = {
   "about.contact_telegram": "Telegram Community",
   "about.explore_desc":
     "Ready to test strategies? Try our simulator or browse verified strategies.",
+
+  "about.roadmap_tag": "WHAT'S NEXT",
+  "about.roadmap_title": "Roadmap",
+  "about.roadmap_desc":
+    "PRUVIQ is actively developed. Here's what we're working on:",
+  "about.roadmap_done1": "Strategy simulator with 36 presets",
+  "about.roadmap_done2": "569+ coin backtesting engine",
+  "about.roadmap_done3": "29 educational guides (EN + KO)",
+  "about.roadmap_done4": "Daily strategy rankings",
+  "about.roadmap_next1": "More strategy types and indicators",
+  "about.roadmap_next2": "Portfolio-level backtesting",
+  "about.roadmap_next3": "Community strategy sharing",
+  "about.roadmap_label_done": "SHIPPED",
+  "about.roadmap_label_next": "IN PROGRESS",
 
   "about.proof_tag": "BUILT IN PUBLIC",
   "about.proof_desc":

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -430,6 +430,9 @@ export const ko: Record<TranslationKey, string> = {
   "market.title": "시장 대시보드",
   "market.desc":
     "실시간 암호화폐 시장 데이터. 공포/탐욕 지수, 상승/하락 순위, 경제 캘린더, 주요 뉴스를 한눈에 확인하세요.",
+  "market.context_tip":
+    "관심 가는 움직임이 있나요? 전략이 어떻게 작동할지 테스트해 보세요.",
+  "market.context_cta": "시뮬레이터 열기",
   "market.fear_greed": "공포/탐욕 지수",
   "market.total_mcap": "총 시가총액",
   "market.btc_dom": "BTC 도미넌스",
@@ -525,6 +528,19 @@ export const ko: Record<TranslationKey, string> = {
   "about.contact_telegram": "텔레그램 커뮤니티",
   "about.explore_desc":
     "전략을 테스트할 준비가 되셨나요? 시뮬레이터를 사용하거나 검증된 전략을 둘러보세요.",
+
+  "about.roadmap_tag": "다음 단계",
+  "about.roadmap_title": "로드맵",
+  "about.roadmap_desc": "PRUVIQ는 활발히 개발 중입니다. 현재 작업 중인 내용:",
+  "about.roadmap_done1": "36개 프리셋 전략 시뮬레이터",
+  "about.roadmap_done2": "569+ 코인 백테스팅 엔진",
+  "about.roadmap_done3": "29개 교육 가이드 (영어 + 한국어)",
+  "about.roadmap_done4": "일일 전략 랭킹",
+  "about.roadmap_next1": "더 많은 전략 유형과 지표",
+  "about.roadmap_next2": "포트폴리오 레벨 백테스팅",
+  "about.roadmap_next3": "커뮤니티 전략 공유",
+  "about.roadmap_label_done": "완료",
+  "about.roadmap_label_next": "진행 중",
 
   "about.proof_tag": "공개 개발",
   "about.proof_desc":

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -148,6 +148,32 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
         </div>
       </div>
 
+      <!-- Roadmap -->
+      <div class="mb-12">
+        <p class="font-mono text-[--color-accent] text-xs tracking-wider mb-2">{t('about.roadmap_tag')}</p>
+        <h2 class="text-2xl font-bold mb-3">{t('about.roadmap_title')}</h2>
+        <p class="text-[--color-text-muted] text-sm mb-6">{t('about.roadmap_desc')}</p>
+        <div class="grid sm:grid-cols-2 gap-4">
+          <div class="border border-[--color-up]/30 rounded-lg p-5 bg-[--color-bg-card]">
+            <p class="font-mono text-xs text-[--color-up] font-bold mb-3">{t('about.roadmap_label_done')}</p>
+            <ul class="space-y-2 text-sm text-[--color-text-muted]">
+              <li class="flex items-start gap-2"><span class="text-[--color-up] shrink-0">&#10003;</span> {t('about.roadmap_done1')}</li>
+              <li class="flex items-start gap-2"><span class="text-[--color-up] shrink-0">&#10003;</span> {t('about.roadmap_done2')}</li>
+              <li class="flex items-start gap-2"><span class="text-[--color-up] shrink-0">&#10003;</span> {t('about.roadmap_done3')}</li>
+              <li class="flex items-start gap-2"><span class="text-[--color-up] shrink-0">&#10003;</span> {t('about.roadmap_done4')}</li>
+            </ul>
+          </div>
+          <div class="border border-[--color-accent]/30 rounded-lg p-5 bg-[--color-bg-card]">
+            <p class="font-mono text-xs text-[--color-accent] font-bold mb-3">{t('about.roadmap_label_next')}</p>
+            <ul class="space-y-2 text-sm text-[--color-text-muted]">
+              <li class="flex items-start gap-2"><span class="text-[--color-accent] shrink-0">&#9679;</span> {t('about.roadmap_next1')}</li>
+              <li class="flex items-start gap-2"><span class="text-[--color-accent] shrink-0">&#9679;</span> {t('about.roadmap_next2')}</li>
+              <li class="flex items-start gap-2"><span class="text-[--color-accent] shrink-0">&#9679;</span> {t('about.roadmap_next3')}</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
       <!-- Contact -->
       <div class="text-center">
         <p class="font-mono text-[--color-accent] text-xs tracking-wider mb-2">{t('about.contact_tag')}</p>

--- a/src/pages/ko/about.astro
+++ b/src/pages/ko/about.astro
@@ -148,6 +148,32 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
         </div>
       </div>
 
+      <!-- Roadmap -->
+      <div class="mb-12">
+        <p class="font-mono text-[--color-accent] text-xs tracking-wider mb-2">{t('about.roadmap_tag')}</p>
+        <h2 class="text-2xl font-bold mb-3">{t('about.roadmap_title')}</h2>
+        <p class="text-[--color-text-muted] text-sm mb-6">{t('about.roadmap_desc')}</p>
+        <div class="grid sm:grid-cols-2 gap-4">
+          <div class="border border-[--color-up]/30 rounded-lg p-5 bg-[--color-bg-card]">
+            <p class="font-mono text-xs text-[--color-up] font-bold mb-3">{t('about.roadmap_label_done')}</p>
+            <ul class="space-y-2 text-sm text-[--color-text-muted]">
+              <li class="flex items-start gap-2"><span class="text-[--color-up] shrink-0">&#10003;</span> {t('about.roadmap_done1')}</li>
+              <li class="flex items-start gap-2"><span class="text-[--color-up] shrink-0">&#10003;</span> {t('about.roadmap_done2')}</li>
+              <li class="flex items-start gap-2"><span class="text-[--color-up] shrink-0">&#10003;</span> {t('about.roadmap_done3')}</li>
+              <li class="flex items-start gap-2"><span class="text-[--color-up] shrink-0">&#10003;</span> {t('about.roadmap_done4')}</li>
+            </ul>
+          </div>
+          <div class="border border-[--color-accent]/30 rounded-lg p-5 bg-[--color-bg-card]">
+            <p class="font-mono text-xs text-[--color-accent] font-bold mb-3">{t('about.roadmap_label_next')}</p>
+            <ul class="space-y-2 text-sm text-[--color-text-muted]">
+              <li class="flex items-start gap-2"><span class="text-[--color-accent] shrink-0">&#9679;</span> {t('about.roadmap_next1')}</li>
+              <li class="flex items-start gap-2"><span class="text-[--color-accent] shrink-0">&#9679;</span> {t('about.roadmap_next2')}</li>
+              <li class="flex items-start gap-2"><span class="text-[--color-accent] shrink-0">&#9679;</span> {t('about.roadmap_next3')}</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
       <!-- Contact -->
       <div class="text-center">
         <p class="font-mono text-[--color-accent] text-xs tracking-wider mb-2">{t('about.contact_tag')}</p>

--- a/src/pages/ko/market/index.astro
+++ b/src/pages/ko/market/index.astro
@@ -12,9 +12,14 @@ const marketDataJson = JSON.stringify(marketDataRaw);
     <div class="max-w-6xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('market.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">{t('market.title')}</h1>
-      <p class="text-[--color-text-muted] text-lg mb-8 max-w-2xl">
+      <p class="text-[--color-text-muted] text-lg mb-4 max-w-2xl">
         {t('market.desc')}
       </p>
+      <div class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-[--color-accent]/20 bg-[--color-accent]/5 text-sm mb-8">
+        <span class="text-[--color-accent] font-mono text-xs font-bold">TIP</span>
+        <span class="text-[--color-text-muted]">{t('market.context_tip')}</span>
+        <a href="/ko/simulate" class="text-[--color-accent] font-semibold hover:underline whitespace-nowrap">{t('market.context_cta')} &rarr;</a>
+      </div>
       <div id="market-mount" data-initial-market={marketDataJson}>
         <div class="animate-pulse space-y-4">
           <div class="flex gap-4 flex-wrap">

--- a/src/pages/market/index.astro
+++ b/src/pages/market/index.astro
@@ -12,9 +12,14 @@ const marketDataJson = JSON.stringify(marketDataRaw);
     <div class="max-w-6xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('market.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">{t('market.title')}</h1>
-      <p class="text-[--color-text-muted] text-lg mb-8 max-w-2xl">
+      <p class="text-[--color-text-muted] text-lg mb-4 max-w-2xl">
         {t('market.desc')}
       </p>
+      <div class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-[--color-accent]/20 bg-[--color-accent]/5 text-sm mb-8">
+        <span class="text-[--color-accent] font-mono text-xs font-bold">TIP</span>
+        <span class="text-[--color-text-muted]">{t('market.context_tip')}</span>
+        <a href="/simulate" class="text-[--color-accent] font-semibold hover:underline whitespace-nowrap">{t('market.context_cta')} &rarr;</a>
+      </div>
       <div id="market-mount" data-initial-market={marketDataJson}>
         <div class="animate-pulse space-y-4">
           <div class="flex gap-4 flex-wrap">


### PR DESCRIPTION
## Summary
- /about에 로드맵 섹션 추가 (shipped 4개 + in progress 3개)
- /market에 시뮬레이터 연결 TIP 배너 추가
- EN/KO 동시 적용, i18n 14키 추가

## Test plan
- [ ] Build 0 errors (2478 pages)
- [ ] /about 로드맵 섹션 (SHIPPED + IN PROGRESS 카드)
- [ ] /ko/about 동일
- [ ] /market TIP 배너 → /simulate 링크
- [ ] /ko/market TIP 배너 → /ko/simulate 링크

🤖 Generated with [Claude Code](https://claude.com/claude-code)