### PR TITLE
fix: ?preset= URL param auto-selects strategy

### DIFF
--- a/src/components/SimulatorPage.tsx
+++ b/src/components/SimulatorPage.tsx
@@ -691,6 +691,11 @@ export default function SimulatorPage({ lang = "en" }: Props) {
         setSelectedCoins([sym]);
         setChartSymbol(sym);
       }
+      // Auto-select preset from URL (e.g., ?preset=bb-squeeze-short)
+      if (params.has("preset")) {
+        const presetId = params.get("preset")!;
+        setTimeout(() => onSelectPreset(presetId), 500);
+      }
     } catch {}
   }, []);
 


### PR DESCRIPTION
Fixes: clicking 'Start with BB Squeeze' or ranking card 'Simulate →' navigates to /simulate but doesn't load the preset. Now reads ?preset= param and calls onSelectPreset().