### PR TITLE
feat: auto-rollback on smoke failure via CF Workers API

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -148,6 +148,7 @@ jobs:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           SHA: ${{ github.sha }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || '' }}
         with:
           script: |
             const commitMsg = process.env.COMMIT_MSG?.split('\n')[0]?.slice(0, 80) || '(no message)';
@@ -172,10 +173,44 @@ jobs:
               return;
             }
 
+            // Auto-rollback: revert to previous Workers deployment
+            try {
+              const acctId = '9314e06569c4da23e48fd088d45707dd';
+              const scriptName = 'pruviq-website';
+              // Self-hosted runner: token from env or ~/.secrets.env
+              let cfToken = process.env.CLOUDFLARE_API_TOKEN;
+              if (!cfToken) {
+                try {
+                  const fs = require('fs');
+                  const envFile = fs.readFileSync(`${process.env.HOME}/.secrets.env`, 'utf8');
+                  const match = envFile.match(/CLOUDFLARE_API_TOKEN=(\S+)/);
+                  if (match) cfToken = match[1];
+                } catch {}
+              }
+              if (!cfToken) throw new Error('No CF token');
+              const depsResp = await fetch(
+                `https://api.cloudflare.com/client/v4/accounts/${acctId}/workers/scripts/${scriptName}/deployments`,
+                { headers: { 'Authorization': `Bearer ${cfToken}` } }
+              );
+              const depsData = await depsResp.json();
+              const deployments = depsData?.result?.deployments || [];
+              if (deployments.length >= 2) {
+                const prevId = deployments[1].id;
+                const rollResp = await fetch(
+                  `https://api.cloudflare.com/client/v4/accounts/${acctId}/workers/deployments/by-script/${scriptName}/detail/${prevId}/rollback`,
+                  { method: 'PUT', headers: { 'Authorization': `Bearer ${cfToken}` } }
+                );
+                const rollData = await rollResp.json();
+                core.info(`Auto-rollback: ${rollData.success ? 'SUCCESS' : 'FAILED'} → ${prevId.slice(0,12)}`);
+              }
+            } catch (e) {
+              core.warning(`Auto-rollback failed: ${e.message}`);
+            }
+
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `[smoke-fail] Production smoke failed on ${sha}`,
+              title: `[smoke-fail] Production smoke failed on ${sha} (auto-rolled back)`,
               body: [
                 '## Production Smoke Test Failure',
                 '',


### PR DESCRIPTION
Smoke fail → instant rollback to previous Workers deployment. No rebuild needed. Token: Pages Edit permission added.