### PR TITLE
fix: load Telegram tokens in monitor.sh

### DIFF
--- a/backend/scripts/monitor.sh
+++ b/backend/scripts/monitor.sh
@@ -15,7 +15,10 @@ ENV_FILE="$REPO_DIR/backend/.env"
 STATE_FILE="/tmp/pruviq-monitor-state"
 LOG_FILE="$HOME/pruviq-monitor.log"
 
-# Load .env if exists
+# Load Telegram tokens
+source "$HOME/.secrets.env" 2>/dev/null || true
+
+# Load project .env if exists
 if [ -f "$ENV_FILE" ]; then
     set -a
     source "$ENV_FILE"


### PR DESCRIPTION
## Summary
- monitor.sh에 `source ~/.secrets.env` 추가
- 이전: TELEGRAM_BOT_TOKEN 미로딩 → API 다운 시 알림 미발송
- 이후: Alert 봇(8057)으로 정상 발송

## Root cause
- backend/.env가 비어있어서 TELEGRAM_BOT_TOKEN이 항상 빈 문자열
- 다른 cron 스크립트(macmini_health, staleness-watch)는 .secrets.env를 source하지만 monitor.sh만 빠져있었음