### PR TITLE
fix: lighthouse self-hosted (36일 실패) + weekly blog + 이슈 0건

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -18,15 +18,15 @@ concurrency:
 
 jobs:
   run-lighthouse:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ops]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18'
+      - name: Verify Chrome available
+        run: |
+          node --version
+          which google-chrome || which chromium || npx playwright install chromium
 
       - name: Install Lighthouse
         run: npm install -g lighthouse@10 || npm install -g lighthouse
@@ -52,7 +52,7 @@ jobs:
           path: reports/
 
       - name: Summarize and comment on PR (if available)
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs')

--- a/.github/workflows/weekly-blog.yml
+++ b/.github/workflows/weekly-blog.yml
@@ -1,0 +1,29 @@
+name: Weekly Blog Auto-Generation
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  generate:
+    name: Generate weekly blog post
+    runs-on: [self-hosted, ops]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        run: |
+          python3 --version
+          pip3 install httpx --quiet 2>/dev/null || true
+
+      - name: Generate blog post + create PR
+        run: python3 backend/scripts/generate_weekly_blog.py --auto-pr
+        env:
+          API_BASE_URL: https://api.pruviq.com
+        timeout-minutes: 5

--- a/backend/scripts/generate_weekly_blog.py
+++ b/backend/scripts/generate_weekly_blog.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from datetime import datetime, timedelta
@@ -27,7 +28,7 @@ import httpx
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 BLOG_EN_DIR = PROJECT_ROOT / "src" / "content" / "blog"
 BLOG_KO_DIR = PROJECT_ROOT / "src" / "content" / "blog-ko"
-API_URL = "http://localhost:8080"
+API_URL = os.environ.get("API_BASE_URL", "https://api.pruviq.com")
 TIMEOUT = 15
 
 


### PR DESCRIPTION
## Lighthouse 36일 실패 뿌리 해결

**근본 원인**: ubuntu-latest에 Chrome 미설치 → lighthouse 크래시
**2026-02-27부터 3연속 failure** — 한 달+ 방치

**수정**: runs-on: self-hosted,ops (Mac Mini에 Chrome 있음)

## 블로그 자동화

- weekly-blog.yml: 매주 월요일 06:00 UTC
- API URL: localhost → env var (GitHub Actions에서 api.pruviq.com 사용)

## 이슈 정리

- #868 smoke-fail: 닫음 (PR #869에서 해결)
- #870 BlogPost image: 닫음 (PR #872에서 해결)
- #871 market noscript: 닫음 (PR #872에서 해결)
- **오픈 이슈: 0건**

Build: 2514/0, Python syntax OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)