### PR TITLE
feat: beginner Quick Start + Compare quantitative data

### DIFF
--- a/src/pages/compare/index.astro
+++ b/src/pages/compare/index.astro
@@ -71,12 +71,12 @@ const comparisons = [
             </tr>
             <tr class="border-b border-[--color-border]/50">
               <td class="py-3 px-3 text-[--color-text-muted]">{t('compare_index.tbl_no_account')}</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-up] bg-[--color-accent]/10 border-x border-[--color-accent]/20">&#10003;</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-down]">&#10007;</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-down]">&#10007;</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-down]">&#10007;</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-down]">&#10007;</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-down]">&#10007;</td>
+              <td class="py-3 px-3 text-center text-[--color-up] bg-[--color-accent]/10 border-x border-[--color-accent]/20"><span class="font-bold">&#10003;</span> <span class="text-xs block mt-0.5">Instant access</span></td>
+              <td class="py-3 px-3 text-center text-[--color-down]"><span class="font-bold">&#10007;</span> <span class="text-xs block mt-0.5">Email + KYC</span></td>
+              <td class="py-3 px-3 text-center text-[--color-down]"><span class="font-bold">&#10007;</span> <span class="text-xs block mt-0.5">Email + KYC</span></td>
+              <td class="py-3 px-3 text-center text-[--color-down]"><span class="font-bold">&#10007;</span> <span class="text-xs block mt-0.5">Email + KYC</span></td>
+              <td class="py-3 px-3 text-center text-[--color-down]"><span class="font-bold">&#10007;</span> <span class="text-xs block mt-0.5">Email req.</span></td>
+              <td class="py-3 px-3 text-center text-[--color-down]"><span class="font-bold">&#10007;</span> <span class="text-xs block mt-0.5">Email req.</span></td>
             </tr>
             <tr class="border-b border-[--color-border]/50">
               <td class="py-3 px-3 text-[--color-text-muted]">{t('compare_index.tbl_multicoin')}</td>
@@ -89,16 +89,16 @@ const comparisons = [
             </tr>
             <tr class="border-b border-[--color-border]/50">
               <td class="py-3 px-3 text-[--color-text-muted]">{t('compare_index.tbl_transparency')}</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-up] bg-[--color-accent]/10 border-x border-[--color-accent]/20">&#10003;</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-down]">&#10007;</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-down]">&#10007;</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-down]">&#10007;</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-down]">&#10007;</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-down]">&#10007;</td>
+              <td class="py-3 px-3 text-center text-[--color-up] bg-[--color-accent]/10 border-x border-[--color-accent]/20"><span class="font-bold">&#10003;</span> <span class="text-xs block mt-0.5">Failures published</span></td>
+              <td class="py-3 px-3 text-center text-[--color-down]"><span class="font-bold">&#10007;</span> <span class="text-xs block mt-0.5">Winners only</span></td>
+              <td class="py-3 px-3 text-center text-[--color-down]"><span class="font-bold">&#10007;</span> <span class="text-xs block mt-0.5">Winners only</span></td>
+              <td class="py-3 px-3 text-center text-[--color-down]"><span class="font-bold">&#10007;</span> <span class="text-xs block mt-0.5">Winners only</span></td>
+              <td class="py-3 px-3 text-center text-[--color-down]"><span class="font-bold">&#10007;</span> <span class="text-xs block mt-0.5">Winners only</span></td>
+              <td class="py-3 px-3 text-center text-[--color-down]"><span class="font-bold">&#10007;</span> <span class="text-xs block mt-0.5">Winners only</span></td>
             </tr>
             <tr>
               <td class="py-3 px-3 text-[--color-text-muted]">{t('compare_index.tbl_no_code')}</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-up] bg-[--color-accent]/10 border-x border-[--color-accent]/20">&#10003;</td>
+              <td class="py-3 px-3 text-center text-[--color-up] bg-[--color-accent]/10 border-x border-[--color-accent]/20"><span class="font-bold">&#10003;</span> <span class="text-xs block mt-0.5">Visual builder</span></td>
               <td class="py-3 px-3 text-center text-[--color-down]">Pine Script</td>
               <td class="py-3 px-3 text-center text-base font-bold text-[--color-up]">&#10003;</td>
               <td class="py-3 px-3 text-center text-base font-bold text-[--color-up]">&#10003;</td>

--- a/src/pages/ko/compare/index.astro
+++ b/src/pages/ko/compare/index.astro
@@ -71,34 +71,34 @@ const comparisons = [
             </tr>
             <tr class="border-b border-[--color-border]/50">
               <td class="py-3 px-3 text-[--color-text-muted] min-w-[140px] whitespace-nowrap">{t('compare_index.tbl_no_account')}</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-up] bg-[--color-accent]/10 border-x border-[--color-accent]/20">&#10003;</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-down]">&#10007;</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-down]">&#10007;</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-down]">&#10007;</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-down]">&#10007;</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-down]">&#10007;</td>
+              <td class="py-3 px-3 text-center text-[--color-up] bg-[--color-accent]/10 border-x border-[--color-accent]/20"><span class="font-bold">&#10003;</span> <span class="text-xs block mt-0.5">즉시 접속</span></td>
+              <td class="py-3 px-3 text-center text-[--color-down]"><span class="font-bold">&#10007;</span> <span class="text-xs block mt-0.5">이메일+KYC</span></td>
+              <td class="py-3 px-3 text-center text-[--color-down]"><span class="font-bold">&#10007;</span> <span class="text-xs block mt-0.5">이메일+KYC</span></td>
+              <td class="py-3 px-3 text-center text-[--color-down]"><span class="font-bold">&#10007;</span> <span class="text-xs block mt-0.5">이메일+KYC</span></td>
+              <td class="py-3 px-3 text-center text-[--color-down]"><span class="font-bold">&#10007;</span> <span class="text-xs block mt-0.5">이메일 필요</span></td>
+              <td class="py-3 px-3 text-center text-[--color-down]"><span class="font-bold">&#10007;</span> <span class="text-xs block mt-0.5">이메일 필요</span></td>
             </tr>
             <tr class="border-b border-[--color-border]/50">
               <td class="py-3 px-3 text-[--color-text-muted] min-w-[140px] whitespace-nowrap">{t('compare_index.tbl_multicoin')}</td>
-              <td class="py-3 px-3 text-center text-[--color-up] font-semibold bg-[--color-accent]/10 border-x border-[--color-accent]/20">570+ coins</td>
-              <td class="py-3 px-3 text-center text-[--color-down]">1 at a time</td>
-              <td class="py-3 px-3 text-center text-[--color-down]">Limited</td>
-              <td class="py-3 px-3 text-center text-[--color-down]">Limited</td>
-              <td class="py-3 px-3 text-center text-[--color-down]">Limited</td>
-              <td class="py-3 px-3 text-center text-[--color-down]">Limited</td>
+              <td class="py-3 px-3 text-center text-[--color-up] font-semibold bg-[--color-accent]/10 border-x border-[--color-accent]/20">570개+ 코인</td>
+              <td class="py-3 px-3 text-center text-[--color-down]">1개씩</td>
+              <td class="py-3 px-3 text-center text-[--color-down]">제한적</td>
+              <td class="py-3 px-3 text-center text-[--color-down]">제한적</td>
+              <td class="py-3 px-3 text-center text-[--color-down]">제한적</td>
+              <td class="py-3 px-3 text-center text-[--color-down]">제한적</td>
             </tr>
             <tr class="border-b border-[--color-border]/50">
               <td class="py-3 px-3 text-[--color-text-muted] min-w-[140px] whitespace-nowrap">{t('compare_index.tbl_transparency')}</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-up] bg-[--color-accent]/10 border-x border-[--color-accent]/20">&#10003;</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-down]">&#10007;</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-down]">&#10007;</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-down]">&#10007;</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-down]">&#10007;</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-down]">&#10007;</td>
+              <td class="py-3 px-3 text-center text-[--color-up] bg-[--color-accent]/10 border-x border-[--color-accent]/20"><span class="font-bold">&#10003;</span> <span class="text-xs block mt-0.5">실패 공개</span></td>
+              <td class="py-3 px-3 text-center text-[--color-down]"><span class="font-bold">&#10007;</span> <span class="text-xs block mt-0.5">성공만 공개</span></td>
+              <td class="py-3 px-3 text-center text-[--color-down]"><span class="font-bold">&#10007;</span> <span class="text-xs block mt-0.5">성공만 공개</span></td>
+              <td class="py-3 px-3 text-center text-[--color-down]"><span class="font-bold">&#10007;</span> <span class="text-xs block mt-0.5">성공만 공개</span></td>
+              <td class="py-3 px-3 text-center text-[--color-down]"><span class="font-bold">&#10007;</span> <span class="text-xs block mt-0.5">성공만 공개</span></td>
+              <td class="py-3 px-3 text-center text-[--color-down]"><span class="font-bold">&#10007;</span> <span class="text-xs block mt-0.5">성공만 공개</span></td>
             </tr>
             <tr>
               <td class="py-3 px-3 text-[--color-text-muted] min-w-[140px] whitespace-nowrap">{t('compare_index.tbl_no_code')}</td>
-              <td class="py-3 px-3 text-center text-base font-bold text-[--color-up] bg-[--color-accent]/10 border-x border-[--color-accent]/20">&#10003;</td>
+              <td class="py-3 px-3 text-center text-[--color-up] bg-[--color-accent]/10 border-x border-[--color-accent]/20"><span class="font-bold">&#10003;</span> <span class="text-xs block mt-0.5">비주얼 빌더</span></td>
               <td class="py-3 px-3 text-center text-[--color-down]">Pine Script</td>
               <td class="py-3 px-3 text-center text-base font-bold text-[--color-up]">&#10003;</td>
               <td class="py-3 px-3 text-center text-base font-bold text-[--color-up]">&#10003;</td>

--- a/src/pages/ko/simulate/index.astro
+++ b/src/pages/ko/simulate/index.astro
@@ -52,6 +52,17 @@ const quickStartPresets = (rankingsData.top3 || []).slice(0, 3);
     </div>
   </section>
 
+  <!-- Quick Start Banner -->
+  <div class="max-w-[1400px] mx-auto px-4 mb-4">
+    <div class="border border-[--color-accent]/30 bg-[--color-accent]/5 rounded-lg p-4 flex flex-col sm:flex-row items-start sm:items-center gap-3">
+      <span class="text-2xl shrink-0">&#9889;</span>
+      <div class="flex-1">
+        <p class="font-semibold text-sm">처음이세요? 프리셋 전략을 사용해보세요</p>
+        <p class="text-xs text-[--color-text-muted]">위에서 전략을 선택하고 시뮬레이션 버튼만 누르면 3초 안에 결과가 나옵니다.</p>
+      </div>
+    </div>
+  </div>
+
   <!-- Simulator Mount (above fold) -->
   <section class="reveal pb-4 md:pb-6">
     <div id="simulator-mount">

--- a/src/pages/simulate/index.astro
+++ b/src/pages/simulate/index.astro
@@ -52,6 +52,17 @@ const quickStartPresets = (rankingsData.top3 || []).slice(0, 3);
     </div>
   </section>
 
+  <!-- Quick Start Banner -->
+  <div class="max-w-[1400px] mx-auto px-4 mb-4">
+    <div class="border border-[--color-accent]/30 bg-[--color-accent]/5 rounded-lg p-4 flex flex-col sm:flex-row items-start sm:items-center gap-3">
+      <span class="text-2xl shrink-0">&#9889;</span>
+      <div class="flex-1">
+        <p class="font-semibold text-sm">First time? Try a preset strategy</p>
+        <p class="text-xs text-[--color-text-muted]">Pick a strategy from Hot Strategies above, hit simulate — see results in 3 seconds. No setup needed.</p>
+      </div>
+    </div>
+  </div>
+
   <!-- Simulator Mount (above fold) -->
   <section class="reveal pb-4 md:pb-6">
     <div id="simulator-mount">


### PR DESCRIPTION
## Summary
페르소나 7명 평가 기반 제품 레벨 수정:

### 시뮬레이터 초보 모드
- Quick Start 배너 (EN+KO): "처음이세요? 프리셋 전략을 사용해보세요"
- 시뮬레이터 마운트 바로 위에 배치
- 대학생 진입장벽 4/10 → 해소 목표

### Compare 정량화
- 체크마크만 있던 셀에 설명 텍스트 추가 (EN+KO)
- "즉시 접속" vs "이메일+KYC"
- "실패 공개" vs "성공만 공개"  
- "비주얼 빌더" vs "Pine Script"
- 퀀트 7.4 → "마케팅 체크마크" 피드백 반영

## Test plan
- [x] `npm run build` → 2518 pages, 0 errors
- [x] `bash scripts/qa-redirects.sh` → PASS
- [ ] /simulate Quick Start banner visible
- [ ] /ko/simulate Korean banner
- [ ] /compare table descriptive text

🤖 Generated with [Claude Code](https://claude.com/claude-code)