### PR TITLE
fix: adjust home hero spacing — too tight after #882

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -31,7 +31,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
   <!-- HERO — 50/50 layout: text left, live demo right -->
   <section class="relative overflow-hidden hero-bg-depth">
     <HeroGlow />
-    <div class="relative max-w-7xl mx-auto px-6 pt-2 pb-16 md:pt-6 md:pb-20 hero-enter">
+    <div class="relative max-w-7xl mx-auto px-6 pt-6 pb-16 md:pt-10 md:pb-20 hero-enter">
       <div class="grid md:grid-cols-2 gap-12 md:gap-16 items-center">
         <!-- Left: Text + CTA -->
         <div>

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -31,7 +31,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
   <!-- HERO — 50/50 layout: text left, live demo right -->
   <section class="relative overflow-hidden hero-bg-depth">
     <HeroGlow />
-    <div class="relative max-w-7xl mx-auto px-6 pt-2 pb-16 md:pt-6 md:pb-20 hero-enter">
+    <div class="relative max-w-7xl mx-auto px-6 pt-6 pb-16 md:pt-10 md:pb-20 hero-enter">
       <div class="grid md:grid-cols-2 gap-12 md:gap-16 items-center">
         <!-- Left: Text + CTA -->
         <div>


### PR DESCRIPTION
## Summary
- 홈 페이지 breadcrumbs 없어서 nav에 콘텐츠가 너무 붙는 문제 수정
- hero padding: pt-2 md:pt-6 → pt-6 md:pt-10 (EN+KO)
- 다른 breadcrumb 페이지와 시각적 간격 통일

## Test plan
- [x] `npm run build` — 2514 pages, 0 errors
- [x] 스크린샷 비교: home vs simulate vs fees — 간격 일관

🤖 Generated with [Claude Code](https://claude.com/claude-code)