### PR TITLE
feat: simulator mobile UX improvements

### DIFF
--- a/src/components/QuickTestPanel.tsx
+++ b/src/components/QuickTestPanel.tsx
@@ -210,7 +210,7 @@ export default function QuickTestPanel({
       </div>
 
       {/* Category Cards Grid — 5 categories, clean layout */}
-      <div class="grid grid-cols-3 sm:grid-cols-5 gap-2">
+      <div class="grid grid-cols-3 sm:grid-cols-5 gap-1.5 sm:gap-2">
         {CATEGORIES.map((cat) => {
           const isSelected = selectedCat === cat.id;
           const isCatRunning =
@@ -223,7 +223,7 @@ export default function QuickTestPanel({
               data-testid={`quick-cat-${cat.id}`}
               onClick={() => handleCategoryClick(cat)}
               disabled={isRunning}
-              class={`relative rounded-lg border p-3 text-center transition-all group
+              class={`relative rounded-lg border p-3 text-center transition-all group min-h-[72px]
                 ${isRunning ? "cursor-not-allowed opacity-60" : "cursor-pointer hover:scale-[1.02] active:scale-[0.98]"}
                 ${isSelected ? "border-[--color-accent]" : "border-[--color-border] hover:border-[--color-text-muted]"}`}
               style={
@@ -280,7 +280,7 @@ export default function QuickTestPanel({
                 <button
                   key={presetId}
                   onClick={() => handleAltPreset(presetId)}
-                  class="px-2 py-1 rounded border border-[--color-border] font-mono text-[10px] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors"
+                  class="px-2.5 py-1.5 min-h-[36px] rounded border border-[--color-border] font-mono text-[10px] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors"
                 >
                   {PRESET_LABELS[presetId]?.[lang] || presetId}
                 </button>

--- a/src/components/ResultHero.tsx
+++ b/src/components/ResultHero.tsx
@@ -44,7 +44,7 @@ export default function ResultHero({ result, t, simMode = "expert" }: Props) {
       </div>
 
       {/* 3 mini stat pills */}
-      <div class="flex justify-center gap-2 mt-3">
+      <div class="flex justify-center gap-1.5 sm:gap-2 mt-3">
         <Pill
           label={t.heroWinRate || "Win Rate"}
           value={`${result.win_rate.toFixed(1)}%`}
@@ -85,7 +85,7 @@ function Pill({
 }) {
   return (
     <div
-      class="px-2.5 py-1.5 rounded-lg bg-[--color-bg-tooltip] border border-[--color-border] text-center min-w-[80px]"
+      class="px-2 py-1.5 sm:px-2.5 rounded-lg bg-[--color-bg-tooltip] border border-[--color-border] text-center min-w-[70px] sm:min-w-[80px] flex-1 max-w-[120px]"
       title={tooltip}
     >
       <div class="text-[9px] font-mono text-[--color-text-muted] uppercase tracking-wider">

--- a/src/components/ResultsPanel.tsx
+++ b/src/components/ResultsPanel.tsx
@@ -9,6 +9,7 @@ import ExchangeCTA from "./ExchangeCTA";
 import EmailCapture from "./EmailCapture";
 import BotCodeSection from "./BotCodeSection";
 import CollapsibleSection from "./ui/CollapsibleSection";
+import ScrollHint from "./ui/ScrollHint";
 import { exchanges } from "../data/exchanges";
 import { COINS_ANALYZED } from "../config/site-stats";
 import {
@@ -681,7 +682,7 @@ export default function ResultsPanel({
                   {t.clearHistory || "Clear"}
                 </button>
               </div>
-              <div class="overflow-x-auto">
+              <ScrollHint label={lang === "ko" ? "스크롤 →" : "Scroll →"}>
                 <table class="w-full text-[10px] font-mono">
                   <caption class="sr-only">{t.history || "History"}</caption>
                   <thead>
@@ -760,7 +761,7 @@ export default function ResultsPanel({
                     })}
                   </tbody>
                 </table>
-              </div>
+              </ScrollHint>
             </div>
           )}
 
@@ -880,7 +881,7 @@ export default function ResultsPanel({
                           <div class="text-[10px] font-mono text-[--color-text-muted] uppercase mb-2">
                             {t.monthlyReturns || "Monthly Returns"}
                           </div>
-                          <div class="overflow-x-auto">
+                          <ScrollHint label={lang === "ko" ? "스크롤 →" : "Scroll →"}>
                             <div class="flex gap-1 min-w-max">
                               {result.monthly_stats.map((m) => {
                                 const maxRet = Math.max(
@@ -919,7 +920,7 @@ export default function ResultsPanel({
                                 );
                               })}
                             </div>
-                          </div>
+                          </ScrollHint>
                         </div>
                       )}
 
@@ -1172,8 +1173,9 @@ export default function ResultsPanel({
 
           {/* Trades tab */}
           {resultTab === "trades" && (
-            <div class="p-2 overflow-x-auto -webkit-overflow-scrolling-touch">
+            <div class="p-2">
               {result.trades && result.trades.length > 0 ? (
+                <ScrollHint label={lang === "ko" ? "스크롤 →" : "Scroll →"}>
                 <table class="w-full text-xs font-mono min-w-[500px] md:min-w-0">
                   <caption class="sr-only">
                     {t.tradeTableCaption || "Simulated trade details"}
@@ -1318,6 +1320,7 @@ export default function ResultsPanel({
                     })}
                   </tbody>
                 </table>
+                </ScrollHint>
               ) : (
                 <div class="text-center py-8 text-[--color-text-muted] text-sm">
                   {t.noTradeDetails ||
@@ -1414,7 +1417,7 @@ export default function ResultsPanel({
                       {profitPct.toFixed(0)}% {t.profitableCoinsUnit}
                     </span>
                   </div>
-                  <div class="overflow-x-auto -webkit-overflow-scrolling-touch">
+                  <ScrollHint label={lang === "ko" ? "스크롤 →" : "Scroll →"}>
                     <table class="w-full text-xs font-mono min-w-[600px] md:min-w-0">
                       <caption class="sr-only">
                         Per-coin backtest results
@@ -1510,7 +1513,7 @@ export default function ResultsPanel({
                         ))}
                       </tbody>
                     </table>
-                  </div>
+                  </ScrollHint>
                 </div>
               );
             })()}

--- a/src/components/SimulatorPage.tsx
+++ b/src/components/SimulatorPage.tsx
@@ -103,6 +103,7 @@ const L = {
     ],
     simNotesTitle: "How it works",
     mobile: { chart: "Chart", config: "Settings", results: "Results" },
+    mobileIcon: { chart: "📊", config: "⚙️", results: "📋" },
     quickStart: "New to backtesting?",
     quickStartDesc:
       "Click 'BB Squeeze (Verified)' preset above, then hit 'Run Backtest'. Takes ~2 seconds. No signup needed.",
@@ -295,6 +296,7 @@ const L = {
     ],
     simNotesTitle: "시뮬레이션 안내",
     mobile: { chart: "차트", config: "설정", results: "결과" },
+    mobileIcon: { chart: "📊", config: "⚙️", results: "📋" },
     quickStart: "백테스트가 처음이라면?",
     quickStartDesc:
       "위의 'BB Squeeze (검증됨)' 프리셋을 선택하고 'Run Backtest'를 누르세요. 약 2초면 됩니다. 회원가입 불필요.",
@@ -1286,7 +1288,7 @@ export default function SimulatorPage({ lang = "en" }: Props) {
             <button
               key={tab}
               onClick={() => handleMobileTabChange(tab)}
-              class={`flex-1 py-3 min-h-[44px] text-xs font-mono uppercase tracking-wider transition-colors
+              class={`flex-1 py-2 min-h-[48px] text-xs font-mono uppercase tracking-wider transition-colors flex flex-col items-center justify-center
                 ${mobileTab === tab ? "font-bold border-b-2" : "text-[--color-text-muted] hover:text-[--color-text]"}`}
               style={
                 mobileTab === tab
@@ -1298,7 +1300,7 @@ export default function SimulatorPage({ lang = "en" }: Props) {
                   : undefined
               }
             >
-              {t.mobile[tab]}
+              {<><span class="block text-base leading-none mb-0.5" aria-hidden="true">{t.mobileIcon[tab]}</span><span class="block text-[10px]">{t.mobile[tab]}</span></>}
             </button>
           ))}
         </div>

--- a/src/components/ui/ScrollHint.tsx
+++ b/src/components/ui/ScrollHint.tsx
@@ -1,0 +1,68 @@
+/**
+ * ScrollHint.tsx — Shows a "Scroll →" hint when content overflows horizontally.
+ *
+ * Wraps a child element with overflow-x-auto and detects if scrollable.
+ * On mobile, shows a subtle right-arrow indicator that fades on scroll.
+ */
+import { useRef, useState, useEffect, useCallback } from "preact/hooks";
+import type { ComponentChildren } from "preact";
+
+interface Props {
+  children: ComponentChildren;
+  class?: string;
+  label?: string;
+}
+
+export default function ScrollHint({
+  children,
+  class: className = "",
+  label = "Scroll \u2192",
+}: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [canScroll, setCanScroll] = useState(false);
+  const [scrolledRight, setScrolledRight] = useState(false);
+
+  const checkOverflow = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const overflows = el.scrollWidth > el.clientWidth + 2;
+    setCanScroll(overflows);
+    setScrolledRight(el.scrollLeft > 20);
+  }, []);
+
+  useEffect(() => {
+    checkOverflow();
+    const el = containerRef.current;
+    if (!el) return;
+
+    el.addEventListener("scroll", checkOverflow, { passive: true });
+    const ro = new ResizeObserver(checkOverflow);
+    ro.observe(el);
+
+    return () => {
+      el.removeEventListener("scroll", checkOverflow);
+      ro.disconnect();
+    };
+  }, [checkOverflow]);
+
+  return (
+    <div class={`relative ${className}`}>
+      <div
+        ref={containerRef}
+        class="overflow-x-auto -webkit-overflow-scrolling-touch"
+      >
+        {children}
+      </div>
+      {canScroll && !scrolledRight && (
+        <div
+          class="absolute right-0 top-0 h-full w-8 pointer-events-none flex items-start pt-2 justify-end pr-1 md:hidden scroll-hint-fade"
+          aria-hidden="true"
+        >
+          <span class="text-[10px] font-mono text-[--color-text-muted] bg-[--color-bg]/80 px-1 py-0.5 rounded border border-[--color-border]/50 backdrop-blur-sm">
+            {label}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1038,3 +1038,20 @@ textarea:focus-visible,
 .hero-enter > *:nth-child(4) { animation: hero-enter 1.0s var(--ease-default) 0.60s both; }
 .hero-enter > *:nth-child(5) { animation: hero-enter 1.0s var(--ease-default) 0.75s both; }
 .hero-enter > *:nth-child(6) { animation: hero-enter 1.0s var(--ease-default) 0.90s both; }
+
+/* ─── Scroll hint fade for horizontally scrollable tables ─── */
+.scroll-hint-fade {
+  animation: scroll-hint-pulse 2s ease-in-out infinite;
+}
+
+@keyframes scroll-hint-pulse {
+  0%, 100% { opacity: 0.6; }
+  50% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scroll-hint-fade {
+    animation: none;
+    opacity: 0.8;
+  }
+}


### PR DESCRIPTION
## Summary
- **Mobile tabs**: Added icons (chart/settings/results) above text labels for better visual recognition on narrow screens
- **ScrollHint component**: New reusable component that detects horizontal overflow and shows a "Scroll →" indicator on mobile (fades after user scrolls)
- **Touch targets**: Increased QuickTest category card min-height (72px) and alt preset button size (36px min-height)
- **ResultHero pills**: Responsive sizing with `flex-1` and `min-w-[70px]`/`max-w-[120px]` so metrics fit on 320px screens

## Test plan
- [ ] Mobile: verify tab icons render correctly (Chart/Settings/Results with emoji)
- [ ] Mobile: verify scroll hint appears on trades/coins tables, disappears after scrolling
- [ ] Mobile: verify QuickTest category cards have adequate touch targets
- [ ] Desktop: verify no layout changes (all additions use `md:hidden` or responsive prefixes)
- [ ] Build passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)