### PR TITLE
fix: language switch broken by transition:persist

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -400,7 +400,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     </a>
     <div id="page-loader"></div>
     <header>
-    <nav class="fixed top-0 w-full z-50 border-b border-[--color-border] bg-[--color-bg]/80 backdrop-blur-md" role="navigation" aria-label="Main" transition:persist>
+    <nav class="fixed top-0 w-full z-50 border-b border-[--color-border] bg-[--color-bg]/80 backdrop-blur-md" role="navigation" aria-label="Main">
       <div class="w-full px-6 lg:px-28 h-16 grid grid-cols-[auto_1fr_auto] items-center">
         <!-- 1열: Logo (좌측) -->
         <a href={lang === 'ko' ? '/ko/' : '/'} class="flex items-center gap-2">
@@ -481,7 +481,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
       <slot />
     </main>
 
-    <footer class="border-t border-[--color-border] mt-20" role="contentinfo" aria-label="Site footer" transition:persist>
+    <footer class="border-t border-[--color-border] mt-20" role="contentinfo" aria-label="Site footer">
       <div class="max-w-7xl mx-auto px-6 lg:px-10 py-12">
         <!-- Brand + 3-column links -->
         <div class="flex flex-col md:flex-row gap-10 mb-10">


### PR DESCRIPTION
Removed transition:persist from nav/footer — it prevents HTML replacement during EN/KO switch.