### PR TITLE
fix: restore Pretendard font + :lang(ko) typography lost in squash merge

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -17,6 +17,16 @@
   src: url('/fonts/geist-mono.woff2') format('woff2');
 }
 
+/* ─── Korean: Pretendard Variable ─── */
+@font-face {
+  font-family: 'Pretendard Variable';
+  font-style: normal;
+  font-weight: 100 900;
+  font-display: swap;
+  src: url('/fonts/pretendard-variable.woff2') format('woff2');
+  unicode-range: U+AC00-D7AF, U+1100-11FF, U+3130-318F, U+A960-A97F, U+D7B0-D7FF, U+0030-0039, U+0020-002F, U+003A-0040, U+2000-206F;
+}
+
 /* Fallback: keep Inter/JetBrains available */
 @font-face {
   font-family: 'Inter';
@@ -115,7 +125,7 @@
   --color-eth: #627EEA;
 
   /* ─── TYPOGRAPHY ─── */
-  --font-sans: 'Geist', 'Inter', system-ui, sans-serif;
+  --font-sans: 'Geist', 'Pretendard Variable', 'Inter', system-ui, sans-serif;
   --font-mono: 'Geist Mono', 'JetBrains Mono', 'Fira Code', monospace;
 
   /* ─── BORDER RADIUS ─── */
@@ -319,6 +329,32 @@ body {
   font-feature-settings: 'kern' 1, 'liga' 1;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+/* ─── Korean typography: :lang(ko) overrides ─── */
+:lang(ko) {
+  word-break: keep-all;
+  overflow-wrap: break-word;
+  line-height: 1.8;
+}
+:lang(ko) h1 {
+  letter-spacing: -0.01em;
+  line-height: 1.15;
+}
+:lang(ko) h2 {
+  letter-spacing: -0.005em;
+  line-height: 1.25;
+}
+:lang(ko) h3 {
+  letter-spacing: 0;
+  line-height: 1.3;
+}
+:lang(ko) .prose {
+  line-height: 1.85;
+  word-break: keep-all;
+}
+:lang(ko) .btn, :lang(ko) .btn-primary, :lang(ko) .btn-ghost {
+  letter-spacing: 0.01em;
 }
 
 /* Tabular numbers for all mono/data contexts */


### PR DESCRIPTION
## Summary

PR #904 squash merge overwrote PR #903's global.css changes (Pretendard font + Korean typography). Restores:
- Pretendard Variable @font-face with CJK unicode-range
- `--font-sans` stack updated to include Pretendard
- `:lang(ko)` rules: `word-break: keep-all`, `line-height: 1.8`, heading letter-spacing, prose/button adjustments

## Root cause

PR #904 branched from main before #903 was merged. Squash merge of #904 replaced global.css entirely, losing #903's Pretendard additions.

## Test plan

- [ ] Build passes (2518 pages, 0 errors)
- [ ] `dist/_astro/*.css` contains "Pretendard" string
- [ ] KO pages render with Pretendard font
- [ ] KO pages use word-break: keep-all

🤖 Generated with [Claude Code](https://claude.com/claude-code)