### PR TITLE
fix: i18n text — remove Bitget/OKX mentions

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -177,7 +177,7 @@ export const en = {
   "features.card3_tag": "FEE CALCULATOR",
   "features.card3_title": "Compare & Save",
   "features.card3_desc":
-    "Compare fees across 3 exchanges. Sign up through PRUVIQ for referral discounts.",
+    "Compare exchange fees and save with PRUVIQ referral discounts.",
 
   // How it works
   "how.tag": "HOW IT WORKS",
@@ -340,7 +340,7 @@ export const en = {
   "fees.title1": "Compare Fees.",
   "fees.title2": "Save on Every Trade.",
   "fees.desc":
-    "3 exchanges, spot & futures fees side by side. Sign up through PRUVIQ and get referral discounts: Binance 10% off, Bitget & OKX up to 20% off.",
+    "Spot & futures fees at a glance. Sign up through PRUVIQ and get a Binance referral discount: 10% off trading fees.",
   "fees.disclosure":
     "Affiliate disclosure: PRUVIQ earns a commission when you sign up through our referral links. Your fee discount is not affected.",
   "fees.compare_title": "Compare Exchanges",
@@ -480,7 +480,7 @@ export const en = {
     "Try PRUVIQ's strategy simulator instantly. Adjust stop-loss and take-profit to see real backtest results on 569+ coins.",
   "meta.fees_title": "Compare Exchange Fees - PRUVIQ",
   "meta.fees_desc":
-    "Compare trading fees across Binance, Bitget, and OKX. Save up to 20% with PRUVIQ referral links. Transparent fee comparison.",
+    "Compare Binance trading fees. Save 10% with PRUVIQ referral link. Transparent fee comparison for spot and futures.",
   "meta.changelog_title": "Changelog - PRUVIQ",
   "meta.changelog_desc":
     "Complete version history of PRUVIQ's trading system. Every change, every reason, every date.",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -175,8 +175,7 @@ export const ko: Record<TranslationKey, string> = {
     "569개 이상의 코인에서 5개 전략 백테스트. 검증된 것과 중단된 것 모두 결과 공개.",
   "features.card3_tag": "수수료 계산기",
   "features.card3_title": "비교하고 절약하기",
-  "features.card3_desc":
-    "3개 거래소 수수료 비교. PRUVIQ 추천 링크로 할인 혜택.",
+  "features.card3_desc": "거래소 수수료 비교. PRUVIQ 추천 링크로 할인 혜택.",
 
   // How it works
   "how.tag": "이렇게 작동합니다",
@@ -339,7 +338,7 @@ export const ko: Record<TranslationKey, string> = {
   "fees.title1": "수수료 비교.",
   "fees.title2": "매 거래마다 절약.",
   "fees.desc":
-    "3개 거래소, 현물 & 선물 수수료 한눈에. PRUVIQ 추천 링크로 가입 시 할인: 바이낸스 10%, 빗겟·OKX 최대 20% 할인.",
+    "현물 & 선물 수수료 한눈에. PRUVIQ 추천 링크로 바이낸스 가입 시 수수료 10% 할인.",
   "fees.disclosure":
     "제휴 공개: PRUVIQ는 추천 링크로 가입 시 거래소로부터 수수료를 받습니다. 회원의 수수료 할인에는 영향이 없습니다.",
   "fees.compare_title": "거래소 비교",
@@ -480,7 +479,7 @@ export const ko: Record<TranslationKey, string> = {
     "PRUVIQ 전략 시뮬레이터를 즉시 체험하세요. 손절/익절을 조정하여 569개+ 코인에 대한 실제 백테스트 결과를 확인하세요.",
   "meta.fees_title": "거래소 수수료 비교 - PRUVIQ",
   "meta.fees_desc":
-    "Binance, Bitget, OKX 거래소 수수료 비교. PRUVIQ 추천 링크로 최대 20% 절약. 투명한 수수료 비교.",
+    "바이낸스 거래소 수수료 비교. PRUVIQ 추천 링크로 10% 절약. 투명한 수수료 비교.",
   "meta.changelog_title": "변경 이력 - PRUVIQ",
   "meta.changelog_desc":
     "PRUVIQ 트레이딩 시스템의 전체 버전 히스토리. 모든 변경, 모든 이유, 모든 날짜.",


### PR DESCRIPTION
## Summary
라이브 검증에서 발견: SSoT에서 Bitget/OKX 제거했지만 i18n 텍스트에 잔여 언급 존재.

- features.card3_desc: "3 exchanges" → 제거
- fees.desc: Bitget/OKX 할인율 언급 → Binance 10%만
- meta.fees_desc: SEO meta description 업데이트
- EN/KO 동시 수정

## Test plan
- [ ] Build 0 errors
- [ ] /fees 설명에 Bitget/OKX 언급 없음
- [ ] /ko/fees 동일
- [ ] SEO meta description 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)