### PR TITLE
ux: ExchangeCTA always visible in results

### DIFF
--- a/src/components/ResultsPanel.tsx
+++ b/src/components/ResultsPanel.tsx
@@ -1012,14 +1012,12 @@ export default function ResultsPanel({
                   {t.saveOnFees} &rarr;
                 </a>
               </div>
-              {/* Fix 1: ExchangeCTA — shown when result is profitable */}
-              {result.total_return_pct > 0 && (
-                <ExchangeCTA
-                  mode="inline"
-                  lang={lang}
-                  strategy={activePreset ?? undefined}
-                />
-              )}
+              {/* ExchangeCTA — always shown: profitable = start trading, loss = save on fees */}
+              <ExchangeCTA
+                mode="inline"
+                lang={lang}
+                strategy={activePreset ?? undefined}
+              />
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- ResultsPanel: ExchangeCTA inline을 수익 결과 조건 없이 항상 표시
- 손실 결과에서도 수수료 절약 메시지 노출 → 전환 기회 증가

## Test plan
- [ ] Build 0 errors (2478 pages)
- [ ] /simulate에서 수익 결과 → ExchangeCTA 표시
- [ ] /simulate에서 손실 결과 → ExchangeCTA 표시 (이전: 미표시)
- [ ] 하단 card 모드 CTA 기존대로 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)