### PR TITLE
fix: remove ClientRouter — breaks mobile menu, filters, search, analytics

### DIFF
--- a/public/scripts/layout-client.js
+++ b/public/scripts/layout-client.js
@@ -1,11 +1,10 @@
-// Client-side layout behaviors
-// Supports Astro View Transitions — re-initializes on every page-load event.
-
-// Global listeners (registered once, never duplicated)
-function initGlobalListeners() {
+// Client-side layout behaviors (moved out of inline HTML to avoid render-blocking)
+(function () {
   // Page loader on navigation
+  const loader = document.getElementById("page-loader");
+  loader?.classList.remove("loading");
+
   document.addEventListener("click", (e) => {
-    const loader = document.getElementById("page-loader");
     const el = e.target;
     const link = el && (el.closest ? el.closest("a[href]") : null);
     if (!link) return;
@@ -25,89 +24,74 @@ function initGlobalListeners() {
   });
 
   // Nav scroll shadow
+  const nav = document.querySelector("nav");
   window.addEventListener(
     "scroll",
     () => {
-      const nav = document.querySelector("nav");
       nav?.classList.toggle("scrolled", window.scrollY > 10);
     },
     { passive: true },
   );
 
-  // Escape to close mobile menu
+  const menuBtn = document.getElementById("mobile-menu-btn");
+  const mobileMenu = document.getElementById("mobile-menu");
+
+  function closeMenu() {
+    mobileMenu?.classList.add("hidden");
+    mobileMenu?.setAttribute("aria-hidden", "true");
+    menuBtn?.setAttribute("aria-expanded", "false");
+  }
+
+  menuBtn?.addEventListener("click", () => {
+    const isHidden = mobileMenu?.classList.toggle("hidden");
+    menuBtn.setAttribute("aria-expanded", String(!isHidden));
+    mobileMenu?.setAttribute("aria-hidden", String(!!isHidden));
+    if (!isHidden) {
+      mobileMenu?.scrollIntoView({ block: "nearest" });
+    }
+  });
+
+  // Escape key closes menu
   document.addEventListener("keydown", (e) => {
-    const mobileMenu = document.getElementById("mobile-menu");
-    const menuBtn = document.getElementById("mobile-menu-btn");
     if (
       e.key === "Escape" &&
       mobileMenu &&
       !mobileMenu.classList.contains("hidden")
     ) {
-      mobileMenu.classList.add("hidden");
-      mobileMenu.setAttribute("aria-hidden", "true");
-      menuBtn?.setAttribute("aria-expanded", "false");
+      closeMenu();
       menuBtn?.focus();
     }
   });
-}
 
-// Element-specific listeners (re-registered on every page-load)
-function initPageElements() {
-  const loader = document.getElementById("page-loader");
-  loader?.classList.remove("loading");
-
-  const menuBtn = document.getElementById("mobile-menu-btn");
-  const mobileMenu = document.getElementById("mobile-menu");
-
-  if (menuBtn && mobileMenu) {
-    function closeMenu() {
-      mobileMenu.classList.add("hidden");
-      mobileMenu.setAttribute("aria-hidden", "true");
-      menuBtn.setAttribute("aria-expanded", "false");
+  // Focus trap when menu is open
+  mobileMenu?.addEventListener("keydown", (e) => {
+    if (e.key !== "Tab") return;
+    const focusable = mobileMenu.querySelectorAll("a, button");
+    if (focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
     }
+  });
 
-    menuBtn.addEventListener("click", () => {
-      const isHidden = mobileMenu.classList.toggle("hidden");
-      menuBtn.setAttribute("aria-expanded", String(!isHidden));
-      mobileMenu.setAttribute("aria-hidden", String(!!isHidden));
-      if (!isHidden) {
-        mobileMenu.scrollIntoView({ block: "nearest" });
-      }
+  // Close menu when clicking a link inside it
+  mobileMenu?.querySelectorAll("a").forEach((link) => {
+    link.addEventListener("click", () => {
+      closeMenu();
     });
+  });
 
-    mobileMenu.addEventListener("keydown", (e) => {
-      if (e.key !== "Tab") return;
-      const focusable = mobileMenu.querySelectorAll("a, button");
-      if (focusable.length === 0) return;
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      if (e.shiftKey && document.activeElement === first) {
-        e.preventDefault();
-        last.focus();
-      } else if (!e.shiftKey && document.activeElement === last) {
-        e.preventDefault();
-        first.focus();
-      }
-    });
-
-    mobileMenu.querySelectorAll("a").forEach((link) => {
-      link.addEventListener("click", () => {
-        closeMenu();
-      });
-    });
-  }
-}
-
-function initInteractions() {
+  // Card glow — mouse-tracking radial highlight
   const prefersReduced = window.matchMedia(
     "(prefers-reduced-motion: reduce)",
   ).matches;
-
-  // Card glow — mouse-tracking radial highlight
   if (!prefersReduced) {
     document.querySelectorAll(".card-glow").forEach((card) => {
-      if (card.dataset.glowInit) return;
-      card.dataset.glowInit = "1";
       card.addEventListener("mousemove", (e) => {
         const rect = card.getBoundingClientRect();
         card.style.setProperty("--glow-x", `${e.clientX - rect.left}px`);
@@ -134,17 +118,13 @@ function initInteractions() {
     },
     { threshold: 0.1, rootMargin: "0px 0px -50px 0px" },
   );
-  document.querySelectorAll(".reveal, .reveal-child").forEach((el) => {
-    if (!el.classList.contains("visible")) {
-      revealObserver.observe(el);
-    }
-  });
+  document
+    .querySelectorAll(".reveal, .reveal-child")
+    .forEach((el) => revealObserver.observe(el));
 
-  // Card 3D tilt on hover (desktop only)
+  // Card 3D tilt on hover (desktop only, pointer: fine)
   if (!prefersReduced && window.matchMedia("(pointer: fine)").matches) {
     document.querySelectorAll(".card-tilt").forEach((card) => {
-      if (card.dataset.tiltInit) return;
-      card.dataset.tiltInit = "1";
       card.addEventListener("mousemove", (e) => {
         const rect = card.getBoundingClientRect();
         const x = (e.clientX - rect.left) / rect.width - 0.5;
@@ -156,15 +136,4 @@ function initInteractions() {
       });
     });
   }
-}
-
-// First load — global listeners once
-initGlobalListeners();
-initPageElements();
-initInteractions();
-
-// Re-init on Astro View Transition page swap
-document.addEventListener("astro:page-load", () => {
-  initPageElements();
-  initInteractions();
-});
+})();

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,7 +3,8 @@ import '../styles/global.css'
 import { getLangFromUrl, useTranslations, getAlternatePath, getBasePath } from '../i18n/index';
 import Breadcrumbs from '../components/Breadcrumbs.astro';
 import CommandPalette from '../components/CommandPalette';
-import { ClientRouter } from 'astro:transitions';
+// ClientRouter removed — SSG + Islands + inline scripts are incompatible with View Transitions.
+// Each page has DOM-dependent scripts that break when ClientRouter swaps the DOM.
 
 interface Props {
   title: string;
@@ -391,7 +392,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
       gtag('config', 'G-DKW84C1CS8');
     </script>
     <noscript><style>.reveal,.reveal-child>*{opacity:1!important;transform:none!important;transition:none!important}</style></noscript>
-    <ClientRouter />
+
 </head>
   <body class="min-h-screen">
     <div class="scroll-progress" aria-hidden="true"></div>


### PR DESCRIPTION
## Summary
**Removes View Transitions (ClientRouter)** — it breaks multiple features across the site.

## What broke
| Feature | Page | Cause |
|---------|------|-------|
| Mobile hamburger | All | DOM swap loses click listener |
| Filter/sort buttons | /strategies | Inline script listeners lost |
| Search | /learn | Input listener lost |
| Simulator observers | /simulate | MutationObserver lost |
| Google Analytics | All | Double pageview tracking |

## Root cause
SSG + Islands + inline `<script>` tags are **incompatible** with ClientRouter's SPA-style DOM swapping. Each page needs a full reload for its scripts to initialize.

## What stays
All other design improvements from PR #793 remain:
- Aurora 3-blob hero animation
- Card glow + 3D tilt
- CountUp animation
- Gradient-text animation
- Scroll progress bar
- Enhanced hero stagger
- Purple/cyan accent colors

## Test plan
- [ ] Mobile hamburger works on every page
- [ ] /strategies filter/sort buttons work
- [ ] /learn search works
- [ ] Language switch EN↔KO works
- [ ] No View Transitions meta tag in HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)