### PR TITLE
fix: font xs→14px sm→16px + GNB lg:px-28

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -386,7 +386,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <div id="page-loader"></div>
     <header>
     <nav class="fixed top-0 w-full z-50 border-b border-[--color-border] bg-[--color-bg]/80 backdrop-blur-md" role="navigation" aria-label="Main">
-      <div class="w-full px-10 lg:px-20 h-16 grid grid-cols-[auto_1fr_auto] items-center">
+      <div class="w-full px-12 lg:px-28 h-16 grid grid-cols-[auto_1fr_auto] items-center">
         <!-- 1열: Logo (좌측) -->
         <a href={lang === 'ko' ? '/ko/' : '/'} class="flex items-center gap-2">
           <img src="/favicon.svg" alt="PRUVIQ" width="32" height="32" class="w-8 h-8" />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -131,8 +131,8 @@
   /* ─── FONT SIZE SCALE (1 step up from Tailwind defaults) ─── */
   /* Default: xs=12, sm=14, base=16, lg=18, xl=20 */
   /* Scaled:  xs=13, sm=15, base=16, lg=18, xl=20 */
-  --text-xs:   0.8125rem;  /* 13px (was 12px) */
-  --text-sm:   0.9375rem;  /* 15px (was 14px) */
+  --text-xs:   0.875rem;   /* 14px (was 12px) */
+  --text-sm:   1rem;       /* 16px (was 14px) */
 
   /* ─── DISPLAY TYPOGRAPHY (Hero-specific) ─── */
   --font-size-display:    clamp(2.5rem, 5vw, 4.5rem);   /* 40-72px */


### PR DESCRIPTION
Previous PR #640 merged with 1px bump (invisible). This adds the full 2px jump + wider GNB.

- text-xs: 12→14px
- text-sm: 14→16px  
- GNB: lg:px-28

🤖 Generated with [Claude Code](https://claude.com/claude-code)