### PR TITLE
feat: premium design craft — gradient, glass, depth

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,8 +29,12 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 <Layout title={t('meta.home_title')} description={t('meta.index_desc')}>
 
   <!-- HERO — 50/50 layout: text left, live demo right -->
-  <section id="hero-section" class="relative overflow-hidden hero-bg-depth bg-noise">
+  <section id="hero-section" class="relative overflow-hidden hero-bg-depth bg-noise section-glow-green">
     <HeroGlow />
+    <!-- Background: faded simulator preview for depth -->
+    <div class="absolute inset-0 hidden md:flex items-center justify-center pointer-events-none" aria-hidden="true">
+      <img src="/images/simulator-preview.png" alt="" class="w-[80%] max-w-4xl opacity-[0.04] blur-[1px] select-none" loading="eager" />
+    </div>
     <div class="relative max-w-7xl mx-auto px-6 pt-10 pb-16 md:pt-14 md:pb-20 hero-enter">
       <div class="grid md:grid-cols-2 gap-12 md:gap-16 items-center">
         <!-- Left: Text + CTA -->
@@ -82,15 +86,15 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
   <!-- STATS BAR -->
   <div class="max-w-7xl mx-auto px-6 py-10 relative z-10">
     <div class="grid grid-cols-3 gap-3 md:gap-4 max-w-3xl mx-auto">
-      <div class="stat-glass text-center">
+      <div class="stat-glass card-frost text-center">
         <p class="text-2xl md:text-3xl font-bold font-mono text-[--color-accent]"><CountUp client:visible target={coinsAnalyzed} suffix="+" locale="en-US" /></p>
         <p class="text-sm text-[--color-text-secondary] mt-1.5 font-mono uppercase tracking-wider">Coins Tested</p>
       </div>
-      <div class="stat-glass text-center">
+      <div class="stat-glass card-frost text-center">
         <p class="text-2xl md:text-3xl font-bold font-mono text-[--color-accent]"><CountUp client:visible target={(siteStats as { simulations_run: number }).simulations_run} suffix="+" locale="en-US" /></p>
         <p class="text-sm text-[--color-text-secondary] mt-1.5 font-mono uppercase tracking-wider">Simulations</p>
       </div>
-      <div class="stat-glass text-center">
+      <div class="stat-glass card-frost text-center">
         <p class="text-2xl md:text-3xl font-bold font-mono text-[--color-accent]"><CountUp client:visible target={simulatorPresetCount} suffix="+" /></p>
         <p class="text-sm text-[--color-text-secondary] mt-1.5 font-mono uppercase tracking-wider">Strategies</p>
       </div>
@@ -107,7 +111,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- HOW IT WORKS -->
   <hr class="section-divider" />
-  <section class="max-w-7xl mx-auto px-6 py-16 md:py-24 bg-[var(--color-bg-subtle)]">
+  <section class="max-w-7xl mx-auto px-6 py-16 md:py-24 pb-20 md:pb-28 bg-[var(--color-bg-subtle)]">
     <h2 class="text-2xl md:text-3xl font-bold text-center mb-4">How It Works</h2>
     <p class="text-[--color-text-secondary] text-center text-lg mb-16 max-w-xl mx-auto">From strategy idea to verified results in 3 steps.</p>
     <div class="grid md:grid-cols-3 gap-8">
@@ -180,7 +184,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       <p class="text-[--color-text-muted] text-lg mb-12 max-w-3xl">{t('evidence.desc')}</p>
 
       <!-- Case Studies: Problem cards -->
-      <div class="grid md:grid-cols-3 gap-8 mb-12 reveal-child">
+      <div class="grid md:grid-cols-3 gap-4 mb-12 reveal-child">
         <div class="card-enterprise p-6 border-[--color-down]/20 card-hover">
           <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
             <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
@@ -352,7 +356,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- CTA -->
   <hr class="section-divider" />
-  <section class="relative py-16 md:py-24 overflow-hidden reveal" aria-labelledby="cta-heading">
+  <section class="relative pt-24 py-16 md:pt-28 md:py-24 overflow-hidden reveal section-glow-cyan" aria-labelledby="cta-heading">
     <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
       <div class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[400px] rounded-full blur-[200px] bg-[--color-accent] opacity-[0.04]"></div>
     </div>

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -29,15 +29,19 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 <Layout title={t('meta.home_title')} description={t('meta.index_desc')}>
 
   <!-- HERO — 50/50 layout: text left, live demo right -->
-  <section id="hero-section" class="relative overflow-hidden hero-bg-depth bg-noise">
+  <section id="hero-section" class="relative overflow-hidden hero-bg-depth bg-noise section-glow-green">
     <HeroGlow />
+    <!-- Background: faded simulator preview for depth -->
+    <div class="absolute inset-0 hidden md:flex items-center justify-center pointer-events-none" aria-hidden="true">
+      <img src="/images/simulator-preview.png" alt="" class="w-[80%] max-w-4xl opacity-[0.04] blur-[1px] select-none" loading="eager" />
+    </div>
     <div class="relative max-w-7xl mx-auto px-6 pt-10 pb-16 md:pt-14 md:pb-20 hero-enter">
       <div class="grid md:grid-cols-2 gap-12 md:gap-16 items-center">
         <!-- Left: Text + CTA -->
         <div>
           <HeroBadge stat={simulationsRun} label="시뮬레이션 실행" cta="무료 체험 →" />
           <p class="font-mono text-[--color-accent] text-sm tracking-wider mb-4 opacity-80">검증하고. 실행하고. 수익내세요.</p>
-          <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold tracking-[-0.02em] leading-[1.2] word-break-keep text-balance">
+          <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold tracking-[-0.04em] leading-[1.2] word-break-keep text-balance">
             대부분의 백테스트는<br/>거짓말합니다.<br/><span class="gradient-text">우리는 증거를 공개합니다.</span>
           </h1>
           <p class="mt-6 text-lg text-[--color-text-secondary] leading-relaxed max-w-lg">
@@ -82,15 +86,15 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
   <!-- STATS BAR -->
   <div class="max-w-7xl mx-auto px-6 py-10 relative z-10">
     <div class="grid grid-cols-3 gap-3 md:gap-4 max-w-3xl mx-auto">
-      <div class="stat-glass text-center">
+      <div class="stat-glass card-frost text-center">
         <p class="text-2xl md:text-3xl font-bold font-mono text-[--color-accent]"><CountUp client:visible target={coinsAnalyzed} suffix="+" locale="ko-KR" /></p>
         <p class="text-sm text-[--color-text-secondary] mt-1.5 font-mono uppercase tracking-wider">코인 테스트</p>
       </div>
-      <div class="stat-glass text-center">
+      <div class="stat-glass card-frost text-center">
         <p class="text-2xl md:text-3xl font-bold font-mono text-[--color-accent]"><CountUp client:visible target={(siteStats as { simulations_run: number }).simulations_run} suffix="+" locale="ko-KR" /></p>
         <p class="text-sm text-[--color-text-secondary] mt-1.5 font-mono uppercase tracking-wider">시뮬레이션</p>
       </div>
-      <div class="stat-glass text-center">
+      <div class="stat-glass card-frost text-center">
         <p class="text-2xl md:text-3xl font-bold font-mono text-[--color-accent]"><CountUp client:visible target={simulatorPresetCount} suffix="+" /></p>
         <p class="text-sm text-[--color-text-secondary] mt-1.5 font-mono uppercase tracking-wider">전략</p>
       </div>
@@ -107,7 +111,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- HOW IT WORKS -->
   <hr class="section-divider" />
-  <section class="max-w-7xl mx-auto px-6 py-16 md:py-24 bg-[var(--color-bg-subtle)]">
+  <section class="max-w-7xl mx-auto px-6 py-16 md:py-24 pb-20 md:pb-28 bg-[var(--color-bg-subtle)]">
     <h2 class="text-2xl md:text-3xl font-bold text-center mb-4">작동 방식</h2>
     <p class="text-[--color-text-secondary] text-center text-lg mb-16 max-w-xl mx-auto">전략 아이디어에서 검증된 결과까지 3단계.</p>
     <div class="grid md:grid-cols-3 gap-8">
@@ -180,7 +184,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       <p class="text-[--color-text-muted] text-lg mb-12 max-w-3xl">{t('evidence.desc')}</p>
 
       <!-- Case Studies: Problem cards -->
-      <div class="grid md:grid-cols-3 gap-8 mb-12 reveal-child">
+      <div class="grid md:grid-cols-3 gap-4 mb-12 reveal-child">
         <div class="card-enterprise p-6 border-[--color-down]/20 card-hover">
           <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
             <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
@@ -352,7 +356,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- CTA -->
   <hr class="section-divider" />
-  <section class="relative py-16 md:py-24 overflow-hidden reveal" aria-labelledby="cta-heading-ko">
+  <section class="relative pt-24 py-16 md:pt-28 md:py-24 overflow-hidden reveal section-glow-cyan" aria-labelledby="cta-heading-ko">
     <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
       <div class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[400px] rounded-full blur-[200px] bg-[--color-accent] opacity-[0.04]"></div>
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -208,6 +208,38 @@
   background: rgba(255,255,255,0.05);
 }
 
+/* ─── Stat card top gradient accent line ─── */
+.stat-glass {
+  position: relative;
+  overflow: hidden;
+}
+.stat-glass::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 20%;
+  right: 20%;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--color-accent), transparent);
+}
+
+/* ─── Section glow backgrounds ─── */
+.section-glow-green {
+  background: radial-gradient(ellipse at 50% 0%, rgba(0,220,130,0.04) 0%, transparent 70%);
+}
+.section-glow-cyan {
+  background: radial-gradient(ellipse at 50% 100%, rgba(44,181,232,0.03) 0%, transparent 70%);
+}
+
+/* ─── Frosted glass enhancement ─── */
+.card-frost {
+  background: rgba(255,255,255,0.03);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid rgba(255,255,255,0.06);
+  box-shadow: 0 4px 24px rgba(0,0,0,0.2), inset 0 1px 0 rgba(255,255,255,0.04);
+}
+
 /* ─── Premium card with gradient border ─── */
 .card-premium {
   position: relative;
@@ -507,7 +539,7 @@ a:not(.btn):not(.btn-primary):not(.btn-ghost):not(.btn-outline):not(.card-hover)
 }
 
 .gradient-text {
-  background: linear-gradient(135deg, #2CB5E8, #A855F7, #06B6D4, #2CB5E8);
+  background: linear-gradient(135deg, #00DC82 0%, #2CB5E8 30%, #06B6D4 55%, #E4E4E7 100%);
   background-size: 300% 300%;
   animation: gradient-shift 8s ease infinite;
   -webkit-background-clip: text;


### PR DESCRIPTION
## Summary
Awwwards 디렉터 7.2점 → 9.0 목표 디자인 크래프트 업그레이드

1. **Gradient text**: green→cyan→white dramatic sweep (hero headline)
2. **Frosted glass**: .card-frost (backdrop-blur + inset highlight + shadow)
3. **Stat card top gradient**: accent-colored 1px gradient border
4. **Section glow**: radial gradients behind hero (green) + CTA (cyan)
5. **Hero depth**: faded simulator screenshot as background (desktop)
6. **Section rhythm**: How It Works breathing room + problem cards tightened + CTA generous spacing

## Test plan
- [x] `npm run build` → 2518 pages, 0 errors
- [x] `bash scripts/qa-redirects.sh` → PASS
- [ ] Visual: hero gradient text vivid
- [ ] Visual: stat cards frosted glass effect
- [ ] Visual: section glow backgrounds
- [ ] Mobile: no overflow from new effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)