### PR TITLE
fix: GNB Signals label i18n

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1421,7 +1421,7 @@ export const en = {
   "nav.compare_tools_desc": "vs TradingView & more",
   "nav.daily_ranking": "Daily Ranking",
   "nav.weekly": "Weekly",
-  "nav.signals": "Live Signals",
+  "nav.signals": "Signals",
 
   // Metric explanation tooltips
   "metric.sharpe_desc":

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -1393,7 +1393,7 @@ export const ko: Record<TranslationKey, string> = {
   "nav.compare_tools_desc": "vs TradingView 등",
   "nav.daily_ranking": "일일 랭킹",
   "nav.weekly": "주간",
-  "nav.signals": "실시간 시그널",
+  "nav.signals": "시그널",
 
   // Metric explanation tooltips
   "metric.sharpe_desc":

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -70,7 +70,7 @@ const navItems = [
   { href: marketPath, match: '/market', label: t('nav.market') },
   { href: simulatePath, match: '/simulate', label: t('nav.simulate') },
   { href: strategiesPath, match: '/strategies', label: t('nav.strategies') },
-  { href: signalsPath, match: '/signals', label: 'Signals' },
+  { href: signalsPath, match: '/signals', label: t('nav.signals') },
   { href: coinsPath, match: '/coins', label: t('nav.coins') },
   { href: learnPath, match: '/learn', label: t('nav.learn') },
   { href: feesPath, match: '/fees', label: t('nav.fees') },


### PR DESCRIPTION
## Summary
- KO GNB에서 `Signals`가 영어로 표시되던 문제 수정
- `label: 'Signals'` (하드코딩) → `label: t('nav.signals')` (i18n)
- EN: "Signals", KO: "시그널"

## Test plan
- [x] `npm run build` — 2490 pages, 0 errors
- [x] EN GNB: Market/Simulate/Strategies/Signals/Coins/Learn/Fees ✅
- [x] KO GNB: 시장/시뮬레이터/전략/시그널/코인/학습/수수료 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)