### PR TITLE
fix: auto-fix #651 (+1 related)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -45,6 +45,11 @@ export default defineConfig({
           { url: enUrl, lang: 'x-default' },
         ];
 
+        // Ensure every URL has lastmod so sitemap-index also gets one
+        if (!item.lastmod) {
+          item.lastmod = new Date();
+        }
+
         // Priority + crawl frequency by page type
         // @ts-ignore — EnumChangefreq accepts these string values at runtime
         const p = basePath;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -9,6 +9,7 @@ interface Props {
   description?: string;
   type?: 'website' | 'article';
   date?: string;
+  updatedDate?: string;
   category?: string;
   keywords?: string;
   ogImage?: string;
@@ -25,8 +26,8 @@ const cfToken = import.meta.env.PUBLIC_CF_ANALYTICS_TOKEN;
 const buildTime = new Date().toISOString();
 const currentYear = new Date().getFullYear();
 
-const { title, description = t('meta.home_desc'), type = 'website', date, category, keywords: customKeywords, canonicalOverride, noAlternate = false } = Astro.props;
-const lastModified = date || buildTime;
+const { title, description = t('meta.home_desc'), type = 'website', date, updatedDate, category, keywords: customKeywords, canonicalOverride, noAlternate = false } = Astro.props;
+const lastModified = updatedDate || date || buildTime;
 const ogImage = new URL(Astro.props.ogImage || '/og-image.jpg', Astro.site || 'https://pruviq.com').href;
 // derive AVIF/WebP variants safely for jpg/png sources
 const ogImageAvif = ogImage.replace(/\.(png|jpe?g)(\?.*)?$/i, '.avif$2');


### PR DESCRIPTION
## Auto-fix for 2 issue(s)

#651: [claude-auto][P2] Sitemap has no `<lastmod>` on any of its 2,420 URLs
#652: [claude-auto][P2] `Article` JSON-LD `dateModified` cannot differ from `datePublished` — update h

### Changes
```
 astro.config.mjs         | 5 +++++
 src/layouts/Layout.astro | 5 +++--
 2 files changed, 8 insertions(+), 2 deletions(-)
```

### Safety Checks
- Files changed: **2** (limit: 20)
- Lines changed: **10** (limit: 1500)

---
*Auto-generated by JEPO auto-fix agent. Requires auto-test pass before merge.*