### PR TITLE
fix: URL params override preset defaults (ranking → simulator)

### DIFF
--- a/src/components/SimulatorPage.tsx
+++ b/src/components/SimulatorPage.tsx
@@ -1081,10 +1081,13 @@ export default function SimulatorPage({ lang = "en" }: Props) {
           })),
         );
       }
-      if (p.direction) setDirection(p.direction);
-      if (p.sl_pct) setSlPct(p.sl_pct);
-      if (p.tp_pct) setTpPct(p.tp_pct);
-      if (p.max_bars) setMaxBars(p.max_bars);
+      // URL params take priority over preset defaults (e.g., ranking → simulator
+      // passes &dir=long&sl=8&tp=6 which should NOT be overwritten by preset defaults)
+      const urlParams = new URLSearchParams(window.location.search);
+      if (p.direction && !urlParams.has("dir")) setDirection(p.direction);
+      if (p.sl_pct && !urlParams.has("sl")) setSlPct(p.sl_pct);
+      if (p.tp_pct && !urlParams.has("tp")) setTpPct(p.tp_pct);
+      if (p.max_bars && !urlParams.has("bars")) setMaxBars(p.max_bars);
       if (p.avoid_hours) setAvoidHours(new Set(p.avoid_hours));
       setPresetLoading(false);
       return p;


### PR DESCRIPTION
## Summary
PR #677에서 랭킹 → 시뮬레이터 URL에 `&dir=&sl=&tp=` 파라미터를 추가했지만, `loadPreset()`이 프리셋 기본값으로 **덮어쓰기**하여 여전히 같은 결과가 표시됨.

### 근본 원인
```
1. URL 파라미터: dir=long, sl=8, tp=6 ← 설정됨
2. loadPreset("rsi-divergence") 호출
3. p.direction="both", p.sl_pct=7, p.tp_pct=5로 덮어쓰기 ← URL 값 소실
```

### 수정
URL에 `dir=`/`sl=`/`tp=` 파라미터가 있으면 preset 기본값 대신 **URL 값 우선**:
```typescript
if (p.direction && !urlParams.has("dir")) setDirection(p.direction);
```

## Test plan
- [x] `npm run build` — 2484 pages, 0 errors
- [x] 랭킹 Top 1 (dir=long) ≠ Top 3 (dir=both) — 다른 결과

🤖 Generated with [Claude Code](https://claude.com/claude-code)