### PR TITLE
fix: SSR ranking cards — dollar amount + simulate button

### DIFF
--- a/src/pages/ko/strategies/ranking.astro
+++ b/src/pages/ko/strategies/ranking.astro
@@ -24,6 +24,7 @@ interface RankingEntry {
   total_trades: number;
   timeframe: string;
   low_sample: boolean;
+  total_return?: number;
 }
 interface RankingData {
   date: string;
@@ -139,6 +140,11 @@ if (!ssrRanking) {
                     </div>
                     <span class={`font-mono text-xs px-2 py-0.5 rounded border shrink-0 ${dirColor}`}>{dirLabel}</span>
                   </div>
+                  {entry.total_return != null && (
+                    <div class="mb-2 font-mono text-xs text-[--color-text-muted]">
+                      $1,000 &rarr; <span class={entry.total_return >= 0 ? 'text-[--color-up]' : 'text-[--color-red]'}>${Math.round(1000 * (1 + entry.total_return / 100)).toLocaleString()}</span>
+                    </div>
+                  )}
                   <div class="grid grid-cols-3 gap-2 font-mono text-sm">
                     <div>
                       <p class="text-[--color-text-muted] text-xs mb-0.5">승률</p>
@@ -157,6 +163,7 @@ if (!ssrRanking) {
                       <p class="font-bold text-base text-[--color-text]">{entry.total_trades}</p>
                     </div>
                   </div>
+                  <a href={`/ko/simulate?preset=${entry.strategy}`} class="mt-3 block text-center text-xs font-mono px-3 py-1.5 rounded border border-[--color-accent]/30 text-[--color-accent] hover:bg-[--color-accent]/10 transition-colors">시뮬레이션 &rarr;</a>
                 </div>
               );
             })}

--- a/src/pages/strategies/ranking.astro
+++ b/src/pages/strategies/ranking.astro
@@ -34,6 +34,7 @@ interface RankingEntry {
   total_trades: number;
   timeframe: string;
   low_sample: boolean;
+  total_return?: number;
 }
 interface RankingData {
   date: string;
@@ -149,6 +150,11 @@ if (!ssrRanking) {
                       </span>
                     </div>
                   )}
+                  {entry.total_return != null && (
+                    <div class="mb-2 font-mono text-xs text-[--color-text-muted]">
+                      $1,000 &rarr; <span class={entry.total_return >= 0 ? 'text-[--color-up]' : 'text-[--color-red]'}>${Math.round(1000 * (1 + entry.total_return / 100)).toLocaleString()}</span>
+                    </div>
+                  )}
                   <div class="grid grid-cols-3 gap-2 font-mono text-sm">
                     <div>
                       <p class="text-[--color-text-muted] text-xs mb-0.5">Win Rate</p>
@@ -167,6 +173,7 @@ if (!ssrRanking) {
                       <p class="font-bold text-base text-[--color-text]">{entry.total_trades}</p>
                     </div>
                   </div>
+                  <a href={`/simulate?preset=${entry.strategy}`} class="mt-3 block text-center text-xs font-mono px-3 py-1.5 rounded border border-[--color-accent]/30 text-[--color-accent] hover:bg-[--color-accent]/10 transition-colors">Simulate &rarr;</a>
                 </div>
               );
             })}


### PR DESCRIPTION
## Summary
- SSR fallback ranking cards now show `$1,000 → $X` dollar translation
- "Simulate →" / "시뮬레이션 →" button added to SSR cards (EN + KO)
- `total_return` field added to SSR RankingEntry interface

Previously these only showed in the client-hydrated RankingCard component.

## Test plan
- [ ] `npm run build` — 0 errors
- [ ] /strategies/ranking/ SSR cards show dollar amount + Simulate button
- [ ] /ko/strategies/ranking/ same in Korean

🤖 Generated with [Claude Code](https://claude.com/claude-code)