### PR TITLE
fix: CI pipeline — Vision QA + Data Contract root cause fixes

### DIFF
--- a/.github/workflows/data-contract.yml
+++ b/.github/workflows/data-contract.yml
@@ -15,6 +15,8 @@ jobs:
   site-stats-contract:
     name: site-stats.json schema
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v4
 
@@ -69,6 +71,8 @@ jobs:
   ranking-json-contract:
     name: Ranking JSON schema (if changed)
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -125,19 +129,21 @@ jobs:
 
   api-response-contract:
     name: API endpoint contract (staging)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ops]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v4
 
       - name: Test API contracts against production
         env:
-          API_BASE: https://api.pruviq.com
+          API_BASE: http://localhost:8080
         run: |
           python3 - <<'EOF'
-          import urllib.request, json, sys
+          import urllib.request, json, sys, os
 
-          API_BASE = "https://api.pruviq.com"
+          API_BASE = os.environ.get("API_BASE", "http://localhost:8080")
           errors = []
 
           # Contract 1: /health returns coins_loaded > 100

--- a/.github/workflows/vision-qa.yml
+++ b/.github/workflows/vision-qa.yml
@@ -33,6 +33,8 @@ jobs:
     name: Vision QA — pruviq.com
     runs-on: [self-hosted, macOS, arm64]
     timeout-minutes: 20
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - uses: actions/checkout@v4
@@ -49,35 +51,24 @@ jobs:
       - name: Wait for site (push only — Cloudflare propagation)
         if: github.event_name == 'push'
         run: |
-          echo "Waiting 120s for Cloudflare Pages deployment..."
-          sleep 120
-          for i in {1..6}; do
+          echo "Waiting for Cloudflare Workers deployment..."
+          for i in {1..30}; do
             STATUS=$(curl -sL -A "Mozilla/5.0" -o /dev/null -w '%{http_code}' \
               https://pruviq.com --max-time 10 || echo "000")
             [ "$STATUS" = "200" ] && echo "Site up (attempt $i)" && exit 0
-            echo "Attempt $i: $STATUS"
+            echo "Attempt $i/30: HTTP $STATUS — waiting 10s..."
             sleep 10
           done
-          echo "::error::pruviq.com not reachable" && exit 1
+          echo "::error::pruviq.com not reachable after 300s" && exit 1
 
-      - name: Create interactive output dir
-        run: mkdir -p test-results/interactive
+      - name: Create output dirs
+        run: mkdir -p test-results/interactive test-results/vision
 
-      - name: Step 1 — Collect screenshots + data (실제 사용자 환경)
+      - name: Step 1 — Collect screenshots + data + Interactive QA
         run: |
-          npx playwright test tests/e2e/vision-collect.spec.ts \
-            --project prod-smoke \
-            --timeout 45000 \
-            --workers 3 \
-            --retries 1
-        env:
-          BASE_URL: https://pruviq.com
-          CI: true
-        timeout-minutes: 8
-
-      - name: Step 1b — Interactive QA (버튼 클릭·기능 검증)
-        run: |
-          npx playwright test tests/e2e/interactive-qa.spec.ts \
+          npx playwright test \
+            tests/e2e/vision-collect.spec.ts \
+            tests/e2e/interactive-qa.spec.ts \
             --project prod-smoke \
             --timeout 60000 \
             --workers 1 \
@@ -85,7 +76,7 @@ jobs:
         env:
           BASE_URL: https://pruviq.com
           CI: true
-        timeout-minutes: 8
+        timeout-minutes: 12
 
       - name: Step 2 — Claude Vision analysis (실제 화면 보고 QA 판단)
         if: ${{ !inputs.skip_vision }}


### PR DESCRIPTION
## Summary
- **Vision QA**: Step 1b (separate Playwright invocation) cleared `test-results/`, destroying Step 1's `collect-data.json` → combined into single Playwright run
- **Data Contract**: `ubuntu-latest` runner blocked by Cloudflare 403 → moved API contract job to `self-hosted, ops` with `localhost:8080`
- **Wait for site**: Replaced 120s fixed sleep + 6 retries with immediate polling (30×10s = 300s max)
- **Node.js 24**: Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` to both workflows

## Test plan
- [ ] Vision QA workflow passes on next push to main (schedule run at 10:30 KST)
- [ ] Data Contract passes on next push that changes `public/data/**`
- [ ] No Node.js 20 deprecation warnings in workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)