### PR TITLE
fix: slogan sync + KO typography + hero depth

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,14 +29,14 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 <Layout title={t('meta.home_title')} description={t('meta.index_desc')}>
 
   <!-- HERO — 50/50 layout: text left, live demo right -->
-  <section class="relative overflow-hidden hero-bg-depth">
+  <section class="relative overflow-hidden hero-bg-depth bg-noise">
     <HeroGlow />
     <div class="relative max-w-7xl mx-auto px-6 pt-10 pb-16 md:pt-14 md:pb-20 hero-enter">
       <div class="grid md:grid-cols-2 gap-12 md:gap-16 items-center">
         <!-- Left: Text + CTA -->
         <div>
           <HeroBadge stat={simulationsRun} label="simulations run" />
-          <p class="font-mono text-[--color-accent] text-sm tracking-wider mb-4 opacity-80">Don't Believe. Verify.</p>
+          <p class="font-mono text-[--color-accent] text-sm tracking-wider mb-4 opacity-80">Verify. Execute. Profit.</p>
           <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold tracking-[-0.04em] leading-[1.08]">
             Most Backtests Lie.<br/><span class="gradient-text">Ours Come with Proof.</span>
           </h1>

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -29,16 +29,16 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 <Layout title={t('meta.home_title')} description={t('meta.index_desc')}>
 
   <!-- HERO — 50/50 layout: text left, live demo right -->
-  <section class="relative overflow-hidden hero-bg-depth">
+  <section class="relative overflow-hidden hero-bg-depth bg-noise">
     <HeroGlow />
     <div class="relative max-w-7xl mx-auto px-6 pt-10 pb-16 md:pt-14 md:pb-20 hero-enter">
       <div class="grid md:grid-cols-2 gap-12 md:gap-16 items-center">
         <!-- Left: Text + CTA -->
         <div>
           <HeroBadge stat={simulationsRun} label="시뮬레이션 실행" cta="무료 체험 →" />
-          <p class="font-mono text-[--color-accent] text-sm tracking-wider mb-4 opacity-80">Don't Believe. Verify.</p>
-          <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold tracking-[-0.02em] leading-[1.15]">
-            대부분의 백테스트는 거짓말합니다.<br/><span class="gradient-text">우리는 증거를 공개합니다.</span>
+          <p class="font-mono text-[--color-accent] text-sm tracking-wider mb-4 opacity-80">검증하고. 실행하고. 수익내세요.</p>
+          <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold tracking-[-0.02em] leading-[1.2] word-break-keep">
+            대부분의 백테스트는<br/>거짓말합니다.<br/><span class="gradient-text">우리는 증거를 공개합니다.</span>
           </h1>
           <p class="mt-6 text-lg text-[--color-text-secondary] leading-relaxed max-w-lg">
             <strong class="text-[--color-text]">{coinsAnalyzed}개 이상의 코인</strong>에서 실제 수수료를 포함한 전략 검증. 실패를 확인하고, 살아남은 전략만 남기세요. 코딩 불필요. 가입 불필요.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1417,12 +1417,46 @@ textarea:focus-visible,
 }
 
 /* ─── Hero staggered entrance animation ─── */
-.hero-enter > *:nth-child(1) { animation: hero-enter 1.0s var(--ease-default) 0.15s both; }
-.hero-enter > *:nth-child(2) { animation: hero-enter 1.0s var(--ease-default) 0.30s both; }
-.hero-enter > *:nth-child(3) { animation: hero-enter 1.0s var(--ease-default) 0.45s both; }
-.hero-enter > *:nth-child(4) { animation: hero-enter 1.0s var(--ease-default) 0.60s both; }
-.hero-enter > *:nth-child(5) { animation: hero-enter 1.0s var(--ease-default) 0.75s both; }
-.hero-enter > *:nth-child(6) { animation: hero-enter 1.0s var(--ease-default) 0.90s both; }
+.hero-enter > *:nth-child(1) { animation: hero-enter 0.8s var(--ease-smooth) 0.1s both; }
+.hero-enter > *:nth-child(2) { animation: hero-enter 0.8s var(--ease-smooth) 0.25s both; }
+.hero-enter > *:nth-child(3) { animation: hero-enter 0.8s var(--ease-smooth) 0.4s both; }
+.hero-enter > *:nth-child(4) { animation: hero-enter 0.8s var(--ease-smooth) 0.55s both; }
+.hero-enter > *:nth-child(5) { animation: hero-enter 0.8s var(--ease-smooth) 0.7s both; }
+.hero-enter > *:nth-child(6) { animation: hero-enter 0.8s var(--ease-smooth) 0.85s both; }
+
+/* ─── Korean word-break: keep whole words together ─── */
+.word-break-keep {
+  word-break: keep-all;
+  overflow-wrap: break-word;
+}
+
+/* ─── Subtle noise texture for depth ─── */
+.bg-noise::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E");
+  background-repeat: repeat;
+  background-size: 256px 256px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* ─── Section divider glow ─── */
+.section-glow-top {
+  position: relative;
+}
+.section-glow-top::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 60%;
+  max-width: 600px;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--color-accent-glow), transparent);
+}
 
 /* ─── Scroll hint fade for horizontally scrollable tables ─── */
 .scroll-hint-fade {


### PR DESCRIPTION
## Summary
- **Slogan**: EN/KO hero "Don't Believe. Verify." → "Verify. Execute. Profit." / "검증하고. 실행하고. 수익내세요."
- **KO typography**: `word-break: keep-all` prevents awkward mid-word breaks on Korean headings. Line-height adjusted for Korean text density
- **Hero depth**: subtle noise texture (SVG feTurbulence @ 3% opacity), section glow dividers, tighter stagger timing

## No functional changes
- 0 component logic changes
- 0 API changes
- Build: 2518 pages, 0 errors

## Test plan
- [x] `npm run build` — 2518 pages, 0 errors
- [x] KO slogan renders in dist/ko/index.html
- [x] EN slogan renders in dist/index.html
- [ ] Visual check: KO hero heading line breaks
- [ ] Visual check: noise texture subtle on dark bg