### PR TITLE
fix: KO homepage gradient-text parity with EN

### DIFF
--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -32,7 +32,7 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
     <div class="relative max-w-7xl mx-auto px-6 pt-28 pb-16 md:pt-36 md:pb-20 hero-enter">
       <HeroBadge stat={simulationsRun} label="시뮬레이션 실행" />
       <h1 class="text-4xl md:text-6xl lg:text-7xl font-bold text-center tracking-[-0.04em] leading-[1.08] max-w-4xl mx-auto">
-        {t('hero.h1_line1')}<br class="hidden md:block" /> {t('hero.h1_line2').replace('{coins}', String(coinsAnalyzed))}
+        {t('hero.h1_line1')}<br class="hidden md:block" /> <span class="gradient-text">{coinsAnalyzed}개 코인</span>, 몇 초 만에 검증
       </h1>
       <p class="mt-6 text-lg md:text-xl text-[--color-text-secondary] text-center max-w-2xl mx-auto leading-relaxed">
         내 전략이 실제로 어떤 성과를 냈을지 확인하세요.<br class="hidden sm:block" /> 무료. 코딩 불필요. 가입 불필요. 실제 수수료 포함.


### PR DESCRIPTION
KO h1 was missing gradient-text on coin count. Now matches EN. Build: 2490/0.