### PR TITLE
fix: KO hero line spacing — 2-line layout like EN

### DIFF
--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -41,8 +41,8 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
         <div>
           <HeroBadge stat={simulationsRun} label="시뮬레이션 실행" cta="무료 체험 →" />
           <p class="font-mono text-[--color-accent] text-sm tracking-wider mb-5 opacity-90">검증하고. 실행하고. 수익내고.</p>
-          <h1 class="text-5xl md:text-6xl lg:text-7xl font-extrabold tracking-[-0.04em] leading-[1.05] word-break-keep text-balance">
-            대부분의 백테스트는<br/>거짓말합니다.<br/><span class="gradient-text-shimmer">우리는 증거를 공개합니다.</span>
+          <h1 class="text-4xl md:text-5xl lg:text-6xl font-extrabold tracking-[-0.04em] leading-[1.1]">
+            대부분의 백테스트는 거짓말합니다.<br/><span class="gradient-text-shimmer">우리는 증거를 공개합니다.</span>
           </h1>
           <p class="mt-10 text-xl md:text-2xl text-[--color-text-secondary] leading-relaxed max-w-lg">
             <strong class="text-[--color-text]">{coinsAnalyzed}개 이상의 코인</strong>에서 실제 수수료를 포함한 전략 검증. 실패를 확인하고, 살아남은 전략만 남기세요. 코딩 불필요. 가입 불필요.


### PR DESCRIPTION
## Summary
- Font size one step down (4xl/5xl/6xl) so Korean fits in 2 lines not 4
- Remove mid-sentence `<br/>` that forced awkward line break
- Remove `text-balance` that caused uneven wrapping on Korean text

## Before / After
Before: 4 lines (대부분의 백테스트는 / 거짓말합니다. / 우리는 증거를 / 공개합니다.)
After: 2 lines (대부분의 백테스트는 거짓말합니다. / 우리는 증거를 공개합니다.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)