### PR TITLE
fix: auto-fix #624 (+1 related)

### DIFF
--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -57,7 +57,7 @@ let cumulativePath = lang === 'ko' ? '/ko' : '';
 for (const seg of segments) {
   cumulativePath += `/${seg}`;
   const label = labelMap[lang]?.[seg] || seg.replace(/-/g, ' ').replace(/usdt$/i, '/USDT').toUpperCase();
-  items.push({ label, href: `${cumulativePath}/` });
+  items.push({ label, href: cumulativePath });
 }
 ---
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -27,9 +27,6 @@ const currentYear = new Date().getFullYear();
 const { title, description = t('meta.home_desc'), type = 'website', date, category, keywords: customKeywords, canonicalOverride, noAlternate = false } = Astro.props;
 const lastModified = date || buildTime;
 const ogImage = new URL(Astro.props.ogImage || '/og-image.jpg', Astro.site || 'https://pruviq.com').href;
-// derive AVIF/WebP variants safely for jpg/png sources
-const ogImageAvif = ogImage.replace(/\.(png|jpe?g)(\?.*)?$/i, '.avif$2');
-const ogImageWebp = ogImage.replace(/\.(png|jpe?g)(\?.*)?$/i, '.webp$2');
 const canonicalPath = canonicalOverride || Astro.url.pathname;
 const canonicalURL = new URL(canonicalPath, Astro.site || 'https://pruviq.com');
 const hreflangBase = canonicalPath.replace(/^\/ko(\/|$)/, '/');
@@ -168,8 +165,6 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <meta property="og:locale" content={lang === 'ko' ? 'ko_KR' : 'en_US'} />
     <meta property="og:image" content={ogImage} />
     <meta property="og:image:alt" content={description} />
-    <link rel="preload" href={ogImageAvif} as="image" type="image/avif" />
-    <link rel="preload" href={ogImageWebp} as="image" type="image/webp" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <!-- Twitter -->


### PR DESCRIPTION
## Auto-fix for 2 issue(s)

#624: [claude-auto][P2] BreadcrumbList JSON-LD `item` URLs lack trailing slash; visible breadcrumb `<a h
#625: [claude-auto][P2] Every page preloads two OG image variants never used in HTML rendering — Light

### Changes
```
 src/components/Breadcrumbs.astro | 2 +-
 src/layouts/Layout.astro         | 5 -----
 2 files changed, 1 insertion(+), 6 deletions(-)
```

### Safety Checks
- Files changed: **2** (limit: 20)
- Lines changed: **7** (limit: 1500)

---
*Auto-generated by JEPO auto-fix agent. Requires auto-test pass before merge.*