### PR TITLE
fix(i18n): correct live trading period date (Mar 5 → Mar 9)

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -748,7 +748,7 @@ export const en = {
     "Strategies we tested and rejected. We show failures because they're just as important as successes.",
   "perf.equity_title": "Live Trading Equity Curve",
   "perf.equity_desc":
-    "Cumulative PnL from live trading (Jan 13 – Mar 5, 2026). Strategy paused after MDD exceeded the 20% risk limit.",
+    "Cumulative PnL from live trading (Jan 13 – Mar 9, 2026). Strategy paused after MDD exceeded the 20% risk limit.",
   "perf.download_csv": "Download CSV",
   "perf.download_json": "Download JSON",
   "perf.verify_title": "Verify It Yourself",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -746,7 +746,7 @@ export const ko: Record<TranslationKey, string> = {
     "테스트 후 기각한 전략들입니다. 실패도 성공만큼 중요하기에 공개합니다.",
   "perf.equity_title": "실거래 손익 곡선",
   "perf.equity_desc":
-    "실거래 누적 PnL (2026년 1월 13일 – 3월 5일). MDD가 20% 리스크 한도를 초과하여 전략이 중단되었습니다.",
+    "실거래 누적 PnL (2026년 1월 13일 – 3월 9일). MDD가 20% 리스크 한도를 초과하여 전략이 중단되었습니다.",
   "perf.download_json": "JSON 다운로드",
   "perf.download_csv": "CSV 다운로드",
   "perf.verify_title": "직접 확인하세요",


### PR DESCRIPTION
## Summary
- i18n 하드코딩 날짜 수정: `Mar 5` → `Mar 9` (EN + KO)
- DO 서버 실제 마지막 거래일: 2026-03-09 (21 closes)
- performance.json `period.to: 2026-03-09` 와 일치

## Test plan
- [x] `npm run build` — 2484 pages, 0 errors
- [ ] CI checks pass