### PR TITLE
fix: auto-fix #801 (+1 related)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -108,7 +108,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <meta name="description" content={description} />
     <link rel="canonical" href={canonicalURL.href} />
     {!noAlternate && <link rel="alternate" hreflang="en" href={enURL.href} />}
-    {!noAlternate && <link rel="alternate" hreflang="ko" href={koURL.href} />}
+    {!noAlternate && <link rel="alternate" hreflang="ko-KR" href={koURL.href} />}
     {!noAlternate && <link rel="alternate" hreflang="x-default" href={enURL.href} />}
     <meta name="naver-site-verification" content="ece19c45b3e33ec86f4fc79060c3283cea1493ee" />
     <meta name="yandex-verification" content="a20aa9b1eacf8e51" />
@@ -173,6 +173,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <meta property="og:url" content={canonicalURL.href} />
     <meta property="og:site_name" content="PRUVIQ" />
     <meta property="og:locale" content={lang === 'ko' ? 'ko_KR' : 'en_US'} />
+    {!noAlternate && <meta property="og:locale:alternate" content={lang === 'ko' ? 'en_US' : 'ko_KR'} />}
     <meta property="og:image" content={ogImage} />
     <meta property="og:image:alt" content={description} />
     <meta property="og:image:width" content="1200" />


### PR DESCRIPTION
## Auto-fix for 2 issue(s)

#801: [claude-auto][P2] `Layout.astro:111` — `hreflang="ko"` targets language, not region; Korean user
#802: [claude-auto][P2] `Layout.astro:175` — `og:locale:alternate` absent; social crawlers cannot adve

### Changes
```
 src/layouts/Layout.astro | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)
```

### Safety Checks
- Files changed: **1** (limit: 20)
- Lines changed: **3** (limit: 1500)

---
*Auto-generated by JEPO auto-fix agent. Requires auto-test pass before merge.*