### PR TITLE
feat: simulator quick-start + strategy card engagement

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -287,6 +287,8 @@ export const en = {
   "strategies.presets_title": "All Simulator Presets ({count})",
   "strategies.presets_desc":
     "Click any preset to load it directly in the simulator. Tests on 570+ coins simultaneously.",
+  "strategies.todays_pick": "Today's Pick",
+  "strategies.click_to_simulate": "Click to simulate",
 
   // Blog
   "blog.tag": "TRADING IQ",
@@ -970,6 +972,9 @@ export const en = {
   "simulate.title2": "Test It on 570+ Coins.",
   "simulate.desc":
     "Pick indicators, set entry conditions, adjust risk parameters. Run a backtest on 2+ years of real data — or start from a preset.",
+  "simulate.quick_start": "QUICK START",
+  "simulate.quick_start_desc":
+    "Top performing strategies this month — click to run instantly",
   "simulate.note":
     "No code. No account. No cost. Results include realistic fees and slippage.",
   "simulate.loading": "Loading strategy builder...",
@@ -1619,6 +1624,7 @@ export const en = {
     "PRUVIQ vs Coinrule — Free Crypto Backtesting Alternative",
   "meta.vs_coinrule_desc":
     "Compare PRUVIQ with Coinrule for crypto strategy backtesting. Free forever, no IF-THEN limits, 570+ coins with real fee simulation.",
+
   "vs_coinrule.tag": "HONEST COMPARISON",
   "vs_coinrule.title": "PRUVIQ vs Coinrule",
   "vs_coinrule.subtitle": "for crypto backtesting",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -285,6 +285,8 @@ export const ko: Record<TranslationKey, string> = {
   "strategies.presets_title": "시뮬레이터 프리셋 전체 ({count}종)",
   "strategies.presets_desc":
     "아래 전략을 클릭하면 시뮬레이터에서 바로 파라미터가 적용됩니다. 570개 코인 동시 테스트.",
+  "strategies.todays_pick": "오늘의 추천",
+  "strategies.click_to_simulate": "클릭하여 시뮬레이션",
 
   // Blog
   "blog.tag": "트레이딩 IQ",
@@ -965,6 +967,8 @@ export const ko: Record<TranslationKey, string> = {
   "simulate.title2": "570개 코인에서 테스트하세요.",
   "simulate.desc":
     "지표를 선택하고, 진입 조건을 설정하고, 리스크 파라미터를 조정하세요. 2년 이상의 실제 데이터로 백테스트를 실행하거나, 프리셋으로 시작하세요.",
+  "simulate.quick_start": "퀵 스타트",
+  "simulate.quick_start_desc": "이번 달 최고 성과 전략 — 클릭하면 바로 실행",
   "simulate.note":
     "코드 불필요. 계정 불필요. 비용 없음. 결과에는 현실적인 수수료와 슬리피지가 포함됩니다.",
   "simulate.loading": "전략 빌더 로딩중...",

--- a/src/pages/ko/simulate/index.astro
+++ b/src/pages/ko/simulate/index.astro
@@ -3,11 +3,16 @@ import Layout from '../../../layouts/Layout.astro';
 import { useTranslations } from '../../../i18n/index';
 import presetsJson from '../../../../public/data/builder-presets.json';
 import siteStats from '../../../../public/data/site-stats.json';
+import rankingsJson from '../../../../public/data/rankings-daily.json';
 
 const t = useTranslations('ko');
 const presetCount = (presetsJson as Array<unknown>).length;
 const simulationsRun = (siteStats as { simulations_run: number }).simulations_run.toLocaleString('ko-KR');
 const coinsAnalyzed = (siteStats as { coins_analyzed: number }).coins_analyzed;
+
+// Quick Start: top 3 from rankings
+const rankingsData = rankingsJson as { top3?: Array<{rank: number; name_ko: string; strategy: string; direction: string; win_rate: number; profit_factor: number; total_return: number; timeframe: string}> };
+const quickStartPresets = (rankingsData.top3 || []).slice(0, 3);
 ---
 
 <Layout title={t('meta.simulate_title')} description={t('meta.simulate_desc')}>
@@ -68,6 +73,32 @@ const coinsAnalyzed = (siteStats as { coins_analyzed: number }).coins_analyzed;
           </div>
         </div>
       </div>
+
+      <!-- Quick Start: Top 3 performing strategies -->
+      {quickStartPresets.length > 0 && (
+        <div class="mb-4">
+          <p class="font-mono text-[--color-accent] text-xs mb-2 tracking-wider">{t('simulate.quick_start')}</p>
+          <p class="text-[--color-text-muted] text-xs mb-3">{t('simulate.quick_start_desc')}</p>
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            {quickStartPresets.map((preset, i) => (
+              <a
+                href={`/ko/simulate?preset=${preset.strategy}-${preset.direction}`}
+                class="border border-[--color-accent]/30 rounded-lg px-4 py-3 bg-[--color-accent]/5 hover:bg-[--color-accent]/10 hover:border-[--color-accent] transition-all group card-glow flex items-center gap-3"
+              >
+                <span class="font-mono text-[--color-accent] text-lg font-bold shrink-0">#{i + 1}</span>
+                <div class="min-w-0">
+                  <p class="font-semibold text-sm truncate">{preset.name_ko}</p>
+                  <p class="text-xs font-mono text-[--color-text-muted] mt-0.5">
+                    WR {preset.win_rate.toFixed(1)}% · PF {preset.profit_factor.toFixed(2)}
+                    <span class={preset.total_return >= 0 ? 'text-[--color-up]' : 'text-[--color-red]'}> · {preset.total_return >= 0 ? '+' : ''}{preset.total_return.toFixed(1)}%</span>
+                  </p>
+                </div>
+                <span class="text-[--color-text-muted] text-xs group-hover:text-[--color-accent] shrink-0 ml-auto">&rarr;</span>
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
 
       <p class="text-xs text-[--color-text-muted] opacity-70">{t('simulate.note')}</p>
     </div>

--- a/src/pages/ko/strategies/index.astro
+++ b/src/pages/ko/strategies/index.astro
@@ -7,6 +7,10 @@ import rankingsJson from '../../../../public/data/rankings-daily.json';
 import StrategyTabs from '../../../components/ui/StrategyTabs.astro';
 
 const rankingsData = rankingsJson as { top3?: Array<{strategy: string; direction: string; win_rate: number; profit_factor: number; total_return: number}>; worst3?: Array<{strategy: string; direction: string; win_rate: number; profit_factor: number; total_return: number}> };
+
+// Today's Pick: top1 strategy from rankings (deterministic per day)
+const todaysPickStrategy = rankingsData.top3?.[0]?.strategy || '';
+const todaysPickDirection = rankingsData.top3?.[0]?.direction || '';
 const allRanked = [...(rankingsData.top3 || []), ...(rankingsData.worst3 || [])];
 const rankingLookup = new Map<string, {win_rate: number; profit_factor: number; total_return: number}>();
 for (const r of allRanked) {
@@ -319,30 +323,46 @@ const isKorean = (id: string) => koIds.has(id);
           <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
             {simulatorPresets.map((preset) => {
               const stats = lookupPresetStats(preset.id, preset.direction);
+              const isTodaysPick = preset.id.includes(todaysPickStrategy) && preset.direction === todaysPickDirection;
+              const glowClass = preset.direction === 'long'
+                ? 'preset-glow-long'
+                : preset.direction === 'short'
+                ? 'preset-glow-short'
+                : '';
               return (
               <a
                 href={`/ko/simulate?preset=${preset.id}`}
-                class="flex items-center justify-between border border-[--color-border] rounded-lg px-4 py-3 bg-[--color-bg-card] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors group"
+                class={`relative flex flex-col border border-[--color-border] rounded-lg px-4 py-3 bg-[--color-bg-card] hover:border-[--color-accent] transition-colors group card-glow ${glowClass}`}
               >
-                <div>
-                  <p class="font-semibold text-sm">{preset.name_ko ?? preset.name}</p>
-                  {stats && (
-                    <p class="text-xs font-mono text-[--color-text-muted] mt-0.5">
-                      WR {stats.win_rate.toFixed(1)}% · PF {stats.profit_factor.toFixed(2)}
-                      {stats.total_return !== undefined && (
-                        <span class={stats.total_return >= 0 ? 'text-[--color-up]' : 'text-[--color-red]'}> · {stats.total_return >= 0 ? '+' : ''}{stats.total_return.toFixed(1)}%</span>
-                      )}
-                    </p>
-                  )}
+                {isTodaysPick && (
+                  <span class="absolute -top-2.5 left-3 font-mono text-[10px] tracking-wider px-2 py-0.5 rounded-full bg-[--color-accent] text-black font-bold z-10">
+                    {t('strategies.todays_pick')}
+                  </span>
+                )}
+                <div class="flex items-center justify-between">
+                  <div class="min-w-0">
+                    <p class="font-semibold text-sm truncate">{preset.name_ko ?? preset.name}</p>
+                    {stats && (
+                      <p class="text-xs font-mono text-[--color-text-muted] mt-0.5">
+                        WR {stats.win_rate.toFixed(1)}% · PF {stats.profit_factor.toFixed(2)}
+                        {stats.total_return !== undefined && (
+                          <span class={stats.total_return >= 0 ? 'text-[--color-up]' : 'text-[--color-red]'}> · {stats.total_return >= 0 ? '+' : ''}{stats.total_return.toFixed(1)}%</span>
+                        )}
+                      </p>
+                    )}
+                  </div>
+                  <div class="flex items-center gap-2 shrink-0 ml-3">
+                    {preset.direction && (
+                      <span class={`font-mono text-xs px-1.5 py-0.5 rounded border ${preset.direction === 'long' ? 'text-[--color-accent] border-[--color-accent]/30' : preset.direction === 'short' ? 'text-[--color-red] border-[--color-red]/30' : 'text-[--color-yellow] border-[--color-yellow]/30'}`}>
+                        {preset.direction.toUpperCase()}
+                      </span>
+                    )}
+                    <span class="text-[--color-text-muted] text-xs group-hover:text-[--color-accent]">&rarr;</span>
+                  </div>
                 </div>
-                <div class="flex items-center gap-2 shrink-0 ml-3">
-                  {preset.direction && (
-                    <span class={`font-mono text-xs px-1.5 py-0.5 rounded border ${preset.direction === 'long' ? 'text-[--color-accent] border-[--color-accent]/30' : preset.direction === 'short' ? 'text-[--color-red] border-[--color-red]/30' : 'text-[--color-yellow] border-[--color-yellow]/30'}`}>
-                      {preset.direction.toUpperCase()}
-                    </span>
-                  )}
-                  <span class="text-[--color-text-muted] text-xs group-hover:text-[--color-accent]">&rarr;</span>
-                </div>
+                <p class="text-[10px] font-mono text-[--color-text-muted] mt-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                  {t('strategies.click_to_simulate')} &rarr;
+                </p>
               </a>
               );
             })}

--- a/src/pages/simulate/index.astro
+++ b/src/pages/simulate/index.astro
@@ -3,11 +3,16 @@ import Layout from '../../layouts/Layout.astro';
 import { useTranslations } from '../../i18n/index';
 import presetsJson from '../../../public/data/builder-presets.json';
 import siteStats from '../../../public/data/site-stats.json';
+import rankingsJson from '../../../public/data/rankings-daily.json';
 
 const t = useTranslations('en');
 const presetCount = (presetsJson as Array<unknown>).length;
 const simulationsRun = (siteStats as { simulations_run: number }).simulations_run.toLocaleString('en-US');
 const coinsAnalyzed = (siteStats as { coins_analyzed: number }).coins_analyzed;
+
+// Quick Start: top 3 from rankings
+const rankingsData = rankingsJson as { top3?: Array<{rank: number; name_en: string; strategy: string; direction: string; win_rate: number; profit_factor: number; total_return: number; timeframe: string}> };
+const quickStartPresets = (rankingsData.top3 || []).slice(0, 3);
 ---
 
 <Layout title={t('meta.simulate_title')} description={t('meta.simulate_desc')}>
@@ -68,6 +73,32 @@ const coinsAnalyzed = (siteStats as { coins_analyzed: number }).coins_analyzed;
           </div>
         </div>
       </div>
+
+      <!-- Quick Start: Top 3 performing strategies -->
+      {quickStartPresets.length > 0 && (
+        <div class="mb-4">
+          <p class="font-mono text-[--color-accent] text-xs mb-2 tracking-wider">{t('simulate.quick_start')}</p>
+          <p class="text-[--color-text-muted] text-xs mb-3">{t('simulate.quick_start_desc')}</p>
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            {quickStartPresets.map((preset, i) => (
+              <a
+                href={`/simulate?preset=${preset.strategy}-${preset.direction}`}
+                class="border border-[--color-accent]/30 rounded-lg px-4 py-3 bg-[--color-accent]/5 hover:bg-[--color-accent]/10 hover:border-[--color-accent] transition-all group card-glow flex items-center gap-3"
+              >
+                <span class="font-mono text-[--color-accent] text-lg font-bold shrink-0">#{i + 1}</span>
+                <div class="min-w-0">
+                  <p class="font-semibold text-sm truncate">{preset.name_en}</p>
+                  <p class="text-xs font-mono text-[--color-text-muted] mt-0.5">
+                    WR {preset.win_rate.toFixed(1)}% · PF {preset.profit_factor.toFixed(2)}
+                    <span class={preset.total_return >= 0 ? 'text-[--color-up]' : 'text-[--color-red]'}> · {preset.total_return >= 0 ? '+' : ''}{preset.total_return.toFixed(1)}%</span>
+                  </p>
+                </div>
+                <span class="text-[--color-text-muted] text-xs group-hover:text-[--color-accent] shrink-0 ml-auto">&rarr;</span>
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
 
       <p class="text-xs text-[--color-text-muted] opacity-70">{t('simulate.note')}</p>
     </div>

--- a/src/pages/strategies/index.astro
+++ b/src/pages/strategies/index.astro
@@ -14,6 +14,10 @@ import StrategyTabs from '../../components/ui/StrategyTabs.astro';
 
 // Build lookup: strategy+direction → ranking stats
 const rankingsData = rankingsJson as { top3?: Array<{strategy: string; direction: string; win_rate: number; profit_factor: number; total_return: number}>; worst3?: Array<{strategy: string; direction: string; win_rate: number; profit_factor: number; total_return: number}>; summary?: {total: number} };
+
+// Today's Pick: top1 strategy from rankings (deterministic per day)
+const todaysPickStrategy = rankingsData.top3?.[0]?.strategy || '';
+const todaysPickDirection = rankingsData.top3?.[0]?.direction || '';
 const allRanked = [...(rankingsData.top3 || []), ...(rankingsData.worst3 || [])];
 const rankingLookup = new Map<string, {win_rate: number; profit_factor: number; total_return: number}>();
 for (const r of allRanked) {
@@ -343,30 +347,46 @@ const difficultyColors: Record<string, string> = {
           <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
             {simulatorPresets.map((preset) => {
               const stats = lookupPresetStats(preset.id, preset.direction);
+              const isTodaysPick = preset.id.includes(todaysPickStrategy) && preset.direction === todaysPickDirection;
+              const glowClass = preset.direction === 'long'
+                ? 'preset-glow-long'
+                : preset.direction === 'short'
+                ? 'preset-glow-short'
+                : '';
               return (
               <a
                 href={`/simulate?preset=${preset.id}`}
-                class="flex items-center justify-between border border-[--color-border] rounded-lg px-4 py-3 bg-[--color-bg-card] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors group"
+                class={`relative flex flex-col border border-[--color-border] rounded-lg px-4 py-3 bg-[--color-bg-card] hover:border-[--color-accent] transition-colors group card-glow ${glowClass}`}
               >
-                <div>
-                  <p class="font-semibold text-sm">{preset.name}</p>
-                  {stats && (
-                    <p class="text-xs font-mono text-[--color-text-muted] mt-0.5">
-                      WR {stats.win_rate.toFixed(1)}% · PF {stats.profit_factor.toFixed(2)}
-                      {stats.total_return !== undefined && (
-                        <span class={stats.total_return >= 0 ? 'text-[--color-up]' : 'text-[--color-red]'}> · {stats.total_return >= 0 ? '+' : ''}{stats.total_return.toFixed(1)}%</span>
-                      )}
-                    </p>
-                  )}
+                {isTodaysPick && (
+                  <span class="absolute -top-2.5 left-3 font-mono text-[10px] tracking-wider px-2 py-0.5 rounded-full bg-[--color-accent] text-black font-bold z-10">
+                    {t('strategies.todays_pick')}
+                  </span>
+                )}
+                <div class="flex items-center justify-between">
+                  <div class="min-w-0">
+                    <p class="font-semibold text-sm truncate">{preset.name}</p>
+                    {stats && (
+                      <p class="text-xs font-mono text-[--color-text-muted] mt-0.5">
+                        WR {stats.win_rate.toFixed(1)}% · PF {stats.profit_factor.toFixed(2)}
+                        {stats.total_return !== undefined && (
+                          <span class={stats.total_return >= 0 ? 'text-[--color-up]' : 'text-[--color-red]'}> · {stats.total_return >= 0 ? '+' : ''}{stats.total_return.toFixed(1)}%</span>
+                        )}
+                      </p>
+                    )}
+                  </div>
+                  <div class="flex items-center gap-2 shrink-0 ml-3">
+                    {preset.direction && (
+                      <span class={`font-mono text-xs px-1.5 py-0.5 rounded border ${preset.direction === 'long' ? 'text-[--color-accent] border-[--color-accent]/30' : preset.direction === 'short' ? 'text-[--color-red] border-[--color-red]/30' : 'text-[--color-yellow] border-[--color-yellow]/30'}`}>
+                        {preset.direction.toUpperCase()}
+                      </span>
+                    )}
+                    <span class="text-[--color-text-muted] text-xs group-hover:text-[--color-accent]">&rarr;</span>
+                  </div>
                 </div>
-                <div class="flex items-center gap-2 shrink-0 ml-3">
-                  {preset.direction && (
-                    <span class={`font-mono text-xs px-1.5 py-0.5 rounded border ${preset.direction === 'long' ? 'text-[--color-accent] border-[--color-accent]/30' : preset.direction === 'short' ? 'text-[--color-red] border-[--color-red]/30' : 'text-[--color-yellow] border-[--color-yellow]/30'}`}>
-                      {preset.direction.toUpperCase()}
-                    </span>
-                  )}
-                  <span class="text-[--color-text-muted] text-xs group-hover:text-[--color-accent]">&rarr;</span>
-                </div>
+                <p class="text-[10px] font-mono text-[--color-text-muted] mt-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                  {t('strategies.click_to_simulate')} &rarr;
+                </p>
               </a>
               );
             })}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -858,6 +858,14 @@ textarea:focus-visible,
 }
 .card-glow:hover::before { opacity: 1; }
 
+/* ─── Direction-based preset glow ─── */
+.preset-glow-long:hover {
+  box-shadow: 0 0 12px rgba(79,142,247,0.15), 0 0 4px rgba(79,142,247,0.08);
+}
+.preset-glow-short:hover {
+  box-shadow: 0 0 12px rgba(239,68,68,0.15), 0 0 4px rgba(239,68,68,0.08);
+}
+
 /* ─── Border gradient on hover ─── */
 .border-gradient {
   position: relative;


### PR DESCRIPTION
## Summary
- /simulate: Quick Start 섹션 추가 (rankings top3 전략 → 클릭 시 바로 백테스트)
- /strategies: 프리셋 카드에 Today's Pick 뱃지, 방향별 glow (LONG=blue, SHORT=red), hover 시 "Click to simulate" 텍스트
- EN+KO 동시 적용, i18n 키 4개 추가

## Test plan
- [ ] /simulate 페이지에서 Quick Start 3개 버튼 노출 확인
- [ ] /ko/simulate 동일 확인
- [ ] /strategies 프리셋 카드에 Today's Pick 뱃지 확인 (rankings top1)
- [ ] 프리셋 카드 hover 시 blue/red glow + "Click to simulate" 텍스트
- [ ] 빌드: 2502 pages, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)