### PR TITLE
fix: mode-aware strategy grade + MDD context tooltip

### DIFF
--- a/src/components/ResultHero.tsx
+++ b/src/components/ResultHero.tsx
@@ -12,9 +12,10 @@ interface Props {
   result: BacktestResult;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   t: Record<string, any>;
+  simMode?: "quick" | "standard" | "expert";
 }
 
-export default function ResultHero({ result, t }: Props) {
+export default function ResultHero({ result, t, simMode = "expert" }: Props) {
   const returnPct = result.total_return_pct;
   const isPositive = returnPct > 0;
   const color = isPositive ? COLORS.green : COLORS.red;
@@ -58,6 +59,13 @@ export default function ResultHero({ result, t }: Props) {
           label={t.heroMDD || "Max DD"}
           value={`${result.max_drawdown_pct.toFixed(1)}%`}
           valueColor={COLORS.red}
+          tooltip={
+            simMode === "standard"
+              ? t.mddPortfolioTip ||
+                "Portfolio-level: capital split across coins equally"
+              : t.mddPositionTip ||
+                "Per-position: based on your capital × leverage setting"
+          }
         />
       </div>
     </div>
@@ -68,13 +76,18 @@ function Pill({
   label,
   value,
   valueColor,
+  tooltip,
 }: {
   label: string;
   value: string;
   valueColor: string;
+  tooltip?: string;
 }) {
   return (
-    <div class="px-2.5 py-1.5 rounded-lg bg-[--color-bg-tooltip] border border-[--color-border] text-center min-w-[80px]">
+    <div
+      class="px-2.5 py-1.5 rounded-lg bg-[--color-bg-tooltip] border border-[--color-border] text-center min-w-[80px]"
+      title={tooltip}
+    >
       <div class="text-[9px] font-mono text-[--color-text-muted] uppercase tracking-wider">
         {label}
       </div>

--- a/src/components/ResultsPanel.tsx
+++ b/src/components/ResultsPanel.tsx
@@ -745,7 +745,7 @@ export default function ResultsPanel({
           {resultTab === "summary" && (
             <div class="p-3 md:p-4">
               {/* Hero: single big number (토스 패턴) */}
-              <ResultHero result={result} t={t} />
+              <ResultHero result={result} t={t} simMode={simMode} />
               {/* Strategy verdict banner */}
               {result &&
                 (() => {
@@ -755,11 +755,15 @@ export default function ResultsPanel({
                   let grade: string;
                   let gradeColor: string;
                   let reason: string;
-                  // Grade thresholds calibrated for multi-coin portfolio (50 coins).
-                  // Single-coin runs naturally produce higher PF; portfolio
-                  // aggregation dilutes edge. Thresholds reflect realistic
-                  // ranges from 2+ years of data across 16 strategies.
-                  if (pf >= 1.3 && wr >= 53 && mdd <= 15) {
+                  // Grade thresholds differ by mode:
+                  // - Standard (/simulate): MDD normalized by n_coins (portfolio-level)
+                  // - Expert (/backtest): MDD based on per-position USD (naturally higher)
+                  const isExpert = simMode === "expert";
+                  const mddStrong = isExpert ? 40 : 15;
+                  const mddGood = isExpert ? 55 : 25;
+                  const mddFair = isExpert ? 70 : 35;
+
+                  if (pf >= 1.3 && wr >= 53 && mdd <= mddStrong) {
                     grade = t.gradeStrong;
                     gradeColor = "#22c55e";
                     reason = t.reasonStrong(
@@ -767,7 +771,7 @@ export default function ResultsPanel({
                       wr.toFixed(1),
                       mdd.toFixed(1),
                     );
-                  } else if (pf >= 1.1 && wr >= 50 && mdd <= 25) {
+                  } else if (pf >= 1.1 && wr >= 50 && mdd <= mddGood) {
                     grade = t.gradeGood;
                     gradeColor = "#86efac";
                     reason = t.reasonGood(
@@ -775,7 +779,7 @@ export default function ResultsPanel({
                       wr.toFixed(1),
                       mdd.toFixed(1),
                     );
-                  } else if (pf >= 1.0 && mdd <= 35) {
+                  } else if (pf >= 1.0 && mdd <= mddFair) {
                     grade = t.gradeFair;
                     gradeColor = "#facc15";
                     const weak =
@@ -789,7 +793,7 @@ export default function ResultsPanel({
                     const mainIssue =
                       pf < 1.0
                         ? t.reasonWeakPf(formatPF(pf))
-                        : mdd > 35
+                        : mdd > mddFair
                           ? t.reasonWeakMdd(mdd.toFixed(1))
                           : t.reasonWeakWr(wr.toFixed(1));
                     reason = t.reasonWeakSuffix(mainIssue);


### PR DESCRIPTION
## Summary
- Standard(/simulate)와 Expert(/backtest)의 MDD 계산 차이로 같은 전략이 다른 등급을 받는 문제 수정
- 모드별 MDD threshold 분리: Standard(15/25/35%) vs Expert(40/55/70%)
- MDD pill에 hover tooltip 추가 ("Portfolio-level" vs "Per-position")
- BB Squeeze SHORT: 두 모드 모두 GOOD (이전: Standard=GOOD, Expert=FAIR)
- 등급 분포: 0% GOOD → 19% GOOD + 12% FAIR

## Test plan
- [x] BB Squeeze SHORT: Standard GOOD + Expert GOOD (일관)
- [x] 26개 프리셋 전수 검증 — 0 trades 없음
- [x] `npm run build` — 2484 pages, 0 errors
- [x] 등급 분포 현실적 (GOOD 5 + FAIR 3 + WEAK 18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)