### PR TITLE
fix(seo): normalize hreflang, fix founder type, improve og:image:alt

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -20,7 +20,7 @@ export default defineConfig({
         defaultLocale: 'en',
         locales: {
           en: 'en',
-          ko: 'ko-KR'
+          ko: 'ko'
         }
       },
       filter(page) {
@@ -39,13 +39,13 @@ export default defineConfig({
         const enUrl = `https://pruviq.com${basePath}`;
         const koUrl = `https://pruviq.com/ko${basePath === '/' ? '/' : basePath}`;
 
-        // Only emit ko-KR hreflang for paths known to have Korean versions
+        // Only emit ko hreflang for paths known to have Korean versions
         const koPathPrefixes = ['/', '/about', '/api', '/fees', '/simulate', '/strategies', '/coins/', '/blog/', '/market', '/compare/', '/leaderboard', '/changelog', '/privacy', '/terms', '/methodology', '/signals', '/learn', '/best-crypto-backtesting', '/crypto-trading-simulator', '/why-backtests-fail'];
         const hasKoVersion = koPathPrefixes.some(prefix => basePath === prefix || basePath.startsWith(prefix));
 
         item.links = [
           { url: enUrl, lang: 'en' },
-          ...(hasKoVersion ? [{ url: koUrl, lang: 'ko-KR' }] : []),
+          ...(hasKoVersion ? [{ url: koUrl, lang: 'ko' }] : []),
           { url: enUrl, lang: 'x-default' },
         ];
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -23,7 +23,7 @@ const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
 const altPath = getAlternatePath(Astro.url.pathname, lang);
 const altLang = lang === 'ko' ? 'en' : 'ko';
-const altHreflang = lang === 'ko' ? 'en' : 'ko-KR';
+const altHreflang = lang === 'ko' ? 'en' : 'ko';
 const basePath = getBasePath(Astro.url.pathname);
 const cfToken = import.meta.env.PUBLIC_CF_ANALYTICS_TOKEN;
 const buildTime = new Date().toISOString();
@@ -109,7 +109,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <meta name="description" content={description} />
     <link rel="canonical" href={canonicalURL.href} />
     {!noAlternate && <link rel="alternate" hreflang="en" href={enURL.href} />}
-    {!noAlternate && <link rel="alternate" hreflang="ko-KR" href={koURL.href} />}
+    {!noAlternate && <link rel="alternate" hreflang="ko" href={koURL.href} />}
     {!noAlternate && <link rel="alternate" hreflang="x-default" href={enURL.href} />}
     <meta name="naver-site-verification" content="ece19c45b3e33ec86f4fc79060c3283cea1493ee" />
     <meta name="yandex-verification" content="a20aa9b1eacf8e51" />
@@ -176,7 +176,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <meta property="og:locale" content={lang === 'ko' ? 'ko_KR' : 'en_US'} />
     {!noAlternate && <meta property="og:locale:alternate" content={lang === 'ko' ? 'en_US' : 'ko_KR'} />}
     <meta property="og:image" content={ogImage} />
-    <meta property="og:image:alt" content={description} />
+    <meta property="og:image:alt" content="PRUVIQ — Free Crypto Strategy Backtester" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <!-- Twitter -->
@@ -184,7 +184,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImage} />
-    <meta name="twitter:image:alt" content={description} />
+    <meta name="twitter:image:alt" content="PRUVIQ — Free Crypto Strategy Backtester" />
     <meta name="twitter:site" content="@pruviq" />
     <title>{title}</title>
     <!-- JSON-LD Organization -->
@@ -204,7 +204,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
         "description": lang === 'ko'
           ? '무료 크립토 전략 백테스팅 플랫폼. 570개 이상 코인에서 2년 이상의 실제 시장 데이터로 트레이딩 전략을 만들고 테스트하세요.'
           : 'Free crypto strategy backtesting platform. Build and test trading strategies on 570+ coins with 2+ years of real market data.',
-        "founder": { "@type": "Organization", "name": "PRUVIQ Team" },
+        "founder": { "@type": "Person", "name": "PRUVIQ Team" },
         "sameAs": ["https://x.com/pruviq", "https://github.com/pruviq/pruviq"],
         "knowsAbout": lang === 'ko'
           ? ['암호화폐 트레이딩', '백테스팅', '알고리즘 트레이딩', '퀀트 금융']


### PR DESCRIPTION
## Summary
- **hreflang ko-KR → ko**: HTML `<link>` tags and sitemap locales normalized to ISO 639-1 `ko` (#801, #808, #817)
- **Organization JSON-LD founder**: `@type` changed from `Organization` to `Person` (#667)
- **og:image:alt / twitter:image:alt**: Replaced verbose description with concise "PRUVIQ — Free Crypto Strategy Backtester" (#754)
- **og:locale:alternate**: Already present (verified, #802)
- **BreadcrumbList KO root + trailing slash**: Already correct (`/ko/` root, trailing slashes on all URLs) (#807, #624)

## Files changed
- `src/layouts/Layout.astro` — hreflang, og:image:alt, founder type
- `astro.config.mjs` — sitemap hreflang locales

## Test plan
- [x] `npm run build` — 2498 pages, 0 errors
- [ ] Verify hreflang in page source (en page → `hreflang="ko"`, ko page → `hreflang="en"`)
- [ ] Validate JSON-LD with Google Rich Results Test
- [ ] Check sitemap hreflang after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)