### PR TITLE
brand: slogan — Verify. Execute. Profit.

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -204,7 +204,7 @@ export const en = {
     "Not financial advice. Crypto trading involves substantial risk of loss. Past performance does not guarantee future results. PRUVIQ is an educational and research project.",
 
   // Footer
-  "footer.tagline": "Don't believe. Verify.",
+  "footer.tagline": "Verify. Execute. Profit.",
   "footer.strategies": "Strategies",
   "footer.learn": "Learn",
   "footer.fees": "Save on Fees",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -202,7 +202,7 @@ export const ko: Record<TranslationKey, string> = {
     "투자 조언이 아닙니다. 암호화폐 트레이딩은 상당한 손실 위험을 수반합니다. 과거 성과는 미래 결과를 보장하지 않습니다. PRUVIQ는 교육 및 연구 프로젝트입니다.",
 
   // Footer
-  "footer.tagline": "믿지 마세요. 검증하세요.",
+  "footer.tagline": "검증하고. 실행하고. 수익내고.",
   "footer.strategies": "전략",
   "footer.learn": "학습",
   "footer.fees": "수수료 절약",

--- a/src/pages/signals/index.astro
+++ b/src/pages/signals/index.astro
@@ -6,7 +6,7 @@ import ErrorBoundary from '../../components/ErrorBoundary';
 const t = useTranslations('en');
 ---
 
-<Layout title="Live Trading Signals — PRUVIQ" description="Real-time crypto trading signals from 17 verified strategies across 30+ coins. Updated every hour. Don't Believe. Verify.">
+<Layout title="Live Trading Signals — PRUVIQ" description="Real-time crypto trading signals from 17 verified strategies across 30+ coins. Updated every hour. Verify. Execute. Profit.">
   <section class="reveal py-16 md:py-24">
     <div class="max-w-4xl mx-auto px-4">
 


### PR DESCRIPTION
## 슬로건 전면 업데이트

**Before**: "Don't Believe. Verify." (방어적)
**After**: "Verify. Execute. Profit." (제품 로드맵 일치)

- footer tagline EN + KO
- signals meta description

Build: 2514/0, vitest 22/22

🤖 Generated with [Claude Code](https://claude.com/claude-code)