### PR TITLE
fix: OKX OAuth — use JS SDK (OKEXOAuthSDK) instead of backend redirect

### DIFF
--- a/backend/okx/oauth.py
+++ b/backend/okx/oauth.py
@@ -53,6 +53,24 @@ def generate_auth_url(redirect_after: str = "", lang: str = "en") -> str:
     return f"{OKX_OAUTH_AUTHORIZE}?{urlencode(params)}"
 
 
+def generate_oauth_params(redirect_after: str = "", lang: str = "en") -> dict:
+    """
+    Generate OAuth params for frontend JS SDK call.
+    Saves CSRF state to DB, returns params dict for OKEXOAuthSDK.authorize().
+    client_id is not a secret — safe to return to frontend.
+    """
+    state = secrets.token_urlsafe(32)
+    save_csrf_state(state, redirect_after or "", lang)
+    return {
+        "state": state,
+        "client_id": OKX_CLIENT_ID,
+        "response_type": "code",
+        "access_type": "offline",
+        "scope": "read_only,trade",
+        "redirect_uri": OKX_REDIRECT_URI,
+    }
+
+
 async def exchange_code(code: str, state: str) -> tuple[str, str, str]:
     """
     Exchange authorization code for access + refresh tokens.

--- a/backend/okx/router.py
+++ b/backend/okx/router.py
@@ -25,6 +25,7 @@ from .oauth import (
     disconnect,
     exchange_code,
     generate_auth_url,
+    generate_oauth_params,
     get_valid_token,
     is_authenticated,
 )
@@ -61,12 +62,27 @@ def _clear_session_cookie(response: Response) -> None:
 
 # ── OAuth Flow ─────────────────────────────────────────────
 
+@router.get("/auth/okx/init")
+async def oauth_init(
+    redirect: str = Query("", description="Post-OAuth redirect URL"),
+    lang: str = Query("en", description="Language for redirect"),
+):
+    """
+    Step 1 (JS SDK flow): Returns OAuth params for OKEXOAuthSDK.authorize().
+    client_id is not secret — safe to return to frontend.
+    Generates and stores CSRF state for callback validation.
+    """
+    if not OKX_CLIENT_ID:
+        raise HTTPException(503, "OKX Broker not configured")
+    return generate_oauth_params(redirect_after=redirect, lang=lang)
+
+
 @router.get("/auth/okx/start")
 async def oauth_start(
     redirect: str = Query("", description="Post-OAuth redirect URL"),
     lang: str = Query("en", description="Language for redirect"),
 ):
-    """Step 1: Redirect user to OKX OAuth login page."""
+    """Step 1 (legacy redirect flow): Redirect user to OKX OAuth login page."""
     if not OKX_CLIENT_ID:
         raise HTTPException(503, "OKX Broker not configured")
     url = generate_auth_url(redirect_after=redirect, lang=lang)

--- a/src/components/OKXConnectButton.tsx
+++ b/src/components/OKXConnectButton.tsx
@@ -1,6 +1,7 @@
 /**
  * OKX Connect/Disconnect button.
- * Checks OAuth status via cookie-based session, shows connect or connected state.
+ * Uses OKX JS SDK (OKEXOAuthSDK) for Authorization Code OAuth flow.
+ * Checks OAuth status via cookie-based session.
  */
 import { useState, useEffect } from "preact/hooks";
 
@@ -11,6 +12,17 @@ interface Props {
 }
 
 const API_BASE = "https://api.pruviq.com";
+const OKX_SDK_URL =
+  "https://static.okx.com/cdn/assets/okfe/libs/okxOAuth/index.js";
+
+declare global {
+  interface Window {
+    OKEXOAuthSDK?: {
+      init: (opts: { requestUrl: string; onInit?: () => void }) => void;
+      authorize: (params: Record<string, string>) => void;
+    };
+  }
+}
 
 const labels = {
   en: {
@@ -45,6 +57,31 @@ const sizeClasses = {
   lg: "btn-lg text-lg",
 };
 
+/** Load OKX SDK script once, resolve when ready */
+let _sdkReady: Promise<void> | null = null;
+
+function loadOKXSDK(): Promise<void> {
+  if (_sdkReady) return _sdkReady;
+  _sdkReady = new Promise<void>((resolve, reject) => {
+    if (window.OKEXOAuthSDK) {
+      resolve();
+      return;
+    }
+    const script = document.createElement("script");
+    script.src = OKX_SDK_URL;
+    script.async = true;
+    script.onload = () => {
+      if (window.OKEXOAuthSDK) {
+        window.OKEXOAuthSDK.init({ requestUrl: "https://www.okx.com" });
+      }
+      resolve();
+    };
+    script.onerror = () => reject(new Error("Failed to load OKX SDK"));
+    document.head.appendChild(script);
+  });
+  return _sdkReady;
+}
+
 export default function OKXConnectButton({
   lang = "en",
   size = "md",
@@ -53,8 +90,32 @@ export default function OKXConnectButton({
   const t = labels[lang];
   const [connected, setConnected] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [connecting, setConnecting] = useState(false);
 
   useEffect(() => {
+    // If this page loaded as OAuth callback popup/redirect, check for result
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("okx") === "success") {
+      setConnected(true);
+      setLoading(false);
+      const url = new URL(window.location.href);
+      url.searchParams.delete("okx");
+      window.history.replaceState({}, "", url.toString());
+      // If we're in a popup opened by SDK, notify parent and close
+      if (window.opener) {
+        try {
+          window.opener.postMessage(
+            { type: "okx:connected" },
+            window.location.origin,
+          );
+        } catch {
+          /* cross-origin guard */
+        }
+        window.close();
+      }
+      return;
+    }
+
     fetch(`${API_BASE}/auth/okx/status`, { credentials: "include" })
       .then((r) => r.json())
       .then((d) => {
@@ -62,18 +123,53 @@ export default function OKXConnectButton({
         setLoading(false);
       })
       .catch(() => setLoading(false));
-
-    // Check URL params for OAuth callback result
-    const params = new URLSearchParams(window.location.search);
-    if (params.get("okx") === "success") {
-      setConnected(true);
-      setLoading(false);
-      // Clean URL
-      const url = new URL(window.location.href);
-      url.searchParams.delete("okx");
-      window.history.replaceState({}, "", url.toString());
-    }
   }, []);
+
+  const handleConnect = async () => {
+    setConnecting(true);
+    try {
+      // Get CSRF state + OAuth params from backend
+      const resp = await fetch(`${API_BASE}/auth/okx/init?lang=${lang}`);
+      if (!resp.ok) throw new Error("Failed to initialize OAuth");
+      const params = await resp.json();
+
+      // Load OKX JS SDK
+      await loadOKXSDK();
+      if (!window.OKEXOAuthSDK) throw new Error("OKX SDK unavailable");
+
+      // Listen for popup-based callback result (if SDK uses popup)
+      const cleanup = () => window.removeEventListener("message", onMessage);
+      const onMessage = (e: MessageEvent) => {
+        if (e.origin !== window.location.origin) return;
+        if (e.data?.type === "okx:connected") {
+          setConnected(true);
+          setConnecting(false);
+          cleanup();
+        } else if (e.data?.type === "okx:error") {
+          setConnecting(false);
+          cleanup();
+        }
+      };
+      window.addEventListener("message", onMessage);
+      // Timeout cleanup in case SDK does full-page redirect (no popup message)
+      setTimeout(() => {
+        cleanup();
+        // Don't reset connecting — full-page redirect is in progress
+      }, 3000);
+
+      // Initiate OAuth via SDK (may do full-page redirect or popup)
+      window.OKEXOAuthSDK.authorize({
+        response_type: params.response_type,
+        access_type: params.access_type,
+        client_id: params.client_id,
+        redirect_uri: encodeURIComponent(params.redirect_uri),
+        scope: params.scope,
+        state: params.state,
+      });
+    } catch {
+      setConnecting(false);
+    }
+  };
 
   const handleDisconnect = async () => {
     await fetch(`${API_BASE}/auth/okx/disconnect`, {
@@ -135,23 +231,27 @@ export default function OKXConnectButton({
             </li>
           ))}
         </ul>
-        <a
-          href={`${API_BASE}/auth/okx/start?lang=${lang}`}
-          class={`btn btn-primary ${sizeClasses[size]} w-full text-center`}
+        <button
+          class={`btn btn-primary ${sizeClasses[size]} w-full`}
+          onClick={handleConnect}
+          disabled={connecting}
+          aria-label={connecting ? t.connecting : t.connect}
         >
-          {t.connect} →
-        </a>
+          {connecting ? t.connecting : `${t.connect} →`}
+        </button>
       </div>
     );
   }
 
   // Simple button
   return (
-    <a
-      href={`${API_BASE}/auth/okx/start?lang=${lang}`}
+    <button
       class={`btn btn-primary ${sizeClasses[size]}`}
+      onClick={handleConnect}
+      disabled={connecting}
+      aria-label={connecting ? t.connecting : t.connect}
     >
-      {t.connect} →
-    </a>
+      {connecting ? t.connecting : `${t.connect} →`}
+    </button>
   );
 }

--- a/src/components/TradingSettings.tsx
+++ b/src/components/TradingSettings.tsx
@@ -9,6 +9,73 @@ interface Props {
 }
 
 const API_BASE = "https://api.pruviq.com";
+const OKX_SDK_URL =
+  "https://static.okx.com/cdn/assets/okfe/libs/okxOAuth/index.js";
+
+declare global {
+  interface Window {
+    OKEXOAuthSDK?: {
+      init: (opts: { requestUrl: string; onInit?: () => void }) => void;
+      authorize: (params: Record<string, string>) => void;
+    };
+  }
+}
+
+let _sdkReady: Promise<void> | null = null;
+function loadOKXSDK(): Promise<void> {
+  if (_sdkReady) return _sdkReady;
+  _sdkReady = new Promise<void>((resolve, reject) => {
+    if (window.OKEXOAuthSDK) {
+      resolve();
+      return;
+    }
+    const script = document.createElement("script");
+    script.src = OKX_SDK_URL;
+    script.async = true;
+    script.onload = () => {
+      window.OKEXOAuthSDK?.init({ requestUrl: "https://www.okx.com" });
+      resolve();
+    };
+    script.onerror = () => reject(new Error("Failed to load OKX SDK"));
+    document.head.appendChild(script);
+  });
+  return _sdkReady;
+}
+
+function OKXSDKConnectButton({ lang, label }: { lang: string; label: string }) {
+  const [connecting, setConnecting] = useState(false);
+
+  const handleConnect = async () => {
+    setConnecting(true);
+    try {
+      const resp = await fetch(`${API_BASE}/auth/okx/init?lang=${lang}`);
+      if (!resp.ok) throw new Error("Failed to initialize OAuth");
+      const params = await resp.json();
+      await loadOKXSDK();
+      if (!window.OKEXOAuthSDK) throw new Error("OKX SDK unavailable");
+      window.OKEXOAuthSDK.authorize({
+        response_type: params.response_type,
+        access_type: params.access_type,
+        client_id: params.client_id,
+        redirect_uri: encodeURIComponent(params.redirect_uri),
+        scope: params.scope,
+        state: params.state,
+      });
+    } catch {
+      setConnecting(false);
+    }
+  };
+
+  return (
+    <button
+      class="btn btn-primary btn-md"
+      onClick={handleConnect}
+      disabled={connecting}
+    >
+      {connecting ? "Connecting..." : `${label} →`}
+    </button>
+  );
+}
 
 const STRATEGIES = [
   { id: "bb-squeeze-short", name: "BB Squeeze SHORT", status: "verified" },
@@ -312,12 +379,7 @@ export default function TradingSettings({ lang = "en" }: Props) {
     return (
       <div class="card-enterprise rounded-xl p-6 text-center">
         <p class="text-[--color-text-muted] mb-4">{t.notConnected}</p>
-        <a
-          href={`${API_BASE}/auth/okx/start?lang=${lang}`}
-          class="btn btn-primary btn-md"
-        >
-          {t.connect} →
-        </a>
+        <OKXSDKConnectButton lang={lang} label={t.connect} />
       </div>
     );
   }


### PR DESCRIPTION
## Summary

- **Root cause**: OKX Broker FD type requires `OKEXOAuthSDK.authorize()` JS call — direct URL redirect to `/account/oauth/authorize` opens the page but never fires the callback
- Add `GET /auth/okx/init` endpoint: generates CSRF state, returns `{state, client_id, scope, redirect_uri, response_type, access_type}` for SDK call
- `OKXConnectButton.tsx`: replace `<a href="/auth/okx/start">` with button that loads SDK + calls `OKEXOAuthSDK.authorize()`
- `TradingSettings.tsx`: same fix for the "Connect OKX" button in the non-connected state
- Backend `/auth/okx/start` kept as legacy fallback; `/auth/okx/callback` unchanged

## Test plan

- [ ] Click "Connect OKX" → OKX login page appears (via SDK popup/redirect)
- [ ] Log in with OKX account → redirected to `https://api.pruviq.com/auth/okx/callback?code=...`
- [ ] Callback sets session cookie → redirects to `/dashboard?okx=success`
- [ ] Dashboard shows "OKX Connected ✓"
- [ ] `GET /auth/okx/init` returns valid JSON with state + client_id
- [ ] Build: 2520 pages, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)