### PR TITLE
feat: UX improvements — Chrome live audit (8 items)

### DIFF
--- a/src/components/CoinListTable.tsx
+++ b/src/components/CoinListTable.tsx
@@ -571,13 +571,19 @@ export default function CoinListTable({ lang = "en" }: { lang?: "en" | "ko" }) {
               >
                 {t.chart}
               </th>
+              <th
+                scope="col"
+                class="px-2 py-2 text-center font-mono text-[0.6875rem] tracking-wider uppercase border-b border-[--color-border] text-[--color-text-muted] hidden lg:table-cell cursor-default select-none"
+              >
+                TEST
+              </th>
             </tr>
           </thead>
           <tbody>
             {pageItems.length === 0 && (
               <tr>
                 <td
-                  colSpan={9}
+                  colSpan={10}
                   class="py-8 text-center text-[--color-text-muted]"
                 >
                   {t.noResults}
@@ -668,6 +674,15 @@ export default function CoinListTable({ lang = "en" }: { lang?: "en" | "ko" }) {
                     ) : (
                       <span class="text-[--color-text-muted]">-</span>
                     )}
+                  </td>
+                  <td class="px-2 py-2.5 hidden lg:table-cell text-center">
+                    <a
+                      href={`${lang === "ko" ? "/ko" : ""}/simulate?coin=${coin.symbol}`}
+                      onClick={(e: MouseEvent) => e.stopPropagation()}
+                      class="text-xs font-mono text-[--color-accent] hover:underline"
+                    >
+                      Test &rarr;
+                    </a>
                   </td>
                 </tr>
               );

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1640,7 +1640,8 @@ export const en = {
   "ranking.card_trades": "Trades",
   "ranking.card_days": "Days in Top",
   "ranking.card_days_unit": "days",
-  "ranking.card_low_sample": "Low sample ({n} trades < 100)",
+  "ranking.card_low_sample":
+    "Limited data ({n} trades). Use as reference, not trading signal.",
   "ranking.card_load_fail": "Failed to load data",
   "ranking.section_best3_title": "Best 3 Strategies",
   "ranking.section_best3_sub": "Top 3 by Profit Factor (PF)",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -1606,7 +1606,8 @@ export const ko: Record<TranslationKey, string> = {
   "ranking.card_trades": "거래 수",
   "ranking.card_days": "집계 일수",
   "ranking.card_days_unit": "일",
-  "ranking.card_low_sample": "샘플 부족 ({n}건 < 100건)",
+  "ranking.card_low_sample":
+    "제한된 데이터 ({n}거래). 참고용으로만 활용하세요.",
   "ranking.card_load_fail": "데이터 로드 실패",
   "ranking.section_best3_title": "상위 3개 전략",
   "ranking.section_best3_sub": "PF(수익팩터) 기준 상위 3개",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -78,6 +78,7 @@ const navItems = [
   { href: coinsPath, match: '/coins', label: t('nav.coins') },
   { href: learnPath, match: '/learn', label: t('nav.learn') },
   { href: feesPath, match: '/fees', label: t('nav.fees') },
+  { href: aboutPath, match: '/about', label: t('footer.about') },
 ];
 const isActive = (match: string) => basePath.startsWith(match);
 

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -35,6 +35,8 @@ const categoryBorderColors: Record<string, string> = {
   autopsy: '#f87171',
 };
 
+const categoryIcons: Record<string, string> = { market: '\u{1F4CA}', quant: '\u{1F4C8}', education: '\u{1F4DA}', weekly: '\u{1F4C5}', strategy: '\u26A1', autopsy: '\u{1F480}' };
+
 const now = new Date();
 function isNew(dateStr: string): boolean {
   const diff = now.getTime() - new Date(dateStr).getTime();
@@ -108,7 +110,7 @@ function getReadingTime(body: string | undefined): string {
                  style={`border-left: 3px solid ${categoryBorderColors[post.data.category] || 'var(--color-text-muted)'};`}>
                 <div class="flex items-center gap-2 mb-3">
                   <span class={`text-xs font-mono font-semibold px-2 py-0.5 rounded ${categoryBadgeClass[post.data.category] || 'badge-education'}`}>
-                    {categoryLabels[post.data.category] || post.data.category.toUpperCase()}
+                    {categoryIcons[post.data.category] || '\u{1F4C4}'} {categoryLabels[post.data.category] || post.data.category.toUpperCase()}
                   </span>
                   {isNew(post.data.date) && (
                     <span class="text-[10px] font-mono font-bold px-1.5 py-0.5 rounded badge-new">NEW</span>

--- a/src/pages/fees.astro
+++ b/src/pages/fees.astro
@@ -52,9 +52,6 @@ const t = useTranslations('en');
       <p class="text-[--color-text-muted] text-lg mb-4 max-w-2xl">
         {t('fees.desc')}
       </p>
-      <p class="text-[--color-text-muted] text-xs mb-4">
-        {t('fees.disclosure')}
-      </p>
       <!-- Savings example callout -->
       <div class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-[--color-up]/30 bg-[--color-up]/5 text-[--color-up] font-mono text-sm">
         <span class="font-bold">&#9650;</span>
@@ -80,6 +77,9 @@ const t = useTranslations('en');
     <div class="max-w-5xl mx-auto px-4">
       <FeeCalculator client:visible lang="en" />
       <noscript><p class="text-[--color-text-muted] text-sm py-4">Enable JavaScript to use the fee calculator.</p></noscript>
+      <p class="text-[--color-text-muted] text-xs mt-6">
+        {t('fees.disclosure')}
+      </p>
     </div>
   </section>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -110,7 +110,8 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
   </div>
 
   <!-- HOW IT WORKS -->
-  <section class="max-w-7xl mx-auto px-6 py-16 md:py-24">
+  <hr class="section-divider" />
+  <section class="max-w-7xl mx-auto px-6 py-16 md:py-24 bg-[--color-bg-subtle]">
     <h2 class="text-2xl md:text-3xl font-bold text-center mb-4">How It Works</h2>
     <p class="text-[--color-text-secondary] text-center text-lg mb-16 max-w-xl mx-auto">From strategy idea to verified results in 3 steps.</p>
     <div class="grid md:grid-cols-3 gap-8">
@@ -309,7 +310,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- FAQ (visible section matching JSON-LD) -->
   <hr class="section-divider" />
-  <section class="py-16 md:py-24 reveal" aria-labelledby="faq-heading">
+  <section class="py-16 md:py-24 bg-[--color-bg-subtle] reveal" aria-labelledby="faq-heading">
     <div class="max-w-7xl mx-auto px-6">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">FAQ</p>
       <h2 id="faq-heading" class="text-2xl md:text-3xl font-bold mb-12">{t('faq.title')}</h2>

--- a/src/pages/ko/blog/index.astro
+++ b/src/pages/ko/blog/index.astro
@@ -43,6 +43,8 @@ const categoryBorderColors: Record<string, string> = {
   autopsy: '#f87171',
 };
 
+const categoryIcons: Record<string, string> = { market: '\u{1F4CA}', quant: '\u{1F4C8}', education: '\u{1F4DA}', weekly: '\u{1F4C5}', strategy: '\u26A1', autopsy: '\u{1F480}' };
+
 const now = new Date();
 function isNew(dateStr: string): boolean {
   const diff = now.getTime() - new Date(dateStr).getTime();
@@ -116,7 +118,7 @@ function getReadingTime(body: string | undefined): string {
                  style={`box-shadow: var(--shadow-card); border-left: 3px solid ${categoryBorderColors[post.data.category] || '#6b7280'};`}>
                 <div class="flex items-center gap-2 mb-3">
                   <span class={`text-xs font-mono font-semibold px-2 py-0.5 rounded ${categoryBadgeClass[post.data.category] || 'badge-education'}`}>
-                    {categoryLabels[post.data.category] || post.data.category.toUpperCase()}
+                    {categoryIcons[post.data.category] || '\u{1F4C4}'} {categoryLabels[post.data.category] || post.data.category.toUpperCase()}
                   </span>
                   {!post.isKorean && (
                     <span class="font-mono text-xs px-1.5 py-0.5 rounded bg-[--color-border] text-[--color-text-muted]">{t('blog.en_badge')}</span>

--- a/src/pages/ko/fees.astro
+++ b/src/pages/ko/fees.astro
@@ -52,9 +52,6 @@ const t = useTranslations('ko');
       <p class="text-[--color-text-muted] text-lg mb-4 max-w-2xl">
         {t('fees.desc')}
       </p>
-      <p class="text-[--color-text-muted] text-xs mb-4">
-        {t('fees.disclosure')}
-      </p>
       <!-- Savings example callout -->
       <div class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-[--color-up]/30 bg-[--color-up]/5 text-[--color-up] font-mono text-sm">
         <span class="font-bold">&#9650;</span>
@@ -70,6 +67,9 @@ const t = useTranslations('ko');
     <div class="max-w-5xl mx-auto px-4">
       <FeeCalculator client:visible lang="ko" />
       <noscript><p class="text-[--color-text-muted] text-sm py-4">JavaScript를 활성화하면 수수료 계산기를 사용할 수 있습니다.</p></noscript>
+      <p class="text-[--color-text-muted] text-xs mt-6">
+        {t('fees.disclosure')}
+      </p>
     </div>
   </section>
 

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -110,7 +110,8 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
   </div>
 
   <!-- HOW IT WORKS -->
-  <section class="max-w-7xl mx-auto px-6 py-16 md:py-24">
+  <hr class="section-divider" />
+  <section class="max-w-7xl mx-auto px-6 py-16 md:py-24 bg-[--color-bg-subtle]">
     <h2 class="text-2xl md:text-3xl font-bold text-center mb-4">작동 방식</h2>
     <p class="text-[--color-text-secondary] text-center text-lg mb-16 max-w-xl mx-auto">전략 아이디어에서 검증된 결과까지 3단계.</p>
     <div class="grid md:grid-cols-3 gap-8">
@@ -309,7 +310,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- FAQ (visible section matching JSON-LD) -->
   <hr class="section-divider" />
-  <section class="py-16 md:py-24 reveal" aria-labelledby="faq-heading-ko">
+  <section class="py-16 md:py-24 bg-[--color-bg-subtle] reveal" aria-labelledby="faq-heading-ko">
     <div class="max-w-7xl mx-auto px-6">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">FAQ</p>
       <h2 id="faq-heading-ko" class="text-2xl md:text-3xl font-bold mb-12">{t('faq.title')}</h2>

--- a/src/pages/ko/learn/index.astro
+++ b/src/pages/ko/learn/index.astro
@@ -107,7 +107,7 @@ const levelConfig = [
   })} />
 
   <!-- HERO -->
-  <section class="pt-2 pb-16 md:pt-4 md:pb-24">
+  <section class="pt-2 pb-8 md:pt-4 md:pb-12">
     <div class="max-w-5xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('learn.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">

--- a/src/pages/ko/simulate/index.astro
+++ b/src/pages/ko/simulate/index.astro
@@ -17,7 +17,8 @@ const quickStartPresets = (rankingsData.top3 || []).slice(0, 3);
 
 <Layout title={t('meta.simulate_title')} description={t('meta.simulate_desc')}>
   <!-- Onboarding header -->
-  <section id="simulator-onboarding" class="pt-2 pb-6 md:pt-4 md:pb-8">
+  <!-- Compact Hero -->
+  <section id="simulator-onboarding" class="pt-2 pb-4 md:pt-4 md:pb-6">
     <div class="max-w-[1400px] mx-auto px-4">
       <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-4 mb-4">
         <div>
@@ -41,15 +42,63 @@ const quickStartPresets = (rankingsData.top3 || []).slice(0, 3);
       </div>
 
       <!-- Social proof counters -->
-      <div class="flex flex-wrap gap-x-4 gap-y-1 mb-4 font-mono text-sm">
+      <div class="flex flex-wrap gap-x-4 gap-y-1 font-mono text-sm">
         <span class="text-[--color-text-muted]"><span class="text-[--color-accent] font-bold">{simulationsRun}</span> 회 시뮬레이션 실행</span>
         <span class="text-[--color-text-muted] hidden sm:inline">·</span>
         <span class="text-[--color-text-muted]"><span class="text-[--color-accent] font-bold">{coinsAnalyzed}</span> 코인 분석</span>
         <span class="text-[--color-text-muted] hidden sm:inline">·</span>
         <span class="text-[--color-text-muted]"><span class="text-[--color-accent] font-bold">{presetCount}</span> 개 전략 이용 가능</span>
       </div>
+    </div>
+  </section>
 
-      <!-- 3단계 온보딩 가이드 + 진행 표시 -->
+  <!-- Simulator Mount (above fold) -->
+  <section class="reveal pb-4 md:pb-6">
+    <div id="simulator-mount">
+      <div class="max-w-[1400px] mx-auto px-4">
+        <div class="border border-[--color-border] rounded-xl p-8 bg-[--color-bg-card]">
+          <div class="animate-pulse space-y-4">
+            <div class="h-6 bg-[--color-bg-hover] rounded w-1/3"></div>
+            <div class="flex gap-4">
+              <div class="w-[70%] h-[400px] bg-[--color-bg-hover] rounded"></div>
+              <div class="w-[30%] space-y-3">
+                <div class="h-8 bg-[--color-bg-hover] rounded"></div>
+                <div class="h-8 bg-[--color-bg-hover] rounded"></div>
+                <div class="h-8 bg-[--color-bg-hover] rounded"></div>
+                <div class="h-8 bg-[--color-bg-hover] rounded"></div>
+              </div>
+            </div>
+          </div>
+          <div class="flex flex-col items-center gap-3 mt-6">
+            <div class="spinner mx-auto"></div>
+            <p class="text-[--color-text-muted] text-sm text-center">{t('simulate.loading')}</p>
+            <p class="text-[--color-text-muted] text-xs text-center opacity-60">프리셋을 선택하거나 직접 전략을 구성할 수 있습니다</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Risk Disclaimer -->
+  <hr class="section-divider" />
+  <div class="max-w-[1400px] mx-auto px-4 mb-4">
+    <p class="text-xs text-[--color-text-muted] leading-relaxed">
+      {t('simulate.risk_disclaimer')}
+    </p>
+    <div class="flex flex-wrap gap-2 mt-2">
+      <a href="/ko/fees" class="btn btn-ghost btn-sm no-underline">
+        {t('simulate.fees_cta')} &rarr;
+      </a>
+      <a href="/ko/methodology" class="btn btn-ghost btn-sm no-underline text-[--color-text-muted]">
+        계산 방법론 &rarr;
+      </a>
+    </div>
+  </div>
+
+  <!-- 3단계 온보딩 가이드 -->
+  <hr class="section-divider" />
+  <section class="pb-4 md:pb-6">
+    <div class="max-w-[1400px] mx-auto px-4">
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-4 reveal-child">
         <div class="relative flex items-start gap-3 border border-[--color-accent]/30 rounded-lg px-4 py-4 bg-[--color-accent]/5 card-hover">
           <div class="step-badge shrink-0 mt-0.5">1</div>
@@ -107,49 +156,6 @@ const quickStartPresets = (rankingsData.top3 || []).slice(0, 3);
       )}
 
       <p class="text-xs text-[--color-text-muted] opacity-70">{t('simulate.note')}</p>
-    </div>
-  </section>
-
-  <!-- Risk Disclaimer -->
-  <hr class="section-divider" />
-  <div class="max-w-[1400px] mx-auto px-4 mb-4">
-    <p class="text-xs text-[--color-text-muted] leading-relaxed">
-      {t('simulate.risk_disclaimer')}
-    </p>
-    <div class="flex flex-wrap gap-2 mt-2">
-      <a href="/ko/fees" class="btn btn-ghost btn-sm no-underline">
-        {t('simulate.fees_cta')} &rarr;
-      </a>
-      <a href="/ko/methodology" class="btn btn-ghost btn-sm no-underline text-[--color-text-muted]">
-        계산 방법론 &rarr;
-      </a>
-    </div>
-  </div>
-
-  <hr class="section-divider" />
-  <section class="reveal pb-4 md:pb-6">
-    <div id="simulator-mount">
-      <div class="max-w-[1400px] mx-auto px-4">
-        <div class="border border-[--color-border] rounded-xl p-8 bg-[--color-bg-card]">
-          <div class="animate-pulse space-y-4">
-            <div class="h-6 bg-[--color-bg-hover] rounded w-1/3"></div>
-            <div class="flex gap-4">
-              <div class="w-[70%] h-[400px] bg-[--color-bg-hover] rounded"></div>
-              <div class="w-[30%] space-y-3">
-                <div class="h-8 bg-[--color-bg-hover] rounded"></div>
-                <div class="h-8 bg-[--color-bg-hover] rounded"></div>
-                <div class="h-8 bg-[--color-bg-hover] rounded"></div>
-                <div class="h-8 bg-[--color-bg-hover] rounded"></div>
-              </div>
-            </div>
-          </div>
-          <div class="flex flex-col items-center gap-3 mt-6">
-            <div class="spinner mx-auto"></div>
-            <p class="text-[--color-text-muted] text-sm text-center">{t('simulate.loading')}</p>
-            <p class="text-[--color-text-muted] text-xs text-center opacity-60">프리셋을 선택하거나 직접 전략을 구성할 수 있습니다</p>
-          </div>
-        </div>
-      </div>
     </div>
   </section>
 

--- a/src/pages/learn/index.astro
+++ b/src/pages/learn/index.astro
@@ -100,7 +100,7 @@ const levelConfig = [
   })} />
 
   <!-- HERO -->
-  <section class="pt-2 pb-16 md:pt-4 md:pb-24">
+  <section class="pt-2 pb-8 md:pt-4 md:pb-12">
     <div class="max-w-5xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('learn.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">

--- a/src/pages/simulate/index.astro
+++ b/src/pages/simulate/index.astro
@@ -17,7 +17,8 @@ const quickStartPresets = (rankingsData.top3 || []).slice(0, 3);
 
 <Layout title={t('meta.simulate_title')} description={t('meta.simulate_desc')}>
   <!-- Onboarding header -->
-  <section id="simulator-onboarding" class="pt-2 pb-6 md:pt-4 md:pb-8">
+  <!-- Compact Hero -->
+  <section id="simulator-onboarding" class="pt-2 pb-4 md:pt-4 md:pb-6">
     <div class="max-w-[1400px] mx-auto px-4">
       <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-4 mb-4">
         <div>
@@ -41,15 +42,63 @@ const quickStartPresets = (rankingsData.top3 || []).slice(0, 3);
       </div>
 
       <!-- Social proof counters -->
-      <div class="flex flex-wrap gap-x-4 gap-y-1 mb-4 font-mono text-sm divide-x-0">
+      <div class="flex flex-wrap gap-x-4 gap-y-1 font-mono text-sm divide-x-0">
         <span class="text-[--color-text-muted]"><span class="text-[--color-accent] font-bold">{simulationsRun}</span> simulations run</span>
         <span class="text-[--color-text-muted] hidden sm:inline">·</span>
         <span class="text-[--color-text-muted]"><span class="text-[--color-accent] font-bold">{coinsAnalyzed}</span> coins analyzed</span>
         <span class="text-[--color-text-muted] hidden sm:inline">·</span>
         <span class="text-[--color-text-muted]"><span class="text-[--color-accent] font-bold">{presetCount}</span> strategies available</span>
       </div>
+    </div>
+  </section>
 
-      <!-- 3-step onboarding guide with progress indicator -->
+  <!-- Simulator Mount (above fold) -->
+  <section class="reveal pb-4 md:pb-6">
+    <div id="simulator-mount">
+      <div class="max-w-[1400px] mx-auto px-4">
+        <div class="border border-[--color-border] rounded-xl p-8 bg-[--color-bg-card]">
+          <div class="animate-pulse space-y-4">
+            <div class="h-6 bg-[--color-bg-hover] rounded w-1/3"></div>
+            <div class="flex gap-4">
+              <div class="w-[70%] h-[400px] bg-[--color-bg-hover] rounded"></div>
+              <div class="w-[30%] space-y-3">
+                <div class="h-8 bg-[--color-bg-hover] rounded"></div>
+                <div class="h-8 bg-[--color-bg-hover] rounded"></div>
+                <div class="h-8 bg-[--color-bg-hover] rounded"></div>
+                <div class="h-8 bg-[--color-bg-hover] rounded"></div>
+              </div>
+            </div>
+          </div>
+          <div class="flex flex-col items-center gap-3 mt-6">
+            <div class="spinner mx-auto"></div>
+            <p class="text-[--color-text-muted] text-sm text-center">{t('simulate.loading')}</p>
+            <p class="text-[--color-text-muted] text-xs text-center opacity-60">Choose a preset or build your own strategy</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Risk Disclaimer -->
+  <hr class="section-divider" />
+  <div class="max-w-[1400px] mx-auto px-4 mb-4">
+    <p class="text-xs text-[--color-text-muted] leading-relaxed">
+      {t('simulate.risk_disclaimer')}
+    </p>
+    <div class="flex flex-wrap gap-2 mt-2">
+      <a href="/fees" class="btn btn-ghost btn-sm no-underline">
+        {t('simulate.fees_cta')} &rarr;
+      </a>
+      <a href="/methodology" class="btn btn-ghost btn-sm no-underline text-[--color-text-muted]">
+        How we calculate &rarr;
+      </a>
+    </div>
+  </div>
+
+  <!-- 3-step onboarding guide -->
+  <hr class="section-divider" />
+  <section class="pb-4 md:pb-6">
+    <div class="max-w-[1400px] mx-auto px-4">
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-4 reveal-child">
         <div class="relative flex items-start gap-3 border border-[--color-accent]/30 rounded-lg px-4 py-4 bg-[--color-accent]/5 card-hover">
           <div class="step-badge shrink-0 mt-0.5">1</div>
@@ -107,49 +156,6 @@ const quickStartPresets = (rankingsData.top3 || []).slice(0, 3);
       )}
 
       <p class="text-xs text-[--color-text-muted] opacity-70">{t('simulate.note')}</p>
-    </div>
-  </section>
-
-  <!-- Risk Disclaimer -->
-  <hr class="section-divider" />
-  <div class="max-w-[1400px] mx-auto px-4 mb-4">
-    <p class="text-xs text-[--color-text-muted] leading-relaxed">
-      {t('simulate.risk_disclaimer')}
-    </p>
-    <div class="flex flex-wrap gap-2 mt-2">
-      <a href="/fees" class="btn btn-ghost btn-sm no-underline">
-        {t('simulate.fees_cta')} &rarr;
-      </a>
-      <a href="/methodology" class="btn btn-ghost btn-sm no-underline text-[--color-text-muted]">
-        How we calculate &rarr;
-      </a>
-    </div>
-  </div>
-
-  <hr class="section-divider" />
-  <section class="reveal pb-4 md:pb-6">
-    <div id="simulator-mount">
-      <div class="max-w-[1400px] mx-auto px-4">
-        <div class="border border-[--color-border] rounded-xl p-8 bg-[--color-bg-card]">
-          <div class="animate-pulse space-y-4">
-            <div class="h-6 bg-[--color-bg-hover] rounded w-1/3"></div>
-            <div class="flex gap-4">
-              <div class="w-[70%] h-[400px] bg-[--color-bg-hover] rounded"></div>
-              <div class="w-[30%] space-y-3">
-                <div class="h-8 bg-[--color-bg-hover] rounded"></div>
-                <div class="h-8 bg-[--color-bg-hover] rounded"></div>
-                <div class="h-8 bg-[--color-bg-hover] rounded"></div>
-                <div class="h-8 bg-[--color-bg-hover] rounded"></div>
-              </div>
-            </div>
-          </div>
-          <div class="flex flex-col items-center gap-3 mt-6">
-            <div class="spinner mx-auto"></div>
-            <p class="text-[--color-text-muted] text-sm text-center">{t('simulate.loading')}</p>
-            <p class="text-[--color-text-muted] text-xs text-center opacity-60">Choose a preset or build your own strategy</p>
-          </div>
-        </div>
-      </div>
     </div>
   </section>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -42,7 +42,7 @@
   --color-bg-elevated:   #1C1C20;   /* hover/active card state */
   --color-bg-hover:      #1C1C20;   /* alias for hover state */
   --color-bg-overlay:    #27272A;   /* dropdown, toast overlay */
-  --color-bg-subtle:     rgba(255,255,255,0.035);
+  --color-bg-subtle:     rgba(255,255,255,0.06);
   --color-bg-tooltip:    rgba(24,24,27,0.95);
 
   /* ─── TEXT (4-level hierarchy: text > secondary > muted > disabled) ─── */


### PR DESCRIPTION
## Summary
Chrome 확장으로 실제 렌더링 기준 평가 후 8건 개선:

1. **홈 섹션 분리**: bg-subtle 강화 (3.5%→6%) + HOW IT WORKS/FAQ 배경 교대 + divider 추가
2. **시뮬레이터 fold 위**: Hero 축소, 시뮬레이터를 fold 위로 이동
3. **코인 "Test →"**: 각 코인 행에 /simulate 인라인 링크
4. **fees disclosure**: H1 아래 → Calculator 아래로 이동
5. **랭킹 Low sample**: "unreliable" → "reference" 톤 변경
6. **About nav 추가**: 메인 내비게이션에 About 링크
7. **블로그 아이콘**: 카테고리별 이모지 (📊📈📚📅⚡💀)
8. **학습 히어로 축소**: 더 많은 가이드 카드 노출

## Test plan
- [x] `npm run build` — 2518 pages, 0 errors
- [ ] Playwright 스크린샷 비교

🤖 Generated with [Claude Code](https://claude.com/claude-code)