### PR TITLE
feat: OKX buttons on strategy detail + fees pages

### DIFF
--- a/src/pages/fees.astro
+++ b/src/pages/fees.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import FeeCalculator from '../components/FeeCalculator';
+import OKXConnectButton from '../components/OKXConnectButton';
 import { useTranslations } from '../i18n/index';
 import { exchanges, formatFeeRange } from '../data/exchanges';
 import { EXCHANGES, discountTooltip } from '../config/exchanges';
@@ -195,6 +196,9 @@ const t = useTranslations('en');
              class="mt-6 block text-center border-2 border-[--color-up] text-[--color-up] px-4 py-3 min-h-[48px] rounded text-sm font-bold hover:bg-[--color-up]/10 transition-colors">
             Sign up on OKX &rarr;
           </a>
+          <div class="mt-3">
+            <OKXConnectButton client:visible lang="en" size="sm" />
+          </div>
         </div>
       </div>
 

--- a/src/pages/ko/strategies/[id].astro
+++ b/src/pages/ko/strategies/[id].astro
@@ -2,6 +2,7 @@
 import { getCollection, render } from 'astro:content';
 import Layout from '../../../layouts/Layout.astro';
 import StrategyDemo from '../../../components/StrategyDemo';
+import OKXExecuteButton from '../../../components/OKXExecuteButton';
 import ReproBadge from '../../../components/ReproBadge';
 import Tooltip from '../../../components/ui/Tooltip.astro';
 import { useTranslations } from '../../../i18n/index';
@@ -189,6 +190,20 @@ const statusLabels: Record<string, string> = {
           defaultSl={demo.sl}
           defaultTp={demo.tp}
         />
+      )}
+
+      {demo && strategy.data.status === 'verified' && (
+        <div class="mt-6">
+          <OKXExecuteButton
+            client:visible
+            strategy={strategy.id}
+            direction={demo.direction}
+            symbol="BTCUSDT"
+            slPct={demo.sl}
+            tpPct={demo.tp}
+            lang="ko"
+          />
+        </div>
       )}
 
       <div id="exchange-cta-mount" data-strategy={strategy.id}></div>

--- a/src/pages/strategies/[id].astro
+++ b/src/pages/strategies/[id].astro
@@ -2,6 +2,7 @@
 import { getCollection, render } from 'astro:content';
 import Layout from '../../layouts/Layout.astro';
 import StrategyDemo from '../../components/StrategyDemo';
+import OKXExecuteButton from '../../components/OKXExecuteButton';
 import ReproBadge from '../../components/ReproBadge';
 import Tooltip from '../../components/ui/Tooltip.astro';
 import { useTranslations } from '../../i18n/index';
@@ -169,6 +170,20 @@ const statusLabels: Record<string, string> = {
           defaultSl={demo.sl}
           defaultTp={demo.tp}
         />
+      )}
+
+      {demo && strategy.data.status === 'verified' && (
+        <div class="mt-6">
+          <OKXExecuteButton
+            client:visible
+            strategy={strategy.id}
+            direction={demo.direction}
+            symbol="BTCUSDT"
+            slPct={demo.sl}
+            tpPct={demo.tp}
+            lang="en"
+          />
+        </div>
       )}
 
       <div id="exchange-cta-mount" data-strategy={strategy.id}></div>


### PR DESCRIPTION
## Summary
- **Strategy detail (EN+KO)**: OKXExecuteButton below StrategyDemo for verified strategies
- **Fees page**: OKXConnectButton below OKX signup CTA
- Dashboard nav link already added in #956

## Test plan
- [x] Build: 2520 pages, 0 errors
- [ ] Strategy detail page shows Execute button for verified strategies
- [ ] Fees page shows Connect button below OKX card

🤖 Generated with [Claude Code](https://claude.com/claude-code)