### PR TITLE
fix: strategy labels + coin chart error UI

### DIFF
--- a/src/components/CoinChart.tsx
+++ b/src/components/CoinChart.tsx
@@ -458,8 +458,23 @@ export default function CoinChart({
   }
   if (error || !ohlcv) {
     return (
-      <div class="py-8 text-center">
-        <p class="font-mono text-sm text-[--color-red] mb-3">{t.error}</p>
+      <div class="py-12 text-center border border-[--color-border] rounded-xl bg-[--color-bg-card]">
+        <div class="w-12 h-12 mx-auto mb-4 rounded-full bg-[--color-red]/10 flex items-center justify-center">
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="var(--color-red)"
+            stroke-width="2"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <path d="M12 8v4M12 16h.01" />
+          </svg>
+        </div>
+        <p class="font-mono text-sm text-[--color-text-muted] mb-4">
+          {t.error}
+        </p>
         <button
           onClick={() => {
             setError(null);

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -240,10 +240,10 @@ export const en = {
     "Want to simulate this strategy with your own parameters?",
 
   // Strategy labels
-  "strategy.verified": "ACTIVE",
+  "strategy.verified": "VERIFIED",
   "strategy.testing": "TESTING",
   "strategy.killed": "RETIRED",
-  "strategy.shelved": "UNDER REVIEW",
+  "strategy.shelved": "SHELVED",
   "strategy.beginner": "BEGINNER",
   "strategy.intermediate": "INTERMEDIATE",
   "strategy.advanced": "ADVANCED",


### PR DESCRIPTION
## Summary
- **Strategy labels**: `ACTIVE`→`VERIFIED`, `UNDER REVIEW`→`SHELVED` (aligns with site-wide terminology)
- **CoinChart error state**: Added icon, card container, better spacing (was bare text + spinner)

## Test plan
- [x] `npm run build` — 2518 pages, 0 errors
- [ ] Strategies page: BB Squeeze SHORT shows "VERIFIED" badge
- [ ] Coin detail: error state shows card with icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)