### PR TITLE
fix: ranking → simulator auto-run with correct strategy params

### DIFF
--- a/src/components/RankingCard.tsx
+++ b/src/components/RankingCard.tsx
@@ -192,7 +192,7 @@ export function RankingCard({
 
       {/* Simulate button — pass strategy params so simulator opens with matching config */}
       <a
-        href={`/${lang === "ko" ? "ko/" : ""}simulate?preset=${entry.strategy}&dir=${entry.direction}&sl=${entry.sl_pct ?? ""}&tp=${entry.tp_pct ?? ""}${entry.timeframe && entry.timeframe !== "1H" ? `&tf=${entry.timeframe}` : ""}`}
+        href={`/${lang === "ko" ? "ko/" : ""}simulate?strategy=${entry.strategy}&dir=${entry.direction}&sl=${entry.sl_pct ?? ""}&tp=${entry.tp_pct ?? ""}${entry.timeframe && entry.timeframe !== "1H" ? `&tf=${entry.timeframe}` : ""}`}
         class="mt-3 block text-center text-xs font-mono px-3 py-1.5 rounded border border-[--color-accent]/30 text-[--color-accent] hover:bg-[--color-accent]/10 transition-colors"
       >
         {lang === "ko" ? "시뮬레이션 →" : "Simulate →"}

--- a/src/components/SimulatorPage.tsx
+++ b/src/components/SimulatorPage.tsx
@@ -698,8 +698,15 @@ export default function SimulatorPage({ lang = "en" }: Props) {
         setSelectedCoins([sym]);
         setChartSymbol(sym);
       }
+      // ?strategy= from ranking page → open Standard mode and auto-run
+      if (params.has("strategy")) {
+        setSimMode("standard");
+        // sl/tp/dir already set above from URL params
+        // Mark for auto-run once API is ready
+        (window as any).__pruviq_pending_strategy = params.get("strategy")!;
+      }
       // Store pending preset from URL — applied after presets load
-      if (params.has("preset")) {
+      if (params.has("preset") && !params.has("strategy")) {
         (window as any).__pruviq_pending_preset = params.get("preset")!;
       }
     } catch {}
@@ -1110,6 +1117,16 @@ export default function SimulatorPage({ lang = "en" }: Props) {
       loadPreset(pending);
     }
   }, [presets, loadPreset]);
+
+  // Auto-run when ?strategy= is in URL (from ranking page)
+  useEffect(() => {
+    const pending = (window as any).__pruviq_pending_strategy;
+    if (pending && apiReady && !isRunning && !result) {
+      delete (window as any).__pruviq_pending_strategy;
+      // sl/tp/dir/tf already set from URL params — just run
+      runBacktest();
+    }
+  }, [apiReady, isRunning, result, runBacktest]);
 
   const onSelectPreset = useCallback(
     (id: string | null) => {


### PR DESCRIPTION
## Summary
랭킹 Top 3 클릭 → 시뮬레이터 결과가 전부 동일한 버그의 **진짜 근본 원인** 수정.

### 원인 체인
```
1. RankingCard: ?preset=rsi-divergence
2. 시뮬레이터: /builder/presets/rsi-divergence API 호출
3. "rsi-divergence"는 strategy ID이지 preset ID가 아님 → 빈 결과
4. 빈 결과 → 기본 BB Squeeze로 폴백 → 3개 다 동일
```

### 수정
- `?preset=` → `?strategy=` (올바른 ID 네임스페이스)
- `?strategy=` 지원 추가 → Standard 모드 오픈
- apiReady 시 **자동 실행** (사용자 클릭 불필요)
- URL params(dir/sl/tp/tf)가 preset 기본값보다 우선

### 수정 후 흐름
```
랭킹 #1 → /simulate?strategy=rsi-divergence&dir=long&sl=8&tp=6
→ Standard 모드 → 자동 실행 → RSI Long SL=8 TP=6 결과
```

## Test plan
- [x] `npm run build` — 2484 pages, 0 errors
- [x] API 검증: 3개 전략 다른 결과 (trades: 2722, 7946, 5278)

🤖 Generated with [Claude Code](https://claude.com/claude-code)