### PR TITLE
fix: nav and breadcrumb visibility

### DIFF
--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -72,11 +72,11 @@ for (const seg of segments) {
 ---
 
 {segments.length > 0 && (
-  <nav aria-label="Breadcrumb" class="max-w-7xl mx-auto px-4 pt-2 pb-1">
-    <ol class="flex flex-wrap items-center gap-2 font-mono text-xs text-[--color-text-muted]">
+  <nav aria-label="Breadcrumb" class="max-w-7xl mx-auto px-4 py-2">
+    <ol class="flex flex-wrap items-center gap-2 text-sm text-[--color-text-secondary]">
       {items.map((item, i) => (
         <li class="flex items-center gap-1.5">
-          {i > 0 && <span class="text-[--color-border]">/</span>}
+          {i > 0 && <span class="text-[--color-text-disabled] opacity-60">/</span>}
           {i < items.length - 1 ? (
             <a href={item.href} class="hover:text-[--color-accent] transition-colors">
               <span>{item.label}</span>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -413,7 +413,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
           <span class="font-mono font-bold text-2xl tracking-wider"><span class="text-[--color-text]">PRUV</span><span class="text-[#2CB5E8]">IQ</span></span>
         </a>
         <!-- 2열: Nav (정중앙, 데스크톱 only) -->
-        <div class="hidden md:flex items-center justify-center gap-10 text-[15px]">
+        <div class="hidden md:flex items-center justify-center gap-12 text-base">
           {navItems.map(item => item.match === '/strategies' ? (
             <div class="relative group" role="navigation" aria-label="Strategy submenu">
               <a href={item.href} aria-current={isActive(item.match) ? "page" : undefined}
@@ -424,19 +424,19 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
                 <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" class="opacity-50 transition-transform duration-200 group-hover:rotate-180" aria-hidden="true"><path d="M2.5 4.5l3.5 3 3.5-3"/></svg>
               </a>
               <div class="absolute top-full left-1/2 -translate-x-1/2 pt-2 hidden group-hover:block group-focus-within:block z-50" role="menu">
-                <div class="bg-[--color-bg-elevated] border border-white/[0.08] rounded-xl p-1.5 min-w-[200px] backdrop-blur-xl" style="box-shadow: 0 8px 32px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.06);">
-                  <a href={rankingPath} class="flex items-center gap-3 px-3.5 py-2.5 rounded-lg text-sm text-[--color-text] hover:bg-white/[0.06] transition-colors">
+                <div class="bg-[--color-bg-elevated] border border-white/[0.15] rounded-xl p-2 min-w-[220px] backdrop-blur-xl" style="box-shadow: 0 12px 40px rgba(0,0,0,0.6), 0 0 0 1px rgba(255,255,255,0.1);">
+                  <a href={rankingPath} class="flex items-center gap-3 px-4 py-3 rounded-lg text-[15px] text-[--color-text] hover:bg-white/[0.06] transition-colors">
                     <span class="w-8 h-8 rounded-lg bg-[--color-accent]/10 flex items-center justify-center shrink-0"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-accent)" stroke-width="2"><path d="M12 20V10M18 20V4M6 20v-4"/></svg></span>
-                    <div><div class="font-medium">{t('nav.ranking')}</div><div class="text-[11px] text-[--color-text-muted] mt-0.5">{t('nav.ranking_desc')}</div></div>
+                    <div><div class="font-medium">{t('nav.ranking')}</div><div class="text-xs text-[--color-text-muted] mt-0.5">{t('nav.ranking_desc')}</div></div>
                   </a>
-                  <a href={leaderboardPath} class="flex items-center gap-3 px-3.5 py-2.5 rounded-lg text-sm text-[--color-text] hover:bg-white/[0.06] transition-colors">
+                  <a href={leaderboardPath} class="flex items-center gap-3 px-4 py-3 rounded-lg text-[15px] text-[--color-text] hover:bg-white/[0.06] transition-colors">
                     <span class="w-8 h-8 rounded-lg bg-[--color-up]/10 flex items-center justify-center shrink-0"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--color-up)" stroke-width="2"><path d="M8 21V11M16 21V3M12 21v-6"/></svg></span>
-                    <div><div class="font-medium">{t('nav.leaderboard')}</div><div class="text-[11px] text-[--color-text-muted] mt-0.5">{t('nav.leaderboard_desc')}</div></div>
+                    <div><div class="font-medium">{t('nav.leaderboard')}</div><div class="text-xs text-[--color-text-muted] mt-0.5">{t('nav.leaderboard_desc')}</div></div>
                   </a>
                   <div class="border-t border-white/[0.06] my-1 mx-2"></div>
-                  <a href={lp('/compare')} class="flex items-center gap-3 px-3.5 py-2.5 rounded-lg text-sm text-[--color-text-muted] hover:text-[--color-text] hover:bg-white/[0.06] transition-colors">
+                  <a href={lp('/compare')} class="flex items-center gap-3 px-4 py-3 rounded-lg text-[15px] text-[--color-text-muted] hover:text-[--color-text] hover:bg-white/[0.06] transition-colors">
                     <span class="w-8 h-8 rounded-lg bg-white/[0.04] flex items-center justify-center shrink-0"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/></svg></span>
-                    <div><div class="font-medium">{t('nav.compare_tools')}</div><div class="text-[11px] text-[--color-text-muted] mt-0.5">{t('nav.compare_tools_desc')}</div></div>
+                    <div><div class="font-medium">{t('nav.compare_tools')}</div><div class="text-xs text-[--color-text-muted] mt-0.5">{t('nav.compare_tools_desc')}</div></div>
                   </a>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- 데스크톱 nav: 15px → 16px, 간격 확대, 드롭다운 테두리/그림자 강화
- Breadcrumb: 13px mono → 15px sans, 색상 밝게, 패딩 대칭
- Build: 2518 pages, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)