### PR TITLE
fix: Learn +8 posts categorized + Compare PRUVIQ highlight

### DIFF
--- a/src/pages/compare/3commas.astro
+++ b/src/pages/compare/3commas.astro
@@ -32,7 +32,7 @@ const rows = [
         <span class="block text-lg md:text-2xl font-normal text-[--color-text-muted] mt-2">{t('vs_3commas.subtitle')}</span>
       </h1>
       <p class="text-[--color-text-muted] text-lg max-w-2xl mb-6">{t('vs_3commas.desc')}</p>
-      <div class="border border-[--color-accent]/30 rounded-lg p-4 bg-[--color-accent]/5 max-w-2xl">
+      <div class="border border-[--color-accent]/30 rounded-lg p-4 bg-[--color-accent]/10 border-x border-[--color-accent]/20 max-w-2xl">
         <p class="font-mono text-[--color-accent] text-xs font-bold mb-1">{t('vs_3commas.tldr')}</p>
         <p class="text-sm text-[--color-text-muted]">{t('vs_3commas.tldr_text')}</p>
       </div>
@@ -55,7 +55,7 @@ const rows = [
           </thead>
           <tbody>
             {rows.map((row) => (
-              <tr class={`border-b border-[--color-border] ${row.highlight ? 'bg-[--color-accent]/5' : ''}`}>
+              <tr class={`border-b border-[--color-border] ${row.highlight ? 'bg-[--color-accent]/10 border-x border-[--color-accent]/20' : ''}`}>
                 <td class="py-3 px-4 font-medium text-[--color-text-secondary] text-xs uppercase tracking-wide">{row.label}</td>
                 <td class={`py-3 px-4 ${row.win === 'p' ? 'text-[--color-up]' : row.win === 'both' ? 'text-[--color-accent]' : 'text-[--color-text-muted]'}`}>
                   <span class="flex items-start gap-2"><span class="mt-0.5 shrink-0 text-base leading-none" aria-hidden="true">{row.win === 'p' ? '\u2713' : row.win === 'both' ? '~' : '\u2014'}</span><span>{row.p}</span></span>
@@ -70,7 +70,7 @@ const rows = [
       </div>
       <div class="md:hidden space-y-4">
         {rows.map((row) => (
-          <div class={`border border-[--color-border] rounded-lg p-4 ${row.highlight ? 'bg-[--color-accent]/5 border-[--color-accent]/30' : 'bg-[--color-bg-card]'}`}>
+          <div class={`border border-[--color-border] rounded-lg p-4 ${row.highlight ? 'bg-[--color-accent]/10 border-x border-[--color-accent]/20 border-[--color-accent]/30' : 'bg-[--color-bg-card]'}`}>
             <p class="font-mono text-xs text-[--color-text-muted] uppercase tracking-wider mb-2">{row.label}</p>
             <div class="grid grid-cols-2 gap-3">
               <div><p class="text-xs text-[--color-accent] font-mono mb-1">PRUVIQ</p><p class="text-sm text-[--color-accent]">{row.p}</p></div>
@@ -135,7 +135,7 @@ const rows = [
   <hr class="section-divider" />
   <section class="pb-12 pt-12 reveal">
     <div class="max-w-5xl mx-auto px-4">
-      <div class="border border-[--color-accent]/30 rounded-lg p-6 bg-[--color-accent]/5 max-w-3xl mx-auto text-center">
+      <div class="border border-[--color-accent]/30 rounded-lg p-6 bg-[--color-accent]/10 border-x border-[--color-accent]/20 max-w-3xl mx-auto text-center">
         <h3 class="font-bold text-xl mb-3 text-[--color-accent]">{t('vs_3commas.best_together')}</h3>
         <p class="text-[--color-text-muted]">{t('vs_3commas.best_together_desc')}</p>
       </div>

--- a/src/pages/compare/coinrule.astro
+++ b/src/pages/compare/coinrule.astro
@@ -31,7 +31,7 @@ const rows = [
       <p class="text-[--color-text-muted] text-lg max-w-2xl mb-6">
         {t('vs_coinrule.desc')}
       </p>
-      <div class="border border-[--color-accent]/30 rounded-lg p-4 bg-[--color-accent]/5 max-w-2xl">
+      <div class="border border-[--color-accent]/30 rounded-lg p-4 bg-[--color-accent]/10 border-x border-[--color-accent]/20 max-w-2xl">
         <p class="font-mono text-[--color-accent] text-xs font-bold mb-1">{t('vs_coinrule.tldr')}</p>
         <p class="text-sm text-[--color-text-muted]">{t('vs_coinrule.tldr_text')}</p>
       </div>
@@ -55,7 +55,7 @@ const rows = [
           </thead>
           <tbody>
             {rows.map((row) => (
-              <tr class={`border-b border-[--color-border] ${row.highlight ? 'bg-[--color-accent]/5' : ''}`}>
+              <tr class={`border-b border-[--color-border] ${row.highlight ? 'bg-[--color-accent]/10 border-x border-[--color-accent]/20' : ''}`}>
                 <td class="py-3 px-4 font-medium">{row.label}</td>
                 <td class="py-3 px-4 text-[--color-accent]">{row.p}</td>
                 <td class="py-3 px-4 text-[--color-text-muted]">{row.other}</td>
@@ -68,7 +68,7 @@ const rows = [
       <!-- Mobile cards -->
       <div class="md:hidden space-y-4">
         {rows.map((row) => (
-          <div class={`border border-[--color-border] rounded-lg p-4 ${row.highlight ? 'bg-[--color-accent]/5 border-[--color-accent]/30' : 'bg-[--color-bg-card]'}`}>
+          <div class={`border border-[--color-border] rounded-lg p-4 ${row.highlight ? 'bg-[--color-accent]/10 border-x border-[--color-accent]/20 border-[--color-accent]/30' : 'bg-[--color-bg-card]'}`}>
             <p class="font-mono text-xs text-[--color-text-muted] uppercase tracking-wider mb-2">{row.label}</p>
             <div class="grid grid-cols-2 gap-3">
               <div>

--- a/src/pages/compare/cryptohopper.astro
+++ b/src/pages/compare/cryptohopper.astro
@@ -32,7 +32,7 @@ const rows = [
         <span class="block text-lg md:text-2xl font-normal text-[--color-text-muted] mt-2">{t('vs_cryptohopper.subtitle')}</span>
       </h1>
       <p class="text-[--color-text-muted] text-lg max-w-2xl mb-6">{t('vs_cryptohopper.desc')}</p>
-      <div class="border border-[--color-accent]/30 rounded-lg p-4 bg-[--color-accent]/5 max-w-2xl">
+      <div class="border border-[--color-accent]/30 rounded-lg p-4 bg-[--color-accent]/10 border-x border-[--color-accent]/20 max-w-2xl">
         <p class="font-mono text-[--color-accent] text-xs font-bold mb-1">{t('vs_cryptohopper.tldr')}</p>
         <p class="text-sm text-[--color-text-muted]">{t('vs_cryptohopper.tldr_text')}</p>
       </div>
@@ -55,7 +55,7 @@ const rows = [
           </thead>
           <tbody>
             {rows.map((row) => (
-              <tr class={`border-b border-[--color-border] ${row.highlight ? 'bg-[--color-accent]/5' : ''}`}>
+              <tr class={`border-b border-[--color-border] ${row.highlight ? 'bg-[--color-accent]/10 border-x border-[--color-accent]/20' : ''}`}>
                 <td class="py-3 px-4 font-medium text-[--color-text-secondary] text-xs uppercase tracking-wide">{row.label}</td>
                 <td class={`py-3 px-4 ${row.win === 'p' ? 'text-[--color-up]' : row.win === 'both' ? 'text-[--color-accent]' : 'text-[--color-text-muted]'}`}>
                   <span class="flex items-start gap-2"><span class="mt-0.5 shrink-0 text-base leading-none" aria-hidden="true">{row.win === 'p' ? '\u2713' : row.win === 'both' ? '~' : '\u2014'}</span><span>{row.p}</span></span>
@@ -70,7 +70,7 @@ const rows = [
       </div>
       <div class="md:hidden space-y-4">
         {rows.map((row) => (
-          <div class={`border border-[--color-border] rounded-lg p-4 ${row.highlight ? 'bg-[--color-accent]/5 border-[--color-accent]/30' : 'bg-[--color-bg-card]'}`}>
+          <div class={`border border-[--color-border] rounded-lg p-4 ${row.highlight ? 'bg-[--color-accent]/10 border-x border-[--color-accent]/20 border-[--color-accent]/30' : 'bg-[--color-bg-card]'}`}>
             <p class="font-mono text-xs text-[--color-text-muted] uppercase tracking-wider mb-2">{row.label}</p>
             <div class="grid grid-cols-2 gap-3">
               <div><p class="text-xs text-[--color-accent] font-mono mb-1">PRUVIQ</p><p class="text-sm text-[--color-accent]">{row.p}</p></div>
@@ -135,7 +135,7 @@ const rows = [
   <hr class="section-divider" />
   <section class="pb-12 pt-12 reveal">
     <div class="max-w-5xl mx-auto px-4">
-      <div class="border border-[--color-accent]/30 rounded-lg p-6 bg-[--color-accent]/5 max-w-3xl mx-auto text-center">
+      <div class="border border-[--color-accent]/30 rounded-lg p-6 bg-[--color-accent]/10 border-x border-[--color-accent]/20 max-w-3xl mx-auto text-center">
         <h3 class="font-bold text-xl mb-3 text-[--color-accent]">{t('vs_cryptohopper.best_together')}</h3>
         <p class="text-[--color-text-muted]">{t('vs_cryptohopper.best_together_desc')}</p>
       </div>

--- a/src/pages/compare/gainium.astro
+++ b/src/pages/compare/gainium.astro
@@ -31,7 +31,7 @@ const rows = [
       <p class="text-[--color-text-muted] text-lg max-w-2xl mb-6">
         {t('vs_gainium.desc')}
       </p>
-      <div class="border border-[--color-accent]/30 rounded-lg p-4 bg-[--color-accent]/5 max-w-2xl">
+      <div class="border border-[--color-accent]/30 rounded-lg p-4 bg-[--color-accent]/10 border-x border-[--color-accent]/20 max-w-2xl">
         <p class="font-mono text-[--color-accent] text-xs font-bold mb-1">{t('vs_gainium.tldr')}</p>
         <p class="text-sm text-[--color-text-muted]">{t('vs_gainium.tldr_text')}</p>
       </div>
@@ -55,7 +55,7 @@ const rows = [
           </thead>
           <tbody>
             {rows.map((row) => (
-              <tr class={`border-b border-[--color-border] ${row.highlight ? 'bg-[--color-accent]/5' : ''}`}>
+              <tr class={`border-b border-[--color-border] ${row.highlight ? 'bg-[--color-accent]/10 border-x border-[--color-accent]/20' : ''}`}>
                 <td class="py-3 px-4 font-medium">{row.label}</td>
                 <td class="py-3 px-4 text-[--color-accent]">{row.p}</td>
                 <td class="py-3 px-4 text-[--color-text-muted]">{row.other}</td>
@@ -68,7 +68,7 @@ const rows = [
       <!-- Mobile cards -->
       <div class="md:hidden space-y-4">
         {rows.map((row) => (
-          <div class={`border border-[--color-border] rounded-lg p-4 ${row.highlight ? 'bg-[--color-accent]/5 border-[--color-accent]/30' : 'bg-[--color-bg-card]'}`}>
+          <div class={`border border-[--color-border] rounded-lg p-4 ${row.highlight ? 'bg-[--color-accent]/10 border-x border-[--color-accent]/20 border-[--color-accent]/30' : 'bg-[--color-bg-card]'}`}>
             <p class="font-mono text-xs text-[--color-text-muted] uppercase tracking-wider mb-2">{row.label}</p>
             <div class="grid grid-cols-2 gap-3">
               <div>

--- a/src/pages/compare/index.astro
+++ b/src/pages/compare/index.astro
@@ -51,7 +51,7 @@ const comparisons = [
           <thead>
             <tr class="border-b border-[--color-border]">
               <th scope="col" class="text-left py-3 px-3 font-mono text-[--color-text-muted] text-xs">{t('compare_index.tbl_feature')}</th>
-              <th scope="col" class="text-center py-3 px-3 font-mono text-[--color-accent] text-xs bg-[--color-accent]/5">PRUVIQ</th>
+              <th scope="col" class="text-center py-3 px-3 font-mono text-[--color-accent] text-xs bg-[--color-accent]/10 border-x border-[--color-accent]/20">PRUVIQ</th>
               <th scope="col" class="text-center py-3 px-3 font-mono text-[--color-text-muted] text-xs">TradingView</th>
               <th scope="col" class="text-center py-3 px-3 font-mono text-[--color-text-muted] text-xs">3Commas</th>
               <th scope="col" class="text-center py-3 px-3 font-mono text-[--color-text-muted] text-xs">Cryptohopper</th>
@@ -62,7 +62,7 @@ const comparisons = [
           <tbody>
             <tr class="border-b border-[--color-border]/50">
               <td class="py-3 px-3 text-[--color-text-muted]">{t('compare_index.tbl_price')}</td>
-              <td class="py-3 px-3 text-center text-[--color-up] font-semibold bg-[--color-accent]/5">$0</td>
+              <td class="py-3 px-3 text-center text-[--color-up] font-semibold bg-[--color-accent]/10 border-x border-[--color-accent]/20">$0</td>
               <td class="py-3 px-3 text-center text-[--color-text-muted]">Free / $15+/mo</td>
               <td class="py-3 px-3 text-center text-[--color-text-muted]">$22+/mo</td>
               <td class="py-3 px-3 text-center text-[--color-text-muted]">$19+/mo</td>
@@ -71,7 +71,7 @@ const comparisons = [
             </tr>
             <tr class="border-b border-[--color-border]/50">
               <td class="py-3 px-3 text-[--color-text-muted]">{t('compare_index.tbl_no_account')}</td>
-              <td class="py-3 px-3 text-center text-[--color-up] bg-[--color-accent]/5">&#10003;</td>
+              <td class="py-3 px-3 text-center text-[--color-up] bg-[--color-accent]/10 border-x border-[--color-accent]/20">&#10003;</td>
               <td class="py-3 px-3 text-center text-[--color-down]">&#10007;</td>
               <td class="py-3 px-3 text-center text-[--color-down]">&#10007;</td>
               <td class="py-3 px-3 text-center text-[--color-down]">&#10007;</td>
@@ -80,7 +80,7 @@ const comparisons = [
             </tr>
             <tr class="border-b border-[--color-border]/50">
               <td class="py-3 px-3 text-[--color-text-muted]">{t('compare_index.tbl_multicoin')}</td>
-              <td class="py-3 px-3 text-center text-[--color-up] font-semibold bg-[--color-accent]/5">570+ coins</td>
+              <td class="py-3 px-3 text-center text-[--color-up] font-semibold bg-[--color-accent]/10 border-x border-[--color-accent]/20">570+ coins</td>
               <td class="py-3 px-3 text-center text-[--color-down]">1 at a time</td>
               <td class="py-3 px-3 text-center text-[--color-down]">Limited</td>
               <td class="py-3 px-3 text-center text-[--color-down]">Limited</td>
@@ -89,7 +89,7 @@ const comparisons = [
             </tr>
             <tr class="border-b border-[--color-border]/50">
               <td class="py-3 px-3 text-[--color-text-muted]">{t('compare_index.tbl_transparency')}</td>
-              <td class="py-3 px-3 text-center text-[--color-up] bg-[--color-accent]/5">&#10003;</td>
+              <td class="py-3 px-3 text-center text-[--color-up] bg-[--color-accent]/10 border-x border-[--color-accent]/20">&#10003;</td>
               <td class="py-3 px-3 text-center text-[--color-down]">&#10007;</td>
               <td class="py-3 px-3 text-center text-[--color-down]">&#10007;</td>
               <td class="py-3 px-3 text-center text-[--color-down]">&#10007;</td>
@@ -98,7 +98,7 @@ const comparisons = [
             </tr>
             <tr>
               <td class="py-3 px-3 text-[--color-text-muted]">{t('compare_index.tbl_no_code')}</td>
-              <td class="py-3 px-3 text-center text-[--color-up] bg-[--color-accent]/5">&#10003;</td>
+              <td class="py-3 px-3 text-center text-[--color-up] bg-[--color-accent]/10 border-x border-[--color-accent]/20">&#10003;</td>
               <td class="py-3 px-3 text-center text-[--color-down]">Pine Script</td>
               <td class="py-3 px-3 text-center text-[--color-up]">&#10003;</td>
               <td class="py-3 px-3 text-center text-[--color-up]">&#10003;</td>

--- a/src/pages/compare/streak.astro
+++ b/src/pages/compare/streak.astro
@@ -31,7 +31,7 @@ const rows = [
       <p class="text-[--color-text-muted] text-lg max-w-2xl mb-6">
         {t('vs_streak.desc')}
       </p>
-      <div class="border border-[--color-accent]/30 rounded-lg p-4 bg-[--color-accent]/5 max-w-2xl">
+      <div class="border border-[--color-accent]/30 rounded-lg p-4 bg-[--color-accent]/10 border-x border-[--color-accent]/20 max-w-2xl">
         <p class="font-mono text-[--color-accent] text-xs font-bold mb-1">{t('vs_streak.tldr')}</p>
         <p class="text-sm text-[--color-text-muted]">{t('vs_streak.tldr_text')}</p>
       </div>
@@ -55,7 +55,7 @@ const rows = [
           </thead>
           <tbody>
             {rows.map((row) => (
-              <tr class={`border-b border-[--color-border] ${row.highlight ? 'bg-[--color-accent]/5' : ''}`}>
+              <tr class={`border-b border-[--color-border] ${row.highlight ? 'bg-[--color-accent]/10 border-x border-[--color-accent]/20' : ''}`}>
                 <td class="py-3 px-4 font-medium">{row.label}</td>
                 <td class="py-3 px-4 text-[--color-accent]">{row.p}</td>
                 <td class="py-3 px-4 text-[--color-text-muted]">{row.other}</td>
@@ -68,7 +68,7 @@ const rows = [
       <!-- Mobile cards -->
       <div class="md:hidden space-y-4">
         {rows.map((row) => (
-          <div class={`border border-[--color-border] rounded-lg p-4 ${row.highlight ? 'bg-[--color-accent]/5 border-[--color-accent]/30' : 'bg-[--color-bg-card]'}`}>
+          <div class={`border border-[--color-border] rounded-lg p-4 ${row.highlight ? 'bg-[--color-accent]/10 border-x border-[--color-accent]/20 border-[--color-accent]/30' : 'bg-[--color-bg-card]'}`}>
             <p class="font-mono text-xs text-[--color-text-muted] uppercase tracking-wider mb-2">{row.label}</p>
             <div class="grid grid-cols-2 gap-3">
               <div>

--- a/src/pages/compare/tradingview.astro
+++ b/src/pages/compare/tradingview.astro
@@ -32,7 +32,7 @@ const rows = [
       <p class="text-[--color-text-muted] text-lg max-w-2xl mb-6">
         {t('vs.desc')}
       </p>
-      <div class="border border-[--color-accent]/30 rounded-lg p-4 bg-[--color-accent]/5 max-w-2xl">
+      <div class="border border-[--color-accent]/30 rounded-lg p-4 bg-[--color-accent]/10 border-x border-[--color-accent]/20 max-w-2xl">
         <p class="font-mono text-[--color-accent] text-xs font-bold mb-1">{t('vs.tldr')}</p>
         <p class="text-sm text-[--color-text-muted]">{t('vs.tldr_text')}</p>
       </div>
@@ -56,7 +56,7 @@ const rows = [
           </thead>
           <tbody>
             {rows.map((row) => (
-              <tr class={`border-b border-[--color-border] ${row.highlight ? 'bg-[--color-accent]/5' : ''}`}>
+              <tr class={`border-b border-[--color-border] ${row.highlight ? 'bg-[--color-accent]/10 border-x border-[--color-accent]/20' : ''}`}>
                 <td class="py-3 px-4 font-medium text-[--color-text-secondary] text-xs uppercase tracking-wide">{row.label}</td>
                 <td class={`py-3 px-4 ${row.win === 'p' ? 'text-[--color-up]' : row.win === 'both' ? 'text-[--color-accent]' : 'text-[--color-text-muted]'}`}>
                   <span class="flex items-start gap-2">
@@ -83,7 +83,7 @@ const rows = [
       <!-- Mobile cards -->
       <div class="md:hidden space-y-4">
         {rows.map((row) => (
-          <div class={`border border-[--color-border] rounded-lg p-4 ${row.highlight ? 'bg-[--color-accent]/5 border-[--color-accent]/30' : 'bg-[--color-bg-card]'}`}>
+          <div class={`border border-[--color-border] rounded-lg p-4 ${row.highlight ? 'bg-[--color-accent]/10 border-x border-[--color-accent]/20 border-[--color-accent]/30' : 'bg-[--color-bg-card]'}`}>
             <p class="font-mono text-xs text-[--color-text-muted] uppercase tracking-wider mb-2">{row.label}</p>
             <div class="grid grid-cols-2 gap-3">
               <div>

--- a/src/pages/ko/compare/3commas.astro
+++ b/src/pages/ko/compare/3commas.astro
@@ -32,7 +32,7 @@ const rows = [
         <span class="block text-lg md:text-2xl font-normal text-[--color-text-muted] mt-2">{t('vs_3commas.subtitle')}</span>
       </h1>
       <p class="text-[--color-text-muted] text-lg max-w-2xl mb-6">{t('vs_3commas.desc')}</p>
-      <div class="border border-[--color-accent]/30 rounded-lg p-4 bg-[--color-accent]/5 max-w-2xl">
+      <div class="border border-[--color-accent]/30 rounded-lg p-4 bg-[--color-accent]/10 border-x border-[--color-accent]/20 max-w-2xl">
         <p class="font-mono text-[--color-accent] text-xs font-bold mb-1">{t('vs_3commas.tldr')}</p>
         <p class="text-sm text-[--color-text-muted]">{t('vs_3commas.tldr_text')}</p>
       </div>
@@ -55,7 +55,7 @@ const rows = [
           </thead>
           <tbody>
             {rows.map((row) => (
-              <tr class={`border-b border-[--color-border] ${row.highlight ? 'bg-[--color-accent]/5' : ''}`}>
+              <tr class={`border-b border-[--color-border] ${row.highlight ? 'bg-[--color-accent]/10 border-x border-[--color-accent]/20' : ''}`}>
                 <td class="py-3 px-4 font-medium text-[--color-text-secondary] text-xs uppercase tracking-wide">{row.label}</td>
                 <td class={`py-3 px-4 ${row.win === 'p' ? 'text-[--color-up]' : row.win === 'both' ? 'text-[--color-accent]' : 'text-[--color-text-muted]'}`}>
                   <span class="flex items-start gap-2"><span class="mt-0.5 shrink-0 text-base leading-none" aria-hidden="true">{row.win === 'p' ? '\u2713' : row.win === 'both' ? '~' : '\u2014'}</span><span>{row.p}</span></span>
@@ -70,7 +70,7 @@ const rows = [
       </div>
       <div class="md:hidden space-y-4">
         {rows.map((row) => (
-          <div class={`border border-[--color-border] rounded-lg p-4 ${row.highlight ? 'bg-[--color-accent]/5 border-[--color-accent]/30' : 'bg-[--color-bg-card]'}`}>
+          <div class={`border border-[--color-border] rounded-lg p-4 ${row.highlight ? 'bg-[--color-accent]/10 border-x border-[--color-accent]/20 border-[--color-accent]/30' : 'bg-[--color-bg-card]'}`}>
             <p class="font-mono text-xs text-[--color-text-muted] uppercase tracking-wider mb-2">{row.label}</p>
             <div class="grid grid-cols-2 gap-3">
               <div><p class="text-xs text-[--color-accent] font-mono mb-1">PRUVIQ</p><p class="text-sm text-[--color-accent]">{row.p}</p></div>
@@ -135,7 +135,7 @@ const rows = [
   <hr class="section-divider" />
   <section class="pb-12 pt-12 reveal">
     <div class="max-w-5xl mx-auto px-4">
-      <div class="border border-[--color-accent]/30 rounded-lg p-6 bg-[--color-accent]/5 max-w-3xl mx-auto text-center">
+      <div class="border border-[--color-accent]/30 rounded-lg p-6 bg-[--color-accent]/10 border-x border-[--color-accent]/20 max-w-3xl mx-auto text-center">
         <h3 class="font-bold text-xl mb-3 text-[--color-accent]">{t('vs_3commas.best_together')}</h3>
         <p class="text-[--color-text-muted]">{t('vs_3commas.best_together_desc')}</p>
       </div>

--- a/src/pages/ko/compare/coinrule.astro
+++ b/src/pages/ko/compare/coinrule.astro
@@ -31,7 +31,7 @@ const rows = [
       <p class="text-[--color-text-muted] text-lg max-w-2xl mb-6">
         {t('vs_coinrule.desc')}
       </p>
-      <div class="border border-[--color-accent]/30 rounded-lg p-4 bg-[--color-accent]/5 max-w-2xl">
+      <div class="border border-[--color-accent]/30 rounded-lg p-4 bg-[--color-accent]/10 border-x border-[--color-accent]/20 max-w-2xl">
         <p class="font-mono text-[--color-accent] text-xs font-bold mb-1">{t('vs_coinrule.tldr')}</p>
         <p class="text-sm text-[--color-text-muted]">{t('vs_coinrule.tldr_text')}</p>
       </div>
@@ -55,7 +55,7 @@ const rows = [
           </thead>
           <tbody>
             {rows.map((row) => (
-              <tr class={`border-b border-[--color-border] ${row.highlight ? 'bg-[--color-accent]/5' : ''}`}>
+              <tr class={`border-b border-[--color-border] ${row.highlight ? 'bg-[--color-accent]/10 border-x border-[--color-accent]/20' : ''}`}>
                 <td class="py-3 px-4 font-medium">{row.label}</td>
                 <td class="py-3 px-4 text-[--color-accent]">{row.p}</td>
                 <td class="py-3 px-4 text-[--color-text-muted]">{row.other}</td>
@@ -68,7 +68,7 @@ const rows = [
       <!-- Mobile cards -->
       <div class="md:hidden space-y-4">
         {rows.map((row) => (
-          <div class={`border border-[--color-border] rounded-lg p-4 ${row.highlight ? 'bg-[--color-accent]/5 border-[--color-accent]/30' : 'bg-[--color-bg-card]'}`}>
+          <div class={`border border-[--color-border] rounded-lg p-4 ${row.highlight ? 'bg-[--color-accent]/10 border-x border-[--color-accent]/20 border-[--color-accent]/30' : 'bg-[--color-bg-card]'}`}>
             <p class="font-mono text-xs text-[--color-text-muted] uppercase tracking-wider mb-2">{row.label}</p>
             <div class="grid grid-cols-2 gap-3">
               <div>

--- a/src/pages/ko/compare/cryptohopper.astro
+++ b/src/pages/ko/compare/cryptohopper.astro
@@ -32,7 +32,7 @@ const rows = [
         <span class="block text-lg md:text-2xl font-normal text-[--color-text-muted] mt-2">{t('vs_cryptohopper.subtitle')}</span>
       </h1>
       <p class="text-[--color-text-muted] text-lg max-w-2xl mb-6">{t('vs_cryptohopper.desc')}</p>
-      <div class="border border-[--color-accent]/30 rounded-lg p-4 bg-[--color-accent]/5 max-w-2xl">
+      <div class="border border-[--color-accent]/30 rounded-lg p-4 bg-[--color-accent]/10 border-x border-[--color-accent]/20 max-w-2xl">
         <p class="font-mono text-[--color-accent] text-xs font-bold mb-1">{t('vs_cryptohopper.tldr')}</p>
         <p class="text-sm text-[--color-text-muted]">{t('vs_cryptohopper.tldr_text')}</p>
       </div>
@@ -55,7 +55,7 @@ const rows = [
           </thead>
           <tbody>
             {rows.map((row) => (
-              <tr class={`border-b border-[--color-border] ${row.highlight ? 'bg-[--color-accent]/5' : ''}`}>
+              <tr class={`border-b border-[--color-border] ${row.highlight ? 'bg-[--color-accent]/10 border-x border-[--color-accent]/20' : ''}`}>
                 <td class="py-3 px-4 font-medium text-[--color-text-secondary] text-xs uppercase tracking-wide">{row.label}</td>
                 <td class={`py-3 px-4 ${row.win === 'p' ? 'text-[--color-up]' : row.win === 'both' ? 'text-[--color-accent]' : 'text-[--color-text-muted]'}`}>
                   <span class="flex items-start gap-2"><span class="mt-0.5 shrink-0 text-base leading-none" aria-hidden="true">{row.win === 'p' ? '\u2713' : row.win === 'both' ? '~' : '\u2014'}</span><span>{row.p}</span></span>
@@ -70,7 +70,7 @@ const rows = [
       </div>
       <div class="md:hidden space-y-4">
         {rows.map((row) => (
-          <div class={`border border-[--color-border] rounded-lg p-4 ${row.highlight ? 'bg-[--color-accent]/5 border-[--color-accent]/30' : 'bg-[--color-bg-card]'}`}>
+          <div class={`border border-[--color-border] rounded-lg p-4 ${row.highlight ? 'bg-[--color-accent]/10 border-x border-[--color-accent]/20 border-[--color-accent]/30' : 'bg-[--color-bg-card]'}`}>
             <p class="font-mono text-xs text-[--color-text-muted] uppercase tracking-wider mb-2">{row.label}</p>
             <div class="grid grid-cols-2 gap-3">
               <div><p class="text-xs text-[--color-accent] font-mono mb-1">PRUVIQ</p><p class="text-sm text-[--color-accent]">{row.p}</p></div>
@@ -135,7 +135,7 @@ const rows = [
   <hr class="section-divider" />
   <section class="pb-12 pt-12 reveal">
     <div class="max-w-5xl mx-auto px-4">
-      <div class="border border-[--color-accent]/30 rounded-lg p-6 bg-[--color-accent]/5 max-w-3xl mx-auto text-center">
+      <div class="border border-[--color-accent]/30 rounded-lg p-6 bg-[--color-accent]/10 border-x border-[--color-accent]/20 max-w-3xl mx-auto text-center">
         <h3 class="font-bold text-xl mb-3 text-[--color-accent]">{t('vs_cryptohopper.best_together')}</h3>
         <p class="text-[--color-text-muted]">{t('vs_cryptohopper.best_together_desc')}</p>
       </div>

--- a/src/pages/ko/compare/gainium.astro
+++ b/src/pages/ko/compare/gainium.astro
@@ -31,7 +31,7 @@ const rows = [
       <p class="text-[--color-text-muted] text-lg max-w-2xl mb-6">
         {t('vs_gainium.desc')}
       </p>
-      <div class="border border-[--color-accent]/30 rounded-lg p-4 bg-[--color-accent]/5 max-w-2xl">
+      <div class="border border-[--color-accent]/30 rounded-lg p-4 bg-[--color-accent]/10 border-x border-[--color-accent]/20 max-w-2xl">
         <p class="font-mono text-[--color-accent] text-xs font-bold mb-1">{t('vs_gainium.tldr')}</p>
         <p class="text-sm text-[--color-text-muted]">{t('vs_gainium.tldr_text')}</p>
       </div>
@@ -55,7 +55,7 @@ const rows = [
           </thead>
           <tbody>
             {rows.map((row) => (
-              <tr class={`border-b border-[--color-border] ${row.highlight ? 'bg-[--color-accent]/5' : ''}`}>
+              <tr class={`border-b border-[--color-border] ${row.highlight ? 'bg-[--color-accent]/10 border-x border-[--color-accent]/20' : ''}`}>
                 <td class="py-3 px-4 font-medium">{row.label}</td>
                 <td class="py-3 px-4 text-[--color-accent]">{row.p}</td>
                 <td class="py-3 px-4 text-[--color-text-muted]">{row.other}</td>
@@ -68,7 +68,7 @@ const rows = [
       <!-- Mobile cards -->
       <div class="md:hidden space-y-4">
         {rows.map((row) => (
-          <div class={`border border-[--color-border] rounded-lg p-4 ${row.highlight ? 'bg-[--color-accent]/5 border-[--color-accent]/30' : 'bg-[--color-bg-card]'}`}>
+          <div class={`border border-[--color-border] rounded-lg p-4 ${row.highlight ? 'bg-[--color-accent]/10 border-x border-[--color-accent]/20 border-[--color-accent]/30' : 'bg-[--color-bg-card]'}`}>
             <p class="font-mono text-xs text-[--color-text-muted] uppercase tracking-wider mb-2">{row.label}</p>
             <div class="grid grid-cols-2 gap-3">
               <div>

--- a/src/pages/ko/compare/index.astro
+++ b/src/pages/ko/compare/index.astro
@@ -51,7 +51,7 @@ const comparisons = [
           <thead>
             <tr class="border-b border-[--color-border]">
               <th scope="col" class="text-left py-3 px-3 font-mono text-[--color-text-muted] text-xs">{t('compare_index.tbl_feature')}</th>
-              <th scope="col" class="text-center py-3 px-3 font-mono text-[--color-accent] text-xs bg-[--color-accent]/5">PRUVIQ</th>
+              <th scope="col" class="text-center py-3 px-3 font-mono text-[--color-accent] text-xs bg-[--color-accent]/10 border-x border-[--color-accent]/20">PRUVIQ</th>
               <th scope="col" class="text-center py-3 px-3 font-mono text-[--color-text-muted] text-xs">TradingView</th>
               <th scope="col" class="text-center py-3 px-3 font-mono text-[--color-text-muted] text-xs">3Commas</th>
               <th scope="col" class="text-center py-3 px-3 font-mono text-[--color-text-muted] text-xs">Cryptohopper</th>
@@ -62,7 +62,7 @@ const comparisons = [
           <tbody>
             <tr class="border-b border-[--color-border]/50">
               <td class="py-3 px-3 text-[--color-text-muted]">{t('compare_index.tbl_price')}</td>
-              <td class="py-3 px-3 text-center text-[--color-up] font-semibold bg-[--color-accent]/5">$0</td>
+              <td class="py-3 px-3 text-center text-[--color-up] font-semibold bg-[--color-accent]/10 border-x border-[--color-accent]/20">$0</td>
               <td class="py-3 px-3 text-center text-[--color-text-muted]">Free / $15+/mo</td>
               <td class="py-3 px-3 text-center text-[--color-text-muted]">$22+/mo</td>
               <td class="py-3 px-3 text-center text-[--color-text-muted]">$19+/mo</td>
@@ -71,7 +71,7 @@ const comparisons = [
             </tr>
             <tr class="border-b border-[--color-border]/50">
               <td class="py-3 px-3 text-[--color-text-muted]">{t('compare_index.tbl_no_account')}</td>
-              <td class="py-3 px-3 text-center text-[--color-up] bg-[--color-accent]/5">&#10003;</td>
+              <td class="py-3 px-3 text-center text-[--color-up] bg-[--color-accent]/10 border-x border-[--color-accent]/20">&#10003;</td>
               <td class="py-3 px-3 text-center text-[--color-down]">&#10007;</td>
               <td class="py-3 px-3 text-center text-[--color-down]">&#10007;</td>
               <td class="py-3 px-3 text-center text-[--color-down]">&#10007;</td>
@@ -80,7 +80,7 @@ const comparisons = [
             </tr>
             <tr class="border-b border-[--color-border]/50">
               <td class="py-3 px-3 text-[--color-text-muted]">{t('compare_index.tbl_multicoin')}</td>
-              <td class="py-3 px-3 text-center text-[--color-up] font-semibold bg-[--color-accent]/5">570+ coins</td>
+              <td class="py-3 px-3 text-center text-[--color-up] font-semibold bg-[--color-accent]/10 border-x border-[--color-accent]/20">570+ coins</td>
               <td class="py-3 px-3 text-center text-[--color-down]">1 at a time</td>
               <td class="py-3 px-3 text-center text-[--color-down]">Limited</td>
               <td class="py-3 px-3 text-center text-[--color-down]">Limited</td>
@@ -89,7 +89,7 @@ const comparisons = [
             </tr>
             <tr class="border-b border-[--color-border]/50">
               <td class="py-3 px-3 text-[--color-text-muted]">{t('compare_index.tbl_transparency')}</td>
-              <td class="py-3 px-3 text-center text-[--color-up] bg-[--color-accent]/5">&#10003;</td>
+              <td class="py-3 px-3 text-center text-[--color-up] bg-[--color-accent]/10 border-x border-[--color-accent]/20">&#10003;</td>
               <td class="py-3 px-3 text-center text-[--color-down]">&#10007;</td>
               <td class="py-3 px-3 text-center text-[--color-down]">&#10007;</td>
               <td class="py-3 px-3 text-center text-[--color-down]">&#10007;</td>
@@ -98,7 +98,7 @@ const comparisons = [
             </tr>
             <tr>
               <td class="py-3 px-3 text-[--color-text-muted]">{t('compare_index.tbl_no_code')}</td>
-              <td class="py-3 px-3 text-center text-[--color-up] bg-[--color-accent]/5">&#10003;</td>
+              <td class="py-3 px-3 text-center text-[--color-up] bg-[--color-accent]/10 border-x border-[--color-accent]/20">&#10003;</td>
               <td class="py-3 px-3 text-center text-[--color-down]">Pine Script</td>
               <td class="py-3 px-3 text-center text-[--color-up]">&#10003;</td>
               <td class="py-3 px-3 text-center text-[--color-up]">&#10003;</td>

--- a/src/pages/ko/compare/streak.astro
+++ b/src/pages/ko/compare/streak.astro
@@ -31,7 +31,7 @@ const rows = [
       <p class="text-[--color-text-muted] text-lg max-w-2xl mb-6">
         {t('vs_streak.desc')}
       </p>
-      <div class="border border-[--color-accent]/30 rounded-lg p-4 bg-[--color-accent]/5 max-w-2xl">
+      <div class="border border-[--color-accent]/30 rounded-lg p-4 bg-[--color-accent]/10 border-x border-[--color-accent]/20 max-w-2xl">
         <p class="font-mono text-[--color-accent] text-xs font-bold mb-1">{t('vs_streak.tldr')}</p>
         <p class="text-sm text-[--color-text-muted]">{t('vs_streak.tldr_text')}</p>
       </div>
@@ -55,7 +55,7 @@ const rows = [
           </thead>
           <tbody>
             {rows.map((row) => (
-              <tr class={`border-b border-[--color-border] ${row.highlight ? 'bg-[--color-accent]/5' : ''}`}>
+              <tr class={`border-b border-[--color-border] ${row.highlight ? 'bg-[--color-accent]/10 border-x border-[--color-accent]/20' : ''}`}>
                 <td class="py-3 px-4 font-medium">{row.label}</td>
                 <td class="py-3 px-4 text-[--color-accent]">{row.p}</td>
                 <td class="py-3 px-4 text-[--color-text-muted]">{row.other}</td>
@@ -68,7 +68,7 @@ const rows = [
       <!-- Mobile cards -->
       <div class="md:hidden space-y-4">
         {rows.map((row) => (
-          <div class={`border border-[--color-border] rounded-lg p-4 ${row.highlight ? 'bg-[--color-accent]/5 border-[--color-accent]/30' : 'bg-[--color-bg-card]'}`}>
+          <div class={`border border-[--color-border] rounded-lg p-4 ${row.highlight ? 'bg-[--color-accent]/10 border-x border-[--color-accent]/20 border-[--color-accent]/30' : 'bg-[--color-bg-card]'}`}>
             <p class="font-mono text-xs text-[--color-text-muted] uppercase tracking-wider mb-2">{row.label}</p>
             <div class="grid grid-cols-2 gap-3">
               <div>

--- a/src/pages/ko/compare/tradingview.astro
+++ b/src/pages/ko/compare/tradingview.astro
@@ -32,7 +32,7 @@ const rows = [
       <p class="text-[--color-text-muted] text-lg max-w-2xl mb-6">
         {t('vs.desc')}
       </p>
-      <div class="border border-[--color-accent]/30 rounded-lg p-4 bg-[--color-accent]/5 max-w-2xl">
+      <div class="border border-[--color-accent]/30 rounded-lg p-4 bg-[--color-accent]/10 border-x border-[--color-accent]/20 max-w-2xl">
         <p class="font-mono text-[--color-accent] text-xs font-bold mb-1">{t('vs.tldr')}</p>
         <p class="text-sm text-[--color-text-muted]">{t('vs.tldr_text')}</p>
       </div>
@@ -56,7 +56,7 @@ const rows = [
           </thead>
           <tbody>
             {rows.map((row) => (
-              <tr class={`border-b border-[--color-border] ${row.highlight ? 'bg-[--color-accent]/5' : ''}`}>
+              <tr class={`border-b border-[--color-border] ${row.highlight ? 'bg-[--color-accent]/10 border-x border-[--color-accent]/20' : ''}`}>
                 <td class="py-3 px-4 font-medium text-[--color-text-secondary] text-xs uppercase tracking-wide">{row.label}</td>
                 <td class={`py-3 px-4 ${row.win === 'p' ? 'text-[--color-up]' : row.win === 'both' ? 'text-[--color-accent]' : 'text-[--color-text-muted]'}`}>
                   <span class="flex items-start gap-2">
@@ -83,7 +83,7 @@ const rows = [
       <!-- Mobile cards -->
       <div class="md:hidden space-y-4">
         {rows.map((row) => (
-          <div class={`border border-[--color-border] rounded-lg p-4 ${row.highlight ? 'bg-[--color-accent]/5 border-[--color-accent]/30' : 'bg-[--color-bg-card]'}`}>
+          <div class={`border border-[--color-border] rounded-lg p-4 ${row.highlight ? 'bg-[--color-accent]/10 border-x border-[--color-accent]/20 border-[--color-accent]/30' : 'bg-[--color-bg-card]'}`}>
             <p class="font-mono text-xs text-[--color-text-muted] uppercase tracking-wider mb-2">{row.label}</p>
             <div class="grid grid-cols-2 gap-3">
               <div>

--- a/src/pages/ko/learn/index.astro
+++ b/src/pages/ko/learn/index.astro
@@ -20,27 +20,26 @@ const allPosts = [
 ].sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime());
 
 // Group by level
+const beginnerIds = new Set(['how-to-backtest-crypto-strategy', 'what-is-bb-squeeze', 'risk-management-101', 'why-pruviq', 'crypto-trading-fees-explained', 'strategy-builder-step-by-step']);
 const beginner = allPosts.filter(p =>
   p.data.tags?.includes('beginners') ||
-  p.id === 'how-to-backtest-crypto-strategy' ||
-  p.id === 'what-is-bb-squeeze' ||
-  p.id === 'risk-management-101' ||
-  p.id === 'why-pruviq' ||
-  p.id === 'crypto-trading-fees-explained'
+  (p.data.category === 'education' && p.data.tags?.includes('how-to')) ||
+  beginnerIds.has(p.id)
 );
+const beginnerIdSet = new Set(beginner.map(p => p.id));
 
+const intermediateIds = new Set(['rsi-oversold-overbought-guide', 'ema-crossover-strategy-guide', 'macd-divergence-trading-guide', 'volume-analysis-crypto-trading', 'stochastic-adx-trend-strength', 'sl-tp-optimization-guide', 'save-on-binance-futures-fees', 'ichimoku-cloud-trading-guide', 'fibonacci-retracement-guide', 'vwap-trading-guide', 'support-resistance-guide', 'candlestick-patterns-guide', 'atr-volatility-guide']);
 const intermediate = allPosts.filter(p =>
-  ['rsi-oversold-overbought-guide', 'ema-crossover-strategy-guide', 'macd-divergence-trading-guide',
-   'volume-analysis-crypto-trading', 'stochastic-adx-trend-strength', 'sl-tp-optimization-guide',
-   'save-on-binance-futures-fees', 'ichimoku-cloud-trading-guide', 'fibonacci-retracement-guide',
-   'vwap-trading-guide', 'support-resistance-guide', 'candlestick-patterns-guide',
-   'atr-volatility-guide'].includes(p.id)
+  (p.data.category === 'education' && !beginnerIdSet.has(p.id)) ||
+  intermediateIds.has(p.id)
 );
 
 const advanced = allPosts.filter(p =>
   p.data.category === 'quant' ||
   p.data.category === 'market' ||
-  ['tp8-decision-process'].includes(p.id)
+  p.data.category === 'autopsy' ||
+  p.data.category === 'weekly' ||
+  p.id === 'tp8-decision-process'
 );
 
 // Tag translation map (EN → KO) from i18n

--- a/src/pages/learn/index.astro
+++ b/src/pages/learn/index.astro
@@ -13,27 +13,26 @@ const posts = (await getCollection('blog')).sort(
 );
 
 // Group by level based on tags and category
+const beginnerIds = new Set(['how-to-backtest-crypto-strategy', 'what-is-bb-squeeze', 'risk-management-101', 'why-pruviq', 'crypto-trading-fees-explained', 'strategy-builder-step-by-step']);
 const beginner = posts.filter(p =>
   p.data.tags?.includes('beginners') ||
-  p.id === 'how-to-backtest-crypto-strategy' ||
-  p.id === 'what-is-bb-squeeze' ||
-  p.id === 'risk-management-101' ||
-  p.id === 'why-pruviq' ||
-  p.id === 'crypto-trading-fees-explained'
+  (p.data.category === 'education' && p.data.tags?.includes('how-to')) ||
+  beginnerIds.has(p.id)
 );
+const beginnerIdSet = new Set(beginner.map(p => p.id));
 
+const intermediateIds = new Set(['rsi-oversold-overbought-guide', 'ema-crossover-strategy-guide', 'macd-divergence-trading-guide', 'volume-analysis-crypto-trading', 'stochastic-adx-trend-strength', 'sl-tp-optimization-guide', 'save-on-binance-futures-fees', 'ichimoku-cloud-trading-guide', 'fibonacci-retracement-guide', 'vwap-trading-guide', 'support-resistance-guide', 'candlestick-patterns-guide', 'atr-volatility-guide']);
 const intermediate = posts.filter(p =>
-  ['rsi-oversold-overbought-guide', 'ema-crossover-strategy-guide', 'macd-divergence-trading-guide',
-   'volume-analysis-crypto-trading', 'stochastic-adx-trend-strength', 'sl-tp-optimization-guide',
-   'save-on-binance-futures-fees', 'ichimoku-cloud-trading-guide', 'fibonacci-retracement-guide',
-   'vwap-trading-guide', 'support-resistance-guide', 'candlestick-patterns-guide',
-   'atr-volatility-guide'].includes(p.id)
+  (p.data.category === 'education' && !beginnerIdSet.has(p.id)) ||
+  intermediateIds.has(p.id)
 );
 
 const advanced = posts.filter(p =>
   p.data.category === 'quant' ||
   p.data.category === 'market' ||
-  ['tp8-decision-process'].includes(p.id)
+  p.data.category === 'autopsy' ||
+  p.data.category === 'weekly' ||
+  p.id === 'tp8-decision-process'
 );
 
 // Tag translation map from i18n (EN → EN, for consistency with KO page)


### PR DESCRIPTION
## Summary
- **Learn**: 8 blog posts were invisible — `education`, `autopsy`, `weekly` categories had no filter match. Now 31→39 items across 3 levels
- **Compare**: PRUVIQ column accent background 5%→10% + border-x for visual distinction across all 14 comparison pages

## Root cause
Learn filters used hardcoded ID lists only. New posts with `category: education/autopsy/weekly` fell through all filters silently.

## Test plan
- [x] `npm run build` — 2518 pages, 0 errors
- [x] `grep data-search-item dist/learn/index.html` → 39 items (was 31)
- [x] EN + KO learn pages both updated
- [x] Compare accent visible in built HTML