### PR TITLE
fix: mobile padding + remove cookie banner

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -386,7 +386,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <div id="page-loader"></div>
     <header>
     <nav class="fixed top-0 w-full z-50 border-b border-[--color-border] bg-[--color-bg]/80 backdrop-blur-md" role="navigation" aria-label="Main">
-      <div class="w-full px-12 lg:px-28 h-16 grid grid-cols-[auto_1fr_auto] items-center">
+      <div class="w-full px-6 lg:px-28 h-16 grid grid-cols-[auto_1fr_auto] items-center">
         <!-- 1열: Logo (좌측) -->
         <a href={lang === 'ko' ? '/ko/' : '/'} class="flex items-center gap-2">
           <img src="/favicon.svg" alt="PRUVIQ" width="32" height="32" class="w-8 h-8" />
@@ -630,60 +630,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
       }
     </script>
 
-    <!-- Cookie Notice (GDPR essential notice) -->
-    <div id="cookie-notice" class="fixed bottom-0 max-sm:bottom-auto max-sm:top-16 left-0 right-0 z-[60] bg-[--color-bg-elevated] border-t border-[--color-border] max-sm:border-t-0 max-sm:border-b px-6 py-4 flex items-center justify-between gap-6 shadow-[0_-4px_20px_rgba(0,0,0,0.5)]" style="display:none" aria-live="polite">
-      <p class="text-[--color-text-secondary] text-sm leading-relaxed max-w-2xl">{t('cookie.notice')}</p>
-      <button id="cookie-ok" class="shrink-0 font-mono text-sm font-medium px-5 py-2.5 rounded-lg border border-[--color-border] bg-[--color-bg-card] hover:border-[--color-accent] hover:text-[--color-accent] hover:bg-[--color-accent]/5 transition-all min-h-[44px]">
-        {t('cookie.ok')}
-      </button>
-    </div>
-    <script>
-      (function() {
-        var notice = document.getElementById('cookie-notice');
-        if (!notice) return;
-        var stickyCta = document.getElementById('sticky-cta');
-
-        function applyOffset() {
-          var h = notice.offsetHeight;
-          if (window.innerWidth < 640) {
-            // Mobile: cookie is at top — push body content down
-            document.body.style.paddingTop = h + 'px';
-          } else {
-            // Desktop: cookie is at bottom — push body content up
-            document.body.style.paddingBottom = h + 'px';
-            if (stickyCta) stickyCta.style.bottom = h + 'px';
-            var bottomCta = document.getElementById('bottom-cta-bar');
-            if (bottomCta) bottomCta.style.bottom = h + 'px';
-          }
-        }
-
-        function removeOffset() {
-          document.body.style.paddingTop = '';
-          document.body.style.paddingBottom = '';
-          if (stickyCta) stickyCta.style.bottom = '';
-          var bottomCta = document.getElementById('bottom-cta-bar');
-          if (bottomCta) bottomCta.style.bottom = '0';
-        }
-
-        if (!localStorage.getItem('cookie-ok')) {
-          function showBanner() {
-            notice.style.display = 'flex';
-            requestAnimationFrame(applyOffset);
-          }
-          if (window.location.pathname.includes('/simulate')) {
-            setTimeout(showBanner, 10000);
-          } else {
-            showBanner();
-          }
-        }
-        var btn = document.getElementById('cookie-ok');
-        if (btn) btn.addEventListener('click', function() {
-          localStorage.setItem('cookie-ok', '1');
-          notice.style.display = 'none';
-          removeOffset();
-        });
-      })();
-    </script>
+    <!-- Cookie notice removed: no tracking, no ads, essential security cookies only -->
     {cfToken && (
       <>
         <script>


### PR DESCRIPTION
## Summary
- Mobile GNB: px-12 → px-6 (edges were too wide on small screens)
- Desktop GNB: lg:px-28 unchanged
- Cookie banner removed entirely (no tracking/ads = no GDPR notice needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)