### PR TITLE
feat: full-width GNB + layout scale-up

### DIFF
--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -62,7 +62,7 @@ for (const seg of segments) {
 ---
 
 {segments.length > 0 && (
-  <nav aria-label="Breadcrumb" class="max-w-6xl mx-auto px-4 pt-4 pb-2">
+  <nav aria-label="Breadcrumb" class="max-w-7xl mx-auto px-4 pt-4 pb-2">
     <ol class="flex flex-wrap items-center gap-1.5 font-mono text-[0.6875rem] text-[--color-text-muted]">
       {items.map((item, i) => (
         <li class="flex items-center gap-1.5">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -386,14 +386,14 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <div id="page-loader"></div>
     <header>
     <nav class="fixed top-0 w-full z-50 border-b border-[--color-border] bg-[--color-bg]/80 backdrop-blur-md" role="navigation" aria-label="Main">
-      <div class="max-w-6xl mx-auto px-4 h-16 grid grid-cols-[auto_1fr_auto] items-center">
+      <div class="w-full px-6 lg:px-10 h-16 grid grid-cols-[auto_1fr_auto] items-center">
         <!-- 1열: Logo (좌측) -->
         <a href={lang === 'ko' ? '/ko/' : '/'} class="flex items-center gap-2">
-          <img src="/favicon.svg" alt="PRUVIQ" width="28" height="28" class="w-7 h-7" />
-          <span class="font-mono font-bold text-xl tracking-wider"><span class="text-[--color-text]">PRUV</span><span class="text-[#2CB5E8]">IQ</span></span>
+          <img src="/favicon.svg" alt="PRUVIQ" width="32" height="32" class="w-8 h-8" />
+          <span class="font-mono font-bold text-2xl tracking-wider"><span class="text-[--color-text]">PRUV</span><span class="text-[#2CB5E8]">IQ</span></span>
         </a>
         <!-- 2열: Nav (정중앙, 데스크톱 only) -->
-        <div class="hidden md:flex items-center justify-center gap-8 text-sm">
+        <div class="hidden md:flex items-center justify-center gap-10 text-[15px]">
           {navItems.map(item => item.match === '/strategies' ? (
             <div class="relative group">
               <a href={item.href} aria-current={isActive(item.match) ? "page" : undefined}
@@ -424,7 +424,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
         </div>
         <!-- 3열: Lang + Mobile hamburger (우측) -->
         <div class="flex items-center justify-end gap-3">
-          <a href={altPath} hreflang={altLang} class="hidden md:inline-flex font-mono text-xs px-3 py-1.5 border border-[--color-border] rounded hover:border-[--color-accent] hover:text-[--color-accent] hover:bg-[--color-accent]/5 text-[--color-text-muted] transition-colors" aria-label={lang === 'ko' ? 'Switch to English' : '한국어로 전환'}>{t('nav.lang')}</a>
+          <a href={altPath} hreflang={altLang} class="hidden md:inline-flex font-mono text-sm px-4 py-2 border border-[--color-border] rounded-lg hover:border-[--color-accent] hover:text-[--color-accent] hover:bg-[--color-accent]/5 text-[--color-text-muted] transition-colors" aria-label={lang === 'ko' ? 'Switch to English' : '한국어로 전환'}>{t('nav.lang')}</a>
           <button id="mobile-menu-btn" class="md:hidden text-[--color-text-muted]" aria-label="Toggle menu" aria-expanded="false" aria-controls="mobile-menu">
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 12h18M3 6h18M3 18h18"/></svg>
           </button>
@@ -462,7 +462,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     </main>
 
     <footer class="border-t border-[--color-border] mt-20" role="contentinfo" aria-label="Site footer">
-      <div class="max-w-6xl mx-auto px-4 py-12">
+      <div class="max-w-7xl mx-auto px-6 lg:px-10 py-12">
         <!-- Brand + 3-column links -->
         <div class="flex flex-col md:flex-row gap-10 mb-10">
           <div class="md:w-1/3">
@@ -584,7 +584,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <!-- Sticky bottom CTA bar (non-simulator pages only) -->
     {!basePath.startsWith('/simulate') && (
       <div id="bottom-cta-bar" class="fixed bottom-0 left-0 right-0 z-40 border-t border-[--color-border] bg-[--color-bg-elevated] transition-transform duration-300 translate-y-full" style="height:48px;" role="complementary" aria-label="Try simulator">
-        <div class="max-w-6xl mx-auto px-4 h-full flex items-center justify-between gap-3">
+        <div class="max-w-7xl mx-auto px-6 lg:px-10 h-full flex items-center justify-between gap-3">
           <p class="text-sm text-[--color-text-muted] truncate">
             {lang === 'ko' ? '569+ 코인에서 전략 테스트' : 'Test your strategy on 569+ coins'}
           </p>

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -9,7 +9,7 @@ const t = useTranslations('en');
 
   <!-- HEADER -->
   <section class="py-20">
-    <div class="max-w-6xl mx-auto px-4">
+    <div class="max-w-7xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('changelog.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">{t('changelog.title')}</h1>
       <p class="text-[--color-text-muted] text-lg max-w-2xl">
@@ -207,7 +207,7 @@ const t = useTranslations('en');
 
   <!-- PHILOSOPHY -->
   <section class="pt-16 pb-8 border-t border-[--color-border]">
-    <div class="max-w-6xl mx-auto px-4 text-center">
+    <div class="max-w-7xl mx-auto px-4 text-center">
       <h2 class="text-2xl md:text-3xl font-bold mb-4">{t('changelog.why_title')}</h2>
       <p class="text-[--color-text-muted] text-lg max-w-2xl mx-auto mb-8">
         {t('changelog.why_desc')}

--- a/src/pages/coins/[symbol].astro
+++ b/src/pages/coins/[symbol].astro
@@ -71,7 +71,7 @@ const canonicalOverride = symbol.endsWith('usdt') ? undefined : `/coins/${symbol
   <script type="application/ld+json" set:html={datasetJsonLd} />
   <script type="application/ld+json" set:html={faqJsonLd} />
   <section class="py-8">
-    <div class="max-w-6xl mx-auto px-4">
+    <div class="max-w-7xl mx-auto px-4">
       <a href="/coins" class="inline-flex items-center gap-1 text-[--color-text-muted] hover:text-[--color-accent] transition-colors text-sm font-mono mb-4">
         &larr; {t('coins.back')}
       </a>

--- a/src/pages/coins/index.astro
+++ b/src/pages/coins/index.astro
@@ -37,7 +37,7 @@ const TOP_COINS = [
 
 <Layout title={t('meta.coins_title')} description={t('meta.coins_desc')}>
   <section class="py-12">
-    <div class="max-w-6xl mx-auto px-4">
+    <div class="max-w-7xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('coins.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">{t('coins.title')}</h1>
       <p class="text-[--color-text-muted] text-lg mb-8 max-w-2xl">

--- a/src/pages/demo.astro
+++ b/src/pages/demo.astro
@@ -7,7 +7,7 @@ const t = useTranslations('en');
 ---
 
 <Layout title={t('meta.demo_title')} description={t('meta.demo_desc')}>
-  <section class="max-w-6xl mx-auto px-4 py-12">
+  <section class="max-w-7xl mx-auto px-4 py-12">
     <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('demo.interactive_tag')}</p>
     <h1 class="text-3xl font-bold mb-4">{t('demo.hero_title')}</h1>
     <p class="text-[--color-text-muted] mb-8 max-w-2xl">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -28,7 +28,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
   <!-- HERO -->
   <section class="relative overflow-hidden min-h-[85vh] flex flex-col justify-center" style="background: var(--gradient-hero)">
     <HeroGlow />
-    <div class="relative max-w-6xl mx-auto px-6 pt-28 pb-16 md:pt-36 md:pb-20 hero-enter">
+    <div class="relative max-w-7xl mx-auto px-6 pt-28 pb-16 md:pt-36 md:pb-20 hero-enter">
       <HeroBadge stat={simulationsRun} label="simulations run" />
       <h1 class="text-4xl md:text-6xl lg:text-7xl font-bold text-center tracking-[-0.04em] leading-[1.08] max-w-4xl mx-auto">
         Test Any Crypto Strategy<br class="hidden md:block" /> on <span class="gradient-text">{coinsAnalyzed} Coins</span> in Seconds
@@ -73,7 +73,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
   </section>
 
   <!-- DATA TRUST BAR -->
-  <div class="max-w-6xl mx-auto px-6 pb-4 relative z-10">
+  <div class="max-w-7xl mx-auto px-6 pb-4 relative z-10">
     <div class="flex items-center justify-center gap-6 text-[--color-text-muted] text-xs font-mono">
       <span class="opacity-60">Data from:</span>
       <span class="opacity-40 hover:opacity-80 transition-opacity">Binance Futures</span>
@@ -82,7 +82,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
   </div>
 
   <!-- PRODUCT PREVIEW (animated) -->
-  <section class="max-w-6xl mx-auto px-6 -mt-4 pb-20 relative z-10">
+  <section class="max-w-7xl mx-auto px-6 -mt-4 pb-20 relative z-10">
     <BrowserFrame
       src="/images/simulator-preview.png"
       alt="PRUVIQ Strategy Simulator — backtest 569 coins in seconds"
@@ -96,7 +96,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
   </section>
 
   <!-- HOW IT WORKS -->
-  <section class="max-w-6xl mx-auto px-6 py-24">
+  <section class="max-w-7xl mx-auto px-6 py-24">
     <h2 class="text-2xl md:text-4xl font-bold text-center mb-4">How It Works</h2>
     <p class="text-[--color-text-secondary] text-center mb-16 max-w-xl mx-auto">From strategy idea to verified results in 3 steps.</p>
     <div class="grid md:grid-cols-3 gap-8">
@@ -124,7 +124,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
   <!-- COMPARISON (compact) -->
   <hr class="section-divider" />
   <section class="py-12 reveal">
-    <div class="max-w-6xl mx-auto px-4 text-center">
+    <div class="max-w-7xl mx-auto px-4 text-center">
       <p class="text-[--color-text-muted] text-sm mb-3">
         Free, no-code, no account — unlike TradingView or QuantConnect.
       </p>
@@ -135,7 +135,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
   <!-- WHY PRUVIQ (Merged Problem + Evidence) -->
   <hr class="section-divider" />
   <section class="py-20 bg-[--color-bg-subtle] reveal" aria-labelledby="why-heading">
-    <div class="max-w-6xl mx-auto px-4">
+    <div class="max-w-7xl mx-auto px-4">
       <p class="font-mono text-[--color-down] text-sm mb-2 tracking-wider">{t('problem.tag')}</p>
       <h2 id="why-heading" class="text-3xl md:text-4xl font-bold mb-4">{t('problem.title')}</h2>
       <p class="text-[--color-text-muted] text-lg mb-12 max-w-3xl">{t('evidence.desc')}</p>
@@ -182,7 +182,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
   <!-- FEATURES & TRUST (Merged) -->
   <hr class="section-divider" />
   <section class="py-20 bg-[--color-bg-subtle] reveal" aria-labelledby="features-heading">
-    <div class="max-w-6xl mx-auto px-4">
+    <div class="max-w-7xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('features.tag')}</p>
       <h2 id="features-heading" class="text-3xl md:text-4xl font-bold mb-12">{t('features.title')}</h2>
 
@@ -254,7 +254,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
   <!-- SOCIAL PROOF QUOTES -->
   <hr class="section-divider" />
   <section class="py-16 reveal" aria-labelledby="quotes-heading">
-    <div class="max-w-6xl mx-auto px-4">
+    <div class="max-w-7xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('home.community_feedback_tag')}</p>
       <h2 id="quotes-heading" class="text-2xl font-bold mb-1">{t('home.quotes_heading')}</h2>
       <p class="text-[--color-text-muted] text-xs font-mono mb-8 opacity-60">{t('home.quotes_initials_note')}</p>
@@ -299,7 +299,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
   <!-- FAQ (visible section matching JSON-LD) -->
   <hr class="section-divider" />
   <section class="py-20 reveal" aria-labelledby="faq-heading">
-    <div class="max-w-6xl mx-auto px-4">
+    <div class="max-w-7xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">FAQ</p>
       <h2 id="faq-heading" class="text-3xl md:text-4xl font-bold mb-12">{t('faq.title')}</h2>
       <div class="max-w-3xl space-y-6">
@@ -345,7 +345,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
   <!-- CTA -->
   <hr class="section-divider" />
   <section class="py-20 bg-[--color-bg-subtle] reveal" aria-labelledby="cta-heading">
-    <div class="max-w-6xl mx-auto px-4 text-center">
+    <div class="max-w-7xl mx-auto px-4 text-center">
       <p class="font-mono text-[--color-text-muted] text-sm mb-4 tracking-wider">{t('cta.tag')}</p>
       <h2 id="cta-heading" class="text-3xl md:text-4xl font-bold mb-4">
         <span class="text-[--color-accent]">{t('cta.title')}</span>

--- a/src/pages/ko/changelog.astro
+++ b/src/pages/ko/changelog.astro
@@ -9,7 +9,7 @@ const t = useTranslations('ko');
 
   <!-- HEADER -->
   <section class="py-20">
-    <div class="max-w-6xl mx-auto px-4">
+    <div class="max-w-7xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('changelog.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">{t('changelog.title')}</h1>
       <p class="text-[--color-text-muted] text-lg max-w-2xl">
@@ -207,7 +207,7 @@ const t = useTranslations('ko');
 
   <!-- PHILOSOPHY -->
   <section class="py-16 border-t border-[--color-border]">
-    <div class="max-w-6xl mx-auto px-4 text-center">
+    <div class="max-w-7xl mx-auto px-4 text-center">
       <h2 class="text-2xl md:text-3xl font-bold mb-4">{t('changelog.why_title')}</h2>
       <p class="text-[--color-text-muted] text-lg max-w-2xl mx-auto mb-8">
         {t('changelog.why_desc')}

--- a/src/pages/ko/coins/[symbol].astro
+++ b/src/pages/ko/coins/[symbol].astro
@@ -72,7 +72,7 @@ const canonicalOverride = symbol.endsWith('usdt') ? undefined : `/ko/coins/${sym
   <script type="application/ld+json" set:html={datasetJsonLd} />
   <script type="application/ld+json" set:html={faqJsonLd} />
   <section class="py-8">
-    <div class="max-w-6xl mx-auto px-4">
+    <div class="max-w-7xl mx-auto px-4">
       <a href="/ko/coins" class="inline-flex items-center gap-1 text-[--color-text-muted] hover:text-[--color-accent] transition-colors text-sm font-mono mb-4">
         &larr; {t('coins.back')}
       </a>

--- a/src/pages/ko/coins/index.astro
+++ b/src/pages/ko/coins/index.astro
@@ -37,7 +37,7 @@ const TOP_COINS = [
 
 <Layout title={t('meta.coins_title')} description={t('meta.coins_desc')}>
   <section class="py-12">
-    <div class="max-w-6xl mx-auto px-4">
+    <div class="max-w-7xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('coins.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">{t('coins.title')}</h1>
       <p class="text-[--color-text-muted] text-lg mb-8 max-w-2xl">

--- a/src/pages/ko/demo.astro
+++ b/src/pages/ko/demo.astro
@@ -7,7 +7,7 @@ const t = useTranslations('ko');
 ---
 
 <Layout title={t('meta.demo_title')} description={t('meta.demo_desc')}>
-  <section class="max-w-6xl mx-auto px-4 py-12">
+  <section class="max-w-7xl mx-auto px-4 py-12">
     <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('demo.interactive_tag')}</p>
     <h1 class="text-3xl font-bold mb-4">{t('demo.hero_title')}</h1>
     <p class="text-[--color-text-muted] mb-8 max-w-2xl">

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -28,7 +28,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
   <!-- HERO -->
   <section class="relative overflow-hidden min-h-[85vh] flex flex-col justify-center" style="background: var(--gradient-hero)">
     <HeroGlow />
-    <div class="relative max-w-6xl mx-auto px-6 pt-28 pb-16 md:pt-36 md:pb-20 hero-enter">
+    <div class="relative max-w-7xl mx-auto px-6 pt-28 pb-16 md:pt-36 md:pb-20 hero-enter">
       <HeroBadge stat={simulationsRun} label="시뮬레이션 실행" />
       <h1 class="text-4xl md:text-6xl lg:text-7xl font-bold text-center tracking-[-0.04em] leading-[1.08] max-w-4xl mx-auto">
         {t('hero.h1_line1')}<br class="hidden md:block" /> {t('hero.h1_line2').replace('{coins}', String(coinsAnalyzed))}
@@ -73,7 +73,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
   </section>
 
   <!-- DATA TRUST BAR -->
-  <div class="max-w-6xl mx-auto px-6 pb-4 relative z-10">
+  <div class="max-w-7xl mx-auto px-6 pb-4 relative z-10">
     <div class="flex items-center justify-center gap-6 text-[--color-text-muted] text-xs font-mono">
       <span class="opacity-60">데이터 출처:</span>
       <span class="opacity-40 hover:opacity-80 transition-opacity">Binance Futures</span>
@@ -82,7 +82,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
   </div>
 
   <!-- PRODUCT PREVIEW (animated) -->
-  <section class="max-w-6xl mx-auto px-6 -mt-4 pb-20 relative z-10">
+  <section class="max-w-7xl mx-auto px-6 -mt-4 pb-20 relative z-10">
     <BrowserFrame
       src="/images/simulator-preview.png"
       alt="PRUVIQ Strategy Simulator — backtest 569 coins in seconds"
@@ -96,7 +96,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
   </section>
 
   <!-- HOW IT WORKS -->
-  <section class="max-w-6xl mx-auto px-6 py-24">
+  <section class="max-w-7xl mx-auto px-6 py-24">
     <h2 class="text-2xl md:text-4xl font-bold text-center mb-4">작동 방식</h2>
     <p class="text-[--color-text-secondary] text-center mb-16 max-w-xl mx-auto">전략 아이디어에서 검증된 결과까지 3단계.</p>
     <div class="grid md:grid-cols-3 gap-8">
@@ -124,7 +124,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
   <!-- COMPARISON (compact) -->
   <hr class="section-divider" />
   <section class="py-12 reveal">
-    <div class="max-w-6xl mx-auto px-4 text-center">
+    <div class="max-w-7xl mx-auto px-4 text-center">
       <p class="text-[--color-text-muted] text-sm mb-3">
         무료, 노코드, 가입 불필요 — TradingView나 QuantConnect와 다릅니다.
       </p>
@@ -135,7 +135,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
   <!-- WHY PRUVIQ (Merged Problem + Evidence) -->
   <hr class="section-divider" />
   <section class="py-20 bg-[--color-bg-subtle] reveal" aria-labelledby="why-heading-ko">
-    <div class="max-w-6xl mx-auto px-4">
+    <div class="max-w-7xl mx-auto px-4">
       <p class="font-mono text-[--color-down] text-sm mb-2 tracking-wider">{t('problem.tag')}</p>
       <h2 id="why-heading-ko" class="text-3xl md:text-4xl font-bold mb-4">{t('problem.title')}</h2>
       <p class="text-[--color-text-muted] text-lg mb-12 max-w-3xl">{t('evidence.desc')}</p>
@@ -182,7 +182,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
   <!-- FEATURES & TRUST (Merged) -->
   <hr class="section-divider" />
   <section class="py-20 bg-[--color-bg-subtle] reveal" aria-labelledby="features-heading-ko">
-    <div class="max-w-6xl mx-auto px-4">
+    <div class="max-w-7xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('features.tag')}</p>
       <h2 id="features-heading-ko" class="text-3xl md:text-4xl font-bold mb-12">{t('features.title')}</h2>
 
@@ -254,7 +254,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
   <!-- SOCIAL PROOF QUOTES -->
   <hr class="section-divider" />
   <section class="py-16 reveal" aria-labelledby="quotes-heading-ko">
-    <div class="max-w-6xl mx-auto px-4">
+    <div class="max-w-7xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('home.community_feedback_tag')}</p>
       <h2 id="quotes-heading-ko" class="text-2xl font-bold mb-1">{t('home.quotes_heading')}</h2>
       <p class="text-[--color-text-muted] text-xs font-mono mb-8 opacity-60">{t('home.quotes_initials_note')}</p>
@@ -299,7 +299,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
   <!-- FAQ (visible section matching JSON-LD) -->
   <hr class="section-divider" />
   <section class="py-20 reveal" aria-labelledby="faq-heading-ko">
-    <div class="max-w-6xl mx-auto px-4">
+    <div class="max-w-7xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">FAQ</p>
       <h2 id="faq-heading-ko" class="text-3xl md:text-4xl font-bold mb-12">{t('faq.title')}</h2>
       <div class="max-w-3xl space-y-6">
@@ -345,7 +345,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
   <!-- CTA -->
   <hr class="section-divider" />
   <section class="py-20 bg-[--color-bg-subtle] reveal" aria-labelledby="cta-heading-ko">
-    <div class="max-w-6xl mx-auto px-4 text-center">
+    <div class="max-w-7xl mx-auto px-4 text-center">
       <p class="font-mono text-[--color-text-muted] text-sm mb-4 tracking-wider">{t('cta.tag')}</p>
       <h2 id="cta-heading-ko" class="text-3xl md:text-4xl font-bold mb-4">
         <span class="text-[--color-accent]">{t('cta.title')}</span>

--- a/src/pages/ko/market/index.astro
+++ b/src/pages/ko/market/index.astro
@@ -9,7 +9,7 @@ const marketDataJson = JSON.stringify(marketDataRaw);
 
 <Layout title={t('meta.market_title')} description={t('meta.market_desc')}>
   <section class="py-12">
-    <div class="max-w-6xl mx-auto px-4">
+    <div class="max-w-7xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('market.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">{t('market.title')}</h1>
       <p class="text-[--color-text-muted] text-lg mb-4 max-w-2xl">

--- a/src/pages/market/index.astro
+++ b/src/pages/market/index.astro
@@ -9,7 +9,7 @@ const marketDataJson = JSON.stringify(marketDataRaw);
 
 <Layout title={t('meta.market_title')} description={t('meta.market_desc')}>
   <section class="py-12">
-    <div class="max-w-6xl mx-auto px-4">
+    <div class="max-w-7xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('market.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">{t('market.title')}</h1>
       <p class="text-[--color-text-muted] text-lg mb-4 max-w-2xl">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -187,6 +187,8 @@ body {
   background-color: var(--color-bg);
   color: var(--color-text);
   font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.6;
   font-feature-settings: 'kern' 1, 'liga' 1;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
## Summary
- GNB: full viewport width (no max-w), TradingView-style spacing
- Logo: 28→32px, nav font 14→15px, gap 32→40px
- All sections: max-w-6xl → max-w-7xl (1152→1280px)
- Body font: 16px explicit + line-height 1.6
- 15 files across EN+KO pages

## Test plan
- [ ] GNB spreads across full viewport on 1920px
- [ ] Logo left, nav center, lang right
- [ ] Content sections wider
- [ ] Mobile unaffected (responsive)
- [ ] Font sizes more readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)