### PR TITLE
fix: last 2 missed spacing pages — ko/api + ko/signals

### DIFF
--- a/src/pages/ko/api.astro
+++ b/src/pages/ko/api.astro
@@ -10,7 +10,7 @@ const API_BASE = 'https://api.pruviq.com';
 <Layout title={t('meta.api_title')} description={t('meta.api_desc')}>
 
   <!-- HERO -->
-  <section class="pt-16 pb-8">
+  <section class="pt-2 pb-8">
     <div class="max-w-5xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('api.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">

--- a/src/pages/ko/signals/index.astro
+++ b/src/pages/ko/signals/index.astro
@@ -7,7 +7,7 @@ const t = useTranslations('ko');
 ---
 
 <Layout title="실시간 매매 시그널 — PRUVIQ" description="17개 검증된 전략이 30개 코인을 매시간 스캔합니다. 실시간 시그널 확인 후 시뮬레이터에서 직접 검증하세요." lang="ko">
-  <section class="reveal py-16 md:py-24">
+  <section class="reveal pt-2 pb-16 md:pt-4 md:pb-24">
     <div class="max-w-4xl mx-auto px-4">
 
 


### PR DESCRIPTION
## Summary
- ko/api.astro: pt-16 → pt-2 (에이전트 배치 수정에서 누락)
- ko/signals/index.astro: py-16 md:py-24 → pt-2 pb-16 md:pt-4 md:pb-24
- 77/77 전 페이지 간격 통일 완료

## Test plan
- [x] `npm run build` — 2514 pages, 0 errors
- [x] 에이전트 전수 검사 완료 (77개 파일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)