### PR TITLE
fix: OKX auto-executor signal_scanner NameError

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -145,9 +145,10 @@ async def _okx_auto_trading_loop():
     while True:
         try:
             from okx.auto_executor import process_signals
-            signals = signal_scanner.scan()
-            if signals:
-                await process_signals(signals)
+            if _signal_scanner is not None:
+                signals = _signal_scanner.scan()
+                if signals:
+                    await process_signals(signals)
         except asyncio.CancelledError:
             raise
         except Exception as e:


### PR DESCRIPTION
## Summary
- `signal_scanner.scan()` → `_signal_scanner.scan()` (NameError every 5min)
- Added `if _signal_scanner is not None` guard (lazy init 전 호출 방지)

## Root cause
`_okx_auto_trading_loop()` referenced undefined local `signal_scanner` instead of module-level `_signal_scanner`. Error repeated every 300s since startup.

## Test
Backend log에서 "OKX auto-trading loop error: name 'signal_scanner' is not defined" 에러 사라짐 확인.