### PR TITLE
fix: design final — sticky banner, news label, FAQ touch, menu blur

### DIFF
--- a/src/components/MarketDashboard.tsx
+++ b/src/components/MarketDashboard.tsx
@@ -847,6 +847,11 @@ export default function MarketDashboard({
                         <div class="flex-1 min-w-0">
                           <div class="text-sm font-medium text-[--color-text] leading-snug mb-1 truncate">
                             {item.title}
+                            {lang === "ko" && (
+                              <span class="ml-1.5 inline-flex align-middle text-[9px] font-mono font-bold text-[--color-text-muted] border border-[--color-border] rounded px-1 py-0.5 leading-none">
+                                EN
+                              </span>
+                            )}
                           </div>
                           {item.summary && (
                             <div class="text-xs text-[--color-text-muted] leading-snug truncate">
@@ -884,18 +889,15 @@ export default function MarketDashboard({
             )}
           </div>
 
-          {/* CTA */}
-          <div class="mt-8 p-6 bg-[--color-bg-card] border border-[--color-border] rounded-xl">
-            <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-              <div>
-                <h3 class="font-bold text-sm mb-1">{l.ctaTitle}</h3>
-                <p class="text-[--color-text-muted] text-xs">
-                  {l.ctaDesc.replace("{coins}", coinsCount)}
-                </p>
-              </div>
+          {/* CTA — ghost style to avoid competing with global bottom CTA bar */}
+          <div class="mt-8 px-4 py-3 border border-[--color-border] rounded-lg">
+            <div class="flex items-center justify-between gap-3">
+              <p class="text-[--color-text-muted] text-xs truncate">
+                {l.ctaDesc.replace("{coins}", coinsCount)}
+              </p>
               <a
                 href={lang === "ko" ? "/ko/simulate" : "/simulate"}
-                class="shrink-0 btn btn-primary btn-md whitespace-nowrap no-underline"
+                class="shrink-0 text-xs font-semibold text-[--color-accent] border border-[--color-accent]/30 px-4 py-2 rounded hover:bg-[--color-accent]/10 transition-colors no-underline whitespace-nowrap"
               >
                 {l.ctaButton} →
               </a>

--- a/src/components/ResultsPanel.tsx
+++ b/src/components/ResultsPanel.tsx
@@ -881,7 +881,9 @@ export default function ResultsPanel({
                           <div class="text-[10px] font-mono text-[--color-text-muted] uppercase mb-2">
                             {t.monthlyReturns || "Monthly Returns"}
                           </div>
-                          <ScrollHint label={lang === "ko" ? "스크롤 →" : "Scroll →"}>
+                          <ScrollHint
+                            label={lang === "ko" ? "스크롤 →" : "Scroll →"}
+                          >
                             <div class="flex gap-1 min-w-max">
                               {result.monthly_stats.map((m) => {
                                 const maxRet = Math.max(
@@ -1176,150 +1178,150 @@ export default function ResultsPanel({
             <div class="p-2">
               {result.trades && result.trades.length > 0 ? (
                 <ScrollHint label={lang === "ko" ? "스크롤 →" : "Scroll →"}>
-                <table class="w-full text-xs font-mono min-w-[500px] md:min-w-0">
-                  <caption class="sr-only">
-                    {t.tradeTableCaption || "Simulated trade details"}
-                  </caption>
-                  <thead>
-                    <tr class="text-[--color-text-muted] border-b border-[--color-border]">
-                      <th class="py-2 px-2 text-left">{t.symbol}</th>
-                      <th class="py-2 px-2 text-left hidden sm:table-cell">
-                        {t.entryTime}
-                      </th>
-                      <th class="py-2 px-2 text-left">{t.exitTime}</th>
-                      <th class="py-2 px-2 text-right">{t.pnl}</th>
-                      <th class="py-2 px-2 text-right">PnL $</th>
-                      <th class="py-2 px-2 text-center">{t.reason}</th>
-                      <th class="py-2 px-2 text-right">{t.held}</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {result.trades.slice(0, 200).map((tr, i) => {
-                      const isExpanded = expandedTrade === i;
-                      return (
-                        <>
-                          <tr
-                            key={i}
-                            class={`border-b border-[--color-border]/30 hover:bg-[--color-bg-hover]/30 cursor-pointer select-none ${isExpanded ? "bg-[--color-bg-hover]/20" : ""}`}
-                            onClick={() =>
-                              setExpandedTrade(isExpanded ? null : i)
-                            }
-                            role="button"
-                            aria-expanded={isExpanded}
-                            tabIndex={0}
-                            onKeyDown={(e: KeyboardEvent) => {
-                              if (e.key === "Enter" || e.key === " ") {
-                                e.preventDefault();
-                                setExpandedTrade(isExpanded ? null : i);
-                              }
-                            }}
-                          >
-                            <td class="py-1.5 px-2">
-                              {tr.symbol?.replace("USDT", "")}
-                            </td>
-                            <td class="py-1.5 px-2 text-[--color-text-muted] hidden sm:table-cell">
-                              {tr.entry_time?.slice(0, 16)}
-                            </td>
-                            <td class="py-1.5 px-2 text-[--color-text-muted]">
-                              {tr.exit_time?.slice(0, 16)}
-                            </td>
-                            <td
-                              class="py-1.5 px-2 text-right"
-                              style={{ color: signColor(tr.pnl_pct) }}
-                            >
-                              {tr.pnl_pct > 0 ? "+" : ""}
-                              {tr.pnl_pct.toFixed(2)}%
-                            </td>
-                            <td
-                              class="py-1.5 px-2 text-right"
-                              style={{ color: signColor(tr.pnl_usd || 0) }}
-                            >
-                              {(tr.pnl_usd || 0) > 0 ? "+" : ""}$
-                              {(tr.pnl_usd || 0).toFixed(2)}
-                            </td>
-                            <td class="py-1.5 px-2 text-center">
-                              <span
-                                class={`px-1.5 py-0.5 rounded text-[10px] ${
-                                  tr.exit_reason === "TP"
-                                    ? "bg-[--color-green]/10 text-[--color-green]"
-                                    : tr.exit_reason === "SL"
-                                      ? "bg-[--color-red]/10 text-[--color-red]"
-                                      : "bg-[--color-yellow]/10 text-[--color-yellow]"
-                                }`}
-                              >
-                                {tr.exit_reason}
-                              </span>
-                            </td>
-                            <td class="py-1.5 px-2 text-right text-[--color-text-muted]">
-                              {tr.bars_held}h
-                            </td>
-                          </tr>
-                          {isExpanded && (
+                  <table class="w-full text-xs font-mono min-w-[500px] md:min-w-0">
+                    <caption class="sr-only">
+                      {t.tradeTableCaption || "Simulated trade details"}
+                    </caption>
+                    <thead>
+                      <tr class="text-[--color-text-muted] border-b border-[--color-border]">
+                        <th class="py-2 px-2 text-left">{t.symbol}</th>
+                        <th class="py-2 px-2 text-left hidden sm:table-cell">
+                          {t.entryTime}
+                        </th>
+                        <th class="py-2 px-2 text-left">{t.exitTime}</th>
+                        <th class="py-2 px-2 text-right">{t.pnl}</th>
+                        <th class="py-2 px-2 text-right">PnL $</th>
+                        <th class="py-2 px-2 text-center">{t.reason}</th>
+                        <th class="py-2 px-2 text-right">{t.held}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {result.trades.slice(0, 200).map((tr, i) => {
+                        const isExpanded = expandedTrade === i;
+                        return (
+                          <>
                             <tr
-                              key={`detail-${i}`}
-                              class="border-b border-[--color-border]/30 bg-[--color-bg-hover]/10"
+                              key={i}
+                              class={`border-b border-[--color-border]/30 hover:bg-[--color-bg-hover]/30 cursor-pointer select-none ${isExpanded ? "bg-[--color-bg-hover]/20" : ""}`}
+                              onClick={() =>
+                                setExpandedTrade(isExpanded ? null : i)
+                              }
+                              role="button"
+                              aria-expanded={isExpanded}
+                              tabIndex={0}
+                              onKeyDown={(e: KeyboardEvent) => {
+                                if (e.key === "Enter" || e.key === " ") {
+                                  e.preventDefault();
+                                  setExpandedTrade(isExpanded ? null : i);
+                                }
+                              }}
                             >
-                              <td colSpan={7} class="px-3 py-2.5">
-                                <div class="grid grid-cols-2 sm:grid-cols-4 gap-x-4 gap-y-1.5 text-[10px] font-mono">
-                                  <div>
-                                    <span class="text-[--color-text-muted] uppercase">
-                                      {t.tradeDirection || "Direction"}
-                                    </span>
-                                    <div
-                                      class={`font-bold ${tr.direction === "SHORT" ? "text-[--color-red]" : "text-[--color-green]"}`}
-                                    >
-                                      {tr.direction}
-                                    </div>
-                                  </div>
-                                  <div>
-                                    <span class="text-[--color-text-muted] uppercase">
-                                      {t.tradeEntryPrice || "Entry Price"}
-                                    </span>
-                                    <div>
-                                      $
-                                      {tr.entry_price?.toLocaleString(
-                                        undefined,
-                                        {
-                                          minimumFractionDigits: 2,
-                                          maximumFractionDigits: 6,
-                                        },
-                                      )}
-                                    </div>
-                                  </div>
-                                  <div>
-                                    <span class="text-[--color-text-muted] uppercase">
-                                      {t.tradeExitPrice || "Exit Price"}
-                                    </span>
-                                    <div>
-                                      $
-                                      {tr.exit_price?.toLocaleString(
-                                        undefined,
-                                        {
-                                          minimumFractionDigits: 2,
-                                          maximumFractionDigits: 6,
-                                        },
-                                      )}
-                                    </div>
-                                  </div>
-                                  <div>
-                                    <span class="text-[--color-text-muted] uppercase">
-                                      {t.tradeHoldTime || "Hold Time"}
-                                    </span>
-                                    <div>
-                                      {tr.bars_held >= 24
-                                        ? `${(tr.bars_held / 24).toFixed(1)}d`
-                                        : `${tr.bars_held}h`}
-                                    </div>
-                                  </div>
-                                </div>
+                              <td class="py-1.5 px-2">
+                                {tr.symbol?.replace("USDT", "")}
+                              </td>
+                              <td class="py-1.5 px-2 text-[--color-text-muted] hidden sm:table-cell">
+                                {tr.entry_time?.slice(0, 16)}
+                              </td>
+                              <td class="py-1.5 px-2 text-[--color-text-muted]">
+                                {tr.exit_time?.slice(0, 16)}
+                              </td>
+                              <td
+                                class="py-1.5 px-2 text-right"
+                                style={{ color: signColor(tr.pnl_pct) }}
+                              >
+                                {tr.pnl_pct > 0 ? "+" : ""}
+                                {tr.pnl_pct.toFixed(2)}%
+                              </td>
+                              <td
+                                class="py-1.5 px-2 text-right"
+                                style={{ color: signColor(tr.pnl_usd || 0) }}
+                              >
+                                {(tr.pnl_usd || 0) > 0 ? "+" : ""}$
+                                {(tr.pnl_usd || 0).toFixed(2)}
+                              </td>
+                              <td class="py-1.5 px-2 text-center">
+                                <span
+                                  class={`px-1.5 py-0.5 rounded text-[10px] ${
+                                    tr.exit_reason === "TP"
+                                      ? "bg-[--color-green]/10 text-[--color-green]"
+                                      : tr.exit_reason === "SL"
+                                        ? "bg-[--color-red]/10 text-[--color-red]"
+                                        : "bg-[--color-yellow]/10 text-[--color-yellow]"
+                                  }`}
+                                >
+                                  {tr.exit_reason}
+                                </span>
+                              </td>
+                              <td class="py-1.5 px-2 text-right text-[--color-text-muted]">
+                                {tr.bars_held}h
                               </td>
                             </tr>
-                          )}
-                        </>
-                      );
-                    })}
-                  </tbody>
-                </table>
+                            {isExpanded && (
+                              <tr
+                                key={`detail-${i}`}
+                                class="border-b border-[--color-border]/30 bg-[--color-bg-hover]/10"
+                              >
+                                <td colSpan={7} class="px-3 py-2.5">
+                                  <div class="grid grid-cols-2 sm:grid-cols-4 gap-x-4 gap-y-1.5 text-[10px] font-mono">
+                                    <div>
+                                      <span class="text-[--color-text-muted] uppercase">
+                                        {t.tradeDirection || "Direction"}
+                                      </span>
+                                      <div
+                                        class={`font-bold ${tr.direction === "SHORT" ? "text-[--color-red]" : "text-[--color-green]"}`}
+                                      >
+                                        {tr.direction}
+                                      </div>
+                                    </div>
+                                    <div>
+                                      <span class="text-[--color-text-muted] uppercase">
+                                        {t.tradeEntryPrice || "Entry Price"}
+                                      </span>
+                                      <div>
+                                        $
+                                        {tr.entry_price?.toLocaleString(
+                                          undefined,
+                                          {
+                                            minimumFractionDigits: 2,
+                                            maximumFractionDigits: 6,
+                                          },
+                                        )}
+                                      </div>
+                                    </div>
+                                    <div>
+                                      <span class="text-[--color-text-muted] uppercase">
+                                        {t.tradeExitPrice || "Exit Price"}
+                                      </span>
+                                      <div>
+                                        $
+                                        {tr.exit_price?.toLocaleString(
+                                          undefined,
+                                          {
+                                            minimumFractionDigits: 2,
+                                            maximumFractionDigits: 6,
+                                          },
+                                        )}
+                                      </div>
+                                    </div>
+                                    <div>
+                                      <span class="text-[--color-text-muted] uppercase">
+                                        {t.tradeHoldTime || "Hold Time"}
+                                      </span>
+                                      <div>
+                                        {tr.bars_held >= 24
+                                          ? `${(tr.bars_held / 24).toFixed(1)}d`
+                                          : `${tr.bars_held}h`}
+                                      </div>
+                                    </div>
+                                  </div>
+                                </td>
+                              </tr>
+                            )}
+                          </>
+                        );
+                      })}
+                    </tbody>
+                  </table>
                 </ScrollHint>
               ) : (
                 <div class="text-center py-8 text-[--color-text-muted] text-sm">
@@ -1400,7 +1402,7 @@ export default function ResultsPanel({
                   : "";
 
               return (
-                <div class="p-2">
+                <div class="p-3 sm:p-4">
                   <div class="flex flex-wrap gap-3 mb-3 px-2 text-[10px] font-mono text-[--color-text-muted]">
                     <span style={{ color: COLORS.green }}>
                       {profitable} {t.profitableUnit}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -453,7 +453,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
           </button>
         </div>
       </div>
-      <div id="mobile-menu" class="hidden md:hidden border-t border-[--color-border] bg-[--color-bg]" aria-hidden="true">
+      <div id="mobile-menu" class="hidden md:hidden border-t border-[--color-border] bg-[--color-bg] backdrop-blur-sm" aria-hidden="true">
         <div class="flex flex-col px-4 py-4 gap-1 text-sm">
           {navItems.map(item => (
             <Fragment>
@@ -570,7 +570,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     </footer>
 
     <!-- Sticky CTA Bar (mobile-only, appears on scroll past hero) -->
-    <div id="sticky-cta" class="sm:hidden fixed bottom-0 left-0 right-0 z-50 translate-y-full transition-transform duration-300 border-t border-[--color-border] bg-[--color-bg]/95 backdrop-blur-md safe-area-bottom" role="complementary" aria-label="Quick action bar">
+    <div id="sticky-cta" data-hide-in-hero class="sm:hidden fixed bottom-0 left-0 right-0 z-50 translate-y-full transition-transform duration-300 border-t border-[--color-border] bg-[--color-bg]/95 backdrop-blur-md safe-area-bottom" role="complementary" aria-label="Quick action bar">
       <div class="px-4 py-3 flex items-center justify-between gap-3">
         <a href={simulatePath} class="btn btn-primary btn-md flex-1 text-center no-underline whitespace-nowrap">
           {t('hero.cta_primary')} →
@@ -609,7 +609,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     </script>
     <!-- Sticky bottom CTA bar (non-simulator pages only) -->
     {!basePath.startsWith('/simulate') && (
-      <div id="bottom-cta-bar" class="fixed bottom-0 left-0 right-0 z-40 border-t border-[--color-border] bg-[--color-bg-elevated] transition-transform duration-300 translate-y-full" style="height:48px;" role="complementary" aria-label="Try simulator">
+      <div id="bottom-cta-bar" data-hide-in-hero class="fixed bottom-0 left-0 right-0 z-40 border-t border-[--color-border] bg-[--color-bg-elevated] transition-transform duration-300 translate-y-full" style="height:48px;" role="complementary" aria-label="Try simulator">
         <div class="max-w-7xl mx-auto px-6 lg:px-10 h-full flex items-center justify-between gap-3">
           <p class="text-sm text-[--color-text-muted] truncate">
             {lang === 'ko' ? '570+ 코인에서 전략 테스트' : 'Test your strategy on 570+ coins'}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,7 +29,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 <Layout title={t('meta.home_title')} description={t('meta.index_desc')}>
 
   <!-- HERO — 50/50 layout: text left, live demo right -->
-  <section class="relative overflow-hidden hero-bg-depth bg-noise">
+  <section id="hero-section" class="relative overflow-hidden hero-bg-depth bg-noise">
     <HeroGlow />
     <div class="relative max-w-7xl mx-auto px-6 pt-10 pb-16 md:pt-14 md:pb-20 hero-enter">
       <div class="grid md:grid-cols-2 gap-12 md:gap-16 items-center">

--- a/src/pages/ko/fees.astro
+++ b/src/pages/ko/fees.astro
@@ -335,7 +335,7 @@ const t = useTranslations('ko');
 
       <div class="space-y-4 max-w-3xl">
         <details class="border border-[--color-border] rounded-lg bg-[--color-bg-card] group">
-          <summary class="p-4 cursor-pointer font-medium flex justify-between items-center min-h-[44px]">
+          <summary class="p-4 cursor-pointer font-medium flex justify-between items-center min-h-[48px]">
             {t('fees.referral.faq.q1')}
             <span class="text-[--color-text-muted] group-open:rotate-45 transition-transform text-xl leading-none">+</span>
           </summary>
@@ -343,7 +343,7 @@ const t = useTranslations('ko');
         </details>
 
         <details class="border border-[--color-border] rounded-lg bg-[--color-bg-card] group">
-          <summary class="p-4 cursor-pointer font-medium flex justify-between items-center min-h-[44px]">
+          <summary class="p-4 cursor-pointer font-medium flex justify-between items-center min-h-[48px]">
             {t('fees.referral.faq.q2')}
             <span class="text-[--color-text-muted] group-open:rotate-45 transition-transform text-xl leading-none">+</span>
           </summary>
@@ -351,7 +351,7 @@ const t = useTranslations('ko');
         </details>
 
         <details class="border border-[--color-border] rounded-lg bg-[--color-bg-card] group">
-          <summary class="p-4 cursor-pointer font-medium flex justify-between items-center min-h-[44px]">
+          <summary class="p-4 cursor-pointer font-medium flex justify-between items-center min-h-[48px]">
             {t('fees.referral.faq.q3')}
             <span class="text-[--color-text-muted] group-open:rotate-45 transition-transform text-xl leading-none">+</span>
           </summary>
@@ -359,7 +359,7 @@ const t = useTranslations('ko');
         </details>
 
         <details class="border border-[--color-border] rounded-lg bg-[--color-bg-card] group">
-          <summary class="p-4 cursor-pointer font-medium flex justify-between items-center min-h-[44px]">
+          <summary class="p-4 cursor-pointer font-medium flex justify-between items-center min-h-[48px]">
             {t('fees.referral.faq.q4')}
             <span class="text-[--color-text-muted] group-open:rotate-45 transition-transform text-xl leading-none">+</span>
           </summary>
@@ -367,7 +367,7 @@ const t = useTranslations('ko');
         </details>
 
         <details class="border border-[--color-border] rounded-lg bg-[--color-bg-card] group">
-          <summary class="p-4 cursor-pointer font-medium flex justify-between items-center min-h-[44px]">
+          <summary class="p-4 cursor-pointer font-medium flex justify-between items-center min-h-[48px]">
             {t('fees.referral.faq.q5')}
             <span class="text-[--color-text-muted] group-open:rotate-45 transition-transform text-xl leading-none">+</span>
           </summary>
@@ -407,7 +407,7 @@ const t = useTranslations('ko');
 
       <div class="space-y-4 max-w-3xl">
         <details class="border border-[--color-border] rounded-lg bg-[--color-bg-card] group">
-          <summary class="p-4 cursor-pointer font-medium flex justify-between items-center min-h-[44px]">
+          <summary class="p-4 cursor-pointer font-medium flex justify-between items-center min-h-[48px]">
             {t('fees.faq1_q')}
             <span class="text-[--color-text-muted] group-open:rotate-45 transition-transform text-xl leading-none">+</span>
           </summary>
@@ -417,7 +417,7 @@ const t = useTranslations('ko');
         </details>
 
         <details class="border border-[--color-border] rounded-lg bg-[--color-bg-card] group">
-          <summary class="p-4 cursor-pointer font-medium flex justify-between items-center min-h-[44px]">
+          <summary class="p-4 cursor-pointer font-medium flex justify-between items-center min-h-[48px]">
             {t('fees.faq2_q')}
             <span class="text-[--color-text-muted] group-open:rotate-45 transition-transform text-xl leading-none">+</span>
           </summary>
@@ -427,7 +427,7 @@ const t = useTranslations('ko');
         </details>
 
         <details class="border border-[--color-border] rounded-lg bg-[--color-bg-card] group">
-          <summary class="p-4 cursor-pointer font-medium flex justify-between items-center min-h-[44px]">
+          <summary class="p-4 cursor-pointer font-medium flex justify-between items-center min-h-[48px]">
             {t('fees.faq3_q')}
             <span class="text-[--color-text-muted] group-open:rotate-45 transition-transform text-xl leading-none">+</span>
           </summary>

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -29,7 +29,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 <Layout title={t('meta.home_title')} description={t('meta.index_desc')}>
 
   <!-- HERO — 50/50 layout: text left, live demo right -->
-  <section class="relative overflow-hidden hero-bg-depth bg-noise">
+  <section id="hero-section" class="relative overflow-hidden hero-bg-depth bg-noise">
     <HeroGlow />
     <div class="relative max-w-7xl mx-auto px-6 pt-10 pb-16 md:pt-14 md:pb-20 hero-enter">
       <div class="grid md:grid-cols-2 gap-12 md:gap-16 items-center">

--- a/src/scripts/layout-client.js
+++ b/src/scripts/layout-client.js
@@ -1,17 +1,23 @@
 // Client-side layout behaviors (moved out of inline HTML to avoid render-blocking)
 (function () {
   // Page loader on navigation
-  const loader = document.getElementById('page-loader');
+  const loader = document.getElementById("page-loader");
   // Reset loader on page load (previous navigation may have left it in loading state)
-  loader?.classList.remove('loading');
+  loader?.classList.remove("loading");
 
-  document.addEventListener('click', (e) => {
+  document.addEventListener("click", (e) => {
     const el = e.target;
-    const link = el && (el.closest ? el.closest('a[href]') : null);
+    const link = el && (el.closest ? el.closest("a[href]") : null);
     if (!link) return;
     try {
-      if (link.href && !link.target && !link.href.startsWith('mailto:') && !link.href.startsWith('tel:') && new URL(link.href).origin === window.location.origin) {
-        loader?.classList.add('loading');
+      if (
+        link.href &&
+        !link.target &&
+        !link.href.startsWith("mailto:") &&
+        !link.href.startsWith("tel:") &&
+        new URL(link.href).origin === window.location.origin
+      ) {
+        loader?.classList.add("loading");
       }
     } catch (err) {
       // ignore malformed URLs
@@ -19,42 +25,50 @@
   });
 
   // Nav scroll shadow
-  const nav = document.querySelector('nav');
-  window.addEventListener('scroll', () => {
-    nav?.classList.toggle('scrolled', window.scrollY > 10);
-  }, { passive: true });
+  const nav = document.querySelector("nav");
+  window.addEventListener(
+    "scroll",
+    () => {
+      nav?.classList.toggle("scrolled", window.scrollY > 10);
+    },
+    { passive: true },
+  );
 
-  const menuBtn = document.getElementById('mobile-menu-btn');
-  const mobileMenu = document.getElementById('mobile-menu');
+  const menuBtn = document.getElementById("mobile-menu-btn");
+  const mobileMenu = document.getElementById("mobile-menu");
 
   function closeMenu() {
-    mobileMenu?.classList.add('hidden');
-    mobileMenu?.setAttribute('aria-hidden', 'true');
-    menuBtn?.setAttribute('aria-expanded', 'false');
+    mobileMenu?.classList.add("hidden");
+    mobileMenu?.setAttribute("aria-hidden", "true");
+    menuBtn?.setAttribute("aria-expanded", "false");
   }
 
-  menuBtn?.addEventListener('click', () => {
-    const isHidden = mobileMenu?.classList.toggle('hidden');
-    menuBtn.setAttribute('aria-expanded', String(!isHidden));
-    mobileMenu?.setAttribute('aria-hidden', String(!!isHidden));
+  menuBtn?.addEventListener("click", () => {
+    const isHidden = mobileMenu?.classList.toggle("hidden");
+    menuBtn.setAttribute("aria-expanded", String(!isHidden));
+    mobileMenu?.setAttribute("aria-hidden", String(!!isHidden));
     // Scroll menu into view without stealing focus (avoids outline on first link)
     if (!isHidden) {
-      mobileMenu?.scrollIntoView({ block: 'nearest' });
+      mobileMenu?.scrollIntoView({ block: "nearest" });
     }
   });
 
   // Escape key closes menu
-  document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape' && mobileMenu && !mobileMenu.classList.contains('hidden')) {
+  document.addEventListener("keydown", (e) => {
+    if (
+      e.key === "Escape" &&
+      mobileMenu &&
+      !mobileMenu.classList.contains("hidden")
+    ) {
       closeMenu();
       menuBtn?.focus();
     }
   });
 
   // Focus trap when menu is open
-  mobileMenu?.addEventListener('keydown', (e) => {
-    if (e.key !== 'Tab') return;
-    const focusable = mobileMenu.querySelectorAll('a, button');
+  mobileMenu?.addEventListener("keydown", (e) => {
+    if (e.key !== "Tab") return;
+    const focusable = mobileMenu.querySelectorAll("a, button");
     if (focusable.length === 0) return;
     const first = focusable[0];
     const last = focusable[focusable.length - 1];
@@ -68,9 +82,30 @@
   });
 
   // Close menu when clicking a link inside it
-  mobileMenu?.querySelectorAll('a').forEach(link => {
-    link.addEventListener('click', () => {
+  mobileMenu?.querySelectorAll("a").forEach((link) => {
+    link.addEventListener("click", () => {
       closeMenu();
     });
   });
+
+  // Hide sticky banners when hero section is in viewport (M3)
+  const heroSection = document.getElementById("hero-section");
+  if (heroSection && window.IntersectionObserver) {
+    const hideTargets = document.querySelectorAll("[data-hide-in-hero]");
+    if (hideTargets.length > 0) {
+      new IntersectionObserver(
+        (entries) => {
+          const heroVisible = entries[0].isIntersecting;
+          hideTargets.forEach((el) => {
+            if (heroVisible) {
+              el.classList.add("hidden");
+            } else {
+              el.classList.remove("hidden");
+            }
+          });
+        },
+        { threshold: 0.3 },
+      ).observe(heroSection);
+    }
+  }
 })();


### PR DESCRIPTION
## Summary
마지막 6건 — 전체 디자인/UX 리뷰 완료

- **M3**: 홈 sticky CTA 배너 → hero 영역 표시 시 자동 숨김 (IntersectionObserver)
- **M5**: ResultsPanel 코인 탭 패딩 증가 (p-2 → p-3 sm:p-4)
- **M9**: Market 하단 CTA ghost 스타일로 변경 (dual CTA 경쟁 해소)
- **M10**: KO Market 뉴스 영문 헤드라인에 EN 뱃지 표시
- **M20**: KO Fees FAQ summary 터치 타겟 48px
- **L15**: Mobile 메뉴 backdrop-blur-sm

## Changed files (7)
- `src/scripts/layout-client.js` — IntersectionObserver 추가
- `src/layouts/Layout.astro` — data-hide-in-hero + backdrop-blur
- `src/pages/index.astro` + `ko/index.astro` — hero id
- `src/components/ResultsPanel.tsx` — padding
- `src/components/MarketDashboard.tsx` — ghost CTA + EN badge
- `src/pages/ko/fees.astro` — FAQ min-h-[48px]

## Test plan
- [x] `npm run build` → 2518 pages, 0 errors
- [x] `bash scripts/qa-redirects.sh` → PASS
- [ ] Home: scroll past hero → sticky banner appears
- [ ] /ko/market: news items show EN badge
- [ ] Mobile: menu backdrop blur visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)