### PR TITLE
fix(seo): resolve remaining SEO P2 items — trailingSlash + cleanup

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,6 +7,7 @@ import preact from '@astrojs/preact';
 // https://astro.build/config
 export default defineConfig({
   site: 'https://pruviq.com',
+  trailingSlash: 'always',
   i18n: {
     defaultLocale: 'en',
     locales: ['en', 'ko'],

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -32,9 +32,6 @@ const currentYear = new Date().getFullYear();
 const { title, description = t('meta.home_desc'), type = 'website', date, updatedDate, category, keywords: customKeywords, canonicalOverride, noAlternate = false } = Astro.props;
 const lastModified = updatedDate || date || buildTime;
 const ogImage = new URL(Astro.props.ogImage || '/og-image.jpg', Astro.site || 'https://pruviq.com').href;
-// derive AVIF/WebP variants safely for jpg/png sources
-const ogImageAvif = ogImage.replace(/\.(png|jpe?g)(\?.*)?$/i, '.avif$2');
-const ogImageWebp = ogImage.replace(/\.(png|jpe?g)(\?.*)?$/i, '.webp$2');
 const canonicalPath = canonicalOverride || Astro.url.pathname;
 const canonicalURL = new URL(canonicalPath, Astro.site || 'https://pruviq.com');
 const hreflangBase = canonicalPath.replace(/^\/ko(\/|$)/, '/');


### PR DESCRIPTION
## Summary
- Add `trailingSlash: 'always'` to `astro.config.mjs` (#755) — ensures all URLs end with `/` for consistent crawling
- Remove unused `ogImageAvif` / `ogImageWebp` variables from `Layout.astro` (#625) — dead code cleanup

### Already resolved (9/11 items confirmed in codebase)
| # | Issue | Status |
|---|-------|--------|
| 1 | og:locale:alternate (#802) | Already present (L177) |
| 2 | BreadcrumbList KO root URL (#807) | Already `/ko/` (L89) |
| 3 | Language switcher hreflang (#817) | Already `ko`/`en` (L26) |
| 4 | Footer compare links (#816) | Already using variables (L52-57) |
| 5 | BreadcrumbList trailing slash (#624) | Already appended (L98) |
| 6 | BlogPosting author + mainEntityOfPage (#550) | Already in both EN/KO blog index |
| 7 | Article dateModified (#652) | Falls back to datePublished (L33) |
| 8 | OG image preload removal (#625) | **Fixed** — removed unused vars |
| 9 | Sitemap lastmod (#651, #549) | Already set build-date (L53) |
| 10 | trailingSlash (#755) | **Fixed** — added `'always'` |

## Test plan
- [x] `npm run build` — 2502 pages, 0 errors
- [x] `qa-redirects.sh` — PASS (0 conflicts)
- [ ] Verify trailing slash behavior on deployed preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)