### PR TITLE
style: add reveal animations and section-dividers to 12 pages

### DIFF
--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -8,7 +8,7 @@ const t = useTranslations('en');
 <Layout title={t('meta.changelog_title')} description={t('meta.changelog_desc')}>
 
   <!-- HEADER -->
-  <section class="py-20">
+  <section class="py-20 reveal">
     <div class="max-w-7xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('changelog.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">{t('changelog.title')}</h1>
@@ -18,8 +18,9 @@ const t = useTranslations('en');
     </div>
   </section>
 
+  <hr class="section-divider" />
   <!-- CONTEXT CALLOUT -->
-  <section class="pb-8">
+  <section class="pb-8 reveal">
     <div class="max-w-4xl mx-auto px-4">
       <div class="bg-[--color-bg-card] border-l-4 border-[--color-accent] p-4 rounded-r">
         <p class="text-sm text-[--color-text-muted]">
@@ -30,8 +31,9 @@ const t = useTranslations('en');
     </div>
   </section>
 
+  <hr class="section-divider" />
   <!-- TIMELINE -->
-  <section class="pb-20">
+  <section class="pb-20 reveal">
     <div class="max-w-4xl mx-auto px-4">
 
       <!-- v1.7.1 -->
@@ -206,7 +208,8 @@ const t = useTranslations('en');
   </section>
 
   <!-- PHILOSOPHY -->
-  <section class="pt-16 pb-8 border-t border-[--color-border]">
+  <hr class="section-divider" />
+  <section class="pt-16 pb-8 reveal">
     <div class="max-w-7xl mx-auto px-4 text-center">
       <h2 class="text-2xl md:text-3xl font-bold mb-4">{t('changelog.why_title')}</h2>
       <p class="text-[--color-text-muted] text-lg max-w-2xl mx-auto mb-8">

--- a/src/pages/coins/index.astro
+++ b/src/pages/coins/index.astro
@@ -36,7 +36,7 @@ const TOP_COINS = [
 ---
 
 <Layout title={t('meta.coins_title')} description={t('meta.coins_desc')}>
-  <section class="py-12">
+  <section class="py-12 reveal">
     <div class="max-w-7xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('coins.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">{t('coins.title')}</h1>
@@ -69,7 +69,8 @@ const TOP_COINS = [
           </ul>
         </noscript>
       </div>
-      <div class="mt-10 pt-8 border-t border-[--color-border] text-center">
+      <hr class="section-divider" />
+      <div class="mt-10 pt-8 text-center">
         <p class="text-[--color-text-muted] text-sm mb-4">{t('coins.explore_next')}</p>
         <div class="flex flex-wrap gap-3 justify-center">
           <a href="/simulate" class="btn btn-primary btn-md no-underline">

--- a/src/pages/ko/changelog.astro
+++ b/src/pages/ko/changelog.astro
@@ -8,7 +8,7 @@ const t = useTranslations('ko');
 <Layout title={t('meta.changelog_title')} description={t('meta.changelog_desc')}>
 
   <!-- HEADER -->
-  <section class="py-20">
+  <section class="py-20 reveal">
     <div class="max-w-7xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('changelog.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">{t('changelog.title')}</h1>
@@ -18,8 +18,9 @@ const t = useTranslations('ko');
     </div>
   </section>
 
+  <hr class="section-divider" />
   <!-- CONTEXT CALLOUT -->
-  <section class="pb-8">
+  <section class="pb-8 reveal">
     <div class="max-w-4xl mx-auto px-4">
       <div class="bg-[--color-bg-card] border-l-4 border-[--color-accent] p-4 rounded-r">
         <p class="text-sm text-[--color-text-muted]">
@@ -30,8 +31,9 @@ const t = useTranslations('ko');
     </div>
   </section>
 
+  <hr class="section-divider" />
   <!-- TIMELINE -->
-  <section class="pb-20">
+  <section class="pb-20 reveal">
     <div class="max-w-4xl mx-auto px-4">
 
       <!-- v1.7.1 -->
@@ -206,7 +208,8 @@ const t = useTranslations('ko');
   </section>
 
   <!-- PHILOSOPHY -->
-  <section class="py-16 border-t border-[--color-border]">
+  <hr class="section-divider" />
+  <section class="py-16 reveal">
     <div class="max-w-7xl mx-auto px-4 text-center">
       <h2 class="text-2xl md:text-3xl font-bold mb-4">{t('changelog.why_title')}</h2>
       <p class="text-[--color-text-muted] text-lg max-w-2xl mx-auto mb-8">

--- a/src/pages/ko/coins/index.astro
+++ b/src/pages/ko/coins/index.astro
@@ -36,7 +36,7 @@ const TOP_COINS = [
 ---
 
 <Layout title={t('meta.coins_title')} description={t('meta.coins_desc')}>
-  <section class="py-12">
+  <section class="py-12 reveal">
     <div class="max-w-7xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('coins.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">{t('coins.title')}</h1>
@@ -69,7 +69,8 @@ const TOP_COINS = [
           </ul>
         </noscript>
       </div>
-      <div class="mt-10 pt-8 border-t border-[--color-border] text-center">
+      <hr class="section-divider" />
+      <div class="mt-10 pt-8 text-center">
         <p class="text-[--color-text-muted] text-sm mb-4">{t('coins.explore_next')}</p>
         <div class="flex flex-wrap gap-3 justify-center">
           <a href="/ko/simulate" class="btn btn-primary btn-md no-underline">

--- a/src/pages/ko/leaderboard.astro
+++ b/src/pages/ko/leaderboard.astro
@@ -30,7 +30,7 @@ function formatDate(iso: string) {
 ---
 
 <Layout title={t('meta.leaderboard_title')} description={t('meta.leaderboard_desc')}>
-  <section class="py-12">
+  <section class="py-12 reveal">
     <div class="max-w-4xl mx-auto px-4">
 
       <StrategyTabs active="leaderboard" lang="ko" />
@@ -58,7 +58,7 @@ function formatDate(iso: string) {
               const wrColor = entry.win_rate >= 55 ? 'text-[--color-up]' : entry.win_rate >= 50 ? 'text-[--color-yellow]' : 'text-[--color-red]';
               const pfColor = entry.profit_factor >= 1.5 ? 'text-[--color-up]' : entry.profit_factor >= 1.0 ? 'text-[--color-yellow]' : 'text-[--color-red]';
               return (
-                <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card]">
+                <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover">
                   <div class="flex items-start justify-between gap-2 mb-3">
                     <div class="flex items-center gap-2 min-w-0">
                       <span class="text-xl shrink-0">{medal}</span>
@@ -145,7 +145,8 @@ function formatDate(iso: string) {
   </script>
 
   <!-- Footer CTAs -->
-  <section class="pb-12 border-t border-[--color-border] pt-8">
+  <hr class="section-divider" />
+  <section class="pb-12 pt-8 reveal">
     <div class="max-w-4xl mx-auto px-4 text-center">
       <div class="flex flex-wrap gap-3 justify-center">
         <a href="/ko/simulate" class="btn btn-primary btn-md no-underline">

--- a/src/pages/ko/market/index.astro
+++ b/src/pages/ko/market/index.astro
@@ -8,7 +8,7 @@ const marketDataJson = JSON.stringify(marketDataRaw);
 ---
 
 <Layout title={t('meta.market_title')} description={t('meta.market_desc')}>
-  <section class="py-12">
+  <section class="py-12 reveal">
     <div class="max-w-7xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('market.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">{t('market.title')}</h1>
@@ -60,7 +60,8 @@ const marketDataJson = JSON.stringify(marketDataRaw);
         </div>
       </div>
     </div>
-    <div class="mt-6 pt-8 border-t border-[--color-border] text-center max-w-5xl mx-auto px-4">
+    <hr class="section-divider" />
+    <div class="mt-6 pt-8 text-center max-w-5xl mx-auto px-4">
       <div class="flex flex-wrap gap-3 justify-center">
         <a href="/ko/simulate" class="btn btn-primary btn-md no-underline">
           {t('cross.simulate_cta')} &rarr;

--- a/src/pages/ko/methodology.astro
+++ b/src/pages/ko/methodology.astro
@@ -8,7 +8,7 @@ const t = useTranslations('ko');
 <Layout title={t('meta.methodology_title')} description={t('meta.methodology_desc')}>
 
   <!-- HERO -->
-  <section class="py-16">
+  <section class="py-16 reveal">
     <div class="max-w-5xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('methodology.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">
@@ -21,7 +21,8 @@ const t = useTranslations('ko');
   </section>
 
   <!-- 백테스트 방법 -->
-  <section class="pb-12 border-t border-[--color-border] pt-12">
+  <hr class="section-divider" />
+  <section class="pb-12 pt-12 reveal">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-6">{t('methodology.backtest_title')}</h2>
 
@@ -60,7 +61,8 @@ const t = useTranslations('ko');
   </section>
 
   <!-- 전략 평가 지표 -->
-  <section class="pb-12 border-t border-[--color-border] pt-12">
+  <hr class="section-divider" />
+  <section class="pb-12 pt-12 reveal">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-2">{t('methodology.metrics_title')}</h2>
       <p class="text-[--color-text-muted] text-sm mb-6">{t('methodology.metrics_desc')}</p>
@@ -100,7 +102,8 @@ const t = useTranslations('ko');
   </section>
 
   <!-- 검증 방법 -->
-  <section class="pb-12 border-t border-[--color-border] pt-12">
+  <hr class="section-divider" />
+  <section class="pb-12 pt-12 reveal">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-2">{t('methodology.validation_title')}</h2>
       <p class="text-[--color-text-muted] text-sm mb-6">{t('methodology.validation_desc')}</p>
@@ -121,7 +124,8 @@ const t = useTranslations('ko');
   </section>
 
   <!-- 모델링하지 않는 것 -->
-  <section class="pb-12 border-t border-[--color-border] pt-12">
+  <hr class="section-divider" />
+  <section class="pb-12 pt-12 reveal">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-2">{t('methodology.not_modeled_title')}</h2>
       <p class="text-[--color-text-muted] text-sm mb-6">{t('methodology.not_modeled_desc')}</p>
@@ -152,7 +156,8 @@ const t = useTranslations('ko');
   </section>
 
   <!-- 재현 가능성 -->
-  <section class="pb-12 border-t border-[--color-border] pt-12">
+  <hr class="section-divider" />
+  <section class="pb-12 pt-12 reveal">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-4">{t('methodology.reproducibility_title')}</h2>
       <div class="prose max-w-3xl">
@@ -162,7 +167,8 @@ const t = useTranslations('ko');
   </section>
 
   <!-- 면책 조항 -->
-  <section class="pb-12 border-t border-[--color-border] pt-12">
+  <hr class="section-divider" />
+  <section class="pb-12 pt-12 reveal">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-4">{t('methodology.disclaimer_title')}</h2>
       <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] max-w-3xl">
@@ -174,7 +180,8 @@ const t = useTranslations('ko');
   </section>
 
   <!-- CTA -->
-  <section class="pb-16 border-t border-[--color-border] pt-12">
+  <hr class="section-divider" />
+  <section class="pb-16 pt-12 reveal">
     <div class="max-w-5xl mx-auto px-4 text-center">
       <h2 class="text-xl font-bold mb-3">{t('methodology.cta_title')}</h2>
       <p class="text-[--color-text-muted] text-sm mb-6">{t('methodology.cta_desc')}</p>

--- a/src/pages/ko/why-backtests-fail.astro
+++ b/src/pages/ko/why-backtests-fail.astro
@@ -50,7 +50,7 @@ const jsonLd = {
   <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
 
   <!-- HERO -->
-  <section class="pt-16 pb-8">
+  <section class="pt-16 pb-8 reveal">
     <div class="max-w-5xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">백테스팅 교육</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">
@@ -66,7 +66,7 @@ const jsonLd = {
 
   <!-- 5 REASONS -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12">
+  <section class="pb-12 pt-12 reveal">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl md:text-3xl font-bold mb-10">백테스트가 실패하는 5가지 이유</h2>
       <div class="space-y-12">
@@ -89,7 +89,7 @@ const jsonLd = {
 
   <!-- 88 KILLED STRATEGIES -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12 bg-[--color-bg-subtle]">
+  <section class="pb-12 pt-12 bg-[--color-bg-subtle] reveal">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl md:text-3xl font-bold mb-4">우리의 증거: 제거된 88개 전략</h2>
       <p class="text-[--color-text-muted] max-w-3xl mb-6">
@@ -109,19 +109,19 @@ const jsonLd = {
 
   <!-- INTERNAL LINKS -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12">
+  <section class="pb-12 pt-12 reveal">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl md:text-3xl font-bold mb-6">더 알아보기</h2>
       <div class="grid sm:grid-cols-2 md:grid-cols-3 gap-4">
-        <a href="/ko/simulate" class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] hover:border-[--color-accent]/50 transition-colors block">
+        <a href="/ko/simulate" class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover block">
           <p class="font-bold mb-1">시뮬레이터</p>
           <p class="text-sm text-[--color-text-muted]">실제 데이터로 직접 백테스트를 실행하세요</p>
         </a>
-        <a href="/ko/learn" class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] hover:border-[--color-accent]/50 transition-colors block">
+        <a href="/ko/learn" class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover block">
           <p class="font-bold mb-1">학습</p>
           <p class="text-sm text-[--color-text-muted]">트레이딩 교육 및 가이드</p>
         </a>
-        <a href="/ko/compare/tradingview" class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] hover:border-[--color-accent]/50 transition-colors block">
+        <a href="/ko/compare/tradingview" class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover block">
           <p class="font-bold mb-1">비교</p>
           <p class="text-sm text-[--color-text-muted]">PRUVIQ vs 다른 플랫폼</p>
         </a>
@@ -131,7 +131,7 @@ const jsonLd = {
 
   <!-- CTA -->
   <hr class="section-divider" />
-  <section class="py-20">
+  <section class="py-20 reveal">
     <div class="max-w-5xl mx-auto px-4 text-center">
       <h2 class="text-3xl md:text-4xl font-bold mb-4">
         <span class="text-[--color-accent]">전략을 테스트하세요</span>

--- a/src/pages/leaderboard.astro
+++ b/src/pages/leaderboard.astro
@@ -31,7 +31,7 @@ function formatDate(iso: string) {
 ---
 
 <Layout title={t('meta.leaderboard_title')} description={t('meta.leaderboard_desc')}>
-  <section class="py-12">
+  <section class="py-12 reveal">
     <div class="max-w-4xl mx-auto px-4">
 
       <StrategyTabs active="leaderboard" lang="en" />
@@ -60,7 +60,7 @@ function formatDate(iso: string) {
               const wrColor = entry.win_rate >= 55 ? 'text-[--color-up]' : entry.win_rate >= 50 ? 'text-[--color-yellow]' : 'text-[--color-red]';
               const pfColor = entry.profit_factor >= 1.5 ? 'text-[--color-up]' : entry.profit_factor >= 1.0 ? 'text-[--color-yellow]' : 'text-[--color-red]';
               return (
-                <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card]">
+                <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover">
                   <div class="flex items-start justify-between gap-2 mb-3">
                     <div class="flex items-center gap-2 min-w-0">
                       <span class="text-xl shrink-0">{medal}</span>
@@ -147,7 +147,8 @@ function formatDate(iso: string) {
   </script>
 
   <!-- Footer CTAs -->
-  <section class="pb-12 border-t border-[--color-border] pt-8">
+  <hr class="section-divider" />
+  <section class="pb-12 pt-8 reveal">
     <div class="max-w-4xl mx-auto px-4 text-center">
       <div class="flex flex-wrap gap-3 justify-center">
         <a href="/simulate" class="btn btn-primary btn-md no-underline">

--- a/src/pages/market/index.astro
+++ b/src/pages/market/index.astro
@@ -8,7 +8,7 @@ const marketDataJson = JSON.stringify(marketDataRaw);
 ---
 
 <Layout title={t('meta.market_title')} description={t('meta.market_desc')}>
-  <section class="py-12">
+  <section class="py-12 reveal">
     <div class="max-w-7xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('market.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">{t('market.title')}</h1>
@@ -60,7 +60,8 @@ const marketDataJson = JSON.stringify(marketDataRaw);
         </div>
       </div>
     </div>
-    <div class="mt-6 pt-8 border-t border-[--color-border] text-center max-w-5xl mx-auto px-4">
+    <hr class="section-divider" />
+    <div class="mt-6 pt-8 text-center max-w-5xl mx-auto px-4">
       <div class="flex flex-wrap gap-3 justify-center">
         <a href="/simulate" class="btn btn-primary btn-md no-underline">
           {t('cross.simulate_cta')} &rarr;

--- a/src/pages/methodology.astro
+++ b/src/pages/methodology.astro
@@ -8,7 +8,7 @@ const t = useTranslations('en');
 <Layout title={t('meta.methodology_title')} description={t('meta.methodology_desc')}>
 
   <!-- HERO -->
-  <section class="pt-16 pb-8">
+  <section class="pt-16 pb-8 reveal">
     <div class="max-w-5xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('methodology.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">
@@ -21,7 +21,8 @@ const t = useTranslations('en');
   </section>
 
   <!-- HOW WE BACKTEST -->
-  <section class="pb-12 border-t border-[--color-border] pt-12">
+  <hr class="section-divider" />
+  <section class="pb-12 pt-12 reveal">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-6">{t('methodology.backtest_title')}</h2>
 
@@ -60,7 +61,8 @@ const t = useTranslations('en');
   </section>
 
   <!-- STRATEGY EVALUATION METRICS -->
-  <section class="pb-12 border-t border-[--color-border] pt-12">
+  <hr class="section-divider" />
+  <section class="pb-12 pt-12 reveal">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-2">{t('methodology.metrics_title')}</h2>
       <p class="text-[--color-text-muted] text-sm mb-6">{t('methodology.metrics_desc')}</p>
@@ -100,7 +102,8 @@ const t = useTranslations('en');
   </section>
 
   <!-- ROBUSTNESS VALIDATION -->
-  <section class="pb-12 border-t border-[--color-border] pt-12">
+  <hr class="section-divider" />
+  <section class="pb-12 pt-12 reveal">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-2">{t('methodology.validation_title')}</h2>
       <p class="text-[--color-text-muted] text-sm mb-6">{t('methodology.validation_desc')}</p>
@@ -121,7 +124,8 @@ const t = useTranslations('en');
   </section>
 
   <!-- WHAT WE DON'T MODEL -->
-  <section class="pb-12 border-t border-[--color-border] pt-12">
+  <hr class="section-divider" />
+  <section class="pb-12 pt-12 reveal">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-2">{t('methodology.not_modeled_title')}</h2>
       <p class="text-[--color-text-muted] text-sm mb-6">{t('methodology.not_modeled_desc')}</p>
@@ -152,7 +156,8 @@ const t = useTranslations('en');
   </section>
 
   <!-- REPRODUCIBILITY -->
-  <section class="pb-12 border-t border-[--color-border] pt-12">
+  <hr class="section-divider" />
+  <section class="pb-12 pt-12 reveal">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-4">{t('methodology.reproducibility_title')}</h2>
       <div class="prose max-w-3xl">
@@ -162,7 +167,8 @@ const t = useTranslations('en');
   </section>
 
   <!-- DISCLAIMER -->
-  <section class="pb-12 border-t border-[--color-border] pt-12">
+  <hr class="section-divider" />
+  <section class="pb-12 pt-12 reveal">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-4">{t('methodology.disclaimer_title')}</h2>
       <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] max-w-3xl">
@@ -174,7 +180,8 @@ const t = useTranslations('en');
   </section>
 
   <!-- CTA -->
-  <section class="pb-16 border-t border-[--color-border] pt-12">
+  <hr class="section-divider" />
+  <section class="pb-16 pt-12 reveal">
     <div class="max-w-5xl mx-auto px-4 text-center">
       <h2 class="text-xl font-bold mb-3">{t('methodology.cta_title')}</h2>
       <p class="text-[--color-text-muted] text-sm mb-6">{t('methodology.cta_desc')}</p>

--- a/src/pages/why-backtests-fail.astro
+++ b/src/pages/why-backtests-fail.astro
@@ -49,7 +49,7 @@ const jsonLd = {
   <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
 
   <!-- HERO -->
-  <section class="pt-16 pb-8">
+  <section class="pt-16 pb-8 reveal">
     <div class="max-w-5xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">BACKTESTING EDUCATION</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">
@@ -65,7 +65,7 @@ const jsonLd = {
 
   <!-- 5 REASONS -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12">
+  <section class="pb-12 pt-12 reveal">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl md:text-3xl font-bold mb-10">5 Common Reasons Backtests Fail</h2>
       <div class="space-y-12">
@@ -88,7 +88,7 @@ const jsonLd = {
 
   <!-- 88 KILLED STRATEGIES -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12 bg-[--color-bg-subtle]">
+  <section class="pb-12 pt-12 bg-[--color-bg-subtle] reveal">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl md:text-3xl font-bold mb-4">Our Proof: 88 Strategies We Killed</h2>
       <p class="text-[--color-text-muted] max-w-3xl mb-6">
@@ -108,19 +108,19 @@ const jsonLd = {
 
   <!-- INTERNAL LINKS -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12">
+  <section class="pb-12 pt-12 reveal">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl md:text-3xl font-bold mb-6">Learn More</h2>
       <div class="grid sm:grid-cols-2 md:grid-cols-3 gap-4">
-        <a href="/simulate" class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] hover:border-[--color-accent]/50 transition-colors block">
+        <a href="/simulate" class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover block">
           <p class="font-bold mb-1">Simulator</p>
           <p class="text-sm text-[--color-text-muted]">Run your own backtest with real data</p>
         </a>
-        <a href="/learn" class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] hover:border-[--color-accent]/50 transition-colors block">
+        <a href="/learn" class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover block">
           <p class="font-bold mb-1">Learn</p>
           <p class="text-sm text-[--color-text-muted]">Trading education and guides</p>
         </a>
-        <a href="/compare/tradingview" class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] hover:border-[--color-accent]/50 transition-colors block">
+        <a href="/compare/tradingview" class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card] card-hover block">
           <p class="font-bold mb-1">Compare</p>
           <p class="text-sm text-[--color-text-muted]">PRUVIQ vs other platforms</p>
         </a>
@@ -130,7 +130,7 @@ const jsonLd = {
 
   <!-- CTA -->
   <hr class="section-divider" />
-  <section class="py-20">
+  <section class="py-20 reveal">
     <div class="max-w-5xl mx-auto px-4 text-center">
       <h2 class="text-3xl md:text-4xl font-bold mb-4">
         <span class="text-[--color-accent]">Test Your Strategy</span>


### PR DESCRIPTION
## Summary
- Added `reveal` scroll animation class to all sections across 12 pages (6 EN + 6 KO): market, coins, leaderboard, changelog, why-backtests-fail, methodology
- Replaced `border-t border-[--color-border]` section separators with `<hr class="section-divider" />` for consistent gradient dividers
- Added `card-hover` class to interactive cards (leaderboard SSR fallback cards, why-backtests-fail "Learn More" cards)
- External links: all already had `target="_blank" rel="noopener noreferrer"` — no changes needed

## Test plan
- [x] `npm run build` — 2510 pages, 0 errors
- [x] `qa-redirects.sh` — PASS, no conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)