### PR TITLE
fix: spacing consistency — missed pages + home hero

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -31,7 +31,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
   <!-- HERO — 50/50 layout: text left, live demo right -->
   <section class="relative overflow-hidden hero-bg-depth">
     <HeroGlow />
-    <div class="relative max-w-7xl mx-auto px-6 pt-6 pb-16 md:pt-10 md:pb-20 hero-enter">
+    <div class="relative max-w-7xl mx-auto px-6 pt-10 pb-16 md:pt-14 md:pb-20 hero-enter">
       <div class="grid md:grid-cols-2 gap-12 md:gap-16 items-center">
         <!-- Left: Text + CTA -->
         <div>

--- a/src/pages/ko/coins/index.astro
+++ b/src/pages/ko/coins/index.astro
@@ -36,7 +36,7 @@ const TOP_COINS = [
 ---
 
 <Layout title={t('meta.coins_title')} description={t('meta.coins_desc')}>
-  <section class="py-16 md:py-24 reveal">
+  <section class="pt-2 pb-16 md:pt-4 md:pb-24 reveal">
     <div class="max-w-7xl mx-auto px-6">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('coins.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">{t('coins.title')}</h1>

--- a/src/pages/ko/fees.astro
+++ b/src/pages/ko/fees.astro
@@ -43,7 +43,7 @@ const t = useTranslations('ko');
   })} />
 
   <!-- HERO -->
-  <section class="py-16">
+  <section class="pt-2 pb-16">
     <div class="max-w-5xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('fees.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -31,7 +31,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
   <!-- HERO — 50/50 layout: text left, live demo right -->
   <section class="relative overflow-hidden hero-bg-depth">
     <HeroGlow />
-    <div class="relative max-w-7xl mx-auto px-6 pt-6 pb-16 md:pt-10 md:pb-20 hero-enter">
+    <div class="relative max-w-7xl mx-auto px-6 pt-10 pb-16 md:pt-14 md:pb-20 hero-enter">
       <div class="grid md:grid-cols-2 gap-12 md:gap-16 items-center">
         <!-- Left: Text + CTA -->
         <div>

--- a/src/pages/ko/leaderboard.astro
+++ b/src/pages/ko/leaderboard.astro
@@ -30,7 +30,7 @@ function formatDate(iso: string) {
 ---
 
 <Layout title={t('meta.leaderboard_title')} description={t('meta.leaderboard_desc')}>
-  <section class="py-12 reveal">
+  <section class="pt-2 pb-12 reveal">
     <div class="max-w-4xl mx-auto px-4">
 
       <StrategyTabs active="leaderboard" lang="ko" />

--- a/src/pages/ko/strategies/compare.astro
+++ b/src/pages/ko/strategies/compare.astro
@@ -6,7 +6,7 @@ const t = useTranslations('ko');
 ---
 
 <Layout title={t('meta.compare_title')} description={t('meta.compare_desc')}>
-  <section class="py-12">
+  <section class="pt-2 pb-12">
     <div class="max-w-5xl mx-auto px-4">
       <a href="/ko/strategies" class="text-[--color-text-muted] text-sm hover:text-[--color-accent] transition-colors mb-8 inline-block">
         &larr; {t('compare.back')}

--- a/src/pages/leaderboard.astro
+++ b/src/pages/leaderboard.astro
@@ -31,7 +31,7 @@ function formatDate(iso: string) {
 ---
 
 <Layout title={t('meta.leaderboard_title')} description={t('meta.leaderboard_desc')}>
-  <section class="py-12 reveal">
+  <section class="pt-2 pb-12 reveal">
     <div class="max-w-4xl mx-auto px-4">
 
       <StrategyTabs active="leaderboard" lang="en" />

--- a/src/pages/strategies/compare.astro
+++ b/src/pages/strategies/compare.astro
@@ -6,7 +6,7 @@ const t = useTranslations('en');
 ---
 
 <Layout title={t('meta.compare_title')} description={t('meta.compare_desc')}>
-  <section class="py-12">
+  <section class="pt-2 pb-12">
     <div class="max-w-5xl mx-auto px-4">
       <a href="/strategies" class="text-[--color-text-muted] text-sm hover:text-[--color-accent] transition-colors mb-8 inline-block">
         &larr; {t('compare.back')}


### PR DESCRIPTION
## Summary
- 홈 히어로 간격 증가 (pt-6→pt-10, md:pt-10→md:pt-14) — 너무 붙어있던 문제
- 누락 페이지 5개 수정: leaderboard, ko/fees, ko/coins, strategies/compare (EN+KO)
- 전 페이지 nav→콘텐츠 간격 통일 완료

## Test plan
- [x] `npm run build` — 2514 pages, 0 errors
- [x] 뷰포트 스크린샷 13개 페이지 비교 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)