### PR TITLE
fix: calibrate strategy grade thresholds for portfolio reality

### DIFF
--- a/src/components/ResultsPanel.tsx
+++ b/src/components/ResultsPanel.tsx
@@ -755,7 +755,11 @@ export default function ResultsPanel({
                   let grade: string;
                   let gradeColor: string;
                   let reason: string;
-                  if (pf >= 2.0 && wr >= 55 && mdd <= 20) {
+                  // Grade thresholds calibrated for multi-coin portfolio (50 coins).
+                  // Single-coin runs naturally produce higher PF; portfolio
+                  // aggregation dilutes edge. Thresholds reflect realistic
+                  // ranges from 2+ years of data across 16 strategies.
+                  if (pf >= 1.3 && wr >= 53 && mdd <= 15) {
                     grade = t.gradeStrong;
                     gradeColor = "#22c55e";
                     reason = t.reasonStrong(
@@ -763,7 +767,7 @@ export default function ResultsPanel({
                       wr.toFixed(1),
                       mdd.toFixed(1),
                     );
-                  } else if (pf >= 1.5 && wr >= 50 && mdd <= 30) {
+                  } else if (pf >= 1.1 && wr >= 50 && mdd <= 25) {
                     grade = t.gradeGood;
                     gradeColor = "#86efac";
                     reason = t.reasonGood(
@@ -771,11 +775,11 @@ export default function ResultsPanel({
                       wr.toFixed(1),
                       mdd.toFixed(1),
                     );
-                  } else if (pf >= 1.2 && mdd <= 40) {
+                  } else if (pf >= 1.0 && mdd <= 35) {
                     grade = t.gradeFair;
                     gradeColor = "#facc15";
                     const weak =
-                      pf < 1.5
+                      pf < 1.1
                         ? t.reasonFairPf(formatPF(pf))
                         : t.reasonFairWr(wr.toFixed(1));
                     reason = t.reasonFairSuffix(weak);
@@ -785,7 +789,7 @@ export default function ResultsPanel({
                     const mainIssue =
                       pf < 1.0
                         ? t.reasonWeakPf(formatPF(pf))
-                        : mdd > 40
+                        : mdd > 35
                           ? t.reasonWeakMdd(mdd.toFixed(1))
                           : t.reasonWeakWr(wr.toFixed(1));
                     reason = t.reasonWeakSuffix(mainIssue);

--- a/src/components/SimulatorPage.tsx
+++ b/src/components/SimulatorPage.tsx
@@ -190,7 +190,7 @@ const L = {
       `PF ${pf}, WR ${wr}%, MDD ${mdd}% — all three metrics strong`,
     reasonGood: (pf: string, wr: string, mdd: string) =>
       `PF ${pf}, WR ${wr}%, MDD ${mdd}% — viable for live use`,
-    reasonFairPf: (pf: string) => `PF ${pf} (target: ≥1.5)`,
+    reasonFairPf: (pf: string) => `PF ${pf} (target: ≥1.1)`,
     reasonFairWr: (wr: string) => `WR ${wr}% (target: ≥50%)`,
     reasonFairSuffix: (weak: string) => `${weak} — consider parameter tuning`,
     reasonWeakPf: (pf: string) => `PF ${pf} (net loss)`,
@@ -377,7 +377,7 @@ const L = {
       `PF ${pf}, 승률 ${wr}%, MDD ${mdd}% — 세 지표 모두 우수`,
     reasonGood: (pf: string, wr: string, mdd: string) =>
       `PF ${pf}, 승률 ${wr}%, MDD ${mdd}% — 실사용 가능 수준`,
-    reasonFairPf: (pf: string) => `PF ${pf} (목표: 1.5 이상)`,
+    reasonFairPf: (pf: string) => `PF ${pf} (목표: 1.1 이상)`,
     reasonFairWr: (wr: string) => `승률 ${wr}% (목표: 50% 이상)`,
     reasonFairSuffix: (weak: string) => `${weak} — 파라미터 조정 권장`,
     reasonWeakPf: (pf: string) => `PF ${pf} (손익 역전)`,


### PR DESCRIPTION
## Summary
- 전략 등급 기준이 50코인 포트폴리오 환경에서 비현실적 → 400/400 조합 전부 "위험"
- PF≥2.0/1.5/1.2 → PF≥1.3/1.1/1.0으로 현실 데이터 기반 조정
- BB Squeeze SHORT: WEAK → **GOOD**, Ichimoku: WEAK → **FAIR**
- 실제 손실 전략은 여전히 WEAK (정확한 경고)

## Test plan
- [x] `npm run build` — 2484 pages, 0 errors
- [x] BB Squeeze SHORT (PF=1.18, WR=53.6%, MDD=9.8%) → GOOD ✅
- [x] 손실 전략 (PF<1.0) → WEAK ✅ (정확)

🤖 Generated with [Claude Code](https://claude.com/claude-code)