### PR TITLE
fix: auto-fix #807 (+1 related)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -20,7 +20,7 @@ export default defineConfig({
         defaultLocale: 'en',
         locales: {
           en: 'en',
-          ko: 'ko'
+          ko: 'ko-KR'
         }
       },
       filter(page) {
@@ -41,7 +41,7 @@ export default defineConfig({
 
         item.links = [
           { url: enUrl, lang: 'en' },
-          { url: koUrl, lang: 'ko' },
+          { url: koUrl, lang: 'ko-KR' },
           { url: enUrl, lang: 'x-default' },
         ];
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -85,7 +85,7 @@ const breadcrumbLabelMap: Record<string, Record<string, string>> = {
   ko: { market: '시장', strategies: '전략', coins: '코인', builder: '빌더', simulate: '시뮬레이션', learn: '학습', fees: '수수료', blog: '블로그', about: '소개', changelog: '변경 이력', performance: '성과', compare: '비교', privacy: '개인정보', terms: '이용약관', methodology: '방법론', api: 'API', leaderboard: '리더보드' },
 };
 const breadcrumbSegments = basePath === '/' ? [] : basePath.split('/').filter(Boolean);
-const breadcrumbItems = [{ name: lang === 'ko' ? '홈' : 'Home', item: 'https://pruviq.com/' }];
+const breadcrumbItems = [{ name: lang === 'ko' ? '홈' : 'Home', item: lang === 'ko' ? 'https://pruviq.com/ko/' : 'https://pruviq.com/' }];
 let cumPath = '';
 for (let i = 0; i < breadcrumbSegments.length; i++) {
   const seg = breadcrumbSegments[i];


### PR DESCRIPTION
## Auto-fix for 2 issue(s)

#807: [claude-auto][P2] `Layout.astro:88` — Korean BreadcrumbList root item points to English home URL
#808: [claude-auto][P1] `astro.config.mjs:23` — Sitemap emits `hreflang="ko"` while HTML head (after P

### Changes
```
 astro.config.mjs         | 4 ++--
 src/layouts/Layout.astro | 2 +-
 2 files changed, 3 insertions(+), 3 deletions(-)
```

### Safety Checks
- Files changed: **2** (limit: 20)
- Lines changed: **6** (limit: 1500)

---
*Auto-generated by JEPO auto-fix agent. Requires auto-test pass before merge.*