### PR TITLE
design: apply shadow depth + metric utilities to all pages

### DIFF
--- a/src/components/ui/StepCard.astro
+++ b/src/components/ui/StepCard.astro
@@ -6,7 +6,7 @@ interface Props {
 }
 const { step, title, description } = Astro.props;
 ---
-<div class="rounded-xl border border-white/5 bg-[--color-bg-card] p-8 text-center hover:border-[--color-accent]/30 hover:-translate-y-0.5 transition-all card-glow" style="box-shadow: inset 0 1px 0 rgba(255,255,255,0.04), 0 4px 16px rgba(0,0,0,0.2)">
+<div class="rounded-xl border border-white/5 bg-[--color-bg-card] p-8 text-center shadow-[var(--shadow-sm)] hover:shadow-[var(--shadow-md)] hover:border-[--color-accent]/30 hover:-translate-y-0.5 transition-all" style="box-shadow: inset 0 1px 0 rgba(255,255,255,0.04), 0 4px 16px rgba(0,0,0,0.2)">
   <div class="w-10 h-10 rounded-full bg-[--color-accent]/10 text-[--color-accent] font-bold text-lg flex items-center justify-center mx-auto mb-4 font-mono">
     {step}
   </div>

--- a/src/pages/compare/index.astro
+++ b/src/pages/compare/index.astro
@@ -27,17 +27,17 @@ const comparisons = [
 
       <!-- Why PRUVIQ: 3 strengths -->
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-10 mb-10 reveal-child">
-        <div class="border border-[--color-up]/30 rounded-lg p-6 bg-[--color-bg-card]">
+        <div class="border border-[--color-up]/30 rounded-lg p-6 bg-[--color-bg-card] shadow-[var(--shadow-sm)]">
           <p class="font-mono text-[--color-up] text-xs font-bold mb-2 tracking-wider">{t('compare_index.strength1_tag')}</p>
           <p class="font-bold text-lg mb-2">{t('compare_index.strength1_title')}</p>
           <p class="text-[--color-text-muted] text-sm leading-relaxed">{t('compare_index.strength1_desc')}</p>
         </div>
-        <div class="border border-[--color-accent]/30 rounded-lg p-6 bg-[--color-bg-card]">
+        <div class="border border-[--color-accent]/30 rounded-lg p-6 bg-[--color-bg-card] shadow-[var(--shadow-sm)]">
           <p class="font-mono text-[--color-accent] text-xs font-bold mb-2 tracking-wider">{t('compare_index.strength2_tag')}</p>
           <p class="font-bold text-lg mb-2">{t('compare_index.strength2_title')}</p>
           <p class="text-[--color-text-muted] text-sm leading-relaxed">{t('compare_index.strength2_desc')}</p>
         </div>
-        <div class="border border-[--color-accent]/30 rounded-lg p-6 bg-[--color-bg-card]">
+        <div class="border border-[--color-accent]/30 rounded-lg p-6 bg-[--color-bg-card] shadow-[var(--shadow-sm)]">
           <p class="font-mono text-[--color-accent] text-xs font-bold mb-2 tracking-wider">{t('compare_index.strength3_tag')}</p>
           <p class="font-bold text-lg mb-2">{t('compare_index.strength3_title')}</p>
           <p class="text-[--color-text-muted] text-sm leading-relaxed">{t('compare_index.strength3_desc')}</p>
@@ -45,7 +45,7 @@ const comparisons = [
       </div>
 
       <!-- Summary comparison table: 6 competitors -->
-      <div class="overflow-x-auto mb-10 table-scroll-hint" role="region" aria-label="Platform comparison summary" tabindex="0">
+      <div class="overflow-x-auto mb-10 table-scroll-hint shadow-[var(--shadow-md)] rounded-xl" role="region" aria-label="Platform comparison summary" tabindex="0">
         <table class="w-full min-w-[700px] text-sm border-collapse" role="table">
           <caption class="sr-only">Feature comparison: PRUVIQ vs TradingView, 3Commas, Cryptohopper, Coinrule, Gainium</caption>
           <thead>
@@ -134,7 +134,7 @@ const comparisons = [
         {comparisons.map((c) => (
           <a
             href={`/compare/${c.slug}`}
-            class="group relative border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] card-hover card-glow overflow-hidden"
+            class="group relative border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] card-hover shadow-[var(--shadow-sm)] overflow-hidden"
             style={`--card-accent: ${c.accent};`}
           >
             {/* Subtle accent line top */}

--- a/src/pages/fees.astro
+++ b/src/pages/fees.astro
@@ -94,7 +94,7 @@ const t = useTranslations('en');
 
       <div class="reveal-child grid md:grid-cols-2 gap-6">
         <!-- Binance Card -->
-        <div class="border border-[--color-accent]/30 rounded-xl p-6 md:p-8 flex flex-col">
+        <div class="border border-[--color-accent]/30 rounded-xl p-6 md:p-8 flex flex-col shadow-[var(--shadow-md)]">
           <div class="flex items-center gap-3 mb-6">
             <h3 class="text-2xl font-bold">{binanceDisplay.name}</h3>
             <span class="font-mono text-[--color-accent] text-xs font-bold px-2 py-0.5 rounded border border-[--color-accent]/30 bg-[--color-accent]/5">{binanceDisplay.tag}</span>
@@ -149,7 +149,7 @@ const t = useTranslations('en');
         </div>
 
         <!-- OKX Card -->
-        <div class="border border-[--color-border] rounded-xl p-6 md:p-8 flex flex-col relative overflow-hidden">
+        <div class="border border-[--color-border] rounded-xl p-6 md:p-8 flex flex-col relative overflow-hidden shadow-[var(--shadow-md)]">
           <div class="flex items-center gap-3 mb-6">
             <h3 class="text-2xl font-bold">{okxDisplay.name}</h3>
             <span class="font-mono text-[--color-up] text-xs font-bold px-2 py-0.5 rounded border border-[--color-up]/30 bg-[--color-up]/5">Official Partner</span>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,7 +35,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
     <div class="absolute inset-0 hidden md:flex items-center justify-center pointer-events-none" aria-hidden="true">
       <img src="/images/simulator-preview.png" alt="" class="w-[80%] max-w-4xl opacity-[0.04] blur-[1px] select-none" loading="eager" />
     </div>
-    <div class="relative max-w-7xl mx-auto px-6 pt-10 pb-16 md:pt-14 md:pb-20 hero-enter">
+    <div class="relative max-w-7xl mx-auto px-6 pt-16 pb-20 md:pt-20 md:pb-28 hero-enter">
       <div class="grid md:grid-cols-2 gap-12 md:gap-16 items-center">
         <!-- Left: Text + CTA -->
         <div>
@@ -87,17 +87,17 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
   <!-- STATS BAR -->
   <div class="max-w-7xl mx-auto px-6 py-10 relative z-10">
     <div class="grid grid-cols-3 gap-3 md:gap-4 max-w-3xl mx-auto">
-      <div class="stat-glass card-frost text-center">
-        <p class="text-2xl md:text-3xl font-bold font-mono text-[--color-accent]"><CountUp client:visible target={coinsAnalyzed} suffix="+" locale="en-US" /></p>
-        <p class="text-sm text-[--color-text-secondary] mt-1.5 font-mono uppercase tracking-wider">Coins Tested</p>
+      <div class="stat-glass text-center shadow-[var(--shadow-md)]">
+        <p class="metric-value-lg text-[--color-accent]"><CountUp client:visible target={coinsAnalyzed} suffix="+" locale="en-US" /></p>
+        <p class="metric-label mt-2">Coins Tested</p>
       </div>
-      <div class="stat-glass card-frost text-center">
-        <p class="text-2xl md:text-3xl font-bold font-mono text-[--color-accent]"><CountUp client:visible target={(siteStats as { simulations_run: number }).simulations_run} suffix="+" locale="en-US" /></p>
-        <p class="text-sm text-[--color-text-secondary] mt-1.5 font-mono uppercase tracking-wider">Simulations</p>
+      <div class="stat-glass text-center shadow-[var(--shadow-md)]">
+        <p class="metric-value-lg text-[--color-accent]"><CountUp client:visible target={(siteStats as { simulations_run: number }).simulations_run} suffix="+" locale="en-US" /></p>
+        <p class="metric-label mt-2">Simulations</p>
       </div>
-      <div class="stat-glass card-frost text-center">
-        <p class="text-2xl md:text-3xl font-bold font-mono text-[--color-accent]"><CountUp client:visible target={simulatorPresetCount} suffix="+" /></p>
-        <p class="text-sm text-[--color-text-secondary] mt-1.5 font-mono uppercase tracking-wider">Strategies</p>
+      <div class="stat-glass text-center shadow-[var(--shadow-md)]">
+        <p class="metric-value-lg text-[--color-accent]"><CountUp client:visible target={simulatorPresetCount} suffix="+" /></p>
+        <p class="metric-label mt-2">Strategies</p>
       </div>
     </div>
     <div class="flex items-center justify-center gap-3 md:gap-8 text-[--color-text-muted] text-xs font-mono mt-6">
@@ -112,8 +112,8 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- HOW IT WORKS -->
   <hr class="section-divider" />
-  <section class="max-w-7xl mx-auto px-6 py-16 md:py-24 pb-20 md:pb-28 bg-[var(--color-bg-subtle)]">
-    <h2 class="text-2xl md:text-3xl font-bold text-center mb-4">How It Works</h2>
+  <section class="max-w-7xl mx-auto px-6 py-20 md:py-28 bg-[var(--color-bg-surface)]/30">
+    <h2 class="text-3xl md:text-4xl font-bold text-center mb-4">How It Works</h2>
     <p class="text-[--color-text-secondary] text-center text-lg mb-16 max-w-xl mx-auto">From strategy idea to verified results in 3 steps.</p>
     <div class="grid md:grid-cols-3 gap-8">
       <StepCard step={1} title="Pick a Strategy" description="36 presets or build your own with 14 indicators." />
@@ -124,17 +124,17 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       <a href="/simulate" class="btn btn-primary btn-md">Open Simulator — Free &rarr;</a>
     </div>
     <!-- Persona entry points -->
-    <div class="mt-12 grid sm:grid-cols-3 gap-4 max-w-3xl mx-auto">
-      <a href="/learn" class="card-premium card-hover card-glow p-5 text-center group">
-        <p class="text-sm text-[--color-text-muted] mb-1 font-mono">New to trading?</p>
+    <div class="mt-12 grid sm:grid-cols-3 gap-5 max-w-3xl mx-auto">
+      <a href="/learn" class="card-premium card-hover p-6 text-center group">
+        <p class="text-sm text-[--color-text-muted] mb-2 font-mono">New to trading?</p>
         <p class="text-base font-semibold group-hover:text-[--color-accent] transition-colors">Start Learning →</p>
       </a>
-      <a href="/simulate" class="card-premium card-hover card-glow card-accent p-5 text-center group">
-        <p class="text-sm text-[--color-text-muted] mb-1 font-mono">Experienced trader?</p>
-        <p class="text-base font-semibold group-hover:text-[--color-accent] transition-colors">Open Simulator →</p>
+      <a href="/simulate" class="card-featured card-hover p-6 text-center group">
+        <p class="text-sm text-[--color-text-muted] mb-2 font-mono">Experienced trader?</p>
+        <p class="text-base font-bold group-hover:text-[--color-accent] transition-colors">Open Simulator →</p>
       </a>
-      <a href="/strategies" class="card-premium card-hover card-glow p-5 text-center group">
-        <p class="text-sm text-[--color-text-muted] mb-1 font-mono">Just exploring?</p>
+      <a href="/strategies" class="card-premium card-hover p-6 text-center group">
+        <p class="text-sm text-[--color-text-muted] mb-2 font-mono">Just exploring?</p>
         <p class="text-base font-semibold group-hover:text-[--color-accent] transition-colors">Explore Strategies →</p>
       </a>
     </div>
@@ -147,7 +147,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider text-center">{t('compare.section_tag')}</p>
       <h2 class="text-2xl md:text-3xl font-bold text-center mb-12">{t('compare.section_title')}</h2>
 
-      <div class="overflow-hidden rounded-xl border border-[--color-border] bg-[--color-bg-card]">
+      <div class="overflow-hidden rounded-xl border border-[--color-border] bg-[--color-bg-card] shadow-[var(--shadow-md)]">
         <!-- Header -->
         <div class="grid grid-cols-3 text-sm font-mono">
           <div class="p-4 md:p-5"></div>
@@ -186,7 +186,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
       <!-- Case Studies: Problem cards -->
       <div class="grid md:grid-cols-3 gap-4 mb-12 reveal-child">
-        <div class="card-enterprise p-6 border-[--color-down]/20 card-hover">
+        <div class="card-enterprise p-6 border-[--color-down]/20 card-hover shadow-[var(--shadow-sm)]">
           <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
             <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
             {t('problem.case1_label')}
@@ -195,7 +195,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
           <p class="text-[--color-text-muted] text-base leading-relaxed mb-3">{t('problem.card1_desc')}</p>
           <p class="text-xs text-[--color-text-muted] opacity-60 italic">{t('problem.card1_source')}</p>
         </div>
-        <div class="card-enterprise p-6 border-[--color-down]/20 card-hover">
+        <div class="card-enterprise p-6 border-[--color-down]/20 card-hover shadow-[var(--shadow-sm)]">
           <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
             <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
             {t('problem.case2_label')}
@@ -204,7 +204,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
           <p class="text-[--color-text-muted] text-base leading-relaxed mb-3">{t('problem.card2_desc')}</p>
           <p class="text-xs text-[--color-text-muted] opacity-60 italic">{t('problem.card2_source')}</p>
         </div>
-        <div class="card-enterprise p-6 border-[--color-down]/20 card-hover">
+        <div class="card-enterprise p-6 border-[--color-down]/20 card-hover shadow-[var(--shadow-sm)]">
           <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
             <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
             {t('problem.case3_label')}
@@ -316,14 +316,14 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">FAQ</p>
       <h2 id="faq-heading" class="text-2xl md:text-3xl font-bold mb-12">{t('faq.title')}</h2>
       <div class="max-w-3xl space-y-6">
-        <details class="group border border-[--color-border] rounded-lg bg-[--color-bg-card] hover:border-[--color-accent]/30 transition-colors focus-within:ring-2 focus-within:ring-[--color-accent]/30">
+        <details class="group border border-[--color-border] rounded-lg bg-[--color-bg-card] shadow-[var(--shadow-sm)] hover:border-[--color-accent]/30 hover:shadow-[var(--shadow-md)] transition-colors focus-within:ring-2 focus-within:ring-[--color-accent]/30">
           <summary class="cursor-pointer px-6 py-4 font-semibold text-sm flex items-center justify-between gap-4 min-h-[44px]">
             {t('faq.q1')}
             <span class="text-[--color-text-muted] group-open:rotate-180 transition-transform shrink-0">&#9662;</span>
           </summary>
           <div class="faq-body"><div><p class="px-6 pb-4 text-[--color-text-muted] text-base leading-relaxed">{t('faq.a1')}</p></div></div>
         </details>
-        <details class="group border border-[--color-border] rounded-lg bg-[--color-bg-card] hover:border-[--color-accent]/30 transition-colors focus-within:ring-2 focus-within:ring-[--color-accent]/30">
+        <details class="group border border-[--color-border] rounded-lg bg-[--color-bg-card] shadow-[var(--shadow-sm)] hover:border-[--color-accent]/30 hover:shadow-[var(--shadow-md)] transition-colors focus-within:ring-2 focus-within:ring-[--color-accent]/30">
           <summary class="cursor-pointer px-6 py-4 font-semibold text-sm flex items-center justify-between gap-4 min-h-[44px]">
             {t('faq.q3')}
             <span class="text-[--color-text-muted] group-open:rotate-180 transition-transform shrink-0">&#9662;</span>
@@ -348,10 +348,10 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
       <!-- Risk reversal badges -->
       <div class="flex flex-wrap gap-3 justify-center mb-8 font-mono text-xs">
-        <span class="px-3 py-1.5 rounded border border-[--color-up]/30 text-[--color-up] bg-[--color-up]/5">{t('cta.badge1')}</span>
-        <span class="px-3 py-1.5 rounded border border-[--color-up]/30 text-[--color-up] bg-[--color-up]/5">{t('cta.badge2')}</span>
-        <span class="px-3 py-1.5 rounded border border-[--color-up]/30 text-[--color-up] bg-[--color-up]/5">{t('cta.badge3')}</span>
-        <span class="px-3 py-1.5 rounded border border-[--color-up]/30 text-[--color-up] bg-[--color-up]/5">{t('cta.badge4')}</span>
+        <span class="px-3 py-1.5 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5 shadow-[var(--shadow-sm)]">{t('cta.badge1')}</span>
+        <span class="px-3 py-1.5 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5 shadow-[var(--shadow-sm)]">{t('cta.badge2')}</span>
+        <span class="px-3 py-1.5 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5 shadow-[var(--shadow-sm)]">{t('cta.badge3')}</span>
+        <span class="px-3 py-1.5 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5 shadow-[var(--shadow-sm)]">{t('cta.badge4')}</span>
       </div>
 
       <div class="flex flex-col sm:flex-row gap-4 justify-center mb-4">

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -35,7 +35,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
     <div class="absolute inset-0 hidden md:flex items-center justify-center pointer-events-none" aria-hidden="true">
       <img src="/images/simulator-preview.png" alt="" class="w-[80%] max-w-4xl opacity-[0.04] blur-[1px] select-none" loading="eager" />
     </div>
-    <div class="relative max-w-7xl mx-auto px-6 pt-10 pb-16 md:pt-14 md:pb-20 hero-enter">
+    <div class="relative max-w-7xl mx-auto px-6 pt-16 pb-20 md:pt-20 md:pb-28 hero-enter">
       <div class="grid md:grid-cols-2 gap-12 md:gap-16 items-center">
         <!-- Left: Text + CTA -->
         <div>
@@ -87,17 +87,17 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
   <!-- STATS BAR -->
   <div class="max-w-7xl mx-auto px-6 py-10 relative z-10">
     <div class="grid grid-cols-3 gap-3 md:gap-4 max-w-3xl mx-auto">
-      <div class="stat-glass card-frost text-center">
-        <p class="text-2xl md:text-3xl font-bold font-mono text-[--color-accent]"><CountUp client:visible target={coinsAnalyzed} suffix="+" locale="ko-KR" /></p>
-        <p class="text-sm text-[--color-text-secondary] mt-1.5 font-mono uppercase tracking-wider">코인 테스트</p>
+      <div class="stat-glass text-center shadow-[var(--shadow-md)]">
+        <p class="metric-value-lg text-[--color-accent]"><CountUp client:visible target={coinsAnalyzed} suffix="+" locale="ko-KR" /></p>
+        <p class="metric-label mt-2">코인 테스트</p>
       </div>
-      <div class="stat-glass card-frost text-center">
-        <p class="text-2xl md:text-3xl font-bold font-mono text-[--color-accent]"><CountUp client:visible target={(siteStats as { simulations_run: number }).simulations_run} suffix="+" locale="ko-KR" /></p>
-        <p class="text-sm text-[--color-text-secondary] mt-1.5 font-mono uppercase tracking-wider">시뮬레이션</p>
+      <div class="stat-glass text-center shadow-[var(--shadow-md)]">
+        <p class="metric-value-lg text-[--color-accent]"><CountUp client:visible target={(siteStats as { simulations_run: number }).simulations_run} suffix="+" locale="ko-KR" /></p>
+        <p class="metric-label mt-2">시뮬레이션</p>
       </div>
-      <div class="stat-glass card-frost text-center">
-        <p class="text-2xl md:text-3xl font-bold font-mono text-[--color-accent]"><CountUp client:visible target={simulatorPresetCount} suffix="+" /></p>
-        <p class="text-sm text-[--color-text-secondary] mt-1.5 font-mono uppercase tracking-wider">전략</p>
+      <div class="stat-glass text-center shadow-[var(--shadow-md)]">
+        <p class="metric-value-lg text-[--color-accent]"><CountUp client:visible target={simulatorPresetCount} suffix="+" /></p>
+        <p class="metric-label mt-2">전략</p>
       </div>
     </div>
     <div class="flex items-center justify-center gap-3 md:gap-8 text-[--color-text-muted] text-xs font-mono mt-6">
@@ -112,8 +112,8 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- HOW IT WORKS -->
   <hr class="section-divider" />
-  <section class="max-w-7xl mx-auto px-6 py-16 md:py-24 pb-20 md:pb-28 bg-[var(--color-bg-subtle)]">
-    <h2 class="text-2xl md:text-3xl font-bold text-center mb-4">작동 방식</h2>
+  <section class="max-w-7xl mx-auto px-6 py-20 md:py-28 bg-[var(--color-bg-surface)]/30">
+    <h2 class="text-3xl md:text-4xl font-bold text-center mb-4">작동 방식</h2>
     <p class="text-[--color-text-secondary] text-center text-lg mb-16 max-w-xl mx-auto">전략 아이디어에서 검증된 결과까지 3단계.</p>
     <div class="grid md:grid-cols-3 gap-8">
       <StepCard step={1} title={t('how.step1')} description={t('how.step1_desc')} />
@@ -124,17 +124,17 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       <a href="/ko/simulate" class="btn btn-primary btn-md">시뮬레이터 열기 — 무료 &rarr;</a>
     </div>
     <!-- 페르소나별 진입점 -->
-    <div class="mt-12 grid sm:grid-cols-3 gap-4 max-w-3xl mx-auto">
-      <a href="/ko/learn" class="card-premium card-hover card-glow p-5 text-center group">
-        <p class="text-sm text-[--color-text-muted] mb-1 font-mono">처음이신가요?</p>
+    <div class="mt-12 grid sm:grid-cols-3 gap-5 max-w-3xl mx-auto">
+      <a href="/ko/learn" class="card-premium card-hover p-6 text-center group">
+        <p class="text-sm text-[--color-text-muted] mb-2 font-mono">처음이신가요?</p>
         <p class="text-base font-semibold group-hover:text-[--color-accent] transition-colors">학습 시작 →</p>
       </a>
-      <a href="/ko/simulate" class="card-premium card-hover card-glow card-accent p-5 text-center group">
-        <p class="text-sm text-[--color-text-muted] mb-1 font-mono">경험 있는 트레이더?</p>
-        <p class="text-base font-semibold group-hover:text-[--color-accent] transition-colors">시뮬레이터 열기 →</p>
+      <a href="/ko/simulate" class="card-featured card-hover p-6 text-center group">
+        <p class="text-sm text-[--color-text-muted] mb-2 font-mono">경험 있는 트레이더?</p>
+        <p class="text-base font-bold group-hover:text-[--color-accent] transition-colors">시뮬레이터 열기 →</p>
       </a>
-      <a href="/ko/strategies" class="card-premium card-hover card-glow p-5 text-center group">
-        <p class="text-sm text-[--color-text-muted] mb-1 font-mono">둘러보는 중?</p>
+      <a href="/ko/strategies" class="card-premium card-hover p-6 text-center group">
+        <p class="text-sm text-[--color-text-muted] mb-2 font-mono">둘러보는 중?</p>
         <p class="text-base font-semibold group-hover:text-[--color-accent] transition-colors">전략 탐색 →</p>
       </a>
     </div>
@@ -147,7 +147,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider text-center">{t('compare.section_tag')}</p>
       <h2 class="text-2xl md:text-3xl font-bold text-center mb-12">{t('compare.section_title')}</h2>
 
-      <div class="overflow-hidden rounded-xl border border-[--color-border] bg-[--color-bg-card]">
+      <div class="overflow-hidden rounded-xl border border-[--color-border] bg-[--color-bg-card] shadow-[var(--shadow-md)]">
         <!-- Header -->
         <div class="grid grid-cols-3 text-sm font-mono">
           <div class="p-4 md:p-5"></div>
@@ -186,7 +186,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
       <!-- Case Studies: Problem cards -->
       <div class="grid md:grid-cols-3 gap-4 mb-12 reveal-child">
-        <div class="card-enterprise p-6 border-[--color-down]/20 card-hover">
+        <div class="card-enterprise p-6 border-[--color-down]/20 card-hover shadow-[var(--shadow-sm)]">
           <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
             <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
             {t('problem.case1_label')}
@@ -195,7 +195,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
           <p class="text-[--color-text-muted] text-base leading-relaxed mb-3">{t('problem.card1_desc')}</p>
           <p class="text-xs text-[--color-text-muted] opacity-60 italic">{t('problem.card1_source')}</p>
         </div>
-        <div class="card-enterprise p-6 border-[--color-down]/20 card-hover">
+        <div class="card-enterprise p-6 border-[--color-down]/20 card-hover shadow-[var(--shadow-sm)]">
           <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
             <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
             {t('problem.case2_label')}
@@ -204,7 +204,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
           <p class="text-[--color-text-muted] text-base leading-relaxed mb-3">{t('problem.card2_desc')}</p>
           <p class="text-xs text-[--color-text-muted] opacity-60 italic">{t('problem.card2_source')}</p>
         </div>
-        <div class="card-enterprise p-6 border-[--color-down]/20 card-hover">
+        <div class="card-enterprise p-6 border-[--color-down]/20 card-hover shadow-[var(--shadow-sm)]">
           <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
             <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
             {t('problem.case3_label')}
@@ -316,14 +316,14 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">FAQ</p>
       <h2 id="faq-heading-ko" class="text-2xl md:text-3xl font-bold mb-12">{t('faq.title')}</h2>
       <div class="max-w-3xl space-y-6">
-        <details class="group border border-[--color-border] rounded-lg bg-[--color-bg-card] hover:border-[--color-accent]/30 transition-colors focus-within:ring-2 focus-within:ring-[--color-accent]/30">
+        <details class="group border border-[--color-border] rounded-lg bg-[--color-bg-card] shadow-[var(--shadow-sm)] hover:border-[--color-accent]/30 hover:shadow-[var(--shadow-md)] transition-colors focus-within:ring-2 focus-within:ring-[--color-accent]/30">
           <summary class="cursor-pointer px-6 py-4 font-semibold text-sm flex items-center justify-between gap-4 min-h-[44px]">
             {t('faq.q1')}
             <span class="text-[--color-text-muted] group-open:rotate-180 transition-transform shrink-0">&#9662;</span>
           </summary>
           <div class="faq-body"><div><p class="px-6 pb-4 text-[--color-text-muted] text-base leading-relaxed">{t('faq.a1')}</p></div></div>
         </details>
-        <details class="group border border-[--color-border] rounded-lg bg-[--color-bg-card] hover:border-[--color-accent]/30 transition-colors focus-within:ring-2 focus-within:ring-[--color-accent]/30">
+        <details class="group border border-[--color-border] rounded-lg bg-[--color-bg-card] shadow-[var(--shadow-sm)] hover:border-[--color-accent]/30 hover:shadow-[var(--shadow-md)] transition-colors focus-within:ring-2 focus-within:ring-[--color-accent]/30">
           <summary class="cursor-pointer px-6 py-4 font-semibold text-sm flex items-center justify-between gap-4 min-h-[44px]">
             {t('faq.q3')}
             <span class="text-[--color-text-muted] group-open:rotate-180 transition-transform shrink-0">&#9662;</span>
@@ -348,10 +348,10 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
       <!-- Risk reversal badges -->
       <div class="flex flex-wrap gap-3 justify-center mb-8 font-mono text-xs">
-        <span class="px-3 py-1.5 rounded border border-[--color-up]/30 text-[--color-up] bg-[--color-up]/5">{t('cta.badge1')}</span>
-        <span class="px-3 py-1.5 rounded border border-[--color-up]/30 text-[--color-up] bg-[--color-up]/5">{t('cta.badge2')}</span>
-        <span class="px-3 py-1.5 rounded border border-[--color-up]/30 text-[--color-up] bg-[--color-up]/5">{t('cta.badge3')}</span>
-        <span class="px-3 py-1.5 rounded border border-[--color-up]/30 text-[--color-up] bg-[--color-up]/5">{t('cta.badge4')}</span>
+        <span class="px-3 py-1.5 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5 shadow-[var(--shadow-sm)]">{t('cta.badge1')}</span>
+        <span class="px-3 py-1.5 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5 shadow-[var(--shadow-sm)]">{t('cta.badge2')}</span>
+        <span class="px-3 py-1.5 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5 shadow-[var(--shadow-sm)]">{t('cta.badge3')}</span>
+        <span class="px-3 py-1.5 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5 shadow-[var(--shadow-sm)]">{t('cta.badge4')}</span>
       </div>
 
       <div class="flex flex-col sm:flex-row gap-4 justify-center mb-4">

--- a/src/pages/market/index.astro
+++ b/src/pages/market/index.astro
@@ -38,19 +38,19 @@ const marketDataJson = JSON.stringify(marketDataRaw);
           <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] mt-4">
             <h2 class="text-lg font-bold mb-4">{t('market.noscript_title')}</h2>
             <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-              <div class="p-3 rounded-lg bg-[--color-bg-hover]">
+              <div class="p-3 rounded-lg bg-[--color-bg-hover] shadow-[var(--shadow-sm)]">
                 <p class="text-xs text-[--color-text-muted]">BTC Price</p>
                 <p class="font-bold font-mono">${marketDataRaw.btc_price?.toLocaleString('en-US', { maximumFractionDigits: 0 })}</p>
               </div>
-              <div class="p-3 rounded-lg bg-[--color-bg-hover]">
+              <div class="p-3 rounded-lg bg-[--color-bg-hover] shadow-[var(--shadow-sm)]">
                 <p class="text-xs text-[--color-text-muted]">BTC Dominance</p>
                 <p class="font-bold font-mono">{marketDataRaw.btc_dominance}%</p>
               </div>
-              <div class="p-3 rounded-lg bg-[--color-bg-hover]">
+              <div class="p-3 rounded-lg bg-[--color-bg-hover] shadow-[var(--shadow-sm)]">
                 <p class="text-xs text-[--color-text-muted]">Fear & Greed</p>
                 <p class="font-bold font-mono">{marketDataRaw.fear_greed_index} — {marketDataRaw.fear_greed_label}</p>
               </div>
-              <div class="p-3 rounded-lg bg-[--color-bg-hover]">
+              <div class="p-3 rounded-lg bg-[--color-bg-hover] shadow-[var(--shadow-sm)]">
                 <p class="text-xs text-[--color-text-muted]">Total Market Cap</p>
                 <p class="font-bold font-mono">${marketDataRaw.total_market_cap_b}B</p>
               </div>

--- a/src/pages/simulate/index.astro
+++ b/src/pages/simulate/index.astro
@@ -149,7 +149,7 @@ const quickStartPresets = (rankingsData.top3 || []).slice(0, 3);
             {quickStartPresets.map((preset, i) => (
               <a
                 href={`/simulate?preset=${preset.strategy}-${preset.direction}`}
-                class="border border-[--color-accent]/30 rounded-lg px-4 py-3 bg-[--color-accent]/5 hover:bg-[--color-accent]/10 hover:border-[--color-accent] transition-all group card-glow flex items-center gap-3"
+                class="border border-[--color-accent]/30 rounded-lg px-4 py-3 bg-[--color-accent]/5 hover:bg-[--color-accent]/10 hover:border-[--color-accent] transition-all group shadow-[var(--shadow-sm)] flex items-center gap-3"
               >
                 <span class="font-mono text-[--color-accent] text-lg font-bold shrink-0">#{i + 1}</span>
                 <div class="min-w-0">

--- a/src/pages/strategies/index.astro
+++ b/src/pages/strategies/index.astro
@@ -176,7 +176,7 @@ const presetDirColors: Record<string, string> = { long: '--color-accent', short:
       </div>
 
       <!-- Filter + Sort Bar -->
-      <div class="mb-6 flex flex-wrap gap-4 strategy-filter-bar" id="strategy-filters">
+      <div class="mb-6 flex flex-wrap gap-4 strategy-filter-bar bg-[--color-bg-surface] rounded-xl p-4" id="strategy-filters">
         <div class="flex items-center gap-1.5 flex-wrap">
           <span class="font-mono text-xs text-[--color-text-muted] mr-1">Status:</span>
           <button data-filter-group="status" data-filter-value="all" aria-label="Show all strategies"
@@ -244,7 +244,7 @@ const presetDirColors: Record<string, string> = { long: '--color-accent', short:
           const cards = (
             <div class="space-y-4">
         {strategyGroups[statusKey].map((strategy) => (
-          <div class={`flex flex-col h-full block card-enterprise p-6 card-hover group ${strategy.data.status === 'verified' ? 'strategy-card-verified' : ''}`}
+          <div class={`flex flex-col h-full block card-enterprise p-6 card-hover shadow-[var(--shadow-sm)] group ${strategy.data.status === 'verified' ? 'strategy-card-verified' : ''}`}
                data-status={strategy.data.status}
                data-direction={strategy.data.direction.toLowerCase()}
                data-win-rate={strategy.data.winRate ?? 0}
@@ -373,7 +373,7 @@ const presetDirColors: Record<string, string> = { long: '--color-accent', short:
                   return (
                   <a
                     href={`/simulate?preset=${preset.id}`}
-                    class={`relative flex flex-col border border-[--color-border] rounded-lg px-4 py-3 bg-[--color-bg-card] hover:border-[--color-accent] transition-colors group card-glow preset-card ${glowClass}`}
+                    class={`relative flex flex-col border border-[--color-border] rounded-lg px-4 py-3 bg-[--color-bg-card] hover:border-[--color-accent] transition-colors group shadow-[var(--shadow-sm)] preset-card ${glowClass}`}
                   >
                     {isTodaysPick && (
                       <span class="absolute -top-2.5 left-3 font-mono text-[10px] tracking-wider px-2 py-0.5 rounded-full bg-[--color-accent] text-black font-bold z-10">


### PR DESCRIPTION
## Summary
- **Homepage (EN+KO)**: Hero breathing room, metric-value-lg stats, card-featured persona, shadow-md tables, shadow-sm FAQ
- **Strategies**: Filter bar bg-surface wrapper, cards with shadow
- **Fees/Market/Simulate/Compare**: Shadow depth applied to all cards and tables
- **StepCard**: shadow-sm base + hover:shadow-md

Applies the design tokens from PR #930 to actual page elements for visible depth.

## Test plan
- [x] `npm run build` — 2518 pages, 0 errors
- [ ] Visual QA: homepage, strategies, fees

🤖 Generated with [Claude Code](https://claude.com/claude-code)