### PR TITLE
fix: replace 'Free forever' with '$0 — no subscription'

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -193,7 +193,7 @@ export const en = {
   "cta.title": "Ready to Test?",
   "cta.desc1":
     "Build a strategy, run a backtest, see the results. No account needed.",
-  "cta.desc2": "Free forever. No email required. No hidden fees.",
+  "cta.desc2": "$0 — no subscription, no email, no hidden fees.",
   "cta.button1": "Open Simulator Free",
   "cta.button2": "Join Community",
   "cta.button3": "Save on Fees",
@@ -606,7 +606,7 @@ export const en = {
   "meta.simulate_title":
     "Strategy Simulator \u2014 Build & Backtest Custom Strategies | PRUVIQ",
   "meta.simulate_desc":
-    "Build a custom crypto trading strategy and backtest it across 570+ coins in seconds. No code, no signup, free forever.",
+    "Build a custom crypto trading strategy and backtest it across 570+ coins in seconds. No code, no signup, $0 — no subscription.",
   "meta.index_desc":
     "Free crypto strategy backtesting — test strategies on 570+ coins with 2+ years of real market data, realistic fees, and published results, including failures.",
   "meta.strategies_title": "Strategy Library - PRUVIQ",
@@ -656,7 +656,7 @@ export const en = {
   "about.philosophy3_title": "Eat Our Own Cooking",
   "about.philosophy3_desc":
     "Every strategy is backtested on 570+ coins with 2+ years of data before publication. We verify with evidence before suggesting you act.",
-  "about.philosophy4_title": "Free Forever",
+  "about.philosophy4_title": "Zero Cost, Zero Catch",
   "about.philosophy4_desc":
     "Strategy verification should be accessible to everyone. Core features will always be free. We earn through exchange referrals only.",
   "about.stack_tag": "BUILT WITH",
@@ -737,7 +737,7 @@ export const en = {
   "home.stat_coins": "Coins Tested",
   "home.stat_trades": "Backtested Trades",
   "home.stat_datapoints": "Data Points",
-  "home.stat_free": "Forever Free",
+  "home.stat_free": "$0 Always",
 
   // Performance page static fallback
   "perf.tag": "BACKTEST RESULTS",
@@ -1293,7 +1293,7 @@ export const en = {
     "Crypto-native 570 coins vs stock-focused platform",
   "compare_index.footer": "All comparisons use real backtest data.",
   "compare_index.try_cta": "Try it yourself →",
-  "compare_index.strength1_tag": "FREE FOREVER",
+  "compare_index.strength1_tag": "$0 — NO SUBSCRIPTION",
   "compare_index.strength1_title": "$0 — No Credit Card",
   "compare_index.strength1_desc":
     "Competitors charge $19–$60/month. PRUVIQ is free, forever. No account required to run a simulation.",
@@ -1365,7 +1365,7 @@ export const en = {
   "meta.vs_tv_title":
     "PRUVIQ vs TradingView - Free Crypto Backtesting Comparison",
   "meta.vs_tv_desc":
-    "Compare PRUVIQ with TradingView for crypto strategy backtesting. No Pine Script needed. Free forever. 570+ coins. Full backtest transparency.",
+    "Compare PRUVIQ with TradingView for crypto strategy backtesting. No Pine Script needed. $0 — no subscription. 570+ coins. Full backtest transparency.",
   "vs.tag": "HONEST COMPARISON",
   "vs.title": "PRUVIQ vs TradingView",
   "vs.subtitle": "for crypto backtesting",
@@ -1378,7 +1378,7 @@ export const en = {
   "vs.pruviq": "PRUVIQ",
   "vs.tradingview": "TradingView",
   "vs.row_price": "Price",
-  "vs.row_price_p": "Free forever",
+  "vs.row_price_p": "$0 — no subscription",
   "vs.row_price_tv": "$14.95-59.95/mo (Essential-Premium)",
   "vs.row_coding": "Coding Required",
   "vs.row_coding_p": "No code — visual builder",
@@ -1585,7 +1585,7 @@ export const en = {
   // CTA badges
   "cta.badge1": "No credit card",
   "cta.badge2": "No account needed",
-  "cta.badge3": "100% free forever",
+  "cta.badge3": "100% $0 — no subscription",
   "cta.badge4": "Results in 3 seconds",
 
   // Homepage comparison section
@@ -1595,7 +1595,7 @@ export const en = {
   "compare.pruviq_label": "PRUVIQ",
   "compare.row1_label": "Cost",
   "compare.row1_other": "$15 - $200/month",
-  "compare.row1_pruviq": "Free forever",
+  "compare.row1_pruviq": "$0 — no subscription",
   "compare.row2_label": "Coding",
   "compare.row2_other": "Python / Pine Script required",
   "compare.row2_pruviq": "No code needed",
@@ -1611,7 +1611,7 @@ export const en = {
 
   // Homepage trust badges (below features)
   "trust_badges.no_signup": "No signup required",
-  "trust_badges.free": "Free forever",
+  "trust_badges.free": "$0 — no subscription",
   "trust_badges.opensource": "Transparent methodology",
   "trust_badges.data_sources": "Data from Binance + CoinGecko",
 
@@ -1672,7 +1672,7 @@ export const en = {
   "meta.vs_3commas_title":
     "PRUVIQ vs 3Commas — Free Crypto Backtesting Alternative",
   "meta.vs_3commas_desc":
-    "Compare PRUVIQ with 3Commas for crypto strategy backtesting. No subscription fees. Free forever. 570+ coins with real fee simulation.",
+    "Compare PRUVIQ with 3Commas for crypto strategy backtesting. No subscription fees. $0 — no subscription. 570+ coins with real fee simulation.",
   "vs_3commas.tag": "HONEST COMPARISON",
   "vs_3commas.title": "PRUVIQ vs 3Commas",
   "vs_3commas.subtitle": "Backtesting research vs. automated trading bots",
@@ -1685,7 +1685,7 @@ export const en = {
   "vs_3commas.pruviq": "PRUVIQ",
   "vs_3commas.other": "3Commas",
   "vs_3commas.row_price": "Price",
-  "vs_3commas.row_price_p": "Free forever — $0/mo",
+  "vs_3commas.row_price_p": "$0 — no subscription — $0/mo",
   "vs_3commas.row_price_other": "$15–110/mo (Starter–Expert)",
   "vs_3commas.row_annual": "Annual Cost",
   "vs_3commas.row_annual_p": "$0",
@@ -1753,13 +1753,13 @@ export const en = {
     "Use PRUVIQ to research and validate your strategy for free. Then deploy the winning strategy on 3Commas for automated execution. Research first, automate second.",
   "vs_3commas.cta_title": "Research First, Trade Later",
   "vs_3commas.cta_desc":
-    "Backtest your strategy on 570+ coins before paying for any bot subscription. Free forever, no signup required.",
+    "Backtest your strategy on 570+ coins before paying for any bot subscription. $0 — no subscription, no signup required.",
 
   // Comparison pages: Coinrule
   "meta.vs_coinrule_title":
     "PRUVIQ vs Coinrule — Free Crypto Backtesting Alternative",
   "meta.vs_coinrule_desc":
-    "Compare PRUVIQ with Coinrule for crypto strategy backtesting. Free forever, no IF-THEN limits, 570+ coins with real fee simulation.",
+    "Compare PRUVIQ with Coinrule for crypto strategy backtesting. $0 — no subscription, no IF-THEN limits, 570+ coins with real fee simulation.",
 
   "vs_coinrule.tag": "HONEST COMPARISON",
   "vs_coinrule.title": "PRUVIQ vs Coinrule",
@@ -1773,7 +1773,7 @@ export const en = {
   "vs_coinrule.pruviq": "PRUVIQ",
   "vs_coinrule.other": "Coinrule",
   "vs_coinrule.row_price": "Price",
-  "vs_coinrule.row_price_p": "Free forever",
+  "vs_coinrule.row_price_p": "$0 — no subscription",
   "vs_coinrule.row_price_other": "$29–449/mo (Starter–Unlimited)",
   "vs_coinrule.row_coding": "Coding Required",
   "vs_coinrule.row_coding_p": "No code — visual builder",
@@ -1822,7 +1822,7 @@ export const en = {
   "meta.vs_cryptohopper_title":
     "PRUVIQ vs Cryptohopper — Free Crypto Backtesting Alternative",
   "meta.vs_cryptohopper_desc":
-    "Compare PRUVIQ with Cryptohopper for crypto strategy backtesting. Free forever, no cloud subscription, 570+ coins with real fee and slippage simulation.",
+    "Compare PRUVIQ with Cryptohopper for crypto strategy backtesting. $0 — no subscription, no cloud subscription, 570+ coins with real fee and slippage simulation.",
   "vs_cryptohopper.tag": "HONEST COMPARISON",
   "vs_cryptohopper.title": "PRUVIQ vs Cryptohopper",
   "vs_cryptohopper.subtitle": "Backtesting research vs. cloud trading bots",
@@ -1835,7 +1835,7 @@ export const en = {
   "vs_cryptohopper.pruviq": "PRUVIQ",
   "vs_cryptohopper.other": "Cryptohopper",
   "vs_cryptohopper.row_price": "Price",
-  "vs_cryptohopper.row_price_p": "Free forever — $0/mo",
+  "vs_cryptohopper.row_price_p": "$0 — no subscription — $0/mo",
   "vs_cryptohopper.row_price_other": "$24–107/mo (Explorer–Hero)",
   "vs_cryptohopper.row_annual": "Annual Cost",
   "vs_cryptohopper.row_annual_p": "$0",
@@ -1921,7 +1921,7 @@ export const en = {
   "meta.vs_gainium_title":
     "PRUVIQ vs Gainium — Free Crypto Backtesting Alternative",
   "meta.vs_gainium_desc":
-    "Compare PRUVIQ with Gainium for crypto strategy backtesting. Free forever, no DCA-only limits, 570+ coins with real slippage and fee simulation.",
+    "Compare PRUVIQ with Gainium for crypto strategy backtesting. $0 — no subscription, no DCA-only limits, 570+ coins with real slippage and fee simulation.",
   "vs_gainium.tag": "HONEST COMPARISON",
   "vs_gainium.title": "PRUVIQ vs Gainium",
   "vs_gainium.subtitle": "for crypto backtesting",
@@ -1934,7 +1934,7 @@ export const en = {
   "vs_gainium.pruviq": "PRUVIQ",
   "vs_gainium.other": "Gainium",
   "vs_gainium.row_price": "Price",
-  "vs_gainium.row_price_p": "Free forever",
+  "vs_gainium.row_price_p": "$0 — no subscription",
   "vs_gainium.row_price_other": "$49+/mo",
   "vs_gainium.row_coding": "Coding Required",
   "vs_gainium.row_coding_p": "No code — visual builder",
@@ -1981,7 +1981,7 @@ export const en = {
   "meta.vs_streak_title":
     "PRUVIQ vs Streak — Free Crypto Backtesting Alternative",
   "meta.vs_streak_desc":
-    "Compare PRUVIQ with Streak for crypto strategy backtesting. Free forever, no Pine Script required, 570+ coins with real fee and slippage simulation.",
+    "Compare PRUVIQ with Streak for crypto strategy backtesting. $0 — no subscription, no Pine Script required, 570+ coins with real fee and slippage simulation.",
   "vs_streak.tag": "HONEST COMPARISON",
   "vs_streak.title": "PRUVIQ vs Streak",
   "vs_streak.subtitle": "for crypto backtesting",
@@ -1994,7 +1994,7 @@ export const en = {
   "vs_streak.pruviq": "PRUVIQ",
   "vs_streak.other": "Streak",
   "vs_streak.row_price": "Price",
-  "vs_streak.row_price_p": "Free forever",
+  "vs_streak.row_price_p": "$0 — no subscription",
   "vs_streak.row_price_other": "$79+/mo",
   "vs_streak.row_coding": "Coding Required",
   "vs_streak.row_coding_p": "No code — visual builder",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1585,7 +1585,7 @@ export const en = {
   // CTA badges
   "cta.badge1": "No credit card",
   "cta.badge2": "No account needed",
-  "cta.badge3": "100% $0 — no subscription",
+  "cta.badge3": "$0 — no subscription",
   "cta.badge4": "Results in 3 seconds",
 
   // Homepage comparison section
@@ -1685,7 +1685,7 @@ export const en = {
   "vs_3commas.pruviq": "PRUVIQ",
   "vs_3commas.other": "3Commas",
   "vs_3commas.row_price": "Price",
-  "vs_3commas.row_price_p": "$0 — no subscription — $0/mo",
+  "vs_3commas.row_price_p": "$0 — no subscription",
   "vs_3commas.row_price_other": "$15–110/mo (Starter–Expert)",
   "vs_3commas.row_annual": "Annual Cost",
   "vs_3commas.row_annual_p": "$0",
@@ -1835,7 +1835,7 @@ export const en = {
   "vs_cryptohopper.pruviq": "PRUVIQ",
   "vs_cryptohopper.other": "Cryptohopper",
   "vs_cryptohopper.row_price": "Price",
-  "vs_cryptohopper.row_price_p": "$0 — no subscription — $0/mo",
+  "vs_cryptohopper.row_price_p": "$0 — no subscription",
   "vs_cryptohopper.row_price_other": "$24–107/mo (Explorer–Hero)",
   "vs_cryptohopper.row_annual": "Annual Cost",
   "vs_cryptohopper.row_annual_p": "$0",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -191,7 +191,7 @@ export const ko: Record<TranslationKey, string> = {
   "cta.title": "검증할 준비 되셨나요?",
   "cta.desc1":
     "전략을 만들고, 백테스트를 돌리고, 결과를 확인하세요. 계정 불필요.",
-  "cta.desc2": "영원히 무료. 이메일 불필요. 숨겨진 비용 없음.",
+  "cta.desc2": "$0 — 구독 없음, 이메일 불필요, 숨겨진 비용 없음.",
   "cta.button1": "시뮬레이터 열기 — 무료",
   "cta.button2": "커뮤니티 참여",
   "cta.button3": "수수료 절약하기",
@@ -651,7 +651,7 @@ export const ko: Record<TranslationKey, string> = {
   "about.philosophy3_title": "직접 검증, 직접 사용",
   "about.philosophy3_desc":
     "모든 전략은 570개 이상의 코인에서 2년 이상의 데이터로 백테스트한 후 공개합니다. 근거 없이 권하지 않습니다.",
-  "about.philosophy4_title": "영원히 무료",
+  "about.philosophy4_title": "비용 제로, 조건 제로",
   "about.philosophy4_desc":
     "전략 검증은 누구나 접근할 수 있어야 합니다. 핵심 기능은 항상 무료. 거래소 제휴를 통해서만 수익을 창출합니다.",
   "about.stack_tag": "기술 스택",
@@ -730,7 +730,7 @@ export const ko: Record<TranslationKey, string> = {
   "home.stat_coins": "테스트 코인",
   "home.stat_trades": "백테스트 거래",
   "home.stat_datapoints": "데이터 포인트",
-  "home.stat_free": "영원히 무료",
+  "home.stat_free": "$0 항상",
 
   // Performance page static fallback
   "perf.tag": "백테스트 결과",
@@ -1268,7 +1268,7 @@ export const ko: Record<TranslationKey, string> = {
   "compare_index.strength1_tag": "완전 무료",
   "compare_index.strength1_title": "$0 — 신용카드 불필요",
   "compare_index.strength1_desc":
-    "경쟁사는 월 $19–$60를 청구합니다. PRUVIQ는 영원히 무료. 계정 없이 시뮬레이션 실행 가능.",
+    "경쟁사는 월 $19–$60를 청구합니다. PRUVIQ는 $0 — 구독 없음. 계정 없이 시뮬레이션 실행 가능.",
   "compare_index.strength2_tag": "570개 코인 동시 테스트",
   "compare_index.strength2_title": "전체 시장을 한 번에",
   "compare_index.strength2_desc":
@@ -1328,13 +1328,13 @@ export const ko: Record<TranslationKey, string> = {
   "home.quotes_cta": "함께 해보세요 — 시뮬레이터 열기",
   "home.ranking_shortcut": "오늘의 상위 전략",
   "home.competitor_banner":
-    "TradingView는 백테스팅에 월 $14~240를 청구합니다. PRUVIQ는 영원히 무료입니다.",
+    "TradingView는 백테스팅에 월 $14~240를 청구합니다. PRUVIQ는 $0 — 구독 없음.",
   "home.social_proof_cta": "이번 달 4,200명 이상이 백테스트를 실행했습니다.",
 
   // TradingView comparison page
   "meta.vs_tv_title": "PRUVIQ vs 트레이딩뷰 - 무료 크립토 백테스팅 비교",
   "meta.vs_tv_desc":
-    "크립토 전략 백테스팅에서 PRUVIQ와 트레이딩뷰를 비교합니다. Pine Script 불필요. 영원히 무료. 570개+ 코인. 완전 백테스트 투명성.",
+    "크립토 전략 백테스팅에서 PRUVIQ와 트레이딩뷰를 비교합니다. Pine Script 불필요. $0 — 구독 없음. 570개+ 코인. 완전 백테스트 투명성.",
   "vs.tag": "솔직한 비교",
   "vs.title": "PRUVIQ vs 트레이딩뷰",
   "vs.subtitle": "크립토 백테스팅용",
@@ -1347,7 +1347,7 @@ export const ko: Record<TranslationKey, string> = {
   "vs.pruviq": "PRUVIQ",
   "vs.tradingview": "트레이딩뷰",
   "vs.row_price": "가격",
-  "vs.row_price_p": "영원히 무료",
+  "vs.row_price_p": "$0 — 구독 없음",
   "vs.row_price_tv": "월 $14.95-59.95 (Essential-Premium)",
   "vs.row_coding": "코딩 필요",
   "vs.row_coding_p": "코딩 불필요 — 비주얼 빌더",
@@ -1559,7 +1559,7 @@ export const ko: Record<TranslationKey, string> = {
   "compare.pruviq_label": "PRUVIQ",
   "compare.row1_label": "비용",
   "compare.row1_other": "월 $15 - $200",
-  "compare.row1_pruviq": "영원히 무료",
+  "compare.row1_pruviq": "$0 — 구독 없음",
   "compare.row2_label": "코딩",
   "compare.row2_other": "Python / Pine Script 필요",
   "compare.row2_pruviq": "코딩 불필요",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -1549,7 +1549,7 @@ export const ko: Record<TranslationKey, string> = {
   // CTA badges
   "cta.badge1": "신용카드 불필요",
   "cta.badge2": "계정 생성 불필요",
-  "cta.badge3": "영구 무료",
+  "cta.badge3": "$0 — 구독 없음",
   "cta.badge4": "3초 만에 결과",
 
   // Homepage comparison section
@@ -1575,7 +1575,7 @@ export const ko: Record<TranslationKey, string> = {
 
   // Homepage trust badges (below features)
   "trust_badges.no_signup": "가입 불필요",
-  "trust_badges.free": "영구 무료",
+  "trust_badges.free": "$0 — 구독 없음",
   "trust_badges.opensource": "투명한 방법론",
   "trust_badges.data_sources": "Binance + CoinGecko 데이터",
 
@@ -1649,7 +1649,7 @@ export const ko: Record<TranslationKey, string> = {
   "vs_3commas.pruviq": "PRUVIQ",
   "vs_3commas.other": "3Commas",
   "vs_3commas.row_price": "가격",
-  "vs_3commas.row_price_p": "영구 무료 — $0/월",
+  "vs_3commas.row_price_p": "$0 — 구독 없음 — $0/월",
   "vs_3commas.row_price_other": "$15–110/월 (Starter–Expert)",
   "vs_3commas.row_annual": "연간 비용",
   "vs_3commas.row_annual_p": "$0",
@@ -1733,7 +1733,7 @@ export const ko: Record<TranslationKey, string> = {
   "vs_coinrule.pruviq": "PRUVIQ",
   "vs_coinrule.other": "Coinrule",
   "vs_coinrule.row_price": "가격",
-  "vs_coinrule.row_price_p": "영구 무료",
+  "vs_coinrule.row_price_p": "$0 — 구독 없음",
   "vs_coinrule.row_price_other": "$29–449/월 (Starter–Unlimited)",
   "vs_coinrule.row_coding": "코딩 필요 여부",
   "vs_coinrule.row_coding_p": "코딩 불필요 — 시각적 빌더",
@@ -1796,7 +1796,7 @@ export const ko: Record<TranslationKey, string> = {
   "vs_cryptohopper.pruviq": "PRUVIQ",
   "vs_cryptohopper.other": "Cryptohopper",
   "vs_cryptohopper.row_price": "가격",
-  "vs_cryptohopper.row_price_p": "영구 무료 — $0/월",
+  "vs_cryptohopper.row_price_p": "$0 — 구독 없음 — $0/월",
   "vs_cryptohopper.row_price_other": "$24–107/월 (Explorer–Hero)",
   "vs_cryptohopper.row_annual": "연간 비용",
   "vs_cryptohopper.row_annual_p": "$0",
@@ -1885,7 +1885,7 @@ export const ko: Record<TranslationKey, string> = {
   "vs_gainium.pruviq": "PRUVIQ",
   "vs_gainium.other": "Gainium",
   "vs_gainium.row_price": "가격",
-  "vs_gainium.row_price_p": "영구 무료",
+  "vs_gainium.row_price_p": "$0 — 구독 없음",
   "vs_gainium.row_price_other": "$49+/월",
   "vs_gainium.row_coding": "코딩 필요 여부",
   "vs_gainium.row_coding_p": "코딩 불필요 — 시각적 빌더",
@@ -1946,7 +1946,7 @@ export const ko: Record<TranslationKey, string> = {
   "vs_streak.pruviq": "PRUVIQ",
   "vs_streak.other": "Streak",
   "vs_streak.row_price": "가격",
-  "vs_streak.row_price_p": "영구 무료",
+  "vs_streak.row_price_p": "$0 — 구독 없음",
   "vs_streak.row_price_other": "$79+/월",
   "vs_streak.row_coding": "코딩 필요 여부",
   "vs_streak.row_coding_p": "코딩 불필요 — 시각적 빌더",

--- a/src/pages/best-crypto-backtesting.astro
+++ b/src/pages/best-crypto-backtesting.astro
@@ -9,11 +9,11 @@ const criteria = [
   { label: 'Real fees & slippage', desc: 'Every backtest includes maker/taker fees, funding rates, and slippage modeling.', pruviq: true },
   { label: 'Failure transparency', desc: 'We publicly show strategies we killed — not just winners.', pruviq: true },
   { label: 'No-code interface', desc: 'Pick indicators, set parameters, run. No Pine Script or Python required.', pruviq: true },
-  { label: 'Free forever', desc: 'No subscription tiers, no credit card, no account needed.', pruviq: true },
+  { label: '$0 — no subscription', desc: 'No subscription tiers, no credit card, no account needed.', pruviq: true },
 ];
 
 const comparisonRows = [
-  { feature: 'Price', pruviq: 'Free forever', tv: '$14.95–59.95/mo', c3: '$14.50–49.50/mo', win: 'p' },
+  { feature: 'Price', pruviq: '$0 — no subscription', tv: '$14.95–59.95/mo', c3: '$14.50–49.50/mo', win: 'p' },
   { feature: 'Coins', pruviq: '570+', tv: '~50 crypto pairs', c3: '~20 supported', win: 'p' },
   { feature: 'Coding required', pruviq: 'No code', tv: 'Pine Script', c3: 'Template-based', win: 'p' },
   { feature: 'Real fees modeled', pruviq: 'Yes (maker/taker/funding)', tv: 'Basic commission only', c3: 'Partial', win: 'p' },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -64,7 +64,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
             </a>
           </div>
           <!-- Trust strip -->
-          <p class="text-xs font-mono text-[--color-text-muted] mt-3">{simulatorPresetCount}+ strategies · {coinsAnalyzed}+ coins · Free forever · No signup required</p>
+          <p class="text-xs font-mono text-[--color-text-muted] mt-3">{simulatorPresetCount}+ strategies · {coinsAnalyzed}+ coins · $0 — no subscription · No signup required</p>
         </div>
         <!-- Right: Live simulator demo -->
         <div class="relative">

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -64,7 +64,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
             </a>
           </div>
           <!-- Trust strip -->
-          <p class="text-xs font-mono text-[--color-text-muted] mt-3">{simulatorPresetCount}개+ 전략 · {coinsAnalyzed}개+ 코인 · 영구 무료 · 가입 불필요</p>
+          <p class="text-xs font-mono text-[--color-text-muted] mt-3">{simulatorPresetCount}개+ 전략 · {coinsAnalyzed}개+ 코인 · $0 — 구독 없음 · 가입 불필요</p>
         </div>
         <!-- Right: Live simulator demo -->
         <div class="relative">


### PR DESCRIPTION
## Summary
"Free forever/영구 무료" → "$0 — no subscription/$0 — 구독 없음"

오너 피드백: "영원히 무료" 워딩이 오히려 신뢰성을 낮춤 → 팩트 기반 표현으로 교체.

- EN: 15+ instances across en.ts, index.astro, best-crypto-backtesting.astro
- KO: 7+ instances across ko.ts, ko/index.astro
- about.philosophy4_title: "Free Forever" → "Zero Cost, Zero Catch"

## Test plan
- [x] `npm run build` → 2518 pages, 0 errors
- [x] `bash scripts/qa-redirects.sh` → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)