### PR TITLE
feat: quality phase 2 — hero, hover, KO colors, mobile, methodology

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -36,26 +36,19 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
         <!-- Left: Text + CTA -->
         <div>
           <HeroBadge stat={simulationsRun} label="simulations run" />
+          <p class="font-mono text-[--color-accent] text-sm tracking-wider mb-4 opacity-80">Don't Believe. Verify.</p>
           <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold tracking-[-0.04em] leading-[1.08]">
-            Test Any Crypto Strategy on <span class="gradient-text">{coinsAnalyzed} Coins</span>
+            Most Backtests Lie.<br/><span class="gradient-text">Ours Come with Proof.</span>
           </h1>
           <p class="mt-6 text-lg text-[--color-text-secondary] leading-relaxed max-w-lg">
-            See exactly how your strategy would have performed. Free. No code. No signup. Real fees included.
+            Test strategies on <strong class="text-[--color-text]">{coinsAnalyzed}+ coins</strong> with real fees. See what fails. Keep what survives. No code. No signup.
           </p>
-          <!-- Trust signals inline -->
-          <div class="flex flex-col gap-2 mt-6 text-sm text-[--color-text-secondary]">
-            <span class="flex items-center gap-2">
-              <svg class="w-4 h-4 text-[--color-up] shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
-              {coinsAnalyzed}+ coins simulated with real fees
-            </span>
-            <span class="flex items-center gap-2">
-              <svg class="w-4 h-4 text-[--color-up] shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
-              No signup · No credit card · 100% free
-            </span>
-            <span class="flex items-center gap-2">
-              <svg class="w-4 h-4 text-[--color-up] shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
-              Failed strategies published openly
-            </span>
+          <!-- Differentiator — front and center -->
+          <div class="mt-6 flex items-start gap-3 px-4 py-3 rounded-lg border border-[--color-verified-border] bg-[--color-verified-subtle]">
+            <span class="text-[--color-verified] text-lg leading-none mt-0.5" aria-hidden="true">&#9888;</span>
+            <p class="text-sm text-[--color-text-secondary]">
+              <strong class="text-[--color-verified]">88 strategies tested, 4 killed.</strong> We publish every failure with full data. <a href="/strategies" class="text-[--color-accent] hover:underline">See them all &rarr;</a>
+            </p>
           </div>
           <!-- CTA -->
           <div class="flex flex-col sm:flex-row gap-3 mt-8">
@@ -66,6 +59,10 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
               Explore Strategies
             </a>
           </div>
+          <!-- Micro trust -->
+          <p class="mt-4 text-xs text-[--color-text-disabled] font-mono">
+            {coinsAnalyzed}+ coins · 2Y+ data · Real fees · No credit card
+          </p>
         </div>
         <!-- Right: Live simulator demo -->
         <div class="relative">

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -36,36 +36,33 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
         <!-- Left: Text + CTA -->
         <div>
           <HeroBadge stat={simulationsRun} label="시뮬레이션 실행" cta="무료 체험 →" />
-          <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold tracking-[-0.04em] leading-[1.08]">
-            {t('hero.h1_line1')} <span class="gradient-text">{coinsAnalyzed}개 코인</span>, 몇 초 만에 검증
+          <p class="font-mono text-[--color-accent] text-sm tracking-wider mb-4 opacity-80">Don't Believe. Verify.</p>
+          <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold tracking-[-0.02em] leading-[1.15]">
+            대부분의 백테스트는 거짓말합니다.<br/><span class="gradient-text">우리는 증거를 공개합니다.</span>
           </h1>
           <p class="mt-6 text-lg text-[--color-text-secondary] leading-relaxed max-w-lg">
-            내 전략이 실제로 어떤 성과를 냈을지 확인하세요. 무료. 코딩 불필요. 가입 불필요. 실제 수수료 포함.
+            <strong class="text-[--color-text]">{coinsAnalyzed}개 이상의 코인</strong>에서 실제 수수료를 포함한 전략 검증. 실패를 확인하고, 살아남은 전략만 남기세요. 코딩 불필요. 가입 불필요.
           </p>
-          <!-- Trust signals inline -->
-          <div class="flex flex-col gap-2 mt-6 text-sm text-[--color-text-secondary]">
-            <span class="flex items-center gap-2">
-              <svg class="w-4 h-4 text-[--color-up] shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
-              {coinsAnalyzed}개 코인 · 실제 수수료 포함 시뮬레이션
-            </span>
-            <span class="flex items-center gap-2">
-              <svg class="w-4 h-4 text-[--color-up] shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
-              가입 불필요 · 무료 · 신용카드 불필요
-            </span>
-            <span class="flex items-center gap-2">
-              <svg class="w-4 h-4 text-[--color-up] shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
-              실패한 전략도 투명하게 공개
-            </span>
+          <!-- Differentiator — front and center -->
+          <div class="mt-6 flex items-start gap-3 px-4 py-3 rounded-lg border border-[--color-verified-border] bg-[--color-verified-subtle]">
+            <span class="text-[--color-verified] text-lg leading-none mt-0.5" aria-hidden="true">&#9888;</span>
+            <p class="text-sm text-[--color-text-secondary]">
+              <strong class="text-[--color-verified]">88개 전략 테스트, 4개 폐기.</strong> 모든 실패를 전체 데이터와 함께 공개합니다. <a href="/ko/strategies" class="text-[--color-accent] hover:underline">전부 보기 &rarr;</a>
+            </p>
           </div>
           <!-- CTA -->
           <div class="flex flex-col sm:flex-row gap-3 mt-8">
             <a href="/ko/simulate" class="btn btn-primary btn-lg text-center">
-              시뮬레이터 열기 — 무료 →
+              시뮬레이터 열기 — 무료 &rarr;
             </a>
             <a href="/ko/strategies" class="btn btn-ghost btn-lg text-center">
               전략 탐색하기
             </a>
           </div>
+          <!-- Micro trust -->
+          <p class="mt-4 text-xs text-[--color-text-disabled] font-mono">
+            {coinsAnalyzed}+ 코인 · 2년+ 데이터 · 실제 수수료 · 신용카드 불필요
+          </p>
         </div>
         <!-- Right: Live simulator demo -->
         <div class="relative">

--- a/src/pages/ko/methodology.astro
+++ b/src/pages/ko/methodology.astro
@@ -26,6 +26,21 @@ const t = useTranslations('ko');
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-6">{t('methodology.backtest_title')}</h2>
 
+      <!-- Visual pipeline diagram -->
+      <div class="flex flex-wrap items-center gap-2 mb-10 text-xs font-mono" role="img" aria-label="백테스트 파이프라인: 데이터 → 유니버스 → 실행 → 수수료 → 슬리피지 → 결과">
+        <span class="px-3 py-1.5 rounded-full bg-[--color-accent-subtle] text-[--color-accent] border border-[--color-accent]/20">OHLCV 데이터</span>
+        <span class="text-[--color-text-disabled]">&rarr;</span>
+        <span class="px-3 py-1.5 rounded-full bg-[--color-accent-subtle] text-[--color-accent] border border-[--color-accent]/20">유니버스 필터</span>
+        <span class="text-[--color-text-disabled]">&rarr;</span>
+        <span class="px-3 py-1.5 rounded-full bg-[--color-accent-subtle] text-[--color-accent] border border-[--color-accent]/20">시그널 → 주문</span>
+        <span class="text-[--color-text-disabled]">&rarr;</span>
+        <span class="px-3 py-1.5 rounded-full bg-[--color-warning]/10 text-[--color-warning] border border-[--color-warning]/20">− 수수료</span>
+        <span class="text-[--color-text-disabled]">&rarr;</span>
+        <span class="px-3 py-1.5 rounded-full bg-[--color-warning]/10 text-[--color-warning] border border-[--color-warning]/20">− 슬리피지</span>
+        <span class="text-[--color-text-disabled]">&rarr;</span>
+        <span class="px-3 py-1.5 rounded-full bg-[--color-up]/10 text-[--color-up] border border-[--color-up]/20 font-bold">결과</span>
+      </div>
+
       <div class="space-y-6 max-w-3xl">
         <div class="border border-[--color-border] rounded-lg p-5 bg-[--color-bg-card]">
           <div class="font-mono text-[--color-accent] text-xs font-bold mb-1">{t('methodology.data_label')}</div>

--- a/src/pages/methodology.astro
+++ b/src/pages/methodology.astro
@@ -26,6 +26,21 @@ const t = useTranslations('en');
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-6">{t('methodology.backtest_title')}</h2>
 
+      <!-- Visual pipeline diagram -->
+      <div class="flex flex-wrap items-center gap-2 mb-10 text-xs font-mono" role="img" aria-label="Backtest pipeline: Data → Universe → Execution → Fees → Slippage → Result">
+        <span class="px-3 py-1.5 rounded-full bg-[--color-accent-subtle] text-[--color-accent] border border-[--color-accent]/20">OHLCV Data</span>
+        <span class="text-[--color-text-disabled]">&rarr;</span>
+        <span class="px-3 py-1.5 rounded-full bg-[--color-accent-subtle] text-[--color-accent] border border-[--color-accent]/20">Universe Filter</span>
+        <span class="text-[--color-text-disabled]">&rarr;</span>
+        <span class="px-3 py-1.5 rounded-full bg-[--color-accent-subtle] text-[--color-accent] border border-[--color-accent]/20">Signal → Order</span>
+        <span class="text-[--color-text-disabled]">&rarr;</span>
+        <span class="px-3 py-1.5 rounded-full bg-[--color-warning]/10 text-[--color-warning] border border-[--color-warning]/20">− Fees</span>
+        <span class="text-[--color-text-disabled]">&rarr;</span>
+        <span class="px-3 py-1.5 rounded-full bg-[--color-warning]/10 text-[--color-warning] border border-[--color-warning]/20">− Slippage</span>
+        <span class="text-[--color-text-disabled]">&rarr;</span>
+        <span class="px-3 py-1.5 rounded-full bg-[--color-up]/10 text-[--color-up] border border-[--color-up]/20 font-bold">Result</span>
+      </div>
+
       <div class="space-y-6 max-w-3xl">
         <div class="border border-[--color-border] rounded-lg p-5 bg-[--color-bg-card]">
           <div class="font-mono text-[--color-accent] text-xs font-bold mb-1">{t('methodology.data_label')}</div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -750,6 +750,29 @@ textarea:focus-visible,
   .stat-glass { min-height: 56px; }
 }
 
+/* ─── Mobile layout improvements ─── */
+@media (max-width: 767px) {
+  /* Tighter hero padding on mobile */
+  .hero-enter { padding-top: 1.5rem; padding-bottom: 2rem; }
+
+  /* Stack stats vertically if cramped */
+  .stat-glass { padding: 0.75rem; }
+  .stat-glass p:first-child { font-size: 1.25rem; }
+
+  /* Full-width buttons on mobile */
+  .btn-lg { width: 100%; justify-content: center; }
+
+  /* Reduce section gaps on mobile */
+  .section-gap { padding-top: 3rem; padding-bottom: 3rem; }
+
+  /* Prose: tighter margins */
+  .prose h2 { margin-top: 1.75rem; font-size: 1.3rem; }
+  .prose h3 { margin-top: 1.25rem; font-size: 1.1rem; }
+
+  /* Hide API sidebar on smaller screens (already xl:block but explicit) */
+  #api-sidebar { display: none; }
+}
+
 /* ─── Metric progress bar ─── */
 .metric-bar {
   display: block;
@@ -1396,4 +1419,44 @@ textarea:focus-visible,
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--color-text-muted);
+}
+
+/* ─── Korean market convention: up=red, down=blue ─── */
+:lang(ko) .color-up, :lang(ko) .stat-positive { color: var(--color-down); }
+:lang(ko) .color-down, :lang(ko) .stat-negative { color: var(--color-up); }
+:lang(ko) .flash-up { animation: flash-red 0.6s ease-out; }
+:lang(ko) .flash-down { animation: flash-green 0.6s ease-out; }
+
+/* ─── Enhanced hover interactions ─── */
+.card-premium:hover::before {
+  background: linear-gradient(
+    135deg,
+    rgba(44,181,232,0.06) 0%,
+    rgba(255,255,255,0.03) 50%,
+    transparent 100%
+  );
+}
+
+/* Link hover: subtle glow */
+a:not(.btn):not(.card-hover):not(nav a):hover {
+  text-shadow: 0 0 12px rgba(44,181,232,0.15);
+}
+
+/* Button hover: micro-lift + glow intensify */
+.btn-ghost:hover {
+  border-color: var(--color-accent);
+  background: rgba(44,181,232,0.06);
+  box-shadow: 0 0 12px rgba(44,181,232,0.08);
+}
+
+/* Card hover: border gradient sweep */
+.card-enterprise:hover {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 1px rgba(44,181,232,0.15), 0 8px 24px rgba(0,0,0,0.15);
+}
+
+/* Stat glass hover: accent tint */
+.stat-glass:hover {
+  border-color: rgba(44,181,232,0.15);
+  background: rgba(44,181,232,0.04);
 }


### PR DESCRIPTION
## Summary

- **Hero redesign** (EN + KO): Lead with "Most Backtests Lie. Ours Come with Proof." + transparency callout (88 tested, 4 killed) + brand tagline eyebrow
- **KO color convention**: `:lang(ko)` swaps up=red/down=blue per Korean market standard
- **Hover interactions**: Ghost buttons glow, cards accent border, stat-glass tint, link text-shadow
- **Mobile layout**: Tighter hero padding, full-width CTA buttons, compact stat-glass, reduced section gaps
- **Methodology pipeline**: CSS pill-chain diagram (Data→Filter→Execution→Fees→Slippage→Result)

## Test plan

- [ ] Build passes (2518 pages, 0 errors)
- [ ] qa-redirects PASS
- [ ] EN hero: new headline renders, differentiator callout visible
- [ ] KO hero: Korean headline + callout renders correctly
- [ ] KO pages: up/down colors swapped (red=up, blue=down)
- [ ] Mobile: buttons full-width, hero compact, stat-glass compact
- [ ] Methodology: pipeline diagram visible (EN + KO)
- [ ] Hover: ghost buttons glow on hover, cards accent border

🤖 Generated with [Claude Code](https://claude.com/claude-code)