### PR TITLE
fix: overflow-x, divider visibility, bg-subtle var()

### DIFF
--- a/src/pages/best-crypto-backtesting.astro
+++ b/src/pages/best-crypto-backtesting.astro
@@ -81,7 +81,7 @@ const jsonLd = {
 
   <!-- WHAT MAKES A GOOD BACKTESTER -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12 bg-[--color-bg-subtle] reveal">
+  <section class="pb-12 pt-12 bg-[var(--color-bg-subtle)] reveal">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl md:text-3xl font-bold mb-8">What Makes a Good Backtesting Platform?</h2>
       <div class="space-y-6">
@@ -126,7 +126,7 @@ const jsonLd = {
 
   <!-- COMPARISON TABLE -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12 bg-[--color-bg-subtle] reveal">
+  <section class="pb-12 pt-12 bg-[var(--color-bg-subtle)] reveal">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl md:text-3xl font-bold mb-8">Quick Comparison: PRUVIQ vs TradingView vs 3Commas</h2>
 

--- a/src/pages/compare/3commas.astro
+++ b/src/pages/compare/3commas.astro
@@ -106,7 +106,7 @@ const rows = [
 
   <!-- WHEN -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12 bg-[--color-bg-subtle] reveal">
+  <section class="pb-12 pt-12 bg-[var(--color-bg-subtle)] reveal">
     <div class="max-w-5xl mx-auto px-4">
       <div class="grid md:grid-cols-2 gap-8">
         <div class="border border-[--color-accent]/30 rounded-lg p-6 bg-[--color-bg-card]">
@@ -119,7 +119,7 @@ const rows = [
           </ul>
         </div>
         <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card]">
-          <div class="flex items-center gap-3 mb-4"><span class="inline-flex items-center justify-center w-8 h-8 rounded bg-[--color-bg-subtle] text-[--color-text-muted] font-mono text-sm font-bold shrink-0">3C</span><h3 class="font-bold text-lg">{t('vs_3commas.when_other')}</h3></div>
+          <div class="flex items-center gap-3 mb-4"><span class="inline-flex items-center justify-center w-8 h-8 rounded bg-[var(--color-bg-subtle)] text-[--color-text-muted] font-mono text-sm font-bold shrink-0">3C</span><h3 class="font-bold text-lg">{t('vs_3commas.when_other')}</h3></div>
           <ul class="space-y-3">
             <li class="flex gap-2 text-sm text-[--color-text-muted]"><span class="shrink-0 mt-0.5">+</span><span>{t('vs_3commas.when_other_1')}</span></li>
             <li class="flex gap-2 text-sm text-[--color-text-muted]"><span class="shrink-0 mt-0.5">+</span><span>{t('vs_3commas.when_other_2')}</span></li>

--- a/src/pages/compare/coinrule.astro
+++ b/src/pages/compare/coinrule.astro
@@ -88,7 +88,7 @@ const rows = [
 
   <!-- WHEN TO CHOOSE -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12 bg-[--color-bg-subtle] reveal">
+  <section class="pb-12 pt-12 bg-[var(--color-bg-subtle)] reveal">
     <div class="max-w-5xl mx-auto px-4">
       <div class="grid md:grid-cols-2 gap-8">
         <!-- Choose PRUVIQ -->
@@ -108,7 +108,7 @@ const rows = [
         <!-- Choose Coinrule -->
         <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card]">
           <div class="flex items-center gap-3 mb-4">
-            <span class="inline-flex items-center justify-center w-8 h-8 rounded bg-[--color-bg-subtle] text-[--color-text-muted] font-mono text-sm font-bold shrink-0">CR</span>
+            <span class="inline-flex items-center justify-center w-8 h-8 rounded bg-[var(--color-bg-subtle)] text-[--color-text-muted] font-mono text-sm font-bold shrink-0">CR</span>
             <h3 class="font-bold text-lg">{t('vs_coinrule.when_other')}</h3>
           </div>
           <ul class="space-y-3">

--- a/src/pages/compare/cryptohopper.astro
+++ b/src/pages/compare/cryptohopper.astro
@@ -106,7 +106,7 @@ const rows = [
 
   <!-- WHEN -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12 bg-[--color-bg-subtle] reveal">
+  <section class="pb-12 pt-12 bg-[var(--color-bg-subtle)] reveal">
     <div class="max-w-5xl mx-auto px-4">
       <div class="grid md:grid-cols-2 gap-8">
         <div class="border border-[--color-accent]/30 rounded-lg p-6 bg-[--color-bg-card]">
@@ -119,7 +119,7 @@ const rows = [
           </ul>
         </div>
         <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card]">
-          <div class="flex items-center gap-3 mb-4"><span class="inline-flex items-center justify-center w-8 h-8 rounded bg-[--color-bg-subtle] text-[--color-text-muted] font-mono text-sm font-bold shrink-0">CH</span><h3 class="font-bold text-lg">{t('vs_cryptohopper.when_other')}</h3></div>
+          <div class="flex items-center gap-3 mb-4"><span class="inline-flex items-center justify-center w-8 h-8 rounded bg-[var(--color-bg-subtle)] text-[--color-text-muted] font-mono text-sm font-bold shrink-0">CH</span><h3 class="font-bold text-lg">{t('vs_cryptohopper.when_other')}</h3></div>
           <ul class="space-y-3">
             <li class="flex gap-2 text-sm text-[--color-text-muted]"><span class="shrink-0 mt-0.5">+</span><span>{t('vs_cryptohopper.when_other_1')}</span></li>
             <li class="flex gap-2 text-sm text-[--color-text-muted]"><span class="shrink-0 mt-0.5">+</span><span>{t('vs_cryptohopper.when_other_2')}</span></li>

--- a/src/pages/compare/gainium.astro
+++ b/src/pages/compare/gainium.astro
@@ -88,7 +88,7 @@ const rows = [
 
   <!-- WHEN TO CHOOSE -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12 bg-[--color-bg-subtle] reveal">
+  <section class="pb-12 pt-12 bg-[var(--color-bg-subtle)] reveal">
     <div class="max-w-5xl mx-auto px-4">
       <div class="grid md:grid-cols-2 gap-8">
         <!-- Choose PRUVIQ -->
@@ -108,7 +108,7 @@ const rows = [
         <!-- Choose Gainium -->
         <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card]">
           <div class="flex items-center gap-3 mb-4">
-            <span class="inline-flex items-center justify-center w-8 h-8 rounded bg-[--color-bg-subtle] text-[--color-text-muted] font-mono text-sm font-bold shrink-0">GA</span>
+            <span class="inline-flex items-center justify-center w-8 h-8 rounded bg-[var(--color-bg-subtle)] text-[--color-text-muted] font-mono text-sm font-bold shrink-0">GA</span>
             <h3 class="font-bold text-lg">{t('vs_gainium.when_other')}</h3>
           </div>
           <ul class="space-y-3">

--- a/src/pages/compare/streak.astro
+++ b/src/pages/compare/streak.astro
@@ -88,7 +88,7 @@ const rows = [
 
   <!-- WHEN TO CHOOSE -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12 bg-[--color-bg-subtle] reveal">
+  <section class="pb-12 pt-12 bg-[var(--color-bg-subtle)] reveal">
     <div class="max-w-5xl mx-auto px-4">
       <div class="grid md:grid-cols-2 gap-8">
         <!-- Choose PRUVIQ -->
@@ -108,7 +108,7 @@ const rows = [
         <!-- Choose Streak -->
         <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card]">
           <div class="flex items-center gap-3 mb-4">
-            <span class="inline-flex items-center justify-center w-8 h-8 rounded bg-[--color-bg-subtle] text-[--color-text-muted] font-mono text-sm font-bold shrink-0">SK</span>
+            <span class="inline-flex items-center justify-center w-8 h-8 rounded bg-[var(--color-bg-subtle)] text-[--color-text-muted] font-mono text-sm font-bold shrink-0">SK</span>
             <h3 class="font-bold text-lg">{t('vs_streak.when_other')}</h3>
           </div>
           <ul class="space-y-3">

--- a/src/pages/compare/tradingview.astro
+++ b/src/pages/compare/tradingview.astro
@@ -103,7 +103,7 @@ const rows = [
 
   <!-- WHEN TO CHOOSE -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12 bg-[--color-bg-subtle] reveal">
+  <section class="pb-12 pt-12 bg-[var(--color-bg-subtle)] reveal">
     <div class="max-w-5xl mx-auto px-4">
       <div class="grid md:grid-cols-2 gap-8">
         <!-- Choose PRUVIQ -->
@@ -135,7 +135,7 @@ const rows = [
         <!-- Choose TradingView -->
         <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card]">
           <div class="flex items-center gap-3 mb-4">
-            <span class="inline-flex items-center justify-center w-8 h-8 rounded bg-[--color-bg-subtle] text-[--color-text-muted] font-mono text-sm font-bold shrink-0">TV</span>
+            <span class="inline-flex items-center justify-center w-8 h-8 rounded bg-[var(--color-bg-subtle)] text-[--color-text-muted] font-mono text-sm font-bold shrink-0">TV</span>
             <h3 class="font-bold text-lg">{t('vs.when_tv')}</h3>
           </div>
           <ul class="space-y-3">

--- a/src/pages/crypto-trading-simulator.astro
+++ b/src/pages/crypto-trading-simulator.astro
@@ -70,7 +70,7 @@ const jsonLd = {
 
   <!-- HOW IT WORKS (reusing i18n step keys) -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12 bg-[--color-bg-subtle] reveal">
+  <section class="pb-12 pt-12 bg-[var(--color-bg-subtle)] reveal">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl md:text-3xl font-bold mb-8">How PRUVIQ's Simulator Works</h2>
       <div class="grid md:grid-cols-3 gap-8">
@@ -106,7 +106,7 @@ const jsonLd = {
 
   <!-- SEE IT IN ACTION -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12 bg-[--color-bg-subtle] reveal">
+  <section class="pb-12 pt-12 bg-[var(--color-bg-subtle)] reveal">
     <div class="max-w-5xl mx-auto px-4 text-center">
       <h2 class="text-2xl md:text-3xl font-bold mb-4">See It in Action</h2>
       <p class="text-[--color-text-muted] text-lg mb-8 max-w-2xl mx-auto">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -111,7 +111,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- HOW IT WORKS -->
   <hr class="section-divider" />
-  <section class="max-w-7xl mx-auto px-6 py-16 md:py-24 bg-[--color-bg-subtle]">
+  <section class="max-w-7xl mx-auto px-6 py-16 md:py-24 bg-[var(--color-bg-subtle)]">
     <h2 class="text-2xl md:text-3xl font-bold text-center mb-4">How It Works</h2>
     <p class="text-[--color-text-secondary] text-center text-lg mb-16 max-w-xl mx-auto">From strategy idea to verified results in 3 steps.</p>
     <div class="grid md:grid-cols-3 gap-8">
@@ -150,7 +150,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
         <!-- Header -->
         <div class="grid grid-cols-3 text-sm font-mono">
           <div class="p-4 md:p-5"></div>
-          <div class="p-4 md:p-5 text-center text-[--color-text-muted] border-l border-[--color-border] bg-[--color-bg-subtle]">{t('compare.other_label')}</div>
+          <div class="p-4 md:p-5 text-center text-[--color-text-muted] border-l border-[--color-border] bg-[var(--color-bg-subtle)]">{t('compare.other_label')}</div>
           <div class="p-4 md:p-5 text-center font-bold text-[--color-accent] border-l border-[--color-accent]/20 bg-[--color-accent]/5">{t('compare.pruviq_label')}</div>
         </div>
         <!-- Rows -->
@@ -163,7 +163,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
         ].map((row) => (
           <div class="grid grid-cols-3 text-sm border-t border-[--color-border]">
             <div class="p-4 md:p-5 font-semibold">{row.label}</div>
-            <div class="p-4 md:p-5 text-center text-[--color-text-muted] border-l border-[--color-border] bg-[--color-bg-subtle]">{row.other}</div>
+            <div class="p-4 md:p-5 text-center text-[--color-text-muted] border-l border-[--color-border] bg-[var(--color-bg-subtle)]">{row.other}</div>
             <div class="p-4 md:p-5 text-center font-semibold text-[--color-up] border-l border-[--color-accent]/20 bg-[--color-accent]/5">{row.pruviq}</div>
           </div>
         ))}
@@ -177,7 +177,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- WHY PRUVIQ (Merged Problem + Evidence) -->
   <hr class="section-divider" />
-  <section class="py-16 md:py-24 bg-[--color-bg-subtle] reveal" aria-labelledby="why-heading">
+  <section class="py-16 md:py-24 bg-[var(--color-bg-subtle)] reveal" aria-labelledby="why-heading">
     <div class="max-w-7xl mx-auto px-6">
       <p class="font-mono text-[--color-down] text-sm mb-2 tracking-wider">{t('problem.tag')}</p>
       <h2 id="why-heading" class="text-2xl md:text-3xl font-bold mb-4">{t('problem.title')}</h2>
@@ -310,7 +310,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- FAQ (visible section matching JSON-LD) -->
   <hr class="section-divider" />
-  <section class="py-16 md:py-24 bg-[--color-bg-subtle] reveal" aria-labelledby="faq-heading">
+  <section class="py-16 md:py-24 bg-[var(--color-bg-subtle)] reveal" aria-labelledby="faq-heading">
     <div class="max-w-7xl mx-auto px-6">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">FAQ</p>
       <h2 id="faq-heading" class="text-2xl md:text-3xl font-bold mb-12">{t('faq.title')}</h2>

--- a/src/pages/ko/best-crypto-backtesting.astro
+++ b/src/pages/ko/best-crypto-backtesting.astro
@@ -81,7 +81,7 @@ const jsonLd = {
 
   <!-- WHAT MAKES A GOOD BACKTESTER -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12 bg-[--color-bg-subtle]">
+  <section class="pb-12 pt-12 bg-[var(--color-bg-subtle)]">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl md:text-3xl font-bold mb-8">좋은 백테스팅 플랫폼의 조건</h2>
       <div class="space-y-6">
@@ -126,7 +126,7 @@ const jsonLd = {
 
   <!-- COMPARISON TABLE -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12 bg-[--color-bg-subtle]">
+  <section class="pb-12 pt-12 bg-[var(--color-bg-subtle)]">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl md:text-3xl font-bold mb-8">빠른 비교: PRUVIQ vs TradingView vs 3Commas</h2>
 

--- a/src/pages/ko/compare/3commas.astro
+++ b/src/pages/ko/compare/3commas.astro
@@ -106,7 +106,7 @@ const rows = [
 
   <!-- WHEN -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12 bg-[--color-bg-subtle] reveal">
+  <section class="pb-12 pt-12 bg-[var(--color-bg-subtle)] reveal">
     <div class="max-w-5xl mx-auto px-4">
       <div class="grid md:grid-cols-2 gap-8">
         <div class="border border-[--color-accent]/30 rounded-lg p-6 bg-[--color-bg-card]">
@@ -119,7 +119,7 @@ const rows = [
           </ul>
         </div>
         <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card]">
-          <div class="flex items-center gap-3 mb-4"><span class="inline-flex items-center justify-center w-8 h-8 rounded bg-[--color-bg-subtle] text-[--color-text-muted] font-mono text-sm font-bold shrink-0">3C</span><h3 class="font-bold text-lg">{t('vs_3commas.when_other')}</h3></div>
+          <div class="flex items-center gap-3 mb-4"><span class="inline-flex items-center justify-center w-8 h-8 rounded bg-[var(--color-bg-subtle)] text-[--color-text-muted] font-mono text-sm font-bold shrink-0">3C</span><h3 class="font-bold text-lg">{t('vs_3commas.when_other')}</h3></div>
           <ul class="space-y-3">
             <li class="flex gap-2 text-sm text-[--color-text-muted]"><span class="shrink-0 mt-0.5">+</span><span>{t('vs_3commas.when_other_1')}</span></li>
             <li class="flex gap-2 text-sm text-[--color-text-muted]"><span class="shrink-0 mt-0.5">+</span><span>{t('vs_3commas.when_other_2')}</span></li>

--- a/src/pages/ko/compare/coinrule.astro
+++ b/src/pages/ko/compare/coinrule.astro
@@ -88,7 +88,7 @@ const rows = [
 
   <!-- WHEN TO CHOOSE -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12 bg-[--color-bg-subtle] reveal">
+  <section class="pb-12 pt-12 bg-[var(--color-bg-subtle)] reveal">
     <div class="max-w-5xl mx-auto px-4">
       <div class="grid md:grid-cols-2 gap-8">
         <!-- Choose PRUVIQ -->
@@ -108,7 +108,7 @@ const rows = [
         <!-- Choose Coinrule -->
         <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card]">
           <div class="flex items-center gap-3 mb-4">
-            <span class="inline-flex items-center justify-center w-8 h-8 rounded bg-[--color-bg-subtle] text-[--color-text-muted] font-mono text-sm font-bold shrink-0">CR</span>
+            <span class="inline-flex items-center justify-center w-8 h-8 rounded bg-[var(--color-bg-subtle)] text-[--color-text-muted] font-mono text-sm font-bold shrink-0">CR</span>
             <h3 class="font-bold text-lg">{t('vs_coinrule.when_other')}</h3>
           </div>
           <ul class="space-y-3">

--- a/src/pages/ko/compare/cryptohopper.astro
+++ b/src/pages/ko/compare/cryptohopper.astro
@@ -106,7 +106,7 @@ const rows = [
 
   <!-- WHEN -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12 bg-[--color-bg-subtle] reveal">
+  <section class="pb-12 pt-12 bg-[var(--color-bg-subtle)] reveal">
     <div class="max-w-5xl mx-auto px-4">
       <div class="grid md:grid-cols-2 gap-8">
         <div class="border border-[--color-accent]/30 rounded-lg p-6 bg-[--color-bg-card]">
@@ -119,7 +119,7 @@ const rows = [
           </ul>
         </div>
         <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card]">
-          <div class="flex items-center gap-3 mb-4"><span class="inline-flex items-center justify-center w-8 h-8 rounded bg-[--color-bg-subtle] text-[--color-text-muted] font-mono text-sm font-bold shrink-0">CH</span><h3 class="font-bold text-lg">{t('vs_cryptohopper.when_other')}</h3></div>
+          <div class="flex items-center gap-3 mb-4"><span class="inline-flex items-center justify-center w-8 h-8 rounded bg-[var(--color-bg-subtle)] text-[--color-text-muted] font-mono text-sm font-bold shrink-0">CH</span><h3 class="font-bold text-lg">{t('vs_cryptohopper.when_other')}</h3></div>
           <ul class="space-y-3">
             <li class="flex gap-2 text-sm text-[--color-text-muted]"><span class="shrink-0 mt-0.5">+</span><span>{t('vs_cryptohopper.when_other_1')}</span></li>
             <li class="flex gap-2 text-sm text-[--color-text-muted]"><span class="shrink-0 mt-0.5">+</span><span>{t('vs_cryptohopper.when_other_2')}</span></li>

--- a/src/pages/ko/compare/gainium.astro
+++ b/src/pages/ko/compare/gainium.astro
@@ -88,7 +88,7 @@ const rows = [
 
   <!-- WHEN TO CHOOSE -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12 bg-[--color-bg-subtle] reveal">
+  <section class="pb-12 pt-12 bg-[var(--color-bg-subtle)] reveal">
     <div class="max-w-5xl mx-auto px-4">
       <div class="grid md:grid-cols-2 gap-8">
         <!-- Choose PRUVIQ -->
@@ -108,7 +108,7 @@ const rows = [
         <!-- Choose Gainium -->
         <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card]">
           <div class="flex items-center gap-3 mb-4">
-            <span class="inline-flex items-center justify-center w-8 h-8 rounded bg-[--color-bg-subtle] text-[--color-text-muted] font-mono text-sm font-bold shrink-0">GA</span>
+            <span class="inline-flex items-center justify-center w-8 h-8 rounded bg-[var(--color-bg-subtle)] text-[--color-text-muted] font-mono text-sm font-bold shrink-0">GA</span>
             <h3 class="font-bold text-lg">{t('vs_gainium.when_other')}</h3>
           </div>
           <ul class="space-y-3">

--- a/src/pages/ko/compare/streak.astro
+++ b/src/pages/ko/compare/streak.astro
@@ -88,7 +88,7 @@ const rows = [
 
   <!-- WHEN TO CHOOSE -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12 bg-[--color-bg-subtle] reveal">
+  <section class="pb-12 pt-12 bg-[var(--color-bg-subtle)] reveal">
     <div class="max-w-5xl mx-auto px-4">
       <div class="grid md:grid-cols-2 gap-8">
         <!-- Choose PRUVIQ -->
@@ -108,7 +108,7 @@ const rows = [
         <!-- Choose Streak -->
         <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card]">
           <div class="flex items-center gap-3 mb-4">
-            <span class="inline-flex items-center justify-center w-8 h-8 rounded bg-[--color-bg-subtle] text-[--color-text-muted] font-mono text-sm font-bold shrink-0">SK</span>
+            <span class="inline-flex items-center justify-center w-8 h-8 rounded bg-[var(--color-bg-subtle)] text-[--color-text-muted] font-mono text-sm font-bold shrink-0">SK</span>
             <h3 class="font-bold text-lg">{t('vs_streak.when_other')}</h3>
           </div>
           <ul class="space-y-3">

--- a/src/pages/ko/compare/tradingview.astro
+++ b/src/pages/ko/compare/tradingview.astro
@@ -103,7 +103,7 @@ const rows = [
 
   <!-- WHEN TO CHOOSE -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12 bg-[--color-bg-subtle] reveal">
+  <section class="pb-12 pt-12 bg-[var(--color-bg-subtle)] reveal">
     <div class="max-w-5xl mx-auto px-4">
       <div class="grid md:grid-cols-2 gap-8">
         <!-- Choose PRUVIQ -->
@@ -135,7 +135,7 @@ const rows = [
         <!-- Choose TradingView -->
         <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card]">
           <div class="flex items-center gap-3 mb-4">
-            <span class="inline-flex items-center justify-center w-8 h-8 rounded bg-[--color-bg-subtle] text-[--color-text-muted] font-mono text-sm font-bold shrink-0">TV</span>
+            <span class="inline-flex items-center justify-center w-8 h-8 rounded bg-[var(--color-bg-subtle)] text-[--color-text-muted] font-mono text-sm font-bold shrink-0">TV</span>
             <h3 class="font-bold text-lg">{t('vs.when_tv')}</h3>
           </div>
           <ul class="space-y-3">

--- a/src/pages/ko/crypto-trading-simulator.astro
+++ b/src/pages/ko/crypto-trading-simulator.astro
@@ -71,7 +71,7 @@ const jsonLd = {
 
   <!-- HOW IT WORKS -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12 bg-[--color-bg-subtle]">
+  <section class="pb-12 pt-12 bg-[var(--color-bg-subtle)]">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl md:text-3xl font-bold mb-8">PRUVIQ 시뮬레이터 작동 방식</h2>
       <div class="grid md:grid-cols-3 gap-8">
@@ -107,7 +107,7 @@ const jsonLd = {
 
   <!-- SEE IT IN ACTION -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12 bg-[--color-bg-subtle]">
+  <section class="pb-12 pt-12 bg-[var(--color-bg-subtle)]">
     <div class="max-w-5xl mx-auto px-4 text-center">
       <h2 class="text-2xl md:text-3xl font-bold mb-4">직접 확인하세요</h2>
       <p class="text-[--color-text-muted] text-lg mb-8 max-w-2xl mx-auto">

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -111,7 +111,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- HOW IT WORKS -->
   <hr class="section-divider" />
-  <section class="max-w-7xl mx-auto px-6 py-16 md:py-24 bg-[--color-bg-subtle]">
+  <section class="max-w-7xl mx-auto px-6 py-16 md:py-24 bg-[var(--color-bg-subtle)]">
     <h2 class="text-2xl md:text-3xl font-bold text-center mb-4">작동 방식</h2>
     <p class="text-[--color-text-secondary] text-center text-lg mb-16 max-w-xl mx-auto">전략 아이디어에서 검증된 결과까지 3단계.</p>
     <div class="grid md:grid-cols-3 gap-8">
@@ -150,7 +150,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
         <!-- Header -->
         <div class="grid grid-cols-3 text-sm font-mono">
           <div class="p-4 md:p-5"></div>
-          <div class="p-4 md:p-5 text-center text-[--color-text-muted] border-l border-[--color-border] bg-[--color-bg-subtle]">{t('compare.other_label')}</div>
+          <div class="p-4 md:p-5 text-center text-[--color-text-muted] border-l border-[--color-border] bg-[var(--color-bg-subtle)]">{t('compare.other_label')}</div>
           <div class="p-4 md:p-5 text-center font-bold text-[--color-accent] border-l border-[--color-accent]/20 bg-[--color-accent]/5">{t('compare.pruviq_label')}</div>
         </div>
         <!-- Rows -->
@@ -163,7 +163,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
         ].map((row) => (
           <div class="grid grid-cols-3 text-sm border-t border-[--color-border]">
             <div class="p-4 md:p-5 font-semibold">{row.label}</div>
-            <div class="p-4 md:p-5 text-center text-[--color-text-muted] border-l border-[--color-border] bg-[--color-bg-subtle]">{row.other}</div>
+            <div class="p-4 md:p-5 text-center text-[--color-text-muted] border-l border-[--color-border] bg-[var(--color-bg-subtle)]">{row.other}</div>
             <div class="p-4 md:p-5 text-center font-semibold text-[--color-up] border-l border-[--color-accent]/20 bg-[--color-accent]/5">{row.pruviq}</div>
           </div>
         ))}
@@ -177,7 +177,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- WHY PRUVIQ (Merged Problem + Evidence) -->
   <hr class="section-divider" />
-  <section class="py-16 md:py-24 bg-[--color-bg-subtle] reveal" aria-labelledby="why-heading-ko">
+  <section class="py-16 md:py-24 bg-[var(--color-bg-subtle)] reveal" aria-labelledby="why-heading-ko">
     <div class="max-w-7xl mx-auto px-6">
       <p class="font-mono text-[--color-down] text-sm mb-2 tracking-wider">{t('problem.tag')}</p>
       <h2 id="why-heading-ko" class="text-2xl md:text-3xl font-bold mb-4">{t('problem.title')}</h2>
@@ -310,7 +310,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- FAQ (visible section matching JSON-LD) -->
   <hr class="section-divider" />
-  <section class="py-16 md:py-24 bg-[--color-bg-subtle] reveal" aria-labelledby="faq-heading-ko">
+  <section class="py-16 md:py-24 bg-[var(--color-bg-subtle)] reveal" aria-labelledby="faq-heading-ko">
     <div class="max-w-7xl mx-auto px-6">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">FAQ</p>
       <h2 id="faq-heading-ko" class="text-2xl md:text-3xl font-bold mb-12">{t('faq.title')}</h2>

--- a/src/pages/ko/performance/index.astro
+++ b/src/pages/ko/performance/index.astro
@@ -121,7 +121,7 @@ const liveTrades = perf.summary.total_trades.toLocaleString();
         <table class="w-full text-sm min-w-[400px]">
           <caption class="sr-only">BB Squeeze SHORT 전략 성과 지표</caption>
           <thead>
-            <tr class="border-b border-[--color-border] bg-[--color-bg-subtle]">
+            <tr class="border-b border-[--color-border] bg-[var(--color-bg-subtle)]">
               <th class="text-left p-3 font-mono text-xs text-[--color-text-muted]">{t('perf.tbl_header_metric')}</th>
               <th class="text-right p-3 font-mono text-xs text-[--color-text-muted]">{t('perf.tbl_header_value')}</th>
             </tr>
@@ -437,7 +437,7 @@ const liveTrades = perf.summary.total_trades.toLocaleString();
   <hr class="section-divider" />
 
   <!-- DISCLAIMER -->
-  <section class="reveal pb-16 bg-[--color-bg-subtle]">
+  <section class="reveal pb-16 bg-[var(--color-bg-subtle)]">
     <div class="max-w-5xl mx-auto px-4 text-center pt-12">
       <p class="text-[--color-text-muted] text-xs max-w-lg mx-auto">
         {t('cta.disclaimer')}

--- a/src/pages/ko/why-backtests-fail.astro
+++ b/src/pages/ko/why-backtests-fail.astro
@@ -89,7 +89,7 @@ const jsonLd = {
 
   <!-- 88 KILLED STRATEGIES -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12 bg-[--color-bg-subtle] reveal">
+  <section class="pb-12 pt-12 bg-[var(--color-bg-subtle)] reveal">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl md:text-3xl font-bold mb-4">우리의 증거: 제거된 88개 전략</h2>
       <p class="text-[--color-text-muted] max-w-3xl mb-6">

--- a/src/pages/performance/index.astro
+++ b/src/pages/performance/index.astro
@@ -124,7 +124,7 @@ const liveTrades = perf.summary.total_trades.toLocaleString();
         <table class="w-full text-sm min-w-[400px]">
           <caption class="sr-only">BB Squeeze SHORT strategy performance metrics</caption>
           <thead>
-            <tr class="border-b border-[--color-border] bg-[--color-bg-subtle]">
+            <tr class="border-b border-[--color-border] bg-[var(--color-bg-subtle)]">
               <th class="text-left p-3 font-mono text-xs text-[--color-text-muted]">{t('perf.tbl_header_metric')}</th>
               <th class="text-right p-3 font-mono text-xs text-[--color-text-muted]">{t('perf.tbl_header_value')}</th>
             </tr>
@@ -499,7 +499,7 @@ const liveTrades = perf.summary.total_trades.toLocaleString();
   <hr class="section-divider" />
 
   <!-- DISCLAIMER -->
-  <section class="reveal pb-16 bg-[--color-bg-subtle]">
+  <section class="reveal pb-16 bg-[var(--color-bg-subtle)]">
     <div class="max-w-5xl mx-auto px-4 text-center pt-12">
       <p class="text-[--color-text-muted] text-xs max-w-lg mx-auto">
         {t('cta.disclaimer')}

--- a/src/pages/why-backtests-fail.astro
+++ b/src/pages/why-backtests-fail.astro
@@ -88,7 +88,7 @@ const jsonLd = {
 
   <!-- 88 KILLED STRATEGIES -->
   <hr class="section-divider" />
-  <section class="pb-12 pt-12 bg-[--color-bg-subtle] reveal">
+  <section class="pb-12 pt-12 bg-[var(--color-bg-subtle)] reveal">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl md:text-3xl font-bold mb-4">Our Proof: 88 Strategies We Killed</h2>
       <p class="text-[--color-text-muted] max-w-3xl mb-6">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -307,6 +307,7 @@
 
 html {
   scroll-behavior: smooth;
+  overflow-x: hidden;
 }
 
 body {
@@ -1003,7 +1004,7 @@ textarea:focus-visible,
 /* ─── Divider line ─── */
 .section-divider {
   height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(79,142,247,0.15), transparent);
+  background: linear-gradient(90deg, transparent, rgba(79,142,247,0.25), transparent);
   border: none;
   margin: 0;
 }


### PR DESCRIPTION
## Summary
- `html { overflow-x: hidden }` — 모바일 가로 스크롤 방지
- section-divider opacity `0.15 → 0.25` — 다크 테마에서 가시성 향상
- `bg-[--color-bg-subtle]` → `bg-[var(--color-bg-subtle)]` (22개 파일, 48곳)
  - Tailwind v4에서 bare property 문법은 `background-color: --color-bg-subtle`로 컴파일되어 무효
  - `var()` 래핑으로 정상 작동

## Test plan
- [x] `npm run build` — 2518 pages, 0 errors
- [x] CSS 컴파일 확인: `var(--color-bg-subtle)` 출력

🤖 Generated with [Claude Code](https://claude.com/claude-code)