### PR TITLE
fix: auto-fix #624 (+1 related)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -88,7 +88,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
   const name = isLast && breadcrumbSegments.length > 1
     ? (breadcrumbLabelMap[lang]?.[seg] || title)
     : (breadcrumbLabelMap[lang]?.[seg] || seg.replace(/-/g, ' ').replace(/usdt$/i, '/USDT').toUpperCase());
-  const fullUrl = `https://pruviq.com${lang === 'ko' ? '/ko' : ''}${cumPath}`;
+  const fullUrl = `https://pruviq.com${lang === 'ko' ? '/ko' : ''}${cumPath}/`;
   breadcrumbItems.push({ name, item: fullUrl });
 }
 ---
@@ -168,8 +168,6 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <meta property="og:locale" content={lang === 'ko' ? 'ko_KR' : 'en_US'} />
     <meta property="og:image" content={ogImage} />
     <meta property="og:image:alt" content={description} />
-    <link rel="preload" href={ogImageAvif} as="image" type="image/avif" />
-    <link rel="preload" href={ogImageWebp} as="image" type="image/webp" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <!-- Twitter -->


### PR DESCRIPTION
## Auto-fix for 2 issue(s)

#624: [claude-auto][P2] BreadcrumbList JSON-LD `item` URLs lack trailing slash; visible breadcrumb `<a h
#625: [claude-auto][P2] Every page preloads two OG image variants never used in HTML rendering — Light

### Changes
```
 src/layouts/Layout.astro | 4 +---
 1 file changed, 1 insertion(+), 3 deletions(-)
```

### Safety Checks
- Files changed: **1** (limit: 20)
- Lines changed: **4** (limit: 1500)

---
*Auto-generated by JEPO auto-fix agent. Requires auto-test pass before merge.*