### PR TITLE
feat: GA4 + UTM tracking

### DIFF
--- a/src/components/ExchangeCTA.tsx
+++ b/src/components/ExchangeCTA.tsx
@@ -1,9 +1,9 @@
-import { exchanges, type Exchange } from '../data/exchanges';
+import { exchanges, type Exchange } from "../data/exchanges";
 
 interface Props {
   /** Display mode: 'inline' for table rows, 'card' for full-width */
-  mode?: 'inline' | 'card';
-  lang?: 'en' | 'ko';
+  mode?: "inline" | "card";
+  lang?: "en" | "ko";
   /** Optional coin symbol for tracking */
   coin?: string;
   /** Optional strategy ID for tracking */
@@ -12,45 +12,61 @@ interface Props {
 
 const labels = {
   en: {
-    heading: 'Start trading with reduced fees',
-    subtext: 'Sign up through PRUVIQ and save on every trade',
-    discount: 'fee discount',
-    off: 'off',
-    signup: 'Sign Up',
-    disclosure: 'Affiliate link — we may earn a commission at no extra cost to you.',
+    heading: "Start trading with reduced fees",
+    subtext: "Sign up through PRUVIQ and save on every trade",
+    discount: "fee discount",
+    off: "off",
+    signup: "Sign Up",
+    disclosure:
+      "Affiliate link — we may earn a commission at no extra cost to you.",
   },
   ko: {
-    heading: '수수료 할인으로 트레이딩 시작',
-    subtext: 'PRUVIQ를 통해 가입하면 매 거래마다 절약',
-    discount: '수수료 할인',
-    off: '할인',
-    signup: '가입하기',
-    disclosure: '제휴 링크 — 추가 비용 없이 저희에게 수수료가 지급됩니다.',
+    heading: "수수료 할인으로 트레이딩 시작",
+    subtext: "PRUVIQ를 통해 가입하면 매 거래마다 절약",
+    discount: "수수료 할인",
+    off: "할인",
+    signup: "가입하기",
+    disclosure: "제휴 링크 — 추가 비용 없이 저희에게 수수료가 지급됩니다.",
   },
 };
 
-function buildUrl(exchange: Exchange, coin?: string, strategy?: string): string {
+function buildUrl(
+  exchange: Exchange,
+  coin?: string,
+  strategy?: string,
+): string {
   const base = exchange.referralUrl;
-  if (base === '#' || !base) return '#';
+  if (base === "#" || !base) return "#";
   const params = new URLSearchParams();
-  if (coin) params.set('utm_content', coin);
-  if (strategy) params.set('utm_campaign', strategy);
+  params.set("utm_source", "pruviq");
+  params.set("utm_medium", "referral");
+  params.set("utm_campaign", strategy || "exchange");
+  if (coin) params.set("utm_content", coin);
   const qs = params.toString();
-  return qs ? `${base}&${qs}` : base;
+  return `${base}&${qs}`;
 }
 
-export default function ExchangeCTA({ mode = 'card', lang = 'en', coin, strategy }: Props) {
+export default function ExchangeCTA({
+  mode = "card",
+  lang = "en",
+  coin,
+  strategy,
+}: Props) {
   const t = labels[lang] || labels.en;
-  const available = exchanges.filter(e => e.available && e.referralUrl !== '#');
+  const available = exchanges.filter(
+    (e) => e.available && e.referralUrl !== "#",
+  );
 
   if (available.length === 0) return null;
 
-  if (mode === 'inline') {
+  if (mode === "inline") {
     return (
       <div class="mt-3 pt-3 border-t border-[--color-border]/50">
         <div class="flex flex-wrap items-center gap-2">
-          <span class="text-[0.625rem] text-[--color-text-muted] uppercase tracking-wider">{t.heading}:</span>
-          {available.map(ex => (
+          <span class="text-[0.625rem] text-[--color-text-muted] uppercase tracking-wider">
+            {t.heading}:
+          </span>
+          {available.map((ex) => (
             <a
               key={ex.id}
               href={buildUrl(ex, coin, strategy)}
@@ -59,11 +75,15 @@ export default function ExchangeCTA({ mode = 'card', lang = 'en', coin, strategy
               class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border border-[--color-border] hover:border-[--color-accent] text-[0.6875rem] font-mono transition-colors"
             >
               <span class="font-semibold text-[--color-text]">{ex.name}</span>
-              <span class="text-[--color-accent] text-[0.625rem]">{ex.discountLabel} {t.off}</span>
+              <span class="text-[--color-accent] text-[0.625rem]">
+                {ex.discountLabel} {t.off}
+              </span>
             </a>
           ))}
         </div>
-        <p class="text-[0.5rem] text-[--color-text-muted] mt-1">{t.disclosure}</p>
+        <p class="text-[0.5rem] text-[--color-text-muted] mt-1">
+          {t.disclosure}
+        </p>
       </div>
     );
   }
@@ -74,7 +94,7 @@ export default function ExchangeCTA({ mode = 'card', lang = 'en', coin, strategy
       <h3 class="text-sm font-bold mb-1">{t.heading}</h3>
       <p class="text-[0.75rem] text-[--color-text-muted] mb-4">{t.subtext}</p>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        {available.map(ex => (
+        {available.map((ex) => (
           <a
             key={ex.id}
             href={buildUrl(ex, coin, strategy)}
@@ -85,16 +105,24 @@ export default function ExchangeCTA({ mode = 'card', lang = 'en', coin, strategy
             <div>
               <div class="font-semibold text-sm">{ex.name}</div>
               <div class="text-[0.6875rem] text-[--color-text-muted]">
-                {ex.tag} &middot; <span class="text-[--color-accent]">{ex.discountLabel} {t.discount}</span>
+                {ex.tag} &middot;{" "}
+                <span class="text-[--color-accent]">
+                  {ex.discountLabel} {t.discount}
+                </span>
               </div>
             </div>
-            <span class="px-3 py-1.5 rounded-md text-xs font-semibold transition-colors whitespace-nowrap" style="background:var(--color-accent);color:#fff">
+            <span
+              class="px-3 py-1.5 rounded-md text-xs font-semibold transition-colors whitespace-nowrap"
+              style="background:var(--color-accent);color:#fff"
+            >
               {t.signup} &rarr;
             </span>
           </a>
         ))}
       </div>
-      <p class="text-[0.5625rem] text-[--color-text-muted] mt-3">{t.disclosure}</p>
+      <p class="text-[0.5625rem] text-[--color-text-muted] mt-3">
+        {t.disclosure}
+      </p>
     </div>
   );
 }

--- a/src/components/FeeCalculator.tsx
+++ b/src/components/FeeCalculator.tsx
@@ -228,7 +228,7 @@ export default function FeeCalculator({ lang = "en" }: Props) {
             <div class="sm:w-28 flex-shrink-0 text-center">
               {ex.available ? (
                 <a
-                  href={ex.referralUrl}
+                  href={`${ex.referralUrl}${ex.referralUrl.includes("?") ? "&" : "?"}utm_source=pruviq&utm_medium=referral&utm_campaign=fee-calculator`}
                   target="_blank"
                   rel="noopener noreferrer"
                   class="inline-block w-full px-4 py-2 min-h-[44px] flex flex-col items-center justify-center rounded text-xs font-semibold hover:opacity-90 transition-opacity"

--- a/src/components/ResultsPanel.tsx
+++ b/src/components/ResultsPanel.tsx
@@ -465,7 +465,7 @@ export default function ResultsPanel({
                 {/* Exchange CTA — most prominent, pushed right */}
                 {topExchange && (
                   <a
-                    href={`${topExchange.referralUrl}`}
+                    href={`${topExchange.referralUrl}${topExchange.referralUrl.includes("?") ? "&" : "?"}utm_source=pruviq&utm_medium=referral&utm_campaign=results`}
                     target="_blank"
                     rel="noopener noreferrer sponsored"
                     class="ml-auto flex items-center gap-2 px-3 py-1.5 rounded-md font-semibold transition-all"

--- a/src/components/StrategyDemo.tsx
+++ b/src/components/StrategyDemo.tsx
@@ -1,10 +1,13 @@
-import { useState, useEffect, useRef } from 'preact/hooks';
-import { getCssVar } from '../utils/format';
-import DiscreteSlider from './DiscreteSlider';
-import ResultsCard from './ResultsCard';
-import { API_BASE_URL as API_URL, STATIC_DATA, fetchWithFallback } from '../config/api';
-import type { IChartApi, ISeriesApi, SeriesType } from 'lightweight-charts';
-
+import { useState, useEffect, useRef } from "preact/hooks";
+import { getCssVar } from "../utils/format";
+import DiscreteSlider from "./DiscreteSlider";
+import ResultsCard from "./ResultsCard";
+import {
+  API_BASE_URL as API_URL,
+  STATIC_DATA,
+  fetchWithFallback,
+} from "../config/api";
+import type { IChartApi, ISeriesApi, SeriesType } from "lightweight-charts";
 
 interface EquityPoint {
   time: string;
@@ -33,7 +36,7 @@ interface DemoData {
 }
 
 interface Props {
-  lang?: 'en' | 'ko';
+  lang?: "en" | "ko";
   strategy?: string;
   direction?: string;
   defaultSl?: number;
@@ -42,40 +45,46 @@ interface Props {
 
 const labels = {
   en: {
-    tag: 'INTERACTIVE SIMULATION',
-    title: 'Try It Yourself',
-    desc: (coins: number, range: string) => `Adjust stop-loss and take-profit to see how they affect performance. Simulated on ${coins} coins over ${range} with realistic fees.`,
-    sl: 'STOP LOSS',
-    tp: 'TAKE PROFIT',
-    chart: 'CUMULATIVE RETURN (%)',
-    loading: 'Loading simulation data...',
-    error: 'Failed to load demo data.',
-    retry: 'Retry',
-    noData: 'No data for this combination.',
-    disclaimer: '* Simulation includes 0.04% futures fees + 0.02% slippage per trade. Past performance does not guarantee future results.',
-    ctaTitle: 'Run this strategy live?',
-    ctaDesc: 'You\'ll need an exchange account. Sign up through PRUVIQ to save on fees.',
-    ctaExchange: 'Sign Up on Binance (Up to 19% off)',
-    ctaFees: 'Compare All Exchanges',
-    ctaCommunity: 'Join Community',
+    tag: "INTERACTIVE SIMULATION",
+    title: "Try It Yourself",
+    desc: (coins: number, range: string) =>
+      `Adjust stop-loss and take-profit to see how they affect performance. Simulated on ${coins} coins over ${range} with realistic fees.`,
+    sl: "STOP LOSS",
+    tp: "TAKE PROFIT",
+    chart: "CUMULATIVE RETURN (%)",
+    loading: "Loading simulation data...",
+    error: "Failed to load demo data.",
+    retry: "Retry",
+    noData: "No data for this combination.",
+    disclaimer:
+      "* Simulation includes 0.04% futures fees + 0.02% slippage per trade. Past performance does not guarantee future results.",
+    ctaTitle: "Run this strategy live?",
+    ctaDesc:
+      "You'll need an exchange account. Sign up through PRUVIQ to save on fees.",
+    ctaExchange: "Sign Up on Binance (Up to 19% off)",
+    ctaFees: "Compare All Exchanges",
+    ctaCommunity: "Join Community",
   },
   ko: {
-    tag: '인터랙티브 시뮬레이션',
-    title: '직접 체험하기',
-    desc: (coins: number, range: string) => `손절과 익절을 조정하여 성과 변화를 확인하세요. ${coins}개 코인, ${range} 데이터, 수수료 포함 시뮬레이션.`,
-    sl: '손절 (STOP LOSS)',
-    tp: '익절 (TAKE PROFIT)',
-    chart: '누적 수익률 (%)',
-    loading: '시뮬레이션 데이터 로딩 중...',
-    error: '데모 데이터 로딩 실패.',
-    retry: '다시 시도',
-    noData: '이 조합에 대한 데이터가 없습니다.',
-    disclaimer: '* 시뮬레이션은 0.04% 선물 수수료 + 0.02% 슬리피지를 포함합니다. 과거 성과는 미래 결과를 보장하지 않습니다.',
-    ctaTitle: '이 전략을 실제로 실행하려면?',
-    ctaDesc: '거래소 계정이 필요합니다. PRUVIQ를 통해 가입하면 수수료를 절약할 수 있습니다.',
-    ctaExchange: '바이낸스 가입 (최대 19% 할인)',
-    ctaFees: '전체 거래소 비교',
-    ctaCommunity: '커뮤니티 참여',
+    tag: "인터랙티브 시뮬레이션",
+    title: "직접 체험하기",
+    desc: (coins: number, range: string) =>
+      `손절과 익절을 조정하여 성과 변화를 확인하세요. ${coins}개 코인, ${range} 데이터, 수수료 포함 시뮬레이션.`,
+    sl: "손절 (STOP LOSS)",
+    tp: "익절 (TAKE PROFIT)",
+    chart: "누적 수익률 (%)",
+    loading: "시뮬레이션 데이터 로딩 중...",
+    error: "데모 데이터 로딩 실패.",
+    retry: "다시 시도",
+    noData: "이 조합에 대한 데이터가 없습니다.",
+    disclaimer:
+      "* 시뮬레이션은 0.04% 선물 수수료 + 0.02% 슬리피지를 포함합니다. 과거 성과는 미래 결과를 보장하지 않습니다.",
+    ctaTitle: "이 전략을 실제로 실행하려면?",
+    ctaDesc:
+      "거래소 계정이 필요합니다. PRUVIQ를 통해 가입하면 수수료를 절약할 수 있습니다.",
+    ctaExchange: "바이낸스 가입 (최대 19% 할인)",
+    ctaFees: "전체 거래소 비교",
+    ctaCommunity: "커뮤니티 참여",
   },
 };
 
@@ -88,12 +97,20 @@ function DemoSkeleton() {
         <div class="skeleton h-4 w-96 max-w-full" />
       </div>
       <div class="p-5 bg-[--color-bg-card] border border-[--color-border] rounded-xl mb-6">
-        <div class="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))' }}>
+        <div
+          class="grid gap-4"
+          style={{
+            gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
+          }}
+        >
           <div class="skeleton h-12 w-full rounded" />
           <div class="skeleton h-12 w-full rounded" />
         </div>
       </div>
-      <div class="grid gap-6" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))' }}>
+      <div
+        class="grid gap-6"
+        style={{ gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))" }}
+      >
         <div class="p-5 bg-[--color-bg-card] border border-[--color-border] rounded-xl">
           <div class="grid grid-cols-2 gap-2 mb-4">
             <div class="skeleton h-16 rounded-lg" />
@@ -115,9 +132,9 @@ function DemoSkeleton() {
 }
 
 export default function StrategyDemo({
-  lang = 'en',
-  strategy = 'bb-squeeze-short',
-  direction = 'short',
+  lang = "en",
+  strategy = "bb-squeeze-short",
+  direction = "short",
   defaultSl = 10,
   defaultTp = 8,
 }: Props) {
@@ -139,7 +156,7 @@ export default function StrategyDemo({
   useEffect(() => {
     fetch(demoUrl)
       .then((res) => {
-        if (!res.ok) throw new Error('Failed to load demo data');
+        if (!res.ok) throw new Error("Failed to load demo data");
         return res.json();
       })
       .then((json: DemoData) => {
@@ -148,11 +165,19 @@ export default function StrategyDemo({
       })
       .catch((err) => {
         // Fallback to legacy demo-results.json for bb-squeeze-short
-        if (strategy === 'bb-squeeze-short') {
-          fetch('/data/demo-results.json')
-            .then((res) => res.ok ? res.json() : Promise.reject('no fallback'))
-            .then((json: DemoData) => { setData(json); setLoading(false); })
-            .catch(() => { setError(err.message); setLoading(false); });
+        if (strategy === "bb-squeeze-short") {
+          fetch("/data/demo-results.json")
+            .then((res) =>
+              res.ok ? res.json() : Promise.reject("no fallback"),
+            )
+            .then((json: DemoData) => {
+              setData(json);
+              setLoading(false);
+            })
+            .catch(() => {
+              setError(err.message);
+              setLoading(false);
+            });
         } else {
           setError(err.message);
           setLoading(false);
@@ -164,38 +189,50 @@ export default function StrategyDemo({
     if (!data || !chartContainerRef.current) return;
     let disposed = false;
 
-    import('lightweight-charts').then(({ createChart, AreaSeries }) => {
+    import("lightweight-charts").then(({ createChart, AreaSeries }) => {
       if (disposed || !chartContainerRef.current) return;
 
       const chart = createChart(chartContainerRef.current, {
         width: chartContainerRef.current.clientWidth,
         height: 300,
         layout: {
-          background: { color: getCssVar('--color-bg-card') },
-          textColor: getCssVar('--color-text-muted'),
+          background: { color: getCssVar("--color-bg-card") },
+          textColor: getCssVar("--color-text-muted"),
           fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
           fontSize: 11,
         },
         grid: {
-          vertLines: { color: getCssVar('--color-bg-hover') },
-          horzLines: { color: getCssVar('--color-bg-hover') },
+          vertLines: { color: getCssVar("--color-bg-hover") },
+          horzLines: { color: getCssVar("--color-bg-hover") },
         },
-        rightPriceScale: { borderColor: getCssVar('--color-border') },
-        timeScale: { borderColor: getCssVar('--color-border'), timeVisible: false },
+        rightPriceScale: { borderColor: getCssVar("--color-border") },
+        timeScale: {
+          borderColor: getCssVar("--color-border"),
+          timeVisible: false,
+        },
         crosshair: {
-          vertLine: { color: getCssVar('--color-chart-crosshair'), width: 1, style: 2 },
-          horzLine: { color: getCssVar('--color-chart-crosshair'), width: 1, style: 2 },
+          vertLine: {
+            color: getCssVar("--color-chart-crosshair"),
+            width: 1,
+            style: 2,
+          },
+          horzLine: {
+            color: getCssVar("--color-chart-crosshair"),
+            width: 1,
+            style: 2,
+          },
         },
       });
 
       const series = chart.addSeries(AreaSeries, {
-        lineColor: getCssVar('--color-accent'),
-        topColor: getCssVar('--color-up-fill'),
-        bottomColor: 'rgba(0, 192, 115, 0.0)',
+        lineColor: getCssVar("--color-accent"),
+        topColor: getCssVar("--color-up-fill"),
+        bottomColor: "rgba(0, 192, 115, 0.0)",
         lineWidth: 2,
         priceFormat: {
-          type: 'custom',
-          formatter: (price: number) => `${price > 0 ? '+' : ''}${price.toFixed(1)}%`,
+          type: "custom",
+          formatter: (price: number) =>
+            `${price > 0 ? "+" : ""}${price.toFixed(1)}%`,
         },
       });
 
@@ -203,7 +240,8 @@ export default function StrategyDemo({
       seriesRef.current = series;
 
       const ro = new ResizeObserver((entries) => {
-        for (const entry of entries) chart.applyOptions({ width: entry.contentRect.width });
+        for (const entry of entries)
+          chart.applyOptions({ width: entry.contentRect.width });
       });
       ro.observe(chartContainerRef.current);
       roRef.current = ro;
@@ -230,18 +268,29 @@ export default function StrategyDemo({
     };
   }, [data]);
 
-  const fetchFromApi = async (slVal: number, tpVal: number): Promise<ResultData | null> => {
+  const fetchFromApi = async (
+    slVal: number,
+    tpVal: number,
+  ): Promise<ResultData | null> => {
     try {
       // Extract base strategy name for API (e.g., "bb-squeeze-short" -> "bb-squeeze")
-      const apiStrategy = strategy.replace(/-short$|-long$/, '');
+      const apiStrategy = strategy.replace(/-short$|-long$/, "");
       const res = await fetch(`${API_URL}/simulate`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ strategy: apiStrategy, direction, sl_pct: slVal, tp_pct: tpVal, top_n: 50 }),
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          strategy: apiStrategy,
+          direction,
+          sl_pct: slVal,
+          tp_pct: tpVal,
+          top_n: 50,
+        }),
       });
       if (!res.ok) return null;
       return await res.json();
-    } catch { return null; }
+    } catch {
+      return null;
+    }
   };
 
   useEffect(() => {
@@ -252,12 +301,19 @@ export default function StrategyDemo({
 
     const updateChart = (result: ResultData) => {
       if (!result?.equity_curve?.length || !seriesRef.current) return;
-      const isPositive = result.equity_curve[result.equity_curve.length - 1]?.value >= 0;
-      const color = isPositive ? getCssVar('--color-accent') : getCssVar('--color-red');
+      const isPositive =
+        result.equity_curve[result.equity_curve.length - 1]?.value >= 0;
+      const color = isPositive
+        ? getCssVar("--color-accent")
+        : getCssVar("--color-red");
       seriesRef.current.applyOptions({
         lineColor: color,
-        topColor: isPositive ? getCssVar('--color-up-fill') : getCssVar('--color-down-fill'),
-        bottomColor: isPositive ? 'rgba(0, 192, 115, 0.0)' : 'rgba(240, 66, 81, 0.0)',
+        topColor: isPositive
+          ? getCssVar("--color-up-fill")
+          : getCssVar("--color-down-fill"),
+        bottomColor: isPositive
+          ? "rgba(0, 192, 115, 0.0)"
+          : "rgba(240, 66, 81, 0.0)",
       });
       seriesRef.current.setData(result.equity_curve);
       chartRef.current?.timeScale().fitContent();
@@ -268,7 +324,11 @@ export default function StrategyDemo({
     } else {
       fetchFromApi(sl, tp).then((apiResult) => {
         if (apiResult) {
-          setData((prev) => prev ? { ...prev, results: { ...prev.results, [key]: apiResult } } : prev);
+          setData((prev) =>
+            prev
+              ? { ...prev, results: { ...prev.results, [key]: apiResult } }
+              : prev,
+          );
           updateChart(apiResult);
         }
       });
@@ -282,7 +342,23 @@ export default function StrategyDemo({
       <div class="py-8 text-center">
         <p class="font-mono text-sm text-[--color-red] mb-3">{t.error}</p>
         <button
-          onClick={() => { setError(null); setLoading(true); fetch(demoUrl).then(res => { if (!res.ok) throw new Error('Failed'); return res.json(); }).then((json: DemoData) => { setData(json); setLoading(false); }).catch(err => { setError(err.message); setLoading(false); }); }}
+          onClick={() => {
+            setError(null);
+            setLoading(true);
+            fetch(demoUrl)
+              .then((res) => {
+                if (!res.ok) throw new Error("Failed");
+                return res.json();
+              })
+              .then((json: DemoData) => {
+                setData(json);
+                setLoading(false);
+              })
+              .catch((err) => {
+                setError(err.message);
+                setLoading(false);
+              });
+          }}
           class="px-4 py-2 rounded-lg border border-[--color-border] bg-[--color-bg-card] text-[--color-text] font-mono text-sm cursor-pointer hover:border-[--color-accent] transition-colors min-h-[44px]"
         >
           {t.retry}
@@ -299,52 +375,91 @@ export default function StrategyDemo({
     <div id="demo" class="border-t border-[--color-border] pt-10 mt-10 fade-in">
       {/* Header */}
       <div class="mb-6">
-        <div class="font-mono text-xs text-[--color-accent] tracking-widest mb-2 uppercase">{t.tag}</div>
+        <div class="font-mono text-xs text-[--color-accent] tracking-widest mb-2 uppercase">
+          {t.tag}
+        </div>
         <h2 class="text-2xl font-bold mb-2">{t.title}</h2>
-        <p class="text-[--color-text-muted] text-sm leading-relaxed">{t.desc(data.coins, data.data_range)}</p>
+        <p class="text-[--color-text-muted] text-sm leading-relaxed">
+          {t.desc(data.coins, data.data_range)}
+        </p>
       </div>
 
       {/* Main content */}
-      <div class="grid gap-6" style={{ gridTemplateColumns: 'minmax(0, 1fr)' }}>
+      <div class="grid gap-6" style={{ gridTemplateColumns: "minmax(0, 1fr)" }}>
         {/* Sliders */}
         <div class="p-5 bg-[--color-bg-card] border border-[--color-border] rounded-xl">
-          <div class="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))' }}>
-            <DiscreteSlider label={t.sl} values={data.grid.sl_values} value={sl} defaultValue={defaultSl} onChange={setSl} />
-            <DiscreteSlider label={t.tp} values={data.grid.tp_values} value={tp} defaultValue={defaultTp} onChange={setTp} />
+          <div
+            class="grid gap-4"
+            style={{
+              gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
+            }}
+          >
+            <DiscreteSlider
+              label={t.sl}
+              values={data.grid.sl_values}
+              value={sl}
+              defaultValue={defaultSl}
+              onChange={setSl}
+            />
+            <DiscreteSlider
+              label={t.tp}
+              values={data.grid.tp_values}
+              value={tp}
+              defaultValue={defaultTp}
+              onChange={setTp}
+            />
           </div>
         </div>
 
         {/* Results + Chart */}
-        <div class="grid gap-6" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))' }}>
+        <div
+          class="grid gap-6"
+          style={{
+            gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
+          }}
+        >
           <div class="p-5 bg-[--color-bg-card] border border-[--color-border] rounded-xl">
             {result ? (
               <ResultsCard data={result} isDefault={isDefault} lang={lang} />
             ) : (
-              <div class="font-mono text-sm text-[--color-text-muted]">{t.noData}</div>
+              <div class="font-mono text-sm text-[--color-text-muted]">
+                {t.noData}
+              </div>
             )}
           </div>
 
           <div class="bg-[--color-bg-card] border border-[--color-border] rounded-xl overflow-hidden">
-            <div class="px-4 pt-3 font-mono text-[0.6875rem] text-[--color-text-muted] tracking-widest uppercase">{t.chart}</div>
+            <div class="px-4 pt-3 font-mono text-[0.6875rem] text-[--color-text-muted] tracking-widest uppercase">
+              {t.chart}
+            </div>
             <div ref={chartContainerRef} class="w-full h-[300px]" />
           </div>
         </div>
       </div>
 
       {/* Disclaimer */}
-      <p class="font-mono text-[0.625rem] text-[--color-text-muted] mt-4 leading-relaxed">{t.disclaimer}</p>
+      <p class="font-mono text-[0.625rem] text-[--color-text-muted] mt-4 leading-relaxed">
+        {t.disclaimer}
+      </p>
 
       {/* CTA */}
       <div class="mt-8 p-6 bg-[--color-bg-card] border border-[--color-border] rounded-xl card-hover">
         <h3 class="text-lg font-bold mb-2">{t.ctaTitle}</h3>
         <p class="text-[--color-text-muted] text-sm mb-4">{t.ctaDesc}</p>
         <div class="flex gap-3 flex-wrap">
-          <a href="https://accounts.binance.com/register?ref=PRUVIQ" target="_blank" rel="noopener noreferrer"
-             class="inline-block px-5 py-2.5 rounded-lg font-semibold text-sm no-underline hover:opacity-90 transition-opacity" style="background:var(--color-accent);color:#fff">
+          <a
+            href="https://accounts.binance.com/register?ref=PRUVIQ&utm_source=pruviq&utm_medium=referral&utm_campaign=strategy-demo"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-block px-5 py-2.5 rounded-lg font-semibold text-sm no-underline hover:opacity-90 transition-opacity"
+            style="background:var(--color-accent);color:#fff"
+          >
             {t.ctaExchange} &rarr;
           </a>
-          <a href={lang === 'ko' ? '/ko/fees' : '/fees'}
-             class="inline-block border border-[--color-border] text-[--color-text] px-5 py-2.5 rounded-lg font-semibold text-sm no-underline hover:border-[--color-accent] transition-colors">
+          <a
+            href={lang === "ko" ? "/ko/fees" : "/fees"}
+            class="inline-block border border-[--color-border] text-[--color-text] px-5 py-2.5 rounded-lg font-semibold text-sm no-underline hover:border-[--color-accent] transition-colors"
+          >
             {t.ctaFees}
           </a>
         </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -161,6 +161,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <link rel="preconnect" href="https://api.pruviq.com" crossorigin />
     <link rel="preconnect" href="https://coin-images.coingecko.com" crossorigin />
     <link rel="preconnect" href="https://static.cloudflareinsights.com" crossorigin />
+    <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin />
     <!-- Open Graph -->
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
@@ -378,6 +379,14 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
         ]
       })} />
     )}
+    <!-- Google Analytics 4 -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-XXXXXXXXXX');
+    </script>
     <noscript><style>.reveal,.reveal-child>*{opacity:1!important;transform:none!important;transition:none!important}</style></noscript>
 </head>
   <body class="min-h-screen">

--- a/src/pages/fees.astro
+++ b/src/pages/fees.astro
@@ -131,7 +131,7 @@ const t = useTranslations('en');
                   </span>
                 )}
               </div>
-              <a href={binanceDisplay.referralUrl} target="_blank" rel="noopener noreferrer"
+              <a href={`${binanceDisplay.referralUrl}&utm_source=pruviq&utm_medium=referral&utm_campaign=fees`} target="_blank" rel="noopener noreferrer"
                  class="block text-center bg-[--color-accent] text-[--color-bg] px-4 py-3 min-h-[48px] flex items-center justify-center rounded text-sm font-bold hover:opacity-90 transition-opacity shadow-sm">
                 {t('fees.signup')} &rarr;
               </a>
@@ -327,7 +327,7 @@ const t = useTranslations('en');
     <div class="max-w-5xl mx-auto px-4 text-center">
       <p class="text-[--color-text-muted] text-sm mb-4">{t('fees.referral.cta.primary')}</p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center mb-6">
-        <a href={binanceDisplay.referralUrl} target="_blank" rel="noopener noreferrer"
+        <a href={`${binanceDisplay.referralUrl}&utm_source=pruviq&utm_medium=referral&utm_campaign=fees`} target="_blank" rel="noopener noreferrer"
            class="inline-flex items-center justify-center bg-[--color-accent] text-[--color-bg] px-6 py-3 min-h-[48px] rounded text-sm font-bold hover:opacity-90 transition-opacity shadow-sm">
           {t('fees.referral.cta.button.signup')} &rarr;
         </a>

--- a/src/pages/ko/fees.astro
+++ b/src/pages/ko/fees.astro
@@ -121,7 +121,7 @@ const t = useTranslations('ko');
                   </span>
                 )}
               </div>
-              <a href={binanceDisplay.referralUrl} target="_blank" rel="noopener noreferrer"
+              <a href={`${binanceDisplay.referralUrl}&utm_source=pruviq&utm_medium=referral&utm_campaign=fees`} target="_blank" rel="noopener noreferrer"
                  class="block text-center bg-[--color-accent] text-[--color-bg] px-4 py-3 min-h-[48px] flex items-center justify-center rounded text-sm font-bold hover:opacity-90 transition-opacity shadow-sm">
                 {t('fees.signup')} &rarr;
               </a>
@@ -317,7 +317,7 @@ const t = useTranslations('ko');
     <div class="max-w-5xl mx-auto px-4 text-center">
       <p class="text-[--color-text-muted] text-sm mb-4">{t('fees.referral.cta.primary')}</p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center mb-6">
-        <a href={binanceDisplay.referralUrl} target="_blank" rel="noopener noreferrer"
+        <a href={`${binanceDisplay.referralUrl}&utm_source=pruviq&utm_medium=referral&utm_campaign=fees`} target="_blank" rel="noopener noreferrer"
            class="inline-flex items-center justify-center bg-[--color-accent] text-[--color-bg] px-6 py-3 min-h-[48px] rounded text-sm font-bold hover:opacity-90 transition-opacity shadow-sm">
           {t('fees.referral.cta.button.signup')} &rarr;
         </a>


### PR DESCRIPTION
## Summary
- GA4 gtag.js placeholder in Layout.astro (replace G-XXXXXXXXXX with real ID)
- UTM params on all 7 exchange referral link locations
- site-stats.json: 16→17 strategies

## Test plan
- [ ] Build passes
- [ ] Referral links include utm_source=pruviq
- [ ] GA4 snippet loads (after ID replacement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)