### PR TITLE
chore: trigger Cloudflare Pages rebuild

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -373,3 +373,4 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
   </section>
 
 </Layout>
+<!-- 20260329T155817 -->


### PR DESCRIPTION
Empty change to trigger CF Pages deployment. Previous PR #795 merge did not trigger a build.