### PR TITLE
fix: remove open-source refs and GitHub links

### DIFF
--- a/backend/scripts/deploy_macmini.sh
+++ b/backend/scripts/deploy_macmini.sh
@@ -22,7 +22,7 @@ if [ -d "$REPO_DIR" ]; then
     cd "$REPO_DIR" && git pull
 else
     echo "Cloning repo..."
-    git clone https://github.com/pruviq/pruviq.git "$REPO_DIR"
+    git clone git@github.com:pruviq/pruviq.git "$REPO_DIR"
     cd "$REPO_DIR"
 fi
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -43,7 +43,7 @@ export const en = {
   "hero.subcopy":
     "We tested 88 strategy combinations. 4 failed — and we published every one.",
   "hero.cta_secondary": "See Simulation Results",
-  "hero.open_source": "Open Source",
+  "hero.open_source": "Transparent",
   "hero.stat1_sub": "Including BTC, ETH, and altcoins",
   "hero.stat4_sub": "Across all verified strategies",
   "hero.stat5_sub": "1-hour candles since Jan 2024",
@@ -160,7 +160,7 @@ export const en = {
   "system.step3": "VERIFY",
   "system.step3_desc":
     "See the full picture: win rate, max drawdown, losing streaks, and profit factor. Then decide.",
-  "system.engine_tag": "SOURCE AVAILABLE ENGINE",
+  "system.engine_tag": "TRANSPARENT ENGINE",
 
   // Features section
   "features.tag": "TOOLS",
@@ -1312,7 +1312,7 @@ export const en = {
 
   // Social proof / trust section
   "trust.badge_api": "CoinGecko Data",
-  "trust.badge_source": "Source Available",
+  "trust.badge_source": "Transparent Methodology",
   "trust.badge_privacy": "No Personal Data",
   "trust.badge_validated": "Monte Carlo Validated",
   "trust.verified_label": "Verified strategies",
@@ -1328,9 +1328,9 @@ export const en = {
   "trust.badge_live": "Full Transparency Journal",
   "trust.badge_live_desc":
     "Every trade, every failure, every result — all published",
-  "trust.badge_open": "Source Available & Auditable",
+  "trust.badge_open": "Fully Auditable",
   "trust.badge_open_desc":
-    "All strategy code public on GitHub. Verify it yourself.",
+    "Every strategy, every parameter, every result — documented and verifiable.",
   "trust.stat_trades": "Trades Backtested",
   "trust.stat_datapoints": "Data Points Processed",
   "trust.stat_live_days": "Coins Backtested",
@@ -1607,7 +1607,7 @@ export const en = {
   // Homepage trust badges (below features)
   "trust_badges.no_signup": "No signup required",
   "trust_badges.free": "Free forever",
-  "trust_badges.opensource": "Source available on GitHub",
+  "trust_badges.opensource": "Transparent methodology",
   "trust_badges.data_sources": "Data from Binance + CoinGecko",
 
   // Coins page

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -44,7 +44,7 @@ export const ko: Record<TranslationKey, string> = {
   "hero.subcopy":
     "88가지 전략 조합을 검증했습니다. 4개가 실패했고 — 전부 공개했습니다.",
   "hero.cta_secondary": "시뮬레이션 결과 보기",
-  "hero.open_source": "오픈 소스",
+  "hero.open_source": "투명한 검증",
   "hero.stat1_sub": "BTC, ETH 포함 알트코인",
   "hero.stat4_sub": "검증된 전략 전체",
   "hero.stat5_sub": "2024년 1월부터 1시간봉",
@@ -143,13 +143,13 @@ export const ko: Record<TranslationKey, string> = {
   "evidence.sim_slippage": "슬리피지",
   "evidence.sim_slippage_val": "반영",
   "evidence.sim_note":
-    "소스 공개 엔진이 현실적인 비용으로 전략을 시뮬레이션합니다. 선행 편향 없음. 신뢰하고 재현할 수 있는 결과.",
+    "투명한 엔진이 현실적인 비용으로 전략을 시뮬레이션합니다. 선행 편향 없음. 신뢰하고 재현할 수 있는 결과.",
 
   // System
   "system.tag": "시스템",
   "system.title": "코드로, 직감이 아닌.",
   "system.desc":
-    "추측 없이. 체리피킹 없이. 현실적인 시장 조건으로 전략을 시뮬레이션하는 소스 공개 Python 엔진.",
+    "추측 없이. 체리피킹 없이. 현실적인 시장 조건으로 전략을 시뮬레이션하는 Python 엔진.",
   "system.step1": "선택",
   "system.step1_desc":
     "전략 라이브러리에서 선택하세요. BB Squeeze, 모멘텀, 평균회귀 — 또는 나만의 전략으로.",
@@ -159,7 +159,7 @@ export const ko: Record<TranslationKey, string> = {
   "system.step3": "검증",
   "system.step3_desc":
     "전체 그림 확인: 승률, 최대 드로다운, 연속 손실, 수익 팩터. 그리고 판단하세요.",
-  "system.engine_tag": "소스 공개 엔진",
+  "system.engine_tag": "투명한 엔진",
 
   // Features section
   "features.tag": "도구",
@@ -652,7 +652,7 @@ export const ko: Record<TranslationKey, string> = {
     "전략 검증은 누구나 접근할 수 있어야 합니다. 핵심 기능은 항상 무료. 거래소 제휴를 통해서만 수익을 창출합니다.",
   "about.stack_tag": "기술 스택",
   "about.stack_desc":
-    "소스 공개 Python 백테스팅 엔진, Astro 정적 사이트, Cloudflare 엣지 배포, Binance Futures API. 독점 블랙박스 없음.",
+    "Python 백테스팅 엔진, Astro 정적 사이트, Cloudflare 엣지 배포, Binance Futures API. 독점 블랙박스 없음.",
   "about.contact_tag": "연락하기",
   "about.contact_desc": "질문, 피드백, 파트너십 문의:",
   "about.contact_email": "contact@pruviq.com",
@@ -1285,7 +1285,7 @@ export const ko: Record<TranslationKey, string> = {
 
   // Social proof / trust section
   "trust.badge_api": "CoinGecko 데이터",
-  "trust.badge_source": "소스 공개",
+  "trust.badge_source": "투명한 방법론",
   "trust.badge_privacy": "개인정보 불필요",
   "trust.badge_validated": "몬테카를로 검증",
   "trust.verified_label": "검증된 전략",
@@ -1299,8 +1299,9 @@ export const ko: Record<TranslationKey, string> = {
   "trust.badge_oos_desc": "2024, 2025, 2026년 데이터에서 독립 검증",
   "trust.badge_live": "완전 투명 저널",
   "trust.badge_live_desc": "모든 거래, 모든 실패, 모든 결과 — 전부 공개",
-  "trust.badge_open": "소스 공개 감사 가능",
-  "trust.badge_open_desc": "모든 전략 코드를 GitHub에 공개. 직접 확인하세요.",
+  "trust.badge_open": "완전 감사 가능",
+  "trust.badge_open_desc":
+    "모든 전략, 모든 파라미터, 모든 결과 — 문서화되고 검증 가능합니다.",
   "trust.stat_trades": "백테스트 거래 수",
   "trust.stat_datapoints": "처리된 데이터 포인트",
   "trust.stat_live_days": "백테스트 코인 수",
@@ -1571,7 +1572,7 @@ export const ko: Record<TranslationKey, string> = {
   // Homepage trust badges (below features)
   "trust_badges.no_signup": "가입 불필요",
   "trust_badges.free": "영구 무료",
-  "trust_badges.opensource": "GitHub에서 소스 공개",
+  "trust_badges.opensource": "투명한 방법론",
   "trust_badges.data_sources": "Binance + CoinGecko 데이터",
 
   // Coins page

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -206,7 +206,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
           ? '무료 크립토 전략 백테스팅 플랫폼. 570개 이상 코인에서 2년 이상의 실제 시장 데이터로 트레이딩 전략을 만들고 테스트하세요.'
           : 'Free crypto strategy backtesting platform. Build and test trading strategies on 570+ coins with 2+ years of real market data.',
         "founder": { "@type": "Person", "name": "PRUVIQ Team" },
-        "sameAs": ["https://x.com/pruviq", "https://github.com/pruviq/pruviq"],
+        "sameAs": ["https://x.com/pruviq"],
         "knowsAbout": lang === 'ko'
           ? ['암호화폐 트레이딩', '백테스팅', '알고리즘 트레이딩', '퀀트 금융']
           : ['cryptocurrency trading', 'backtesting', 'algorithmic trading', 'quantitative finance']
@@ -520,7 +520,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
                 <a href={apiPath} class="text-[--color-text-muted] hover:text-[--color-text] transition-colors">{t('footer.api')}</a>
                 <a href="https://x.com/pruviq" target="_blank" rel="noopener noreferrer" class="text-[--color-text-muted] hover:text-[--color-text] transition-colors">X / Twitter</a>
                 <a href="https://t.me/PRUVIQ" target="_blank" rel="noopener noreferrer" class="text-[--color-text-muted] hover:text-[--color-text] transition-colors">Telegram</a>
-                <a href="https://github.com/pruviq/pruviq" target="_blank" rel="noopener noreferrer" class="text-[--color-text-muted] hover:text-[--color-text] transition-colors">GitHub</a>
+                <a href="mailto:contact@pruviq.com" class="text-[--color-text-muted] hover:text-[--color-text] transition-colors">contact@pruviq.com</a>
               </div>
             </div>
             <div>
@@ -540,7 +540,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
                 <a href={privacyPath} class="text-[--color-text-muted] hover:text-[--color-text] transition-colors">{t('footer.privacy')}</a>
                 <a href={termsPath} class="text-[--color-text-muted] hover:text-[--color-text] transition-colors">{t('footer.terms')}</a>
                 <a href={`mailto:${t('about.contact_email')}`} class="text-[--color-text-muted] hover:text-[--color-text] transition-colors">{t('about.contact_email')}</a>
-                <span class="text-[--color-text-muted] text-xs">PRUVIQ Project (Seoul, Korea) · {lang === 'ko' ? '오픈소스 퀀트 리서치 플랫폼' : 'Open-source quant research platform'}</span>
+                <span class="text-[--color-text-muted] text-xs">PRUVIQ · {lang === 'ko' ? '투명한 퀀트 리서치 플랫폼' : 'Transparent quant research platform'}</span>
               </div>
             </div>
           </div>
@@ -560,8 +560,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
           <div class="flex items-center gap-4 flex-wrap">
             <span class="font-mono opacity-60">{lang === 'ko' ? '독립 리서치 플랫폼' : 'Independent Research'}</span>
             <span class="font-mono opacity-40">v0.3.0</span>
-            <a href="https://github.com/pruviq" target="_blank" rel="noopener noreferrer" class="font-mono opacity-40 hover:opacity-80 transition-opacity">GitHub</a>
-            {lang === 'ko' && <span>운영: PRUVIQ Project</span>}
+            {lang === 'ko' && <span>운영: PRUVIQ</span>}
             <p>{t('footer.affiliate')} <a href={feesPath} class="text-[--color-accent] hover:underline">{t('footer.details')}</a></p>
             <span>&copy; {currentYear} PRUVIQ</span>
           </div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -23,7 +23,7 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
       "url": "https://pruviq.com",
       "foundingDate": "2025",
       "email": "contact@pruviq.com",
-      "sameAs": ["https://github.com/pruviq", "https://x.com/pruviq"]
+      "sameAs": ["https://x.com/pruviq"]
     }
   })} />
 
@@ -96,9 +96,9 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
                 <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75"/></svg>
                 contact@pruviq.com
               </a>
-              <a href="https://github.com/pruviq" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 font-mono text-xs px-3 py-2 rounded-lg border border-[--color-border] text-[--color-text-muted] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
-                <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
-                GitHub
+              <a href="https://t.me/PRUVIQ" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 font-mono text-xs px-3 py-2 rounded-lg border border-[--color-border] text-[--color-text-muted] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
+                <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24"><path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/></svg>
+                Telegram
               </a>
               <a href="https://x.com/pruviq" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 font-mono text-xs px-3 py-2 rounded-lg border border-[--color-border] text-[--color-text-muted] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
                 <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
@@ -267,13 +267,12 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
         <p class="font-mono text-[--color-accent] text-xs tracking-wider mb-3">{t('about.proof_tag')}</p>
         <p class="text-[--color-text-muted] text-sm leading-relaxed mb-6">{t('about.proof_desc')}</p>
         <div class="flex flex-wrap gap-3">
-          <a href="https://github.com/pruviq" target="_blank" rel="noopener noreferrer"
-             class="inline-flex items-center gap-2 font-mono text-xs px-4 py-2.5 rounded-lg border border-[--color-border] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
-            <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+          <span class="inline-flex items-center gap-2 font-mono text-xs px-4 py-2.5 rounded-lg border border-[--color-border] text-[--color-text-muted]">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"/>
             </svg>
             {t('about.proof_github')}
-          </a>
+          </span>
           <span class="inline-flex items-center gap-2 font-mono text-xs px-4 py-2.5 rounded-lg border border-[--color-border] text-[--color-text-muted]">
             <span class="w-2 h-2 rounded-full bg-[--color-up] animate-pulse inline-block"></span>
             {t('about.proof_commits')}

--- a/src/pages/ko/about.astro
+++ b/src/pages/ko/about.astro
@@ -22,7 +22,7 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
       "url": "https://pruviq.com",
       "foundingDate": "2025",
       "email": "contact@pruviq.com",
-      "sameAs": ["https://github.com/pruviq", "https://x.com/pruviq"]
+      "sameAs": ["https://x.com/pruviq"]
     }
   })} />
 
@@ -94,8 +94,9 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
               <a href="mailto:contact@pruviq.com" class="inline-flex items-center gap-1.5 font-mono text-xs px-3 py-2 rounded-lg border border-[--color-border] text-[--color-accent] hover:border-[--color-accent] transition-colors">
                 contact@pruviq.com
               </a>
-              <a href="https://github.com/pruviq" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 font-mono text-xs px-3 py-2 rounded-lg border border-[--color-border] text-[--color-text-muted] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
-                GitHub
+              <a href="https://t.me/PRUVIQ" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 font-mono text-xs px-3 py-2 rounded-lg border border-[--color-border] text-[--color-text-muted] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
+                <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24"><path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/></svg>
+                Telegram
               </a>
             </div>
           </div>
@@ -236,13 +237,12 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
         <p class="font-mono text-[--color-accent] text-xs tracking-wider mb-3">{t('about.proof_tag')}</p>
         <p class="text-[--color-text-muted] text-sm leading-relaxed mb-6">{t('about.proof_desc')}</p>
         <div class="flex flex-wrap gap-3">
-          <a href="https://github.com/pruviq" target="_blank" rel="noopener noreferrer"
-             class="inline-flex items-center gap-2 font-mono text-xs px-4 py-2.5 rounded-lg border border-[--color-border] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">
-            <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/>
+          <span class="inline-flex items-center gap-2 font-mono text-xs px-4 py-2.5 rounded-lg border border-[--color-border] text-[--color-text-muted]">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"/>
             </svg>
             {t('about.proof_github')}
-          </a>
+          </span>
           <span class="inline-flex items-center gap-2 font-mono text-xs px-4 py-2.5 rounded-lg border border-[--color-border] text-[--color-text-muted]">
             <span class="w-2 h-2 rounded-full bg-[--color-up] animate-pulse inline-block"></span>
             {t('about.proof_commits')}


### PR DESCRIPTION
## Summary
- All "Open Source" / "Source Available" / "소스 공개" → "Transparent" / "투명한 방법론"
- All github.com/pruviq links removed from src/ (About, Footer, JSON-LD)
- deploy_macmini.sh: HTTPS clone → SSH clone (private repo ready)
- Build: 2518 pages, 0 errors

## Test plan
- [x] `npm run build` — 0 errors
- [x] grep for `github.com/pruviq|Open Source|소스 공개` in src/ — 0 matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)