### PR TITLE
design: improve /learn and /blog page visuals

### DIFF
--- a/src/components/LearnCard.tsx
+++ b/src/components/LearnCard.tsx
@@ -53,7 +53,18 @@ export default function LearnCard({
   return (
     <a
       href={href}
-      class="border border-[--color-border] rounded-lg p-5 bg-[--color-bg-card] card-hover block group relative"
+      class="border border-[--color-border] rounded-lg p-5 bg-[--color-bg-card] card-hover card-glow block group relative"
+      onMouseMove={(e) => {
+        const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+        (e.currentTarget as HTMLElement).style.setProperty(
+          "--glow-x",
+          `${e.clientX - rect.left}px`,
+        );
+        (e.currentTarget as HTMLElement).style.setProperty(
+          "--glow-y",
+          `${e.clientY - rect.top}px`,
+        );
+      }}
     >
       {read && (
         <span

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -17,21 +17,29 @@ const categoryLabels: Record<string, string> = {
   education: t('blog.cat_short.education'),
 };
 
-const categoryColors: Record<string, string> = {
-  market: '--color-yellow',
-  quant: '--color-accent',
-  strategy: '--color-text',
-  weekly: '--color-accent',
-  education: '--color-text-muted',
+const categoryBadgeClass: Record<string, string> = {
+  market: 'badge-market',
+  quant: 'badge-quant',
+  strategy: 'badge-strategy',
+  weekly: 'badge-weekly',
+  education: 'badge-education',
+  autopsy: 'badge-autopsy',
 };
 
 const categoryBorderColors: Record<string, string> = {
-  market: 'var(--color-yellow)',
-  quant: 'var(--color-accent)',
-  strategy: 'var(--color-text)',
-  weekly: 'var(--color-accent)',
-  education: 'var(--color-text-muted)',
+  market: '#fbbf24',
+  quant: '#60a5fa',
+  strategy: '#fb923c',
+  weekly: '#c084fc',
+  education: '#4ade80',
+  autopsy: '#f87171',
 };
+
+const now = new Date();
+function isNew(dateStr: string): boolean {
+  const diff = now.getTime() - new Date(dateStr).getTime();
+  return diff < 7 * 24 * 60 * 60 * 1000;
+}
 
 function getReadingTime(body: string | undefined): string {
   if (!body) return '1 min read';
@@ -96,14 +104,16 @@ function getReadingTime(body: string | undefined): string {
           <div class="space-y-6">
             {posts.map((post) => (
               <a href={`/blog/${post.id}`}
-                 class="block border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] card-hover group"
-                 style={`box-shadow: var(--shadow-card); border-left: 3px solid ${categoryBorderColors[post.data.category] || 'var(--color-text-muted)'};`}>
+                 class="block border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] card-hover card-glow group"
+                 style={`box-shadow: var(--shadow-card); border-left: 3px solid ${categoryBorderColors[post.data.category] || '#6b7280'};`}>
                 <div class="flex items-center gap-2 mb-3">
-                  <span class="text-xs font-mono px-2 py-0.5 rounded"
-                        style={`color: var(${categoryColors[post.data.category] || '--color-text-muted'}); background: color-mix(in srgb, var(${categoryColors[post.data.category] || '--color-text-muted'}) 10%, transparent)`}>
+                  <span class={`text-xs font-mono font-semibold px-2 py-0.5 rounded ${categoryBadgeClass[post.data.category] || 'badge-education'}`}>
                     {categoryLabels[post.data.category] || post.data.category.toUpperCase()}
                   </span>
-                  <span class="text-[--color-text-disabled] text-xs font-mono">{post.data.date}</span>
+                  {isNew(post.data.date) && (
+                    <span class="text-[10px] font-mono font-bold px-1.5 py-0.5 rounded badge-new">NEW</span>
+                  )}
+                  <span class="text-[--color-text] text-xs font-mono font-medium">{post.data.date}</span>
                   <span class="text-[--color-text-disabled] text-xs font-mono ml-auto">{getReadingTime(post.body)}</span>
                 </div>
                 <h2 class="text-xl font-bold mb-2 group-hover:text-[--color-accent] transition-colors">

--- a/src/pages/ko/blog/index.astro
+++ b/src/pages/ko/blog/index.astro
@@ -25,21 +25,29 @@ const categoryLabels: Record<string, string> = {
   education: t('blog.category.education'),
 };
 
-const categoryColors: Record<string, string> = {
-  market: '--color-yellow',
-  quant: '--color-accent',
-  strategy: '--color-text',
-  weekly: '--color-accent',
-  education: '--color-text-muted',
+const categoryBadgeClass: Record<string, string> = {
+  market: 'badge-market',
+  quant: 'badge-quant',
+  strategy: 'badge-strategy',
+  weekly: 'badge-weekly',
+  education: 'badge-education',
+  autopsy: 'badge-autopsy',
 };
 
 const categoryBorderColors: Record<string, string> = {
-  market: 'var(--color-yellow)',
-  quant: 'var(--color-accent)',
-  strategy: 'var(--color-text)',
-  weekly: 'var(--color-accent)',
-  education: 'var(--color-text-muted)',
+  market: '#fbbf24',
+  quant: '#60a5fa',
+  strategy: '#fb923c',
+  weekly: '#c084fc',
+  education: '#4ade80',
+  autopsy: '#f87171',
 };
+
+const now = new Date();
+function isNew(dateStr: string): boolean {
+  const diff = now.getTime() - new Date(dateStr).getTime();
+  return diff < 7 * 24 * 60 * 60 * 1000;
+}
 
 function getReadingTime(body: string | undefined): string {
   if (!body) return '1분';
@@ -104,17 +112,19 @@ function getReadingTime(body: string | undefined): string {
           <div class="space-y-6">
             {allPosts.map((post) => (
               <a href={post.isKorean ? `/ko/blog/${post.id}` : `/blog/${post.id}`}
-                 class="block border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] card-hover group"
-                 style={`box-shadow: var(--shadow-card); border-left: 3px solid ${categoryBorderColors[post.data.category] || 'var(--color-text-muted)'};`}>
+                 class="block border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] card-hover card-glow group"
+                 style={`box-shadow: var(--shadow-card); border-left: 3px solid ${categoryBorderColors[post.data.category] || '#6b7280'};`}>
                 <div class="flex items-center gap-2 mb-3">
-                  <span class="text-xs font-mono px-2 py-0.5 rounded"
-                        style={`color: var(${categoryColors[post.data.category] || '--color-text-muted'}); background: color-mix(in srgb, var(${categoryColors[post.data.category] || '--color-text-muted'}) 10%, transparent)`}>
+                  <span class={`text-xs font-mono font-semibold px-2 py-0.5 rounded ${categoryBadgeClass[post.data.category] || 'badge-education'}`}>
                     {categoryLabels[post.data.category] || post.data.category.toUpperCase()}
                   </span>
                   {!post.isKorean && (
                     <span class="font-mono text-xs px-1.5 py-0.5 rounded bg-[--color-border] text-[--color-text-muted]">{t('blog.en_badge')}</span>
                   )}
-                  <span class="text-[--color-text-disabled] text-xs font-mono">{post.data.date}</span>
+                  {isNew(post.data.date) && (
+                    <span class="text-[10px] font-mono font-bold px-1.5 py-0.5 rounded badge-new">NEW</span>
+                  )}
+                  <span class="text-[--color-text] text-xs font-mono font-medium">{post.data.date}</span>
                   <span class="text-[--color-text-disabled] text-xs font-mono ml-auto">{getReadingTime(post.body)}</span>
                 </div>
                 <h2 class="text-xl font-bold mb-2 group-hover:text-[--color-accent] transition-colors">

--- a/src/pages/ko/learn/index.astro
+++ b/src/pages/ko/learn/index.astro
@@ -123,7 +123,7 @@ const levelConfig = [
           type="search"
           placeholder="아티클 검색..."
           autocomplete="off"
-          class="w-full bg-[--color-bg-hover] border border-[--color-border] rounded-lg pl-9 pr-4 py-2 text-sm text-[--color-text] placeholder:text-[--color-text-muted] outline-none focus:border-[--color-accent] transition-colors"
+          class="w-full bg-[--color-bg-hover] border border-[--color-border] rounded-lg pl-9 pr-4 py-2 text-sm text-[--color-text] placeholder:text-[--color-text-muted] outline-none search-glow transition-all"
         />
         <svg class="absolute left-2.5 top-2.5 w-4 h-4 text-[--color-text-muted] pointer-events-none" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
           <circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/>

--- a/src/pages/learn/index.astro
+++ b/src/pages/learn/index.astro
@@ -116,7 +116,7 @@ const levelConfig = [
           type="search"
           placeholder="Search articles..."
           autocomplete="off"
-          class="w-full bg-[--color-bg-hover] border border-[--color-border] rounded-lg pl-9 pr-4 py-2 text-sm text-[--color-text] placeholder:text-[--color-text-muted] outline-none focus:border-[--color-accent] transition-colors"
+          class="w-full bg-[--color-bg-hover] border border-[--color-border] rounded-lg pl-9 pr-4 py-2 text-sm text-[--color-text] placeholder:text-[--color-text-muted] outline-none search-glow transition-all"
         />
         <svg class="absolute left-2.5 top-2.5 w-4 h-4 text-[--color-text-muted] pointer-events-none" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
           <circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -858,6 +858,31 @@ textarea:focus-visible,
 }
 .card-glow:hover::before { opacity: 1; }
 
+/* ─── Search input focus glow ─── */
+.search-glow:focus {
+  border-color: var(--color-accent) !important;
+  box-shadow: 0 0 0 3px rgba(79,142,247,0.15), 0 0 12px rgba(79,142,247,0.1);
+}
+
+/* ─── Blog category badge colors ─── */
+.badge-quant { color: #60a5fa; background: rgba(96,165,250,0.12); }
+.badge-education { color: #4ade80; background: rgba(74,222,128,0.12); }
+.badge-weekly { color: #c084fc; background: rgba(192,132,252,0.12); }
+.badge-strategy { color: #fb923c; background: rgba(251,146,60,0.12); }
+.badge-market { color: #fbbf24; background: rgba(251,191,36,0.12); }
+.badge-autopsy { color: #f87171; background: rgba(248,113,113,0.12); }
+
+.badge-new {
+  color: #4ade80;
+  background: rgba(74,222,128,0.15);
+  border: 1px solid rgba(74,222,128,0.3);
+  animation: badge-pulse 2s ease-in-out infinite;
+}
+@keyframes badge-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}
+
 /* ─── Direction-based preset glow ─── */
 .preset-glow-long:hover {
   box-shadow: 0 0 12px rgba(79,142,247,0.15), 0 0 4px rgba(79,142,247,0.08);
@@ -865,6 +890,84 @@ textarea:focus-visible,
 .preset-glow-short:hover {
   box-shadow: 0 0 12px rgba(239,68,68,0.15), 0 0 4px rgba(239,68,68,0.08);
 }
+
+/* ─── Strategy page: Verified card enhancement ─── */
+.strategy-card-verified {
+  border-color: var(--color-verified-border) !important;
+  box-shadow:
+    0 0 0 1px var(--color-verified-border),
+    0 0 16px var(--color-verified-subtle),
+    0 2px 8px rgba(0,0,0,0.3);
+}
+.strategy-card-verified:hover {
+  box-shadow:
+    0 0 0 1px rgba(245, 158, 11, 0.45),
+    0 0 24px rgba(245, 158, 11, 0.15),
+    0 4px 16px rgba(0,0,0,0.4);
+}
+
+/* ─── Strategy page: Status group headers ─── */
+.strategy-group-header {
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-sm);
+}
+.strategy-group-header--verified {
+  border-left: 3px solid var(--color-verified);
+  background: var(--color-verified-subtle);
+}
+.strategy-group-header--testing {
+  border-left: 3px solid var(--color-yellow);
+  background: rgba(245, 158, 11, 0.05);
+}
+.strategy-group-header--killed {
+  border-left: 3px solid var(--color-red);
+  background: rgba(242, 54, 69, 0.04);
+}
+.strategy-group-header--shelved {
+  border-left: 3px solid var(--color-text-disabled);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+/* ─── Strategy page: Verified badge ─── */
+.badge-verified {
+  background: var(--color-verified-subtle);
+  color: var(--color-verified);
+  border-color: var(--color-verified-border);
+  font-weight: 700;
+  padding: 0.25rem 0.625rem;
+  box-shadow: 0 0 8px var(--color-verified-subtle);
+}
+
+/* ─── Strategy page: Filter bar scrollable on mobile ─── */
+.strategy-filter-bar {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+.strategy-filter-bar::-webkit-scrollbar {
+  display: none;
+}
+
+/* ─── Strategy page: Active filter button ─── */
+.filter-btn-active {
+  box-shadow: 0 1px 4px rgba(79, 142, 247, 0.25);
+}
+
+/* ─── Strategy page: Preset card lift on hover ─── */
+.preset-card {
+  transition: border-color var(--duration-normal) var(--ease-smooth),
+              transform var(--duration-normal) var(--ease-default),
+              box-shadow var(--duration-normal) var(--ease-smooth);
+}
+.preset-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-card-hover);
+}
+
+/* ─── Strategy page: Stats color classes ─── */
+.stat-positive { color: var(--color-up); }
+.stat-warning  { color: var(--color-yellow); }
+.stat-negative { color: var(--color-red); }
 
 /* ─── Border gradient on hover ─── */
 .border-gradient {


### PR DESCRIPTION
## Summary
- Learn pages: added `card-glow` mouse-tracking effect to LearnCard, search input focus glow with accent border + shadow
- Blog pages: category-specific colored badges (quant=blue, education=green, weekly=purple, strategy=orange, market=yellow, autopsy=red), more prominent date text, animated NEW badge for posts published within 7 days, card-glow hover effect
- All changes applied to both EN and KO pages

## Test plan
- [ ] `/learn` -- hover cards to verify glow tracking, focus search input for glow effect
- [ ] `/ko/learn` -- same checks in Korean
- [ ] `/blog` -- verify category badges have distinct colors, check NEW badge on recent posts
- [ ] `/ko/blog` -- same checks in Korean, verify EN badge still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)