### PR TITLE
fix: CTA button color contrast WCAG AA

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -52,7 +52,7 @@
   --color-text-disabled: #52525B;   /* Zinc-600 — inactive, placeholder */
 
   /* ─── ACCENT ─── */
-  --color-accent:        #4F8EF7;   /* premium blue (was #3182f6) */
+  --color-accent:        #2563EB;   /* blue-600, WCAG AA 5.17:1 vs white */
   --color-accent-dim:    #2563EB;   /* hover state */
   --color-accent-bright: #93C5FD;   /* highlight, selected */
   --color-accent-subtle: rgba(79,142,247,0.10);


### PR DESCRIPTION
## Summary
- `--color-accent`: `#4F8EF7` (3.21:1) → `#2563EB` (5.17:1 vs white)
- WCAG AA 4.5:1 기준 충족
- Build: 2518 pages, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)