### PR TITLE
fix: font scale-up (Tailwind theme override) + GNB px-20

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -386,7 +386,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <div id="page-loader"></div>
     <header>
     <nav class="fixed top-0 w-full z-50 border-b border-[--color-border] bg-[--color-bg]/80 backdrop-blur-md" role="navigation" aria-label="Main">
-      <div class="w-full px-8 lg:px-16 h-16 grid grid-cols-[auto_1fr_auto] items-center">
+      <div class="w-full px-10 lg:px-20 h-16 grid grid-cols-[auto_1fr_auto] items-center">
         <!-- 1열: Logo (좌측) -->
         <a href={lang === 'ko' ? '/ko/' : '/'} class="flex items-center gap-2">
           <img src="/favicon.svg" alt="PRUVIQ" width="32" height="32" class="w-8 h-8" />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -128,6 +128,12 @@
   --duration-slow:     350ms;
   --duration-entrance: 500ms;
 
+  /* ─── FONT SIZE SCALE (1 step up from Tailwind defaults) ─── */
+  /* Default: xs=12, sm=14, base=16, lg=18, xl=20 */
+  /* Scaled:  xs=13, sm=15, base=16, lg=18, xl=20 */
+  --text-xs:   0.8125rem;  /* 13px (was 12px) */
+  --text-sm:   0.9375rem;  /* 15px (was 14px) */
+
   /* ─── DISPLAY TYPOGRAPHY (Hero-specific) ─── */
   --font-size-display:    clamp(2.5rem, 5vw, 4.5rem);   /* 40-72px */
   --font-size-display-sm: clamp(2rem, 4vw, 3.5rem);     /* 32-56px */


### PR DESCRIPTION
## Summary
- Tailwind theme override: --text-xs 12→13px, --text-sm 14→15px
- GNB padding: px-16 → px-20
- Fixes rollback issue: previous manual deploy was overwritten by auto-deploy from stale origin/main

## Test plan
- [ ] text-xs = 0.8125rem in compiled CSS
- [ ] text-sm = 0.9375rem in compiled CSS
- [ ] GNB has px-20 padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)