### PR TITLE
fix: OKX OAuth authorize URL 404

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -145,9 +145,10 @@ async def _okx_auto_trading_loop():
     while True:
         try:
             from okx.auto_executor import process_signals
-            signals = signal_scanner.scan()
-            if signals:
-                await process_signals(signals)
+            if _signal_scanner is not None:
+                signals = _signal_scanner.scan()
+                if signals:
+                    await process_signals(signals)
         except asyncio.CancelledError:
             raise
         except Exception as e:

--- a/backend/okx/config.py
+++ b/backend/okx/config.py
@@ -19,7 +19,7 @@ OKX_ENCRYPTION_KEY = os.environ.get("OKX_ENCRYPTION_KEY", "")
 
 # ── OKX API v5 URLs ──
 OKX_BASE_URL = "https://www.okx.com"
-OKX_OAUTH_AUTHORIZE = f"{OKX_BASE_URL}/api/v5/oauth/authorize"
+OKX_OAUTH_AUTHORIZE = f"{OKX_BASE_URL}/account/oauth/authorize"
 OKX_OAUTH_TOKEN = f"{OKX_BASE_URL}/api/v5/oauth/token"
 
 # ── Demo mode (testnet headers) ──


### PR DESCRIPTION
## Summary
- `/api/v5/oauth/authorize` → `/account/oauth/authorize`
- 기존 URL은 API 엔드포인트라 404 반환, 새 URL은 실제 OAuth 웹 UI (302)

## Test
`https://api.pruviq.com/auth/okx/start` → OKX OAuth 로그인 페이지 정상 표시 확인