### PR TITLE
fix: ranking → simulator calls /simulate API with strategy ID

### DIFF
--- a/src/components/SimulatorPage.tsx
+++ b/src/components/SimulatorPage.tsx
@@ -1119,14 +1119,45 @@ export default function SimulatorPage({ lang = "en" }: Props) {
   }, [presets, loadPreset]);
 
   // Auto-run when ?strategy= is in URL (from ranking page)
+  // Uses /simulate API (not /backtest) since we have strategy ID, not conditions
   useEffect(() => {
     const pending = (window as any).__pruviq_pending_strategy;
     if (pending && apiReady && !isRunning && !result) {
       delete (window as any).__pruviq_pending_strategy;
-      // sl/tp/dir/tf already set from URL params — just run
-      runBacktest();
+
+      // Call /simulate with strategy ID directly (matching Standard mode behavior)
+      setIsRunning(true);
+      setProgressStep(0);
+      setElapsedSec(0);
+      const timer = setInterval(
+        () => setElapsedSec((s: number) => s + 1),
+        1000,
+      );
+
+      fetch(`${API_BASE}/simulate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          strategy: pending,
+          direction: direction,
+          sl_pct: slPct,
+          tp_pct: tpPct,
+          top_n: topN,
+        }),
+      })
+        .then((r) => r.json())
+        .then((data) => {
+          setResult(data);
+          setResultTab("summary");
+          setMobileTab("results");
+        })
+        .catch((err) => setError(String(err.message || err)))
+        .finally(() => {
+          setIsRunning(false);
+          clearInterval(timer);
+        });
     }
-  }, [apiReady, isRunning, result, runBacktest]);
+  }, [apiReady, isRunning, result, direction, slPct, tpPct, topN]);
 
   const onSelectPreset = useCallback(
     (id: string | null) => {


### PR DESCRIPTION
## Root Cause
`?strategy=supertrend` URL → `runBacktest()` 호출 → `/backtest` API 사용 → UI의 conditions (BB Squeeze 기본값)로 실행 → **strategy ID 무시** → 3개 다 같은 결과

## Fix
`?strategy=` 있으면 `/simulate` API를 strategy ID + dir + sl + tp로 직접 호출.

```
이전: /backtest { conditions: [BB Squeeze 기본...] }  ← strategy 무시
이후: /simulate { strategy: "supertrend", direction: "long", sl_pct: 10, tp_pct: 8 }
```

## Test plan
- [x] `npm run build` — 2484 pages, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)