### PR TITLE
feat: UX 10/10 improvements — 6 phases

### DIFF
--- a/src/components/BuilderPanel.tsx
+++ b/src/components/BuilderPanel.tsx
@@ -252,7 +252,7 @@ export default function BuilderPanel(props: Props) {
               {t.addCondition}
             </button>
           </div>
-          <div class="space-y-1">
+          <div class="space-y-2 sm:space-y-1">
             {props.conditions.map((c) => (
               <ConditionRow
                 key={c.id}
@@ -282,7 +282,7 @@ export default function BuilderPanel(props: Props) {
           <div class="text-xs font-mono text-[--color-text-muted] uppercase mb-1">
             {t.parameters}
           </div>
-          <div class="grid grid-cols-3 gap-x-2 gap-y-1.5">
+          <div class="grid grid-cols-3 gap-x-2 gap-y-3 sm:gap-y-1.5">
             {/* Timeframe - spans full width */}
             <div class="col-span-3 mb-1">
               <label class="text-[10px] text-[--color-text-muted]">

--- a/src/components/ConditionRow.tsx
+++ b/src/components/ConditionRow.tsx
@@ -92,7 +92,7 @@ export default function ConditionRow({
 
   return (
     <div class="text-xs">
-      <div class="flex items-center gap-1.5">
+      <div class="flex flex-wrap sm:flex-nowrap items-center gap-1.5">
         {/* Field */}
         <select
           value={c.field}

--- a/src/components/RankingCard.tsx
+++ b/src/components/RankingCard.tsx
@@ -170,7 +170,16 @@ export function RankingCard({
       {/* Stats row */}
       <div class="grid grid-cols-3 gap-2 font-mono text-sm">
         <div>
-          <p class="text-[--color-text-muted] text-xs mb-0.5">{lbl.wr}</p>
+          <p
+            class="text-[--color-text-muted] text-xs mb-0.5 cursor-help"
+            title={
+              lang === "ko"
+                ? "승률 = 수익 거래 비율. 55%+ 양호."
+                : "Win Rate = % of profitable trades. 55%+ is good."
+            }
+          >
+            {lbl.wr} <span class="opacity-50 text-[0.6rem]">?</span>
+          </p>
           <p class={`font-bold text-base ${winRateColor(entry.win_rate)}`}>
             {entry.win_rate.toFixed(1)}%
           </p>
@@ -178,7 +187,11 @@ export function RankingCard({
         <div>
           <p
             class="text-[--color-text-muted] text-xs mb-0.5 cursor-help"
-            title="Profit Factor = avg win ÷ avg loss. 1.0 = breakeven, 1.5+ = good, 2.0+ = strong. Capped at 99.99 for low-sample results."
+            title={
+              lang === "ko"
+                ? "수익팩터 = 평균 수익 ÷ 평균 손실. 1.0 = 본전, 1.5+ = 양호, 2.0+ = 강함. 샘플 부족 시 99.99로 제한."
+                : "Profit Factor = avg win ÷ avg loss. 1.0 = breakeven, 1.5+ = good, 2.0+ = strong. Capped at 99.99 for low-sample results."
+            }
           >
             PF <span class="opacity-50 text-[0.6rem]">?</span>
           </p>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -98,13 +98,13 @@ function getReadingTime(body: string | undefined): string {
               <a href={`/blog/${post.id}`}
                  class="block border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] card-hover group"
                  style={`box-shadow: var(--shadow-card); border-left: 3px solid ${categoryBorderColors[post.data.category] || 'var(--color-text-muted)'};`}>
-                <div class="flex items-center gap-3 mb-3">
-                  <span class={`font-mono text-xs tracking-wider`}
-                        style={`color: var(${categoryColors[post.data.category] || '--color-text-muted'})`}>
+                <div class="flex items-center gap-2 mb-3">
+                  <span class="text-xs font-mono px-2 py-0.5 rounded"
+                        style={`color: var(${categoryColors[post.data.category] || '--color-text-muted'}); background: color-mix(in srgb, var(${categoryColors[post.data.category] || '--color-text-muted'}) 10%, transparent)`}>
                     {categoryLabels[post.data.category] || post.data.category.toUpperCase()}
                   </span>
-                  <span class="text-[--color-text-muted] text-xs font-mono">{post.data.date}</span>
-                  <span class="text-[--color-text-muted] text-xs font-mono ml-auto">{getReadingTime(post.body)}</span>
+                  <span class="text-[--color-text-disabled] text-xs font-mono">{post.data.date}</span>
+                  <span class="text-[--color-text-disabled] text-xs font-mono ml-auto">{getReadingTime(post.body)}</span>
                 </div>
                 <h2 class="text-xl font-bold mb-2 group-hover:text-[--color-accent] transition-colors">
                   {post.data.title}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -37,18 +37,20 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
         See exactly how your strategy would have performed.<br class="hidden sm:block" /> Free. No code. No signup. Real fees included.
       </p>
       <!-- Founder story hook -->
-      <p class="mt-3 text-sm text-[--color-text-muted] max-w-xl mx-auto text-center italic">
-        "I lost $4,000 on a strategy that backtested perfectly. That's why I built PRUVIQ — to show what others hide."
-        <a href="/about" class="text-[--color-accent] not-italic hover:underline ml-1">Read the full story &rarr;</a>
-      </p>
-      <!-- CTA pair -->
-      <div class="flex flex-col sm:flex-row items-center justify-center gap-4 mt-10">
+      <blockquote class="mt-6 border-l-2 border-[--color-accent]/40 pl-4 py-2 bg-[--color-accent]/5 rounded-r-lg max-w-xl mx-auto">
+        <p class="text-base text-[--color-text-secondary]">
+          "I lost $4,000 on a strategy that backtested perfectly. That's why I built PRUVIQ — to show what others hide."
+        </p>
+        <a href="/about" class="text-sm text-[--color-accent] hover:underline mt-1 inline-block">Read the full story &rarr;</a>
+      </blockquote>
+      <!-- CTA -->
+      <div class="flex flex-col items-center gap-3 mt-10">
         <a href="/simulate" class="btn btn-primary btn-lg w-full sm:w-auto text-center">
-          Open Simulator →
+          Open Simulator — It's Free →
         </a>
-        <a href="/strategies" class="btn btn-ghost btn-lg w-full sm:w-auto text-center">
-          Browse Strategies
-        </a>
+        <span class="text-sm text-[--color-text-muted]">
+          or <a href="/strategies" class="text-[--color-accent] hover:underline">browse verified strategies</a>
+        </span>
       </div>
       <!-- Stats bar -->
       <div class="grid grid-cols-2 gap-4 md:gap-6 mt-16 max-w-3xl mx-auto">

--- a/src/pages/ko/blog/index.astro
+++ b/src/pages/ko/blog/index.astro
@@ -106,16 +106,16 @@ function getReadingTime(body: string | undefined): string {
               <a href={post.isKorean ? `/ko/blog/${post.id}` : `/blog/${post.id}`}
                  class="block border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] card-hover group"
                  style={`box-shadow: var(--shadow-card); border-left: 3px solid ${categoryBorderColors[post.data.category] || 'var(--color-text-muted)'};`}>
-                <div class="flex items-center gap-3 mb-3">
-                  <span class={`font-mono text-xs tracking-wider`}
-                        style={`color: var(${categoryColors[post.data.category] || '--color-text-muted'})`}>
+                <div class="flex items-center gap-2 mb-3">
+                  <span class="text-xs font-mono px-2 py-0.5 rounded"
+                        style={`color: var(${categoryColors[post.data.category] || '--color-text-muted'}); background: color-mix(in srgb, var(${categoryColors[post.data.category] || '--color-text-muted'}) 10%, transparent)`}>
                     {categoryLabels[post.data.category] || post.data.category.toUpperCase()}
                   </span>
                   {!post.isKorean && (
                     <span class="font-mono text-xs px-1.5 py-0.5 rounded bg-[--color-border] text-[--color-text-muted]">{t('blog.en_badge')}</span>
                   )}
-                  <span class="text-[--color-text-muted] text-xs font-mono">{post.data.date}</span>
-                  <span class="text-[--color-text-muted] text-xs font-mono ml-auto">{getReadingTime(post.body)}</span>
+                  <span class="text-[--color-text-disabled] text-xs font-mono">{post.data.date}</span>
+                  <span class="text-[--color-text-disabled] text-xs font-mono ml-auto">{getReadingTime(post.body)}</span>
                 </div>
                 <h2 class="text-xl font-bold mb-2 group-hover:text-[--color-accent] transition-colors">
                   {post.data.title}

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -37,18 +37,20 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
         내 전략이 실제로 어떤 성과를 냈을지 확인하세요.<br class="hidden sm:block" /> 무료. 코딩 불필요. 가입 불필요. 실제 수수료 포함.
       </p>
       <!-- Founder story hook -->
-      <p class="mt-3 text-sm text-[--color-text-muted] max-w-xl mx-auto text-center italic">
-        "백테스트 결과가 완벽했던 전략에서 $4,000를 잃었습니다. 그래서 다른 사람들이 숨기는 것을 보여주는 PRUVIQ를 만들었습니다."
-        <a href="/ko/about" class="text-[--color-accent] not-italic hover:underline ml-1">전체 스토리 &rarr;</a>
-      </p>
-      <!-- CTA pair -->
-      <div class="flex flex-col sm:flex-row items-center justify-center gap-4 mt-10">
+      <blockquote class="mt-6 border-l-2 border-[--color-accent]/40 pl-4 py-2 bg-[--color-accent]/5 rounded-r-lg max-w-xl mx-auto">
+        <p class="text-base text-[--color-text-secondary]">
+          "백테스트 결과가 완벽했던 전략에서 $4,000를 잃었습니다. 그래서 다른 사람들이 숨기는 것을 보여주는 PRUVIQ를 만들었습니다."
+        </p>
+        <a href="/ko/about" class="text-sm text-[--color-accent] hover:underline mt-1 inline-block">전체 스토리 &rarr;</a>
+      </blockquote>
+      <!-- CTA -->
+      <div class="flex flex-col items-center gap-3 mt-10">
         <a href="/ko/simulate" class="btn btn-primary btn-lg w-full sm:w-auto text-center">
-          {t('hero.cta_primary')} →
+          무료 시뮬레이터 체험 →
         </a>
-        <a href="/ko/strategies" class="btn btn-ghost btn-lg w-full sm:w-auto text-center">
-          {t('hero.cta_secondary')}
-        </a>
+        <span class="text-sm text-[--color-text-muted]">
+          또는 <a href="/ko/strategies" class="text-[--color-accent] hover:underline">검증된 전략 탐색하기</a>
+        </span>
       </div>
       <!-- Stats bar -->
       <div class="grid grid-cols-2 gap-4 md:gap-6 mt-16 max-w-3xl mx-auto">

--- a/src/pages/ko/market/index.astro
+++ b/src/pages/ko/market/index.astro
@@ -48,7 +48,19 @@ const marketDataJson = JSON.stringify(marketDataRaw);
         </noscript>
       </div>
     </div>
-    <div class="mt-10 pt-8 border-t border-[--color-border] text-center max-w-5xl mx-auto px-4">
+    <div class="max-w-5xl mx-auto px-4 mt-10">
+      <div class="border border-[--color-accent]/20 rounded-lg p-5 bg-[--color-accent]/5">
+        <p class="font-mono text-[--color-accent] text-xs mb-2">다음 행동</p>
+        <p class="text-sm text-[--color-text-secondary] mb-3">
+          흥미로운 점을 발견하셨나요? 이 시장에서 전략이 어떻게 수행될지 테스트해 보세요.
+        </p>
+        <div class="flex flex-wrap gap-3">
+          <a href="/ko/simulate" class="btn btn-primary btn-sm no-underline">전략 테스트 &rarr;</a>
+          <a href="/ko/strategies/ranking" class="btn btn-ghost btn-sm no-underline">오늘의 랭킹 &rarr;</a>
+        </div>
+      </div>
+    </div>
+    <div class="mt-6 pt-8 border-t border-[--color-border] text-center max-w-5xl mx-auto px-4">
       <div class="flex flex-wrap gap-3 justify-center">
         <a href="/ko/simulate" class="btn btn-primary btn-md no-underline">
           {t('cross.simulate_cta')} &rarr;

--- a/src/pages/ko/strategies/index.astro
+++ b/src/pages/ko/strategies/index.astro
@@ -162,16 +162,19 @@ const isKorean = (id: string) => koIds.has(id);
       </div>
 
       <div class="space-y-8" id="strategy-list-ko">
-        {statusGroupOrder.map((statusKey) => (
-          <div data-status-group={statusKey}>
-            {/* Section divider */}
+        {statusGroupOrder.map((statusKey) => {
+          const isCollapsible = statusKey === 'killed' || statusKey === 'shelved';
+          const header = (
             <div class="flex items-center gap-3 mb-4">
               <span class={`font-mono text-xs font-bold tracking-widest ${statusKey === 'verified' ? 'text-[--color-accent]' : statusKey === 'testing' ? 'text-[--color-yellow]' : 'text-[--color-text-muted]'}`}>
                 {statusGroupLabels[statusKey]}
               </span>
               <div class="flex-1 border-t border-[--color-border]"></div>
               <span class="font-mono text-xs text-[--color-text-disabled]">{strategyGroups[statusKey].length}</span>
+              {isCollapsible && <span class="text-xs text-[--color-text-muted] transition-transform">▾</span>}
             </div>
+          );
+          const cards = (
             <div class="space-y-4">
         {strategyGroups[statusKey].map((strategy) => (
           <div class="block border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] card-hover group"
@@ -251,9 +254,26 @@ const isKorean = (id: string) => koIds.has(id);
           </div>
         ))}
             </div>
-          </div>
-        ))}
+          );
+          return isCollapsible ? (
+            <details data-status-group={statusKey} class="group/collapse">
+              <summary class="cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+                {header}
+              </summary>
+              {cards}
+            </details>
+          ) : (
+            <div data-status-group={statusKey}>
+              {header}
+              {cards}
+            </div>
+          );
+        })}
       </div>
+
+      <p class="text-xs text-[--color-text-muted] mt-8 mb-2">
+        왜 실패한 전략을 보여주나요? <a href="/ko/about" class="text-[--color-accent] hover:underline">급진적 투명성</a> — 성공과 실패 모두 공개합니다.
+      </p>
 
       {simulatorPresets.length > 0 && (
         <div class="mt-12">
@@ -314,11 +334,14 @@ const isKorean = (id: string) => koIds.has(id);
         card.style.display = activeStatus.status === 'all' || card.dataset.status === activeStatus.status ? '' : 'none';
       });
 
-      // Hide empty group sections
+      // Hide empty group sections + auto-open collapsed details when filtering
       document.querySelectorAll<HTMLElement>('[data-status-group]').forEach((group) => {
         const visibleCards = group.querySelectorAll<HTMLElement>('[data-status]');
         const anyVisible = Array.from(visibleCards).some(c => c.style.display !== 'none');
         group.style.display = anyVisible ? '' : 'none';
+        if (group.tagName === 'DETAILS' && anyVisible && activeStatus.status !== 'all') {
+          (group as HTMLDetailsElement).open = true;
+        }
       });
     }
 

--- a/src/pages/market/index.astro
+++ b/src/pages/market/index.astro
@@ -48,7 +48,19 @@ const marketDataJson = JSON.stringify(marketDataRaw);
         </noscript>
       </div>
     </div>
-    <div class="mt-10 pt-8 border-t border-[--color-border] text-center max-w-5xl mx-auto px-4">
+    <div class="max-w-5xl mx-auto px-4 mt-10">
+      <div class="border border-[--color-accent]/20 rounded-lg p-5 bg-[--color-accent]/5">
+        <p class="font-mono text-[--color-accent] text-xs mb-2">WHAT TO DO</p>
+        <p class="text-sm text-[--color-text-secondary] mb-3">
+          See something interesting? Test how a strategy would perform in this market.
+        </p>
+        <div class="flex flex-wrap gap-3">
+          <a href="/simulate" class="btn btn-primary btn-sm no-underline">Test a Strategy &rarr;</a>
+          <a href="/strategies/ranking" class="btn btn-ghost btn-sm no-underline">Today's Rankings &rarr;</a>
+        </div>
+      </div>
+    </div>
+    <div class="mt-6 pt-8 border-t border-[--color-border] text-center max-w-5xl mx-auto px-4">
       <div class="flex flex-wrap gap-3 justify-center">
         <a href="/simulate" class="btn btn-primary btn-md no-underline">
           {t('cross.simulate_cta')} &rarr;

--- a/src/pages/strategies/index.astro
+++ b/src/pages/strategies/index.astro
@@ -176,16 +176,19 @@ const difficultyColors: Record<string, string> = {
       </div>
 
       <div class="space-y-8" id="strategy-list">
-        {statusGroupOrder.map((statusKey) => (
-          <div data-status-group={statusKey}>
-            {/* Section divider */}
+        {statusGroupOrder.map((statusKey) => {
+          const isCollapsible = statusKey === 'killed' || statusKey === 'shelved';
+          const header = (
             <div class="flex items-center gap-3 mb-4">
               <span class={`font-mono text-xs font-bold tracking-widest ${statusKey === 'verified' ? 'text-[--color-verified]' : statusKey === 'testing' ? 'text-[--color-yellow]' : 'text-[--color-text-muted]'}`}>
                 {statusGroupLabels[statusKey]}
               </span>
               <div class="flex-1 border-t border-[--color-border]"></div>
               <span class="font-mono text-xs text-[--color-text-disabled]">{strategyGroups[statusKey].length}</span>
+              {isCollapsible && <span class="text-xs text-[--color-text-muted] transition-transform">▾</span>}
             </div>
+          );
+          const cards = (
             <div class="space-y-4">
         {strategyGroups[statusKey].map((strategy) => (
           <div class="block border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] card-hover group"
@@ -271,9 +274,26 @@ const difficultyColors: Record<string, string> = {
           </div>
         ))}
             </div>
-          </div>
-        ))}
+          );
+          return isCollapsible ? (
+            <details data-status-group={statusKey} class="group/collapse">
+              <summary class="cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+                {header}
+              </summary>
+              {cards}
+            </details>
+          ) : (
+            <div data-status-group={statusKey}>
+              {header}
+              {cards}
+            </div>
+          );
+        })}
       </div>
+
+      <p class="text-xs text-[--color-text-muted] mt-8 mb-2">
+        Why show failed strategies? <a href="/about" class="text-[--color-accent] hover:underline">Radical transparency</a> — we publish everything, wins and losses.
+      </p>
 
       {simulatorPresets.length > 0 && (
         <div class="mt-12">
@@ -341,11 +361,14 @@ const difficultyColors: Record<string, string> = {
         card.style.display = statusMatch && directionMatch ? '' : 'none';
       });
 
-      // Hide empty group sections
+      // Hide empty group sections + auto-open collapsed details when filtering
       document.querySelectorAll<HTMLElement>('[data-status-group]').forEach((group) => {
         const visibleCards = group.querySelectorAll<HTMLElement>('[data-status]');
         const anyVisible = Array.from(visibleCards).some(c => c.style.display !== 'none');
         group.style.display = anyVisible ? '' : 'none';
+        if (group.tagName === 'DETAILS' && anyVisible && activeStatus.status !== 'all') {
+          (group as HTMLDetailsElement).open = true;
+        }
       });
     }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -436,12 +436,13 @@ textarea:focus-visible,
   background-color: var(--color-accent) !important;
   color: #FFFFFF !important;
   font-weight: 600;
+  box-shadow: 0 0 16px rgba(79,142,247,0.3), 0 2px 8px rgba(0,0,0,0.3);
   transition: background-color var(--duration-fast) var(--ease-smooth),
               box-shadow var(--duration-fast) var(--ease-smooth);
 }
 .btn-primary:hover {
   background-color: var(--color-accent-dim) !important;
-  box-shadow: var(--shadow-accent-glow);
+  box-shadow: 0 0 24px rgba(79,142,247,0.45), 0 4px 12px rgba(0,0,0,0.4);
 }
 
 /* ─── Card hover ─── */
@@ -572,6 +573,9 @@ textarea:focus-visible,
     min-height: 44px;
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;
+  }
+  select, input[type="number"], input[type="text"], input[type="search"] {
+    min-height: 44px;
   }
 }
 


### PR DESCRIPTION
## Summary
- **Phase 1 (Hero)**: Single primary CTA "Open Simulator — It's Free" + text link, btn-primary blue glow, founder quote blockquote
- **Phase 2 (Strategies)**: killed/shelved groups collapsed by default, auto-open on filter, transparency message
- **Phase 3 (Rankings)**: WR/PF bilingual tooltips with cursor-help
- **Phase 4 (Market)**: "What to do" action bridge → /simulate + /rankings
- **Phase 5 (Blog)**: Category pill badges with colored backgrounds
- **Phase 6 (Mobile)**: Simulator input touch targets 44px, condition row wrap, params grid spacing

## Changed files (12)
- `src/pages/index.astro`, `src/pages/ko/index.astro` — Hero CTA + quote
- `src/styles/global.css` — btn-primary glow + mobile touch targets
- `src/pages/strategies/index.astro`, `src/pages/ko/strategies/index.astro` — Collapse + filter
- `src/pages/market/index.astro`, `src/pages/ko/market/index.astro` — Action bridge
- `src/components/RankingCard.tsx` — WR/PF tooltips
- `src/pages/blog/index.astro`, `src/pages/ko/blog/index.astro` — Category badges
- `src/components/BuilderPanel.tsx`, `src/components/ConditionRow.tsx` — Mobile spacing

## Test plan
- [x] `npm run build` — 2490 pages, 0 errors
- [x] E2E smoke: 10/10 passed
- [x] E2E i18n: 74/76 passed (2 pre-existing local preview 404, prod 6/6 pass)
- [ ] Visual: manual browser walkthrough Home → Simulate → Strategies → Rankings → Market → Blog

🤖 Generated with [Claude Code](https://claude.com/claude-code)