### PR TITLE
fix: ranking SSR fallback — timeout + daily JSON chain

### DIFF
--- a/src/pages/ko/strategies/ranking.astro
+++ b/src/pages/ko/strategies/ranking.astro
@@ -38,20 +38,22 @@ interface RankingData {
 let ssrRanking: RankingData | null = null;
 try {
   const res = await fetch('https://api.pruviq.com/rankings/daily?period=30d&group=top50', {
-    signal: AbortSignal.timeout(5000),
+    signal: AbortSignal.timeout(10000),
   });
   if (res.ok) ssrRanking = await res.json() as RankingData;
 } catch {
-  // API unavailable at build time
+  // API unavailable at build time — fallback below
 }
 
-// Static fallback: ensure SSR div always renders for crawlers
+// Static fallback: try rankings-daily.json first (always fresh), then ranking-fallback.json
 if (!ssrRanking) {
   try {
     const fs = await import('node:fs');
     const path = await import('node:path');
+    const dailyPath = path.default.join(process.cwd(), 'public/data/rankings-daily.json');
     const fallbackPath = path.default.join(process.cwd(), 'public/data/ranking-fallback.json');
-    ssrRanking = JSON.parse(fs.default.readFileSync(fallbackPath, 'utf-8')) as RankingData;
+    const dataPath = fs.default.existsSync(dailyPath) ? dailyPath : fallbackPath;
+    ssrRanking = JSON.parse(fs.default.readFileSync(dataPath, 'utf-8')) as RankingData;
   } catch {
     // Both API and static fallback failed
   }

--- a/src/pages/strategies/ranking.astro
+++ b/src/pages/strategies/ranking.astro
@@ -48,20 +48,23 @@ interface RankingData {
 let ssrRanking: RankingData | null = null;
 try {
   const res = await fetch('https://api.pruviq.com/rankings/daily?period=30d&group=top50', {
-    signal: AbortSignal.timeout(5000),
+    signal: AbortSignal.timeout(10000),
   });
   if (res.ok) ssrRanking = await res.json() as RankingData;
 } catch {
-  // API unavailable at build time
+  // API unavailable at build time — fallback below
 }
 
-// Static fallback: ensure SSR div always renders for crawlers
+// Static fallback: try rankings-daily.json first (always fresh), then ranking-fallback.json
 if (!ssrRanking) {
   try {
     const fs = await import('node:fs');
     const path = await import('node:path');
+    // Try daily rankings first (refreshed every 20min by cron)
+    const dailyPath = path.default.join(process.cwd(), 'public/data/rankings-daily.json');
     const fallbackPath = path.default.join(process.cwd(), 'public/data/ranking-fallback.json');
-    ssrRanking = JSON.parse(fs.default.readFileSync(fallbackPath, 'utf-8')) as RankingData;
+    const dataPath = fs.default.existsSync(dailyPath) ? dailyPath : fallbackPath;
+    ssrRanking = JSON.parse(fs.default.readFileSync(dataPath, 'utf-8')) as RankingData;
   } catch {
     // Both API and static fallback failed
   }


### PR DESCRIPTION
## 스모크 3연속 실패 뿌리 해결

**근본 원인**: 빌드 시 API 타임아웃 5초가 간헐적 부족 → SSR 데이터 빈 상태로 배포 → 스모크 "strategy names" 체크 실패

**수정**:
1. API 타임아웃: 5s → 10s
2. Fallback 체인: `rankings-daily.json` (크론 20분 갱신) → `ranking-fallback.json` (정적)
3. EN + KO 동시 적용

**검증**: 빌드 2514/0, SSR HTML에 MACD+RSI 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)