### PR TITLE
fix: coins table mobile — remove min-w horizontal scroll

### DIFF
--- a/src/components/CoinListTable.tsx
+++ b/src/components/CoinListTable.tsx
@@ -310,7 +310,7 @@ export default function CoinListTable({ lang = "en" }: { lang?: "en" | "ko" }) {
         </div>
         <div class="relative overflow-x-auto border border-[--color-border] rounded-xl bg-[--color-bg-card]">
           <table
-            class="w-full min-w-[900px] border-collapse font-mono text-[0.8125rem]"
+            class="w-full md:min-w-[900px] border-collapse font-mono text-[0.8125rem]"
             aria-busy="true"
           >
             <caption class="sr-only">{t.tableCaption}</caption>
@@ -492,7 +492,7 @@ export default function CoinListTable({ lang = "en" }: { lang?: "en" | "ko" }) {
 
       {/* Table */}
       <div class="relative overflow-x-auto border border-[--color-border] rounded-xl bg-[--color-bg-card]">
-        <table class="w-full min-w-[900px] border-collapse font-mono text-[0.8125rem]">
+        <table class="w-full md:min-w-[900px] border-collapse font-mono text-[0.8125rem]">
           <caption class="sr-only">{t.tableCaption}</caption>
           <thead>
             <tr>


### PR DESCRIPTION
Root cause: min-w-[900px] forced horizontal scroll on mobile. Changed to md:min-w-[900px].

🤖 Generated with [Claude Code](https://claude.com/claude-code)