### PR TITLE
style: hero polish, KO i18n fix, signals shimmer loading

### DIFF
--- a/src/components/SignalsDashboard.tsx
+++ b/src/components/SignalsDashboard.tsx
@@ -131,26 +131,52 @@ export default function SignalsDashboard({ lang = "en" }: Props) {
     return (
       <div class="py-8">
         <div class="flex flex-col items-center gap-4 mb-8">
-          <div class="relative">
-            <div class="w-12 h-12 rounded-full border-2 border-[--color-border]"></div>
-            <div class="absolute inset-0 w-12 h-12 rounded-full border-2 border-transparent border-t-[--color-accent] animate-spin"></div>
+          <div class="flex gap-1.5">
+            <span
+              class="w-2 h-2 rounded-full bg-[--color-accent] animate-pulse"
+              style={{ animationDelay: "0s" }}
+            ></span>
+            <span
+              class="w-2 h-2 rounded-full bg-[--color-accent] animate-pulse"
+              style={{ animationDelay: "0.2s" }}
+            ></span>
+            <span
+              class="w-2 h-2 rounded-full bg-[--color-accent] animate-pulse"
+              style={{ animationDelay: "0.4s" }}
+            ></span>
           </div>
           <div class="text-center">
             <p class="text-base font-semibold mb-1">
               {lang === "ko" ? "시그널 스캔 중" : "Scanning Signals"}
             </p>
             <p class="text-sm text-[--color-text-muted]">
-              {lang === "ko"
-                ? "535개 코인에서 전략 조건을 분석하고 있습니다..."
-                : "Analyzing strategy conditions across 535 coins..."}
+              {lang === "ko" ? (
+                <>
+                  전략 조건을{" "}
+                  <span class="font-mono text-[--color-accent]">535</span>개
+                  코인에서 분석 중...
+                </>
+              ) : (
+                <>
+                  Analyzing strategy conditions across{" "}
+                  <span class="font-mono text-[--color-accent]">535</span>{" "}
+                  coins...
+                </>
+              )}
             </p>
           </div>
         </div>
-        <div class="space-y-3 animate-pulse">
+        <div class="space-y-3">
           {[1, 2, 3, 4, 5].map((i) => (
             <div
               key={i}
-              class="flex items-center justify-between p-4 rounded-lg bg-[--color-bg-card] border border-[--color-border]"
+              class="flex items-center justify-between p-4 rounded-lg border border-[--color-border]"
+              style={{
+                background:
+                  "linear-gradient(90deg, var(--color-bg-card) 25%, var(--color-bg-elevated) 50%, var(--color-bg-card) 75%)",
+                backgroundSize: "200% 100%",
+                animation: "shimmer 1.5s infinite",
+              }}
             >
               <div class="flex items-center gap-4">
                 <div class="w-12 h-6 rounded bg-[--color-bg-elevated]"></div>

--- a/src/components/ui/StrategyTabs.astro
+++ b/src/components/ui/StrategyTabs.astro
@@ -21,7 +21,7 @@ const tabs = [
 ];
 ---
 
-<nav class="flex gap-1 mb-8 border-b border-[--color-border]" aria-label={lang === 'ko' ? '전략 내비게이션' : 'Strategy navigation'}>
+<nav class="flex gap-1 mb-4 border-b border-[--color-border]" aria-label={lang === 'ko' ? '전략 내비게이션' : 'Strategy navigation'}>
   {tabs.map(tab => (
     tab.id === active ? (
       <a href={tab.href} aria-current="page"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -27,9 +27,9 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
 <Layout title={t('meta.home_title')} description={t('meta.index_desc')}>
 
   <!-- HERO -->
-  <section class="relative overflow-hidden min-h-[85vh] flex flex-col justify-center" style="background: var(--gradient-hero)">
+  <section class="relative overflow-hidden min-h-[85vh] flex flex-col justify-center hero-bg-depth">
     <HeroGlow />
-    <div class="relative max-w-7xl mx-auto px-6 pt-28 pb-16 md:pt-36 md:pb-20 hero-enter">
+    <div class="relative max-w-7xl mx-auto px-6 pt-20 pb-12 md:pt-28 md:pb-16 hero-enter">
       <HeroBadge stat={simulationsRun} label="simulations run" />
       <h1 class="text-4xl md:text-6xl lg:text-7xl font-bold text-center tracking-[-0.04em] leading-[1.08] max-w-4xl mx-auto">
         Test Any Crypto Strategy<br class="hidden md:block" /> on <span class="gradient-text">{coinsAnalyzed} Coins</span> in Seconds

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -27,10 +27,10 @@ const candlesProcessed = ((siteStats as { candles_processed: number }).candles_p
 <Layout title={t('meta.home_title')} description={t('meta.index_desc')}>
 
   <!-- HERO -->
-  <section class="relative overflow-hidden min-h-[85vh] flex flex-col justify-center" style="background: var(--gradient-hero)">
+  <section class="relative overflow-hidden min-h-[85vh] flex flex-col justify-center hero-bg-depth">
     <HeroGlow />
-    <div class="relative max-w-7xl mx-auto px-6 pt-28 pb-16 md:pt-36 md:pb-20 hero-enter">
-      <HeroBadge stat={simulationsRun} label="시뮬레이션 실행" />
+    <div class="relative max-w-7xl mx-auto px-6 pt-20 pb-12 md:pt-28 md:pb-16 hero-enter">
+      <HeroBadge stat={simulationsRun} label="시뮬레이션 실행" cta="무료 체험 →" />
       <h1 class="text-4xl md:text-6xl lg:text-7xl font-bold text-center tracking-[-0.04em] leading-[1.08] max-w-4xl mx-auto">
         {t('hero.h1_line1')}<br class="hidden md:block" /> <span class="gradient-text">{coinsAnalyzed}개 코인</span>, 몇 초 만에 검증
       </h1>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -163,6 +163,13 @@
   --color-bg-hero: #0A0E1A;
 }
 
+/* ─── Hero background depth ─── */
+.hero-bg-depth {
+  background:
+    radial-gradient(ellipse at 50% 0%, rgba(79,142,247,0.08) 0%, transparent 60%),
+    var(--gradient-hero);
+}
+
 /* ─── Shadows (not in @theme — multi-value not supported) ─── */
 :root {
   --shadow-card:


### PR DESCRIPTION
## Summary
- Hero section: reduced padding + radial-gradient depth overlay (EN+KO)
- Fixed KO HeroBadge defaulting to "Try free" instead of "무료 체험"
- Signals loading: pulse dots + shimmer skeleton + accent-highlighted coin count
- StrategyTabs: tighter spacing (mb-8 → mb-4)

## Test plan
- [ ] Verify hero visual on / and /ko/ (tighter, blue radial glow)
- [ ] Confirm KO badge shows "무료 체험 →"
- [ ] Check /signals loading state shows shimmer + pulse dots
- [ ] Verify strategies tabs spacing is tighter

Build: 2514 pages, 0 errors. qa-redirects: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)