### PR TITLE
fix: auto-fix #651 (+1 related)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,8 @@ import tailwindcss from '@tailwindcss/vite';
 import preact from '@astrojs/preact';
 
 // https://astro.build/config
+const buildDate = new Date().toISOString();
+
 export default defineConfig({
   site: 'https://pruviq.com',
   i18n: {
@@ -65,6 +67,8 @@ export default defineConfig({
         } else {
           item.priority = 0.5; item.changefreq = /** @type {any} */ ('monthly');
         }
+
+        item.lastmod = buildDate;
 
         return item;
       }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -9,6 +9,7 @@ interface Props {
   description?: string;
   type?: 'website' | 'article';
   date?: string;
+  updatedDate?: string;
   category?: string;
   keywords?: string;
   ogImage?: string;
@@ -25,8 +26,8 @@ const cfToken = import.meta.env.PUBLIC_CF_ANALYTICS_TOKEN;
 const buildTime = new Date().toISOString();
 const currentYear = new Date().getFullYear();
 
-const { title, description = t('meta.home_desc'), type = 'website', date, category, keywords: customKeywords, canonicalOverride, noAlternate = false } = Astro.props;
-const lastModified = date || buildTime;
+const { title, description = t('meta.home_desc'), type = 'website', date, updatedDate, category, keywords: customKeywords, canonicalOverride, noAlternate = false } = Astro.props;
+const lastModified = updatedDate || date || buildTime;
 const ogImage = new URL(Astro.props.ogImage || '/og-image.jpg', Astro.site || 'https://pruviq.com').href;
 // derive AVIF/WebP variants safely for jpg/png sources
 const ogImageAvif = ogImage.replace(/\.(png|jpe?g)(\?.*)?$/i, '.avif$2');


### PR DESCRIPTION
## Auto-fix for 2 issue(s)

#651: [claude-auto][P2] Sitemap has no `<lastmod>` on any of its 2,420 URLs
#652: [claude-auto][P2] `Article` JSON-LD `dateModified` cannot differ from `datePublished` — update h

### Changes
```
 astro.config.mjs         | 4 ++++
 src/layouts/Layout.astro | 5 +++--
 2 files changed, 7 insertions(+), 2 deletions(-)
```

### Safety Checks
- Files changed: **2** (limit: 20)
- Lines changed: **9** (limit: 1500)

---
*Auto-generated by JEPO auto-fix agent. Requires auto-test pass before merge.*