### PR TITLE
fix: API_BASE → API_URL typo (ranking→simulator error)

### DIFF
--- a/src/components/SimulatorPage.tsx
+++ b/src/components/SimulatorPage.tsx
@@ -1134,7 +1134,7 @@ export default function SimulatorPage({ lang = "en" }: Props) {
         1000,
       );
 
-      fetch(`${API_BASE}/simulate`, {
+      fetch(`${API_URL}/simulate`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({


### PR DESCRIPTION
랭킹에서 시뮬레이터 클릭 시 오류 발생 원인. API_BASE(미정의) → API_URL(정상).