### PR TITLE
fix: full-site QA — 7 issues (reveal, i18n, compare, a11y)

### DIFF
--- a/src/components/MarketDashboard.tsx
+++ b/src/components/MarketDashboard.tsx
@@ -54,7 +54,7 @@ const labels = {
     totalMcap: "총 시가총액",
     btcDom: "BTC 도미넌스",
     volume24h: "24시간 거래량",
-    latestNews: "최신 뉴스",
+    latestNews: "최신 뉴스 (영문)",
     cryptoNews: "크립토",
     macroNews: "매크로",
     loading: "시장 데이터 로딩 중...",
@@ -693,7 +693,7 @@ export default function MarketDashboard({
                 {l.calendarNote}
               </span>
             </div>
-            <div class="w-full h-[300px] md:h-[400px] relative">
+            <div class="w-full h-[400px] md:h-[500px] relative">
               {/* Loading placeholder — shown until iframe paints */}
               <div
                 class="absolute inset-0 flex flex-col items-center justify-center gap-2 text-[--color-text-muted] text-xs font-mono pointer-events-none"

--- a/src/components/StrategyComparison.tsx
+++ b/src/components/StrategyComparison.tsx
@@ -160,7 +160,7 @@ export default function StrategyComparison({ lang = "en" }: Props) {
         const list = Array.isArray(listData) ? listData : [];
         if (cancelled) return;
 
-        // 2. Load static comparison results in parallel (instant render)
+        // 2. Load static comparison results (instant render)
         let staticResults: Record<string, BacktestResult> | null = null;
         try {
           const staticRes = await fetchWithTimeout(
@@ -195,7 +195,13 @@ export default function StrategyComparison({ lang = "en" }: Props) {
           // static fallback failed, proceed without it
         }
 
-        // 3. Fetch preset details with timeout + bounded concurrency
+        // 3. Show static results immediately — don't wait for preset details
+        if (staticResults && Object.keys(staticResults).length > 0) {
+          setResults(staticResults);
+        }
+        setIsLoading(false);
+
+        // 4. Fetch preset details in background (enrich data, non-blocking)
         const concurrency = 5;
         const resultsArr: Array<PresetFull | null> = [];
         for (let i = 0; i < list.length; i += concurrency) {
@@ -222,12 +228,6 @@ export default function StrategyComparison({ lang = "en" }: Props) {
 
         const loadedPresets = resultsArr.filter(Boolean) as PresetFull[];
         setPresets(loadedPresets);
-
-        // 4. If we got static results, show them immediately (no auto-run needed)
-        if (staticResults && Object.keys(staticResults).length > 0) {
-          setResults(staticResults);
-        }
-        setIsLoading(false);
       } catch {
         setError(t.error);
         setIsLoading(false);

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -378,6 +378,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
         ]
       })} />
     )}
+    <noscript><style>.reveal,.reveal-child>*{opacity:1!important;transform:none!important;transition:none!important}</style></noscript>
 </head>
   <body class="min-h-screen">
     <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:px-4 focus:py-2 focus:bg-[--color-accent] focus:text-white focus:rounded">
@@ -642,6 +643,8 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
             // Desktop: cookie is at bottom — push body content up
             document.body.style.paddingBottom = h + 'px';
             if (stickyCta) stickyCta.style.bottom = h + 'px';
+            var bottomCta = document.getElementById('bottom-cta-bar');
+            if (bottomCta) bottomCta.style.bottom = h + 'px';
           }
         }
 
@@ -649,6 +652,8 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
           document.body.style.paddingTop = '';
           document.body.style.paddingBottom = '';
           if (stickyCta) stickyCta.style.bottom = '';
+          var bottomCta = document.getElementById('bottom-cta-bar');
+          if (bottomCta) bottomCta.style.bottom = '0';
         }
 
         if (!localStorage.getItem('cookie-ok')) {
@@ -696,5 +701,20 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
         </script>
       </>
     )}
+    <script>
+      (function() {
+        var els = document.querySelectorAll('.reveal, .reveal-child');
+        if (!els.length) return;
+        var observer = new IntersectionObserver(function(entries) {
+          entries.forEach(function(entry) {
+            if (entry.isIntersecting) {
+              entry.target.classList.add('visible');
+              observer.unobserve(entry.target);
+            }
+          });
+        }, { threshold: 0.1, rootMargin: '0px 0px -40px 0px' });
+        els.forEach(function(el) { observer.observe(el); });
+      })();
+    </script>
   </body>
 </html>

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -30,10 +30,10 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
     <div class="relative max-w-6xl mx-auto px-6 pt-28 pb-16 md:pt-36 md:pb-20 hero-enter">
       <HeroBadge stat={simulationsRun} label="시뮬레이션 실행" />
       <h1 class="text-4xl md:text-6xl lg:text-7xl font-bold text-center tracking-[-0.04em] leading-[1.08] max-w-4xl mx-auto">
-        Test Any Crypto Strategy<br class="hidden md:block" /> on {coinsAnalyzed} Coins in Seconds
+        {t('hero.h1_line1')}<br class="hidden md:block" /> {t('hero.h1_line2').replace('{coins}', String(coinsAnalyzed))}
       </h1>
       <p class="mt-6 text-lg md:text-xl text-[--color-text-secondary] text-center max-w-2xl mx-auto leading-relaxed">
-        Free backtesting with real fees. No code. No signup.<br class="hidden sm:block" /> We publish our failures too.
+        {t('hero.subtitle_new')}<br class="hidden sm:block" /> 우리는 실패한 전략도 공개합니다.
       </p>
       <!-- Founder story hook -->
       <p class="mt-3 text-sm text-[--color-text-muted] max-w-xl mx-auto text-center italic">
@@ -43,29 +43,29 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
       <!-- CTA pair -->
       <div class="flex flex-col sm:flex-row items-center justify-center gap-4 mt-10">
         <a href="/ko/simulate" class="btn btn-primary btn-lg w-full sm:w-auto text-center">
-          Open Simulator →
+          {t('hero.cta_primary')} →
         </a>
         <a href="/ko/strategies" class="btn btn-ghost btn-lg w-full sm:w-auto text-center">
-          Browse Strategies
+          {t('hero.cta_secondary')}
         </a>
       </div>
       <!-- Stats bar -->
       <div class="grid grid-cols-2 md:grid-cols-4 gap-6 mt-16 max-w-3xl mx-auto">
         <div class="text-center">
           <p class="text-2xl md:text-3xl font-bold font-mono">{coinsAnalyzed}+</p>
-          <p class="text-sm text-[--color-text-muted] mt-1">Coins Tested</p>
+          <p class="text-sm text-[--color-text-muted] mt-1">코인 테스트</p>
         </div>
         <div class="text-center">
           <p class="text-2xl md:text-3xl font-bold font-mono">2,898+</p>
-          <p class="text-sm text-[--color-text-muted] mt-1">Simulated Trades</p>
+          <p class="text-sm text-[--color-text-muted] mt-1">시뮬레이션 거래</p>
         </div>
         <div class="text-center">
           <p class="text-2xl md:text-3xl font-bold font-mono">9.4M+</p>
-          <p class="text-sm text-[--color-text-muted] mt-1">Data Points</p>
+          <p class="text-sm text-[--color-text-muted] mt-1">데이터 포인트</p>
         </div>
         <div class="text-center">
           <p class="text-2xl md:text-3xl font-bold font-mono">{simulatorPresetCount}+</p>
-          <p class="text-sm text-[--color-text-muted] mt-1">Strategies</p>
+          <p class="text-sm text-[--color-text-muted] mt-1">전략</p>
         </div>
       </div>
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -48,7 +48,7 @@
   /* ─── TEXT ─── */
   --color-text:          #FAFAFA;   /* Zinc-50 — primary text */
   --color-text-secondary:#A1A1AA;   /* Zinc-400 — secondary description */
-  --color-text-muted:    #71717A;   /* Zinc-500 — labels, meta */
+  --color-text-muted:    #A1A1AA;   /* Zinc-400 — labels, meta (WCAG AA 6.29:1) */
   --color-text-disabled: #52525B;   /* Zinc-600 — inactive */
 
   /* ─── ACCENT ─── */


### PR DESCRIPTION
## Summary

100장 스크린샷 기반 전체 사이트 QA 검수 결과 — CRITICAL 3건 + HIGH 4건 수정.

- **C1**: `.reveal` 섹션 영구 숨김 → IntersectionObserver JS + noscript fallback 추가
- **C2**: KO 홈 Hero 영어 하드코딩 → 한국어 번역 (커밋 #614 회귀)
- **C3**: Strategies Compare 빈 페이지 → 정적 데이터 즉시 렌더 (API 대기 제거)
- **H1**: Market Economic Calendar 높이 부족 → 300→400 / 400→500px
- **H2**: KO Market 뉴스 영어 표시 → "최신 뉴스 (영문)" 라벨
- **H3**: 쿠키 배너 + CTA 바 중첩 → bottom-cta-bar offset 적용
- **H4**: text-muted 대비 WCAG AA 미달 → #71717A→#A1A1AA (6.29:1)

## Test plan

- [ ] `npm run build` 0 errors (2487 pages)
- [ ] EN 홈 스크롤 시 비교/기능/FAQ/CTA 섹션 정상 표시
- [ ] KO 홈 Hero h1/CTA/stats 한국어 표시
- [ ] /strategies/compare 페이지 콘텐츠 즉시 로딩
- [ ] Market 페이지 Calendar 영역 정상 크기
- [ ] 쿠키 배너 + CTA 바 미중첩 확인
- [ ] muted 텍스트 가독성 개선 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)