### PR TITLE
fix: eliminate hardcoded 570+, pt-2 heroes, KO card patterns

### DIFF
--- a/src/pages/api.astro
+++ b/src/pages/api.astro
@@ -10,7 +10,7 @@ const API_BASE = 'https://api.pruviq.com';
 <Layout title={t('meta.api_title')} description={t('meta.api_desc')}>
 
   <!-- HERO -->
-  <section class="pt-2 pb-8">
+  <section class="pt-4 pb-8">
     <div class="max-w-5xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('api.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">

--- a/src/pages/best-crypto-backtesting.astro
+++ b/src/pages/best-crypto-backtesting.astro
@@ -1,11 +1,13 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import { useTranslations } from '../i18n/index';
+import siteStats from '../../public/data/site-stats.json';
 
 const t = useTranslations('en');
+const coinsAnalyzed = (siteStats as Record<string, number>).coins_analyzed ?? 570;
 
 const criteria = [
-  { label: 'Multi-coin support', desc: '570+ coins across major exchanges — test any pair, not just BTC/ETH.', pruviq: true },
+  { label: 'Multi-coin support', desc: `${coinsAnalyzed}+ coins across major exchanges — test any pair, not just BTC/ETH.`, pruviq: true },
   { label: 'Real fees & slippage', desc: 'Every backtest includes maker/taker fees, funding rates, and slippage modeling.', pruviq: true },
   { label: 'Failure transparency', desc: 'We publicly show strategies we killed — not just winners.', pruviq: true },
   { label: 'No-code interface', desc: 'Pick indicators, set parameters, run. No Pine Script or Python required.', pruviq: true },
@@ -14,7 +16,7 @@ const criteria = [
 
 const comparisonRows = [
   { feature: 'Price', pruviq: '$0 — no subscription', tv: '$14.95–59.95/mo', c3: '$14.50–49.50/mo', win: 'p' },
-  { feature: 'Coins', pruviq: '570+', tv: '~50 crypto pairs', c3: '~20 supported', win: 'p' },
+  { feature: 'Coins', pruviq: `${coinsAnalyzed}+`, tv: '~50 crypto pairs', c3: '~20 supported', win: 'p' },
   { feature: 'Coding required', pruviq: 'No code', tv: 'Pine Script', c3: 'Template-based', win: 'p' },
   { feature: 'Real fees modeled', pruviq: 'Yes (maker/taker/funding)', tv: 'Basic commission only', c3: 'Partial', win: 'p' },
   { feature: 'Failed strategies shown', pruviq: 'Yes (88 killed)', tv: 'No', c3: 'No', win: 'p' },
@@ -26,7 +28,7 @@ const jsonLd = {
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Best Free Crypto Backtesting Platform (2026)",
-  "description": "Compare the best crypto backtesting platforms in 2026. PRUVIQ offers free, no-code backtesting with 570+ coins, real fees, and transparent failure data.",
+  "description": `Compare the best crypto backtesting platforms in 2026. PRUVIQ offers free, no-code backtesting with ${coinsAnalyzed}+ coins, real fees, and transparent failure data.`,
   "datePublished": "2026-03-22",
   "dateModified": "2026-03-22",
   "author": { "@type": "Organization", "name": "PRUVIQ", "url": "https://pruviq.com" },
@@ -105,7 +107,7 @@ const jsonLd = {
       <h2 class="text-2xl md:text-3xl font-bold mb-8">How PRUVIQ Meets Every Criterion</h2>
       <div class="grid md:grid-cols-2 gap-6">
         <div class="card-enterprise card-hover p-6">
-          <h3 class="font-bold mb-2">570+ Coins, Real Data</h3>
+          <h3 class="font-bold mb-2">{coinsAnalyzed}+ Coins, Real Data</h3>
           <p class="text-sm text-[--color-text-muted]">Test on any Binance Futures pair with 2+ years of OHLCV data. Not just the top 10 — every listed coin.</p>
         </div>
         <div class="card-enterprise card-hover p-6">

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -8,7 +8,7 @@ const t = useTranslations('en');
 <Layout title={t('meta.changelog_title')} description={t('meta.changelog_desc')}>
 
   <!-- HEADER -->
-  <section class="pt-2 pb-20 reveal">
+  <section class="pt-4 pb-20 reveal">
     <div class="max-w-7xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('changelog.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">{t('changelog.title')}</h1>

--- a/src/pages/crypto-trading-simulator.astro
+++ b/src/pages/crypto-trading-simulator.astro
@@ -1,8 +1,10 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import { useTranslations } from '../i18n/index';
+import siteStats from '../../public/data/site-stats.json';
 
 const t = useTranslations('en');
+const coinsAnalyzed = (siteStats as Record<string, number>).coins_analyzed ?? 570;
 
 const steps = [
   { num: '01', title: t('how.step1'), desc: t('how.step1_desc') },
@@ -11,7 +13,7 @@ const steps = [
 ];
 
 const features = [
-  { stat: '570+', label: 'Coins', desc: 'Every Binance Futures pair — not just the top 10.' },
+  { stat: `${coinsAnalyzed}+`, label: 'Coins', desc: 'Every Binance Futures pair — not just the top 10.' },
   { stat: '36', label: 'Strategies', desc: 'Pre-built strategies you can test immediately, or customize your own.' },
   { stat: '2+ Years', label: 'Historical Data', desc: 'OHLCV candles with realistic fee and slippage modeling.' },
   { stat: 'Real Fees', label: 'Included', desc: 'Maker/taker fees, funding rates, and slippage in every simulation.' },
@@ -21,7 +23,7 @@ const jsonLd = {
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Free Crypto Trading Simulator — No Account Needed",
-  "description": "Practice crypto trading with a free simulator. Test 570+ coins with real fees, 36 strategies, and 2+ years of historical data. No signup required.",
+  "description": `Practice crypto trading with a free simulator. Test ${coinsAnalyzed}+ coins with real fees, 36 strategies, and 2+ years of historical data. No signup required.`,
   "datePublished": "2026-03-22",
   "dateModified": "2026-03-22",
   "author": { "@type": "Organization", "name": "PRUVIQ", "url": "https://pruviq.com" },
@@ -42,7 +44,7 @@ const jsonLd = {
         <span class="block text-lg md:text-2xl font-normal text-[--color-text-muted] mt-2">Test strategies with real market data before risking real money.</span>
       </h1>
       <p class="text-[--color-text-muted] text-lg max-w-2xl mb-6">
-        PRUVIQ's trading simulator lets you backtest any strategy on 570+ cryptocurrencies
+        PRUVIQ's trading simulator lets you backtest any strategy on {coinsAnalyzed}+ cryptocurrencies
         with realistic fees — completely free, no signup required.
       </p>
     </div>

--- a/src/pages/ko/api.astro
+++ b/src/pages/ko/api.astro
@@ -10,7 +10,7 @@ const API_BASE = 'https://api.pruviq.com';
 <Layout title={t('meta.api_title')} description={t('meta.api_desc')}>
 
   <!-- HERO -->
-  <section class="pt-2 pb-8">
+  <section class="pt-4 pb-8">
     <div class="max-w-5xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('api.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">

--- a/src/pages/ko/best-crypto-backtesting.astro
+++ b/src/pages/ko/best-crypto-backtesting.astro
@@ -1,11 +1,13 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import { useTranslations } from '../../i18n/index';
+import siteStats from '../../../public/data/site-stats.json';
 
 const t = useTranslations('ko');
+const coinsAnalyzed = (siteStats as Record<string, number>).coins_analyzed ?? 570;
 
 const criteria = [
-  { label: '멀티코인 지원', desc: '주요 거래소의 570개 이상 코인 — BTC/ETH뿐만 아니라 모든 페어를 테스트할 수 있습니다.' },
+  { label: '멀티코인 지원', desc: `주요 거래소의 ${coinsAnalyzed}개 이상 코인 — BTC/ETH뿐만 아니라 모든 페어를 테스트할 수 있습니다.` },
   { label: '실제 수수료 및 슬리피지', desc: '모든 백테스트에 메이커/테이커 수수료, 펀딩비, 슬리피지 모델링이 포함됩니다.' },
   { label: '실패 투명성', desc: '성공한 전략만 보여주지 않습니다 — 실패한 전략도 공개합니다.' },
   { label: '노코드 인터페이스', desc: '지표를 선택하고, 파라미터를 설정하고, 실행하세요. Pine Script나 Python이 필요 없습니다.' },
@@ -14,7 +16,7 @@ const criteria = [
 
 const comparisonRows = [
   { feature: '가격', pruviq: '영원히 무료', tv: '$14.95~59.95/월', c3: '$14.50~49.50/월', win: 'p' },
-  { feature: '코인 수', pruviq: '570+', tv: '~50개 암호화폐 페어', c3: '~20개 지원', win: 'p' },
+  { feature: '코인 수', pruviq: `${coinsAnalyzed}+`, tv: '~50개 암호화폐 페어', c3: '~20개 지원', win: 'p' },
   { feature: '코딩 필요', pruviq: '노코드', tv: 'Pine Script', c3: '템플릿 기반', win: 'p' },
   { feature: '실제 수수료 모델링', pruviq: '예 (메이커/테이커/펀딩)', tv: '기본 커미션만', c3: '일부', win: 'p' },
   { feature: '실패 전략 공개', pruviq: '예 (88개 제거)', tv: '아니오', c3: '아니오', win: 'p' },
@@ -26,7 +28,7 @@ const jsonLd = {
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "2026년 최고의 무료 크립토 백테스팅 플랫폼",
-  "description": "2026년 최고의 크립토 백테스팅 플랫폼을 비교하세요. PRUVIQ는 570개 이상 코인, 실제 수수료, 투명한 실패 데이터를 갖춘 무료 노코드 백테스팅을 제공합니다.",
+  "description": `2026년 최고의 크립토 백테스팅 플랫폼을 비교하세요. PRUVIQ는 ${coinsAnalyzed}개 이상 코인, 실제 수수료, 투명한 실패 데이터를 갖춘 무료 노코드 백테스팅을 제공합니다.`,
   "datePublished": "2026-03-22",
   "dateModified": "2026-03-22",
   "author": { "@type": "Organization", "name": "PRUVIQ", "url": "https://pruviq.com" },
@@ -105,7 +107,7 @@ const jsonLd = {
       <h2 class="text-2xl md:text-3xl font-bold mb-8">PRUVIQ가 모든 기준을 충족하는 방법</h2>
       <div class="grid md:grid-cols-2 gap-6">
         <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card]">
-          <h3 class="font-bold mb-2">570개 이상 코인, 실제 데이터</h3>
+          <h3 class="font-bold mb-2">{coinsAnalyzed}개 이상 코인, 실제 데이터</h3>
           <p class="text-sm text-[--color-text-muted]">바이낸스 선물의 모든 페어를 2년 이상의 OHLCV 데이터로 테스트할 수 있습니다. 상위 10개뿐만 아니라 상장된 모든 코인이 포함됩니다.</p>
         </div>
         <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card]">

--- a/src/pages/ko/blog/[id].astro
+++ b/src/pages/ko/blog/[id].astro
@@ -37,7 +37,7 @@ const { Content } = await render(post);
   isKorean={isKorean}
 >
   {!isKorean && (
-    <div class="mb-6 px-3 py-2 border border-[--color-border] rounded bg-[--color-bg-card] text-sm text-[--color-text-muted]">
+    <div class="mb-6 px-3 py-2 border border-[--color-border] rounded-xl bg-[--color-bg-card] shadow-[var(--shadow-sm)] text-sm text-[--color-text-muted]">
       This content is available in English only.
     </div>
   )}

--- a/src/pages/ko/changelog.astro
+++ b/src/pages/ko/changelog.astro
@@ -8,7 +8,7 @@ const t = useTranslations('ko');
 <Layout title={t('meta.changelog_title')} description={t('meta.changelog_desc')}>
 
   <!-- HEADER -->
-  <section class="pt-2 pb-20 reveal">
+  <section class="pt-4 pb-20 reveal">
     <div class="max-w-7xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('changelog.tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-4">{t('changelog.title')}</h1>

--- a/src/pages/ko/compare/index.astro
+++ b/src/pages/ko/compare/index.astro
@@ -1,8 +1,10 @@
 ---
 import Layout from '../../../layouts/Layout.astro';
 import { useTranslations } from '../../../i18n/index';
+import siteStats from '../../../../public/data/site-stats.json';
 
 const t = useTranslations('ko');
+const coinsAnalyzed = (siteStats as Record<string, number>).coins_analyzed ?? 570;
 
 const comparisons = [
   { slug: 'tradingview', name: 'TradingView', desc: t('compare_index.tradingview_desc'), badge: t('compare_index.most_popular'), accent: '#2962FF', icon: '📈' },
@@ -80,7 +82,7 @@ const comparisons = [
             </tr>
             <tr class="border-b border-[--color-border]/50">
               <td class="py-3 px-3 text-[--color-text-muted] min-w-[140px] whitespace-nowrap">{t('compare_index.tbl_multicoin')}</td>
-              <td class="py-3 px-3 text-center text-[--color-up] font-semibold bg-[--color-accent]/10 border-x border-[--color-accent]/20">570개+ 코인</td>
+              <td class="py-3 px-3 text-center text-[--color-up] font-semibold bg-[--color-accent]/10 border-x border-[--color-accent]/20">{coinsAnalyzed}개+ 코인</td>
               <td class="py-3 px-3 text-center text-[--color-down]">1개씩</td>
               <td class="py-3 px-3 text-center text-[--color-down]">제한적</td>
               <td class="py-3 px-3 text-center text-[--color-down]">제한적</td>
@@ -113,7 +115,7 @@ const comparisons = [
       <div class="max-w-3xl mx-auto mt-10 mb-6">
         <h3 class="text-lg font-bold mb-3">왜 이 수치가 중요한가</h3>
         <div class="space-y-4 text-sm text-[--color-text-muted] leading-relaxed">
-          <p><strong class="text-[--color-text]">멀티코인 테스트</strong> — 대부분의 플랫폼은 코인 1개씩 테스트합니다. PRUVIQ는 570개+ 코인에서 동시에 전략을 실행해, 어떤 시장에서 통하고 어디서 실패하는지 한눈에 보여줍니다. 체리피킹 편향을 제거합니다.</p>
+          <p><strong class="text-[--color-text]">멀티코인 테스트</strong> — 대부분의 플랫폼은 코인 1개씩 테스트합니다. PRUVIQ는 {coinsAnalyzed}개+ 코인에서 동시에 전략을 실행해, 어떤 시장에서 통하고 어디서 실패하는지 한눈에 보여줍니다. 체리피킹 편향을 제거합니다.</p>
           <p><strong class="text-[--color-text]">실패 투명성</strong> — 88개 전략 조합 중 87개가 탈락했습니다. 저희는 실패한 전략을 전부 공개합니다. 다른 플랫폼은 성공한 것만 보여주며, 생존자 편향으로 백테스트 결과를 부풀립니다.</p>
           <p><strong class="text-[--color-text]">가입 불필요</strong> — 이메일, KYC, 신용카드 없이 즉시 전략을 테스트할 수 있습니다. 데이터는 브라우저에 남습니다. 가입 장벽이 없어야 솔직한 평가가 가능하기 때문입니다.</p>
         </div>

--- a/src/pages/ko/crypto-trading-simulator.astro
+++ b/src/pages/ko/crypto-trading-simulator.astro
@@ -1,8 +1,10 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import { useTranslations } from '../../i18n/index';
+import siteStats from '../../../public/data/site-stats.json';
 
 const t = useTranslations('ko');
+const coinsAnalyzed = (siteStats as Record<string, number>).coins_analyzed ?? 570;
 
 const steps = [
   { num: '01', title: t('how.step1'), desc: t('how.step1_desc') },
@@ -11,7 +13,7 @@ const steps = [
 ];
 
 const features = [
-  { stat: '570+', label: '코인', desc: '바이낸스 선물의 모든 페어 — 상위 10개만이 아닙니다.' },
+  { stat: `${coinsAnalyzed}+`, label: '코인', desc: '바이낸스 선물의 모든 페어 — 상위 10개만이 아닙니다.' },
   { stat: '36', label: '전략', desc: '즉시 테스트할 수 있는 사전 구축 전략, 또는 직접 커스터마이즈하세요.' },
   { stat: '2년+', label: '과거 데이터', desc: '현실적인 수수료와 슬리피지 모델링이 포함된 OHLCV 캔들.' },
   { stat: '실제 수수료', label: '포함', desc: '모든 시뮬레이션에 메이커/테이커 수수료, 펀딩비, 슬리피지가 반영됩니다.' },
@@ -21,7 +23,7 @@ const jsonLd = {
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "무료 크립토 트레이딩 시뮬레이터 — 회원가입 불필요",
-  "description": "무료 시뮬레이터로 크립토 트레이딩을 연습하세요. 570개 이상 코인, 실제 수수료, 36개 프리셋 + 무한 커스텀 전략, 2년 이상의 과거 데이터로 테스트할 수 있습니다.",
+  "description": `무료 시뮬레이터로 크립토 트레이딩을 연습하세요. ${coinsAnalyzed}개 이상 코인, 실제 수수료, 36개 프리셋 + 무한 커스텀 전략, 2년 이상의 과거 데이터로 테스트할 수 있습니다.`,
   "datePublished": "2026-03-22",
   "dateModified": "2026-03-22",
   "author": { "@type": "Organization", "name": "PRUVIQ", "url": "https://pruviq.com" },
@@ -43,7 +45,7 @@ const jsonLd = {
         <span class="block text-lg md:text-2xl font-normal text-[--color-text-muted] mt-2">실제 돈을 투자하기 전에 실제 시장 데이터로 전략을 테스트하세요.</span>
       </h1>
       <p class="text-[--color-text-muted] text-lg max-w-2xl mb-6">
-        PRUVIQ의 트레이딩 시뮬레이터는 570개 이상의 암호화폐에서 현실적인 수수료를 반영하여
+        PRUVIQ의 트레이딩 시뮬레이터는 {coinsAnalyzed}개 이상의 암호화폐에서 현실적인 수수료를 반영하여
         어떤 전략이든 백테스트할 수 있게 해줍니다 — 완전 무료, 회원가입 불필요.
       </p>
     </div>

--- a/src/pages/ko/market/index.astro
+++ b/src/pages/ko/market/index.astro
@@ -2,8 +2,10 @@
 import Layout from '../../../layouts/Layout.astro';
 import { useTranslations } from '../../../i18n/index';
 import marketDataRaw from '../../../../public/data/market.json';
+import siteStats from '../../../../public/data/site-stats.json';
 
 const t = useTranslations('ko');
+const coinsAnalyzed = (siteStats as Record<string, number>).coins_analyzed ?? 570;
 const marketDataJson = JSON.stringify(marketDataRaw);
 ---
 
@@ -57,7 +59,7 @@ const marketDataJson = JSON.stringify(marketDataRaw);
             </div>
             <p class="text-[--color-text-muted] text-sm mb-4">{t('market.noscript_desc')}</p>
             <div class="flex flex-wrap gap-3">
-              <a href="/ko/coins" class="text-[--color-accent] text-sm font-semibold hover:underline">570+ 코인 탐색 &rarr;</a>
+              <a href="/ko/coins" class="text-[--color-accent] text-sm font-semibold hover:underline">{coinsAnalyzed}+ 코인 탐색 &rarr;</a>
               <a href="/ko/simulate" class="text-[--color-accent] text-sm font-semibold hover:underline">시뮬레이션 실행 &rarr;</a>
               <a href="/ko/strategies" class="text-[--color-accent] text-sm font-semibold hover:underline">전략 보기 &rarr;</a>
             </div>

--- a/src/pages/ko/privacy.astro
+++ b/src/pages/ko/privacy.astro
@@ -7,7 +7,7 @@ const t = useTranslations('ko');
 
 <Layout title={t('meta.privacy_title')} description={t('meta.privacy_desc')}>
 
-  <section class="pt-2 pb-20">
+  <section class="pt-4 pb-20">
     <div class="max-w-3xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('meta.privacy_tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-2">{t('meta.privacy_heading')}</h1>

--- a/src/pages/ko/strategies/[id].astro
+++ b/src/pages/ko/strategies/[id].astro
@@ -79,7 +79,7 @@ const statusLabels: Record<string, string> = {
       </a>
 
       {!isKorean && (
-        <div class="mb-4 px-3 py-2 border border-[--color-border] rounded bg-[--color-bg-card] text-sm text-[--color-text-muted]">
+        <div class="mb-4 px-3 py-2 border border-[--color-border] rounded-xl bg-[--color-bg-card] shadow-[var(--shadow-sm)] text-sm text-[--color-text-muted]">
           {t('strategy_detail.english_only')}
         </div>
       )}

--- a/src/pages/ko/strategies/compare.astro
+++ b/src/pages/ko/strategies/compare.astro
@@ -6,7 +6,7 @@ const t = useTranslations('ko');
 ---
 
 <Layout title={t('meta.compare_title')} description={t('meta.compare_desc')}>
-  <section class="pt-2 pb-12">
+  <section class="pt-6 md:pt-8 pb-12">
     <div class="max-w-5xl mx-auto px-4">
       <a href="/ko/strategies" class="text-[--color-text-muted] text-sm hover:text-[--color-accent] transition-colors mb-8 inline-block">
         &larr; {t('compare.back')}

--- a/src/pages/ko/strategies/ranking.astro
+++ b/src/pages/ko/strategies/ranking.astro
@@ -61,7 +61,7 @@ if (!ssrRanking) {
 ---
 
 <Layout title={t('meta.ranking_title')} description={t('meta.ranking_desc')}>
-  <section class="pt-2 pb-16 md:pt-4 md:pb-24">
+  <section class="pt-6 pb-16 md:pt-8 md:pb-24">
     <div class="max-w-5xl mx-auto px-6">
 
       <StrategyTabs active="ranking" lang="ko" />

--- a/src/pages/ko/terms.astro
+++ b/src/pages/ko/terms.astro
@@ -7,7 +7,7 @@ const t = useTranslations('ko');
 
 <Layout title={t('meta.terms_title')} description={t('meta.terms_desc')}>
 
-  <section class="pt-2 pb-20">
+  <section class="pt-4 pb-20">
     <div class="max-w-3xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('meta.terms_tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-2">{t('meta.terms_heading')}</h1>

--- a/src/pages/ko/why-backtests-fail.astro
+++ b/src/pages/ko/why-backtests-fail.astro
@@ -1,8 +1,10 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import { useTranslations } from '../../i18n/index';
+import siteStats from '../../../public/data/site-stats.json';
 
 const t = useTranslations('ko');
+const coinsAnalyzed = (siteStats as Record<string, number>).coins_analyzed ?? 570;
 
 const reasons = [
   {
@@ -18,7 +20,7 @@ const reasons = [
   {
     title: 'Overfitting (과적합)',
     desc: '과거 데이터에서 백테스트가 완벽해 보일 때까지 파라미터를 조정하지만, 새로운 데이터에서는 전략이 실패합니다. 20개의 최적화된 파라미터를 가진 전략은 다음 달에 작동하지 않을 가능성이 높습니다.',
-    fix: 'PRUVIQ는 570개 이상의 코인에서 동일한 전략을 실행할 수 있게 하여 표본 외 테스트를 장려합니다. 3개 코인에서만 작동하면 과적합입니다. 또한 몬테카를로 시뮬레이션을 보여주어 결과가 무작위성에 얼마나 민감한지 드러냅니다.'
+    fix: `PRUVIQ는 ${coinsAnalyzed}개 이상의 코인에서 동일한 전략을 실행할 수 있게 하여 표본 외 테스트를 장려합니다. 3개 코인에서만 작동하면 과적합입니다. 또한 몬테카를로 시뮬레이션을 보여주어 결과가 무작위성에 얼마나 민감한지 드러냅니다.`
   },
   {
     title: '수수료와 슬리피지 무시',

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -7,7 +7,7 @@ const t = useTranslations('en');
 
 <Layout title={t('meta.privacy_title')} description={t('meta.privacy_desc')}>
 
-  <section class="pt-2 pb-20">
+  <section class="pt-4 pb-20">
     <div class="max-w-3xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('meta.privacy_tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-2">{t('meta.privacy_heading')}</h1>

--- a/src/pages/strategies/compare.astro
+++ b/src/pages/strategies/compare.astro
@@ -6,7 +6,7 @@ const t = useTranslations('en');
 ---
 
 <Layout title={t('meta.compare_title')} description={t('meta.compare_desc')}>
-  <section class="pt-2 pb-12">
+  <section class="pt-6 md:pt-8 pb-12">
     <div class="max-w-5xl mx-auto px-4">
       <a href="/strategies" class="text-[--color-text-muted] text-sm hover:text-[--color-accent] transition-colors mb-8 inline-block">
         &larr; {t('compare.back')}

--- a/src/pages/strategies/ranking.astro
+++ b/src/pages/strategies/ranking.astro
@@ -72,7 +72,7 @@ if (!ssrRanking) {
 ---
 
 <Layout title={t('meta.ranking_title')} description={t('meta.ranking_desc')}>
-  <section class="pt-2 pb-16 md:pt-4 md:pb-24">
+  <section class="pt-6 pb-16 md:pt-8 md:pb-24">
     <div class="max-w-5xl mx-auto px-6">
 
       <StrategyTabs active="ranking" lang="en" />

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -7,7 +7,7 @@ const t = useTranslations('en');
 
 <Layout title={t('meta.terms_title')} description={t('meta.terms_desc')}>
 
-  <section class="pt-2 pb-20">
+  <section class="pt-4 pb-20">
     <div class="max-w-3xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('meta.terms_tag')}</p>
       <h1 class="text-3xl md:text-5xl font-bold mb-2">{t('meta.terms_heading')}</h1>

--- a/src/pages/why-backtests-fail.astro
+++ b/src/pages/why-backtests-fail.astro
@@ -1,8 +1,10 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import { useTranslations } from '../i18n/index';
+import siteStats from '../../public/data/site-stats.json';
 
 const t = useTranslations('en');
+const coinsAnalyzed = (siteStats as Record<string, number>).coins_analyzed ?? 570;
 
 const reasons = [
   {
@@ -18,7 +20,7 @@ const reasons = [
   {
     title: 'Overfitting',
     desc: 'Tweaking parameters until the backtest looks perfect on historical data, but the strategy fails on new data. A strategy with 20 optimized parameters probably won\'t work next month.',
-    fix: 'PRUVIQ encourages out-of-sample testing by letting you run the same strategy across 570+ coins. If it only works on 3 coins, it\'s overfit. We also show Monte Carlo simulations to reveal how sensitive results are to randomness.'
+    fix: `PRUVIQ encourages out-of-sample testing by letting you run the same strategy across ${coinsAnalyzed}+ coins. If it only works on 3 coins, it's overfit. We also show Monte Carlo simulations to reveal how sensitive results are to randomness.`
   },
   {
     title: 'Ignoring Fees and Slippage',


### PR DESCRIPTION
## Summary
- **Dynamic coin count**: 8 SEO landing pages now use `site-stats.json` instead of hardcoded "570+"
- **Hero spacing**: 4 strategy sub-pages `pt-2`→`pt-6 md:pt-8`, 8 utility pages `pt-2`→`pt-4`
- **KO card patterns**: `ko/blog/[id]` + `ko/strategies/[id]` → `rounded-xl` + `shadow-sm`

## Test plan
- [x] `npm run build` — 2518 pages, 0 errors
- [x] `npx vitest run` — 22/22 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)