### PR TITLE
feat: OKX Broker full-stack — OAuth, trade execution, dashboard

### DIFF
--- a/src/config/exchanges.ts
+++ b/src/config/exchanges.ts
@@ -9,8 +9,10 @@
  *   Spot:    PRUVIQ keeps 1%, User gets 19% → total pool 20%
  *   Futures: PRUVIQ keeps 1%, User gets 9%  → total pool 10%
  *
- * OKX affiliate dashboard (verified 2026-04-01):
- *   PRUVIQ rate: 30%, Invitee rate: 20% (max rebate to user)
+ * OKX Broker dashboard (verified 2026-04-10, Level 2):
+ *   Non-affiliate rebate: 30%, Affiliate rebate: 7.5%
+ *   Broker code: c12571e26a02OCDE
+ *   User discount: 20% (configurable in broker dashboard)
  */
 
 export interface ExchangeFeeConfig {
@@ -30,6 +32,8 @@ export interface ExchangeFeeConfig {
   marketingLabel: string;
   url: string;
   referralUrl: string;
+  /** Broker code for order tagging (OKX Broker) */
+  brokerCode?: string;
 }
 
 /**
@@ -69,9 +73,10 @@ export const EXCHANGES: ExchangeFeeConfig[] = [
     standardTakerFee: 0.05,
     spotDiscountPct: 20,
     futuresDiscountPct: 20,
-    platformCommissionPct: 30,
+    platformCommissionPct: 30, // Broker Level 2 non-affiliate rate
     marketingLabel: "20% off fees",
     url: "https://www.okx.com",
     referralUrl: "https://okx.com/join/PRUVIQ",
+    brokerCode: "c12571e26a02OCDE",
   },
 ];

--- a/src/data/exchanges.ts
+++ b/src/data/exchanges.ts
@@ -19,6 +19,7 @@ export interface Exchange {
   tag: string; // English tag, e.g. "#1 Volume"
   spotOnly?: boolean; // true for exchanges without futures (e.g. Korean exchanges)
   infoOnly?: boolean; // true for non-affiliate info-only exchanges
+  brokerCode?: string; // OKX Broker order tag for commission tracking
 }
 
 /** Spot fee rates per exchange (not in config — config only tracks futures) */
@@ -53,6 +54,7 @@ function configToExchange(cfg: (typeof EXCHANGES)[number]): Exchange {
     referralUrl: cfg.referralUrl,
     available: true,
     tag: EXCHANGE_TAGS[cfg.id] ?? "",
+    brokerCode: cfg.brokerCode,
   };
 }
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -358,9 +358,9 @@ export const en = {
   "fees.card_bitget_tag": "COPY TRADING",
   "fees.card_bitget_desc":
     "Leading copy trading platform. Follow successful traders automatically.",
-  "fees.card_okx_tag": "120+ COUNTRIES",
+  "fees.card_okx_tag": "BROKER PARTNER",
   "fees.card_okx_desc":
-    "Available in 120+ countries. Good alternative when Binance is restricted.",
+    "Official OKX Broker partner. Available in 120+ countries with 20% fee discount.",
   "fees.label_spot": "Spot",
   "fees.label_futures": "Futures",
   "fees.pruviq_discount": "PRUVIQ Discount",
@@ -368,7 +368,8 @@ export const en = {
   "fees.signup": "Sign Up",
   "fees.coming_soon": "Affiliate link — coming soon",
   "fees.visit_okx": "Visit OKX",
-  "fees.okx_discount_pending": "20% discount code coming — affiliate pending",
+  "fees.okx_discount_pending":
+    "Official Broker Partner — 20% fee discount active",
   "fees.footnote":
     "Maker / Taker rates shown. Higher-volume traders unlock lower tiers automatically. Last updated: Feb 2026.",
   "fees.korean_title": "Korean Exchanges (Reference)",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -355,9 +355,9 @@ export const ko: Record<TranslationKey, string> = {
   "fees.card_bitget_tag": "카피 트레이딩",
   "fees.card_bitget_desc":
     "카피 트레이딩 선두 플랫폼. 성공한 트레이더를 자동으로 따라하기.",
-  "fees.card_okx_tag": "120개국 이상",
+  "fees.card_okx_tag": "공식 브로커 파트너",
   "fees.card_okx_desc":
-    "120개국 이상 이용 가능. 바이낸스 제한 지역에서 좋은 대안.",
+    "OKX 공식 브로커 파트너. 120개국 이상 이용 가능, 수수료 20% 할인.",
   "fees.label_spot": "현물",
   "fees.label_futures": "선물",
   "fees.pruviq_discount": "PRUVIQ 할인",
@@ -365,7 +365,7 @@ export const ko: Record<TranslationKey, string> = {
   "fees.signup": "가입하기",
   "fees.coming_soon": "제휴 링크 — 준비 중",
   "fees.visit_okx": "OKX 방문",
-  "fees.okx_discount_pending": "20% 할인 코드 준비 중 — 제휴 승인 대기",
+  "fees.okx_discount_pending": "공식 브로커 파트너 — 수수료 20% 할인 활성",
   "fees.footnote":
     "메이커 / 테이커 수수료 기준. 거래량이 높으면 자동으로 낮은 등급이 적용됩니다. 최종 업데이트: 2026년 2월.",
   "fees.korean_title": "국내 거래소 (참고용)",


### PR DESCRIPTION
## Summary — OKX Broker Full-Stack Integration

### Backend (`backend/api/okx_broker.py` — 796 lines, NEW)
- **OAuth**: /api/auth/okx/start → callback → status → refresh → disconnect
- **Trade**: /api/okx/execute (market/limit + SL/TP), /api/okx/execute-algo
- **Data**: /api/okx/positions, /api/okx/orders
- **Security**: Fernet token encryption, CSRF state, httpOnly cookies, IP validation
- **Error handling**: OKX codes 53000-53017, auto-refresh on expiry

### Frontend
- **OKXConnectButton.tsx** (NEW): OAuth connect/disconnect, EN+KO i18n, size variants
- **OKXExecuteButton.tsx** (rewritten): confirm modal with trade params + disclaimer
- **Simulator**: #okx-connect-mount added to both EN/KO pages

### Dashboard (NEW)
- `/dashboard` + `/ko/dashboard`: OKX status, orders, positions
- Added to navigation in Layout.astro

### Config
- `config/exchanges.ts`: brokerCode field added
- `requirements.txt`: cryptography>=42.0.0
- `main.py`: router + CORS credentials
- `i18n`: 14 dashboard keys (EN+KO)

### Security ✅
- 0 hardcoded secrets (all via os.getenv)
- Fernet encryption for tokens at rest
- CSRF protection via random state
- httpOnly secure cookies

## Before deploying
1. Set env vars on Mac Mini: OKX_CLIENT_ID, OKX_CLIENT_SECRET, OKX_ENCRYPTION_KEY, OKX_REDIRECT_URI
2. `pip install cryptography>=42.0.0`
3. Register redirect URI in OKX Broker dashboard

## Test plan
- [x] Build: 2520 pages, 0 errors
- [x] Vitest: 22/22 pass
- [x] Security scan: 0 secrets exposed
- [x] Python syntax: OK
- [ ] OAuth flow E2E (requires env vars)
- [ ] Trade execution on testnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)