### PR TITLE
design: visual impact round 2 — hero glow, section depth, mobile stats

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -407,8 +407,8 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <div id="page-loader"></div>
     <header>
     <!-- shadow-nav handles visual separation — no border-b needed -->
-    <nav class="fixed top-0 w-full z-50 bg-[--color-bg-surface]/92 backdrop-blur-md" role="navigation" aria-label="Main" style="box-shadow: var(--shadow-nav);">
-      <div class="w-full px-6 lg:px-28 h-16 grid grid-cols-[auto_1fr_auto] items-center">
+    <nav class="fixed top-0 w-full z-50 bg-[--color-bg-surface]/90 backdrop-blur-xl" role="navigation" aria-label="Main" style="box-shadow: var(--shadow-nav);">
+      <div class="w-full px-6 lg:px-28 h-14 grid grid-cols-[auto_1fr_auto] items-center">
         <!-- 1열: Logo (좌측) -->
         <a href={lang === 'ko' ? '/ko/' : '/'} class="flex items-center gap-2">
           <img src="/favicon.svg" alt="PRUVIQ" width="32" height="32" class="w-8 h-8" loading="eager" />
@@ -489,8 +489,8 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
       <slot />
     </main>
 
-    <footer class="border-t border-[--color-border] mt-20 bg-[--color-bg-surface]" role="contentinfo" aria-label="Site footer">
-      <div class="max-w-7xl mx-auto px-6 lg:px-10 py-12">
+    <footer class="border-t border-[--color-border] mt-0 bg-[--color-bg-surface]" role="contentinfo" aria-label="Site footer">
+      <div class="max-w-7xl mx-auto px-6 lg:px-10 py-16">
         <!-- Brand + 3-column links -->
         <div class="flex flex-col md:flex-row gap-10 mb-10">
           <div class="md:w-1/3">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -85,8 +85,8 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
   </section>
 
   <!-- STATS BAR -->
-  <div class="max-w-7xl mx-auto px-6 py-10 relative z-10">
-    <div class="grid grid-cols-3 gap-3 md:gap-4 max-w-3xl mx-auto">
+  <div class="max-w-7xl mx-auto px-6 py-12 md:py-16 relative z-10">
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 md:gap-5 max-w-3xl mx-auto">
       <div class="stat-glass text-center shadow-[var(--shadow-md)]">
         <p class="metric-value-lg text-[--color-accent]"><CountUp client:visible target={coinsAnalyzed} suffix="+" locale="en-US" /></p>
         <p class="metric-label mt-2">Coins Tested</p>
@@ -142,7 +142,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- COMPARISON TABLE -->
   <hr class="section-divider" />
-  <section class="py-16 md:py-24 bg-white/[0.02] reveal">
+  <section class="py-20 md:py-28 section-surface-subtle reveal">
     <div class="max-w-4xl mx-auto px-6">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider text-center">{t('compare.section_tag')}</p>
       <h2 class="text-2xl md:text-3xl font-bold text-center mb-12">{t('compare.section_title')}</h2>
@@ -225,7 +225,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- FEATURES & TRUST (Merged) -->
   <hr class="section-divider" />
-  <section class="py-16 md:py-24 bg-white/[0.02] reveal" aria-labelledby="features-heading">
+  <section class="py-20 md:py-28 section-surface-subtle reveal" aria-labelledby="features-heading">
     <div class="max-w-7xl mx-auto px-6">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('features.tag')}</p>
       <h2 id="features-heading" class="text-2xl md:text-3xl font-bold mb-12">{t('features.title')}</h2>
@@ -233,32 +233,32 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       <!-- Feature cards -->
       <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-16 reveal-child">
         <a href="/simulate" class="card-premium p-6 block group">
-          <div class="w-10 h-10 rounded-xl bg-[--color-accent]/10 flex items-center justify-center mb-4">
-            <svg class="w-5 h-5 text-[--color-accent]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0112 15a9.065 9.065 0 00-6.23.693L5 14.5m14.8.8l1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0112 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5"/></svg>
+          <div class="w-12 h-12 rounded-xl bg-[--color-accent]/10 flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-[--color-accent]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0112 15a9.065 9.065 0 00-6.23.693L5 14.5m14.8.8l1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0112 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5"/></svg>
           </div>
           <p class="font-mono text-[--color-accent] text-xs font-bold mb-2 tracking-wider">{t('features.card1_tag')}</p>
           <h3 class="font-bold text-lg mb-2 group-hover:text-[--color-accent] transition-colors">{t('features.card1_title')}</h3>
           <p class="text-[--color-text-muted] text-sm leading-relaxed">{t('features.card1_desc')}</p>
         </a>
         <a href="/strategies" class="card-premium p-6 block group">
-          <div class="w-10 h-10 rounded-xl bg-[--color-up]/10 flex items-center justify-center mb-4">
-            <svg class="w-5 h-5 text-[--color-up]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z"/></svg>
+          <div class="w-12 h-12 rounded-xl bg-[--color-up]/10 flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-[--color-up]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z"/></svg>
           </div>
           <p class="font-mono text-[--color-accent] text-xs font-bold mb-2 tracking-wider">{t('features.card2_tag')}</p>
           <h3 class="font-bold text-lg mb-2 group-hover:text-[--color-accent] transition-colors">{t('features.card2_title')}</h3>
           <p class="text-[--color-text-muted] text-sm leading-relaxed">{t('features.card2_desc')}</p>
         </a>
         <a href="/fees" class="card-premium p-6 block group">
-          <div class="w-10 h-10 rounded-xl bg-[--color-verified]/10 flex items-center justify-center mb-4">
-            <svg class="w-5 h-5 text-[--color-verified]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818l.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+          <div class="w-12 h-12 rounded-xl bg-[--color-verified]/10 flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-[--color-verified]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818l.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
           </div>
           <p class="font-mono text-[--color-accent] text-xs font-bold mb-2 tracking-wider">{t('features.card3_tag')}</p>
           <h3 class="font-bold text-lg mb-2 group-hover:text-[--color-accent] transition-colors">{t('features.card3_title')}</h3>
           <p class="text-[--color-text-muted] text-sm leading-relaxed">{t('features.card3_desc')}</p>
         </a>
         <a href="/learn" class="card-premium card-accent-gradient p-6 block group">
-          <div class="w-10 h-10 rounded-xl bg-[--color-purple]/10 flex items-center justify-center mb-4">
-            <svg class="w-5 h-5 text-[--color-purple]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M4.26 10.147a60.436 60.436 0 00-.491 6.347A48.627 48.627 0 0112 20.904a48.627 48.627 0 018.232-4.41 60.46 60.46 0 00-.491-6.347m-15.482 0a50.57 50.57 0 00-2.658-.813A59.905 59.905 0 0112 3.493a59.902 59.902 0 0110.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.697 50.697 0 0112 13.489a50.702 50.702 0 017.74-3.342"/></svg>
+          <div class="w-12 h-12 rounded-xl bg-[--color-purple]/10 flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-[--color-purple]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M4.26 10.147a60.436 60.436 0 00-.491 6.347A48.627 48.627 0 0112 20.904a48.627 48.627 0 018.232-4.41 60.46 60.46 0 00-.491-6.347m-15.482 0a50.57 50.57 0 00-2.658-.813A59.905 59.905 0 0112 3.493a59.902 59.902 0 0110.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.697 50.697 0 0112 13.489a50.702 50.702 0 017.74-3.342"/></svg>
           </div>
           <p class="font-mono text-[--color-accent] text-xs font-bold mb-2 tracking-wider">{t('features.learn_tag')}</p>
           <h3 class="font-bold text-lg mb-2 group-hover:text-[--color-accent] transition-colors">{t('features.learn_title')}</h3>

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -85,8 +85,8 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
   </section>
 
   <!-- STATS BAR -->
-  <div class="max-w-7xl mx-auto px-6 py-10 relative z-10">
-    <div class="grid grid-cols-3 gap-3 md:gap-4 max-w-3xl mx-auto">
+  <div class="max-w-7xl mx-auto px-6 py-12 md:py-16 relative z-10">
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 md:gap-5 max-w-3xl mx-auto">
       <div class="stat-glass text-center shadow-[var(--shadow-md)]">
         <p class="metric-value-lg text-[--color-accent]"><CountUp client:visible target={coinsAnalyzed} suffix="+" locale="ko-KR" /></p>
         <p class="metric-label mt-2">코인 테스트</p>
@@ -142,7 +142,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- COMPARISON TABLE -->
   <hr class="section-divider" />
-  <section class="py-16 md:py-24 bg-white/[0.02] reveal">
+  <section class="py-20 md:py-28 section-surface-subtle reveal">
     <div class="max-w-4xl mx-auto px-6">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider text-center">{t('compare.section_tag')}</p>
       <h2 class="text-2xl md:text-3xl font-bold text-center mb-12">{t('compare.section_title')}</h2>
@@ -225,7 +225,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- FEATURES & TRUST (Merged) -->
   <hr class="section-divider" />
-  <section class="py-16 md:py-24 bg-white/[0.02] reveal" aria-labelledby="features-heading-ko">
+  <section class="py-20 md:py-28 section-surface-subtle reveal" aria-labelledby="features-heading-ko">
     <div class="max-w-7xl mx-auto px-6">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('features.tag')}</p>
       <h2 id="features-heading-ko" class="text-2xl md:text-3xl font-bold mb-12">{t('features.title')}</h2>
@@ -233,32 +233,32 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       <!-- Feature cards -->
       <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-16 reveal-child">
         <a href="/ko/simulate" class="card-premium p-6 block group">
-          <div class="w-10 h-10 rounded-xl bg-[--color-accent]/10 flex items-center justify-center mb-4">
-            <svg class="w-5 h-5 text-[--color-accent]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0112 15a9.065 9.065 0 00-6.23.693L5 14.5m14.8.8l1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0112 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5"/></svg>
+          <div class="w-12 h-12 rounded-xl bg-[--color-accent]/10 flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-[--color-accent]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0112 15a9.065 9.065 0 00-6.23.693L5 14.5m14.8.8l1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0112 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5"/></svg>
           </div>
           <p class="font-mono text-[--color-accent] text-xs font-bold mb-2 tracking-wider">{t('features.card1_tag')}</p>
           <h3 class="font-bold text-lg mb-2 group-hover:text-[--color-accent] transition-colors">{t('features.card1_title')}</h3>
           <p class="text-[--color-text-muted] text-sm leading-relaxed">{t('features.card1_desc')}</p>
         </a>
         <a href="/ko/strategies" class="card-premium p-6 block group">
-          <div class="w-10 h-10 rounded-xl bg-[--color-up]/10 flex items-center justify-center mb-4">
-            <svg class="w-5 h-5 text-[--color-up]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z"/></svg>
+          <div class="w-12 h-12 rounded-xl bg-[--color-up]/10 flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-[--color-up]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z"/></svg>
           </div>
           <p class="font-mono text-[--color-accent] text-xs font-bold mb-2 tracking-wider">{t('features.card2_tag')}</p>
           <h3 class="font-bold text-lg mb-2 group-hover:text-[--color-accent] transition-colors">{t('features.card2_title')}</h3>
           <p class="text-[--color-text-muted] text-sm leading-relaxed">{t('features.card2_desc')}</p>
         </a>
         <a href="/ko/fees" class="card-premium p-6 block group">
-          <div class="w-10 h-10 rounded-xl bg-[--color-verified]/10 flex items-center justify-center mb-4">
-            <svg class="w-5 h-5 text-[--color-verified]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818l.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+          <div class="w-12 h-12 rounded-xl bg-[--color-verified]/10 flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-[--color-verified]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818l.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
           </div>
           <p class="font-mono text-[--color-accent] text-xs font-bold mb-2 tracking-wider">{t('features.card3_tag')}</p>
           <h3 class="font-bold text-lg mb-2 group-hover:text-[--color-accent] transition-colors">{t('features.card3_title')}</h3>
           <p class="text-[--color-text-muted] text-sm leading-relaxed">{t('features.card3_desc')}</p>
         </a>
         <a href="/ko/learn" class="card-premium card-accent-gradient p-6 block group">
-          <div class="w-10 h-10 rounded-xl bg-[--color-purple]/10 flex items-center justify-center mb-4">
-            <svg class="w-5 h-5 text-[--color-purple]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M4.26 10.147a60.436 60.436 0 00-.491 6.347A48.627 48.627 0 0112 20.904a48.627 48.627 0 018.232-4.41 60.46 60.46 0 00-.491-6.347m-15.482 0a50.57 50.57 0 00-2.658-.813A59.905 59.905 0 0112 3.493a59.902 59.902 0 0110.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.697 50.697 0 0112 13.489a50.702 50.702 0 017.74-3.342"/></svg>
+          <div class="w-12 h-12 rounded-xl bg-[--color-purple]/10 flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-[--color-purple]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M4.26 10.147a60.436 60.436 0 00-.491 6.347A48.627 48.627 0 0112 20.904a48.627 48.627 0 018.232-4.41 60.46 60.46 0 00-.491-6.347m-15.482 0a50.57 50.57 0 00-2.658-.813A59.905 59.905 0 0112 3.493a59.902 59.902 0 0110.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.697 50.697 0 0112 13.489a50.702 50.702 0 017.74-3.342"/></svg>
           </div>
           <p class="font-mono text-[--color-accent] text-xs font-bold mb-2 tracking-wider">{t('features.learn_tag')}</p>
           <h3 class="font-bold text-lg mb-2 group-hover:text-[--color-accent] transition-colors">{t('features.learn_title')}</h3>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -176,10 +176,10 @@
 /* ─── Hero background depth ─── */
 .hero-bg-depth {
   background:
-    radial-gradient(ellipse at 50% -20%, rgba(44,181,232,0.12) 0%, transparent 50%),
-    radial-gradient(ellipse at 80% 50%, rgba(168,85,247,0.04) 0%, transparent 50%),
-    radial-gradient(ellipse at 20% 80%, rgba(6,182,212,0.03) 0%, transparent 50%),
-    var(--gradient-hero);
+    radial-gradient(ellipse at 50% -10%, rgba(44,181,232,0.18) 0%, transparent 55%),
+    radial-gradient(ellipse at 80% 40%, rgba(168,85,247,0.08) 0%, transparent 45%),
+    radial-gradient(ellipse at 20% 70%, rgba(6,182,212,0.06) 0%, transparent 45%),
+    linear-gradient(180deg, #09090B 0%, #0C1220 40%, #0A0F1A 70%, #09090B 100%);
 }
 
 /* ─── Subtle grid pattern for hero ─── */
@@ -226,10 +226,18 @@
 
 /* ─── Section glow backgrounds ─── */
 .section-glow-green {
-  background: radial-gradient(ellipse at 50% 0%, rgba(0,220,130,0.04) 0%, transparent 70%);
+  background: radial-gradient(ellipse at 50% 0%, rgba(0,220,130,0.06) 0%, transparent 60%);
 }
 .section-glow-cyan {
-  background: radial-gradient(ellipse at 50% 100%, rgba(44,181,232,0.03) 0%, transparent 70%);
+  background: radial-gradient(ellipse at 50% 100%, rgba(44,181,232,0.05) 0%, transparent 60%);
+}
+
+/* ─── Alternating section surfaces ─── */
+.section-surface {
+  background-color: var(--color-bg-surface);
+}
+.section-surface-subtle {
+  background: linear-gradient(180deg, rgba(255,255,255,0.015) 0%, transparent 100%);
 }
 
 /* ─── Frosted glass enhancement ─── */


### PR DESCRIPTION
## Summary
- **Hero gradient**: Cyan glow 0.12→0.18, purple 0.04→0.08, deeper blue gradient tones
- **Section surfaces**: New `section-surface-subtle` for visible alternating depth
- **Stats bar mobile**: Vertical stack (grid-cols-1 sm:grid-cols-3) — no more cramped 3-col on phone
- **Feature icons**: w-10/h-10 → w-12/h-12 containers, w-5/h-5 → w-6/h-6 icons
- **Nav**: h-16→h-14 compact, backdrop-blur-xl stronger glass effect
- **Footer**: More breathing room (py-16), sections own spacing (mt-0)

## Test plan
- [x] `npm run build` — 2518 pages, 0 errors
- [x] `npx vitest run` — 22/22 pass
- [ ] Visual QA desktop + mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)