### PR TITLE
fix: toward 9.5 — motion polish + value prop + spacing

### DIFF
--- a/src/components/BuilderPanel.tsx
+++ b/src/components/BuilderPanel.tsx
@@ -205,7 +205,7 @@ export default function BuilderPanel(props: Props) {
         )}
 
         {/* Indicators */}
-        <div class="px-4 py-3 border-b border-[--color-border]">
+        <div class="px-4 py-4 border-b border-[--color-border]">
           <div class="text-xs font-mono text-[--color-text-muted] uppercase mb-2">
             {t.indicators}
           </div>
@@ -240,7 +240,7 @@ export default function BuilderPanel(props: Props) {
         </div>
 
         {/* Entry Conditions */}
-        <div class="px-4 py-3 border-b border-[--color-border]">
+        <div class="px-4 py-4 border-b border-[--color-border]">
           <div class="flex items-center justify-between mb-1">
             <span class="text-xs font-mono text-[--color-text-muted] uppercase">
               {t.conditions}
@@ -252,7 +252,7 @@ export default function BuilderPanel(props: Props) {
               {t.addCondition}
             </button>
           </div>
-          <div class="space-y-3 sm:space-y-2">
+          <div class="space-y-4 sm:space-y-3">
             {props.conditions.map((c) => (
               <ConditionRow
                 key={c.id}
@@ -278,11 +278,11 @@ export default function BuilderPanel(props: Props) {
         </div>
 
         {/* Parameters + Date Range (merged 3-column grid) */}
-        <div class="px-4 py-3 border-b border-[--color-border]">
+        <div class="px-4 py-4 border-b border-[--color-border]">
           <div class="text-xs font-mono text-[--color-text-muted] uppercase mb-2">
             {t.parameters}
           </div>
-          <div class="grid grid-cols-3 gap-x-2 gap-y-3 sm:gap-y-2">
+          <div class="grid grid-cols-3 gap-x-2 gap-y-4 sm:gap-y-3">
             {/* Timeframe - spans full width */}
             <div class="col-span-3 mb-1">
               <label class="text-[10px] text-[--color-text-muted]">
@@ -563,7 +563,7 @@ export default function BuilderPanel(props: Props) {
         </div>
 
         {/* Coin Selection */}
-        <div class="px-4 py-3 border-b border-[--color-border]">
+        <div class="px-4 py-4 border-b border-[--color-border]">
           <div class="text-xs font-mono text-[--color-text-muted] uppercase mb-2">
             {t.coins}
           </div>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -351,6 +351,7 @@ export const en = {
     "Spot & futures fees at a glance. Sign up through PRUVIQ and get up to 19% off Binance trading fees.",
   "fees.disclosure":
     "Affiliate disclosure: PRUVIQ earns a commission when you sign up through our referral links. Your fee discount is not affected.",
+  "fees.ctaSimulate": "Start Free Simulation",
   "fees.compare_title": "Compare Exchanges",
   "fees.compare_desc":
     "Base tier (VIP 0). Referral discounts stack on top of VIP tiers.",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -349,6 +349,7 @@ export const ko: Record<TranslationKey, string> = {
     "현물 & 선물 수수료 한눈에. PRUVIQ 추천 링크로 바이낸스 가입 시 최대 19% 할인.",
   "fees.disclosure":
     "제휴 공개: PRUVIQ는 추천 링크로 가입 시 거래소로부터 수수료를 받습니다. 회원의 수수료 할인에는 영향이 없습니다.",
+  "fees.ctaSimulate": "무료 시뮬레이션 시작",
   "fees.compare_title": "거래소 비교",
   "fees.compare_desc":
     "기본 등급 (VIP 0). 추천 할인은 VIP 등급 할인 위에 추가 적용됩니다.",

--- a/src/pages/fees.astro
+++ b/src/pages/fees.astro
@@ -80,7 +80,7 @@ const t = useTranslations('en');
       <p class="text-[--color-text-muted] text-xs mt-6">
         {t('fees.disclosure')}
       </p>
-      <a href="/simulate" class="btn btn-primary btn-md w-full sm:w-auto mt-4">Start Free Simulation &rarr;</a>
+      <a href="/simulate" class="btn btn-primary btn-md w-full sm:w-auto mt-4">{t('fees.ctaSimulate')} &rarr;</a>
     </div>
   </section>
 

--- a/src/pages/fees.astro
+++ b/src/pages/fees.astro
@@ -80,6 +80,7 @@ const t = useTranslations('en');
       <p class="text-[--color-text-muted] text-xs mt-6">
         {t('fees.disclosure')}
       </p>
+      <a href="/simulate" class="btn btn-primary btn-md w-full sm:w-auto mt-4">Start Free Simulation &rarr;</a>
     </div>
   </section>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -60,7 +60,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
             </a>
           </div>
           <!-- Trust strip -->
-          <p class="text-xs font-mono text-[--color-text-muted] mt-3">572+ strategies · 2,000+ coins · Free forever · No signup required</p>
+          <p class="text-xs font-mono text-[--color-text-muted] mt-3">{simulatorPresetCount}+ strategies · {coinsAnalyzed}+ coins · Free forever · No signup required</p>
         </div>
         <!-- Right: Live simulator demo -->
         <div class="relative">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -52,17 +52,15 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
           </div>
           <!-- CTA -->
           <div class="flex flex-col sm:flex-row gap-3 mt-8">
-            <a href="/simulate" class="btn btn-primary btn-lg text-center">
+            <a href="/simulate" class="btn btn-primary btn-lg text-center w-full sm:w-auto">
               Open Simulator — Free &rarr;
             </a>
-            <a href="/strategies" class="btn btn-ghost btn-sm text-center">
+            <a href="/strategies" class="btn btn-ghost btn-sm text-center w-full sm:w-auto">
               Explore Strategies
             </a>
           </div>
-          <!-- Micro trust -->
-          <p class="mt-4 text-xs text-[--color-text-disabled] font-mono">
-            {coinsAnalyzed}+ coins · 2Y+ data · Real fees · No credit card
-          </p>
+          <!-- Trust strip -->
+          <p class="text-xs font-mono text-[--color-text-muted] mt-3">572+ strategies · 2,000+ coins · Free forever · No signup required</p>
         </div>
         <!-- Right: Live simulator demo -->
         <div class="relative">

--- a/src/pages/ko/fees.astro
+++ b/src/pages/ko/fees.astro
@@ -70,6 +70,7 @@ const t = useTranslations('ko');
       <p class="text-[--color-text-muted] text-xs mt-6">
         {t('fees.disclosure')}
       </p>
+      <a href="/ko/simulate" class="btn btn-primary btn-md w-full sm:w-auto mt-4">무료 시뮬레이션 시작 &rarr;</a>
     </div>
   </section>
 

--- a/src/pages/ko/fees.astro
+++ b/src/pages/ko/fees.astro
@@ -70,7 +70,7 @@ const t = useTranslations('ko');
       <p class="text-[--color-text-muted] text-xs mt-6">
         {t('fees.disclosure')}
       </p>
-      <a href="/ko/simulate" class="btn btn-primary btn-md w-full sm:w-auto mt-4">무료 시뮬레이션 시작 &rarr;</a>
+      <a href="/ko/simulate" class="btn btn-primary btn-md w-full sm:w-auto mt-4">{t('fees.ctaSimulate')} &rarr;</a>
     </div>
   </section>
 

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -60,7 +60,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
             </a>
           </div>
           <!-- Trust strip -->
-          <p class="text-xs font-mono text-[--color-text-muted] mt-3">572개+ 전략 · 2,000개+ 코인 · 영구 무료 · 가입 불필요</p>
+          <p class="text-xs font-mono text-[--color-text-muted] mt-3">{simulatorPresetCount}개+ 전략 · {coinsAnalyzed}개+ 코인 · 영구 무료 · 가입 불필요</p>
         </div>
         <!-- Right: Live simulator demo -->
         <div class="relative">

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -52,17 +52,15 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
           </div>
           <!-- CTA -->
           <div class="flex flex-col sm:flex-row gap-3 mt-8">
-            <a href="/ko/simulate" class="btn btn-primary btn-lg text-center">
+            <a href="/ko/simulate" class="btn btn-primary btn-lg text-center w-full sm:w-auto">
               시뮬레이터 열기 — 무료 &rarr;
             </a>
-            <a href="/ko/strategies" class="btn btn-ghost btn-sm text-center">
+            <a href="/ko/strategies" class="btn btn-ghost btn-sm text-center w-full sm:w-auto">
               전략 탐색하기
             </a>
           </div>
-          <!-- Micro trust -->
-          <p class="mt-4 text-xs text-[--color-text-disabled] font-mono">
-            {coinsAnalyzed}+ 코인 · 2년+ 데이터 · 실제 수수료 · 신용카드 불필요
-          </p>
+          <!-- Trust strip -->
+          <p class="text-xs font-mono text-[--color-text-muted] mt-3">572개+ 전략 · 2,000개+ 코인 · 영구 무료 · 가입 불필요</p>
         </div>
         <!-- Right: Live simulator demo -->
         <div class="relative">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -58,7 +58,7 @@
   /* ─── TEXT (4-level hierarchy: text > secondary > muted > disabled) ─── */
   --color-text:          #E4E4E7;   /* Zinc-200 — headings, body */
   --color-text-secondary:#A1A1AA;   /* Zinc-400 — descriptions, subtitles */
-  --color-text-muted:    #898992;   /* Zinc-450 — labels, meta, captions (distinct from secondary) */
+  --color-text-muted:    #9A9AA3;   /* Zinc-450 bumped — WCAG AA 4.6:1 on #09090B */
   --color-text-disabled: #52525B;   /* Zinc-600 — inactive, placeholder */
 
   /* ─── ACCENT — unified with logo IQ cyan ─── */
@@ -650,17 +650,14 @@ textarea:focus-visible,
 
 /* ─── Card hover ─── */
 .card-hover {
-  transition: border-color var(--duration-normal) var(--ease-smooth),
-              transform var(--duration-normal) var(--ease-default),
-              box-shadow var(--duration-normal) var(--ease-smooth);
+  transition: border-color 0.2s ease,
+              transform 0.2s ease,
+              box-shadow 0.2s ease;
 }
 .card-hover:hover {
-  border-color: rgba(255,255,255,0.15);
-  transform: translateY(-2px);
-  box-shadow:
-    0 0 0 1px rgba(255,255,255,0.10),
-    0 8px 24px rgba(0,0,0,0.35),
-    0 20px 48px rgba(0,0,0,0.25);
+  border-color: rgba(0,220,130,0.2);
+  transform: translateY(-2px) scale(1.005);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.3);
 }
 
 /* ─── Table row hover ─── */
@@ -1054,7 +1051,7 @@ textarea:focus-visible,
 
 /* ─── Section alternating backgrounds ─── */
 .section-alt {
-  background-color: var(--color-bg-subtle);
+  background: rgba(255,255,255,0.015);
 }
 .section-accent {
   background: var(--gradient-section);
@@ -1497,13 +1494,22 @@ textarea:focus-visible,
 :lang(ko) .flash-up { animation: flash-red 0.6s ease-out; }
 :lang(ko) .flash-down { animation: flash-green 0.6s ease-out; }
 
-/* ─── #5 CTA glow pulse ─── */
-@keyframes cta-glow {
-  0%, 100% { box-shadow: 0 0 16px rgba(44,181,232,0.2), 0 2px 8px rgba(0,0,0,0.3); }
-  50% { box-shadow: 0 0 24px rgba(44,181,232,0.35), 0 2px 8px rgba(0,0,0,0.3); }
+/* ─── #5 CTA subtle gradient sweep ─── */
+@keyframes cta-sweep {
+  0%   { background-position: -200% center; }
+  100% { background-position: 200% center; }
 }
 .btn-primary {
-  animation: cta-glow 3s ease-in-out infinite;
+  background-image: linear-gradient(
+    110deg,
+    var(--color-accent) 0%,
+    var(--color-accent) 40%,
+    rgba(92,200,237,0.5) 50%,
+    var(--color-accent) 60%,
+    var(--color-accent) 100%
+  );
+  background-size: 200% 100%;
+  animation: cta-sweep 4s var(--ease-smooth) infinite;
 }
 
 /* ─── #6 Tab switch fade ─── */
@@ -1511,7 +1517,7 @@ textarea:focus-visible,
   from { opacity: 0; transform: translateY(6px); }
   to   { opacity: 1; transform: translateY(0); }
 }
-.tab-entering { animation: tab-enter 0.2s ease-out both; }
+.tab-entering { animation: tab-enter 0.3s var(--ease-smooth) both; }
 
 /* ─── #7 Nav active underline slide ─── */
 .nav-slide-underline {
@@ -1522,13 +1528,15 @@ textarea:focus-visible,
   position: absolute;
   bottom: -2px;
   left: 0;
-  width: 0;
+  width: 100%;
   height: 2px;
   background: var(--color-accent);
-  transition: width 0.2s ease;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.25s var(--ease-smooth);
 }
 .nav-slide-underline:hover::after {
-  width: 100%;
+  transform: scaleX(1);
 }
 
 /* ─── #1 Equity chart draw-in ─── */
@@ -1541,9 +1549,9 @@ textarea:focus-visible,
 }
 
 /* ─── #2 Ranking card number reveal (staggered) ─── */
-.ranking-metric-reveal > div:nth-child(1) { animation: number-reveal 0.35s ease-out both; animation-delay: 0ms; }
-.ranking-metric-reveal > div:nth-child(2) { animation: number-reveal 0.35s ease-out both; animation-delay: 60ms; }
-.ranking-metric-reveal > div:nth-child(3) { animation: number-reveal 0.35s ease-out both; animation-delay: 120ms; }
+.ranking-metric-reveal > div:nth-child(1) { animation: number-reveal 0.35s var(--ease-bounce) both; animation-delay: 0ms; }
+.ranking-metric-reveal > div:nth-child(2) { animation: number-reveal 0.35s var(--ease-bounce) both; animation-delay: 60ms; }
+.ranking-metric-reveal > div:nth-child(3) { animation: number-reveal 0.35s var(--ease-bounce) both; animation-delay: 120ms; }
 
 /* ─── #3 Skeleton→content crossfade (staggered card enter) ─── */
 .ranking-card-enter { animation: card-enter 0.3s ease-out both; }


### PR DESCRIPTION
## Summary
5개 페르소나 평가 (평균 7.9) → 9.5 목표 수정

### Motion Polish (global.css)
- CTA glow pulse → subtle gradient sweep (cta-sweep)
- Nav underline: width → scaleX (layout thrash 제거)
- Card hover: scale(1.005) + accent border glow
- --color-text-muted contrast bump (#898992 → #9A9AA3, WCAG AA)
- Tab transition 300ms + ease-smooth
- Number reveal bounce easing

### UX Root Cause
- Hero trust strip above-fold ("572+ strategies · free forever")
- Mobile CTA full-width (w-full sm:w-auto)
- Fees CTA after calculator result (전환 drop-off 방지)
- BuilderPanel spacing py-3→py-4, gap-3→gap-4

## Test plan
- [x] `npm run build` → 2518 pages, 0 errors
- [x] `bash scripts/qa-redirects.sh` → PASS
- [ ] Visual: home hero trust strip
- [ ] Visual: card hover animation
- [ ] Mobile: CTA full-width

🤖 Generated with [Claude Code](https://claude.com/claude-code)