### PR TITLE
fix: auto-fix #870 (+1 related)

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -46,7 +46,7 @@ const categoryLabels: Record<string, string> = {
       "@type": "WebPage",
       "@id": `https://pruviq.com/learn/${Astro.params.id || ''}/`
     },
-    ...(image ? { "image": `https://pruviq.com${image}` } : {})
+    ...(image ? { "image": { "@type": "ImageObject", "url": `https://pruviq.com${image}`, "width": 1200, "height": 630 } } : {})
   })} />
   <article class="py-12">
     <div class="max-w-[45rem] mx-auto px-4">

--- a/src/pages/ko/market/index.astro
+++ b/src/pages/ko/market/index.astro
@@ -36,9 +36,26 @@ const marketDataJson = JSON.stringify(marketDataRaw);
         </div>
         <noscript>
           <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] mt-4">
-            <h2 class="text-lg font-bold mb-2">{t('market.noscript_title')}</h2>
-            <p class="text-[--color-text-muted] text-sm mb-3">{t('market.noscript_desc')}</p>
-            <p class="text-[--color-text-muted] text-sm mb-4">{t('market.noscript_alt')}</p>
+            <h2 class="text-lg font-bold mb-4">{t('market.noscript_title')}</h2>
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+              <div class="p-3 rounded-lg bg-[--color-bg-hover]">
+                <p class="text-xs text-[--color-text-muted]">BTC 가격</p>
+                <p class="font-bold font-mono">${marketDataRaw.btc_price?.toLocaleString('en-US', { maximumFractionDigits: 0 })}</p>
+              </div>
+              <div class="p-3 rounded-lg bg-[--color-bg-hover]">
+                <p class="text-xs text-[--color-text-muted]">BTC 도미넌스</p>
+                <p class="font-bold font-mono">{marketDataRaw.btc_dominance}%</p>
+              </div>
+              <div class="p-3 rounded-lg bg-[--color-bg-hover]">
+                <p class="text-xs text-[--color-text-muted]">공포 & 탐욕</p>
+                <p class="font-bold font-mono">{marketDataRaw.fear_greed_index} — {marketDataRaw.fear_greed_label}</p>
+              </div>
+              <div class="p-3 rounded-lg bg-[--color-bg-hover]">
+                <p class="text-xs text-[--color-text-muted]">총 시가총액</p>
+                <p class="font-bold font-mono">${marketDataRaw.total_market_cap_b}B</p>
+              </div>
+            </div>
+            <p class="text-[--color-text-muted] text-sm mb-4">{t('market.noscript_desc')}</p>
             <div class="flex flex-wrap gap-3">
               <a href="/ko/coins" class="text-[--color-accent] text-sm font-semibold hover:underline">570+ 코인 탐색 &rarr;</a>
               <a href="/ko/simulate" class="text-[--color-accent] text-sm font-semibold hover:underline">시뮬레이션 실행 &rarr;</a>

--- a/src/pages/market/index.astro
+++ b/src/pages/market/index.astro
@@ -36,9 +36,26 @@ const marketDataJson = JSON.stringify(marketDataRaw);
         </div>
         <noscript>
           <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] mt-4">
-            <h2 class="text-lg font-bold mb-2">{t('market.noscript_title')}</h2>
-            <p class="text-[--color-text-muted] text-sm mb-3">{t('market.noscript_desc')}</p>
-            <p class="text-[--color-text-muted] text-sm mb-4">{t('market.noscript_alt')}</p>
+            <h2 class="text-lg font-bold mb-4">{t('market.noscript_title')}</h2>
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+              <div class="p-3 rounded-lg bg-[--color-bg-hover]">
+                <p class="text-xs text-[--color-text-muted]">BTC Price</p>
+                <p class="font-bold font-mono">${marketDataRaw.btc_price?.toLocaleString('en-US', { maximumFractionDigits: 0 })}</p>
+              </div>
+              <div class="p-3 rounded-lg bg-[--color-bg-hover]">
+                <p class="text-xs text-[--color-text-muted]">BTC Dominance</p>
+                <p class="font-bold font-mono">{marketDataRaw.btc_dominance}%</p>
+              </div>
+              <div class="p-3 rounded-lg bg-[--color-bg-hover]">
+                <p class="text-xs text-[--color-text-muted]">Fear & Greed</p>
+                <p class="font-bold font-mono">{marketDataRaw.fear_greed_index} — {marketDataRaw.fear_greed_label}</p>
+              </div>
+              <div class="p-3 rounded-lg bg-[--color-bg-hover]">
+                <p class="text-xs text-[--color-text-muted]">Total Market Cap</p>
+                <p class="font-bold font-mono">${marketDataRaw.total_market_cap_b}B</p>
+              </div>
+            </div>
+            <p class="text-[--color-text-muted] text-sm mb-4">{t('market.noscript_desc')}</p>
             <div class="flex flex-wrap gap-3">
               <a href="/coins" class="text-[--color-accent] text-sm font-semibold hover:underline">Browse 570+ Coins &rarr;</a>
               <a href="/simulate" class="text-[--color-accent] text-sm font-semibold hover:underline">Run Simulation &rarr;</a>


### PR DESCRIPTION
## Auto-fix for 2 issue(s)

#870: [claude-auto][P2] `layouts/BlogPost.astro:49` — Article JSON-LD `image` is a bare string, not `I
#871: [claude-auto][P2] `pages/market/index.astro:37-48` — noscript block has zero crawlable market da

### Changes
```
 src/layouts/BlogPost.astro      |  2 +-
 src/pages/ko/market/index.astro | 23 ++++++++++++++++++++---
 src/pages/market/index.astro    | 23 ++++++++++++++++++++---
 3 files changed, 41 insertions(+), 7 deletions(-)
```

### Safety Checks
- Files changed: **3** (limit: 20)
- Lines changed: **48** (limit: 1500)

---
*Auto-generated by JEPO auto-fix agent. Requires auto-test pass before merge.*