### PR TITLE
fix: OKX OAuth — remove SDK, direct URL redirect

### DIFF
--- a/src/components/OKXConnectButton.tsx
+++ b/src/components/OKXConnectButton.tsx
@@ -1,7 +1,7 @@
 /**
  * OKX Connect/Disconnect button.
- * Uses OKX JS SDK (OKEXOAuthSDK) for Authorization Code OAuth flow.
- * Checks OAuth status via cookie-based session.
+ * OAuth flow: fetch /auth/okx/init → build URL → window.location.assign()
+ * Mirrors OKX JS SDK behavior (domain + /account/oauth + queryString) without loading SDK.
  */
 import { useState, useEffect } from "preact/hooks";
 
@@ -12,17 +12,7 @@ interface Props {
 }
 
 const API_BASE = "https://api.pruviq.com";
-const OKX_SDK_URL =
-  "https://static.okx.com/cdn/assets/okfe/libs/okxOAuth/index.js";
-
-declare global {
-  interface Window {
-    OKEXOAuthSDK?: {
-      init: (opts: { requestUrl: string; onInit?: () => void }) => void;
-      authorize: (params: Record<string, string>) => void;
-    };
-  }
-}
+const OKX_OAUTH_BASE = "https://www.okx.com/account/oauth";
 
 const labels = {
   en: {
@@ -57,31 +47,6 @@ const sizeClasses = {
   lg: "btn-lg text-lg",
 };
 
-/** Load OKX SDK script once, resolve when ready */
-let _sdkReady: Promise<void> | null = null;
-
-function loadOKXSDK(): Promise<void> {
-  if (_sdkReady) return _sdkReady;
-  _sdkReady = new Promise<void>((resolve, reject) => {
-    if (window.OKEXOAuthSDK) {
-      resolve();
-      return;
-    }
-    const script = document.createElement("script");
-    script.src = OKX_SDK_URL;
-    script.async = true;
-    script.onload = () => {
-      if (window.OKEXOAuthSDK) {
-        window.OKEXOAuthSDK.init({ requestUrl: "https://www.okx.com" });
-      }
-      resolve();
-    };
-    script.onerror = () => reject(new Error("Failed to load OKX SDK"));
-    document.head.appendChild(script);
-  });
-  return _sdkReady;
-}
-
 export default function OKXConnectButton({
   lang = "en",
   size = "md",
@@ -93,7 +58,7 @@ export default function OKXConnectButton({
   const [connecting, setConnecting] = useState(false);
 
   useEffect(() => {
-    // If this page loaded as OAuth callback popup/redirect, check for result
+    // Handle OAuth callback result (?okx=success)
     const params = new URLSearchParams(window.location.search);
     if (params.get("okx") === "success") {
       setConnected(true);
@@ -101,18 +66,6 @@ export default function OKXConnectButton({
       const url = new URL(window.location.href);
       url.searchParams.delete("okx");
       window.history.replaceState({}, "", url.toString());
-      // If we're in a popup opened by SDK, notify parent and close
-      if (window.opener) {
-        try {
-          window.opener.postMessage(
-            { type: "okx:connected" },
-            window.location.origin,
-          );
-        } catch {
-          /* cross-origin guard */
-        }
-        window.close();
-      }
       return;
     }
 
@@ -130,43 +83,22 @@ export default function OKXConnectButton({
     try {
       // Get CSRF state + OAuth params from backend
       const resp = await fetch(`${API_BASE}/auth/okx/init?lang=${lang}`);
-      if (!resp.ok) throw new Error("Failed to initialize OAuth");
-      const params = await resp.json();
+      if (!resp.ok) throw new Error(`init failed: ${resp.status}`);
+      const p = await resp.json();
 
-      // Load OKX JS SDK
-      await loadOKXSDK();
-      if (!window.OKEXOAuthSDK) throw new Error("OKX SDK unavailable");
+      // Build OKX authorize URL (same as OKEXOAuthSDK.authorize() internally)
+      const qs = new URLSearchParams({
+        client_id: p.client_id,
+        response_type: p.response_type,
+        access_type: p.access_type,
+        scope: p.scope,
+        redirect_uri: p.redirect_uri,
+        state: p.state,
+      }).toString();
 
-      // Listen for popup-based callback result (if SDK uses popup)
-      const cleanup = () => window.removeEventListener("message", onMessage);
-      const onMessage = (e: MessageEvent) => {
-        if (e.origin !== window.location.origin) return;
-        if (e.data?.type === "okx:connected") {
-          setConnected(true);
-          setConnecting(false);
-          cleanup();
-        } else if (e.data?.type === "okx:error") {
-          setConnecting(false);
-          cleanup();
-        }
-      };
-      window.addEventListener("message", onMessage);
-      // Timeout cleanup in case SDK does full-page redirect (no popup message)
-      setTimeout(() => {
-        cleanup();
-        // Don't reset connecting — full-page redirect is in progress
-      }, 3000);
-
-      // Initiate OAuth via SDK (may do full-page redirect or popup)
-      window.OKEXOAuthSDK.authorize({
-        response_type: params.response_type,
-        access_type: params.access_type,
-        client_id: params.client_id,
-        redirect_uri: encodeURIComponent(params.redirect_uri),
-        scope: params.scope,
-        state: params.state,
-      });
-    } catch {
+      window.location.assign(`${OKX_OAUTH_BASE}?${qs}`);
+    } catch (e) {
+      console.error("OKX OAuth init failed:", e);
       setConnecting(false);
     }
   };

--- a/src/components/TradingSettings.tsx
+++ b/src/components/TradingSettings.tsx
@@ -9,59 +9,34 @@ interface Props {
 }
 
 const API_BASE = "https://api.pruviq.com";
-const OKX_SDK_URL =
-  "https://static.okx.com/cdn/assets/okfe/libs/okxOAuth/index.js";
+const OKX_OAUTH_BASE = "https://www.okx.com/account/oauth";
 
-declare global {
-  interface Window {
-    OKEXOAuthSDK?: {
-      init: (opts: { requestUrl: string; onInit?: () => void }) => void;
-      authorize: (params: Record<string, string>) => void;
-    };
-  }
-}
-
-let _sdkReady: Promise<void> | null = null;
-function loadOKXSDK(): Promise<void> {
-  if (_sdkReady) return _sdkReady;
-  _sdkReady = new Promise<void>((resolve, reject) => {
-    if (window.OKEXOAuthSDK) {
-      resolve();
-      return;
-    }
-    const script = document.createElement("script");
-    script.src = OKX_SDK_URL;
-    script.async = true;
-    script.onload = () => {
-      window.OKEXOAuthSDK?.init({ requestUrl: "https://www.okx.com" });
-      resolve();
-    };
-    script.onerror = () => reject(new Error("Failed to load OKX SDK"));
-    document.head.appendChild(script);
-  });
-  return _sdkReady;
-}
-
-function OKXSDKConnectButton({ lang, label }: { lang: string; label: string }) {
+function OKXDirectConnectButton({
+  lang,
+  label,
+}: {
+  lang: string;
+  label: string;
+}) {
   const [connecting, setConnecting] = useState(false);
 
   const handleConnect = async () => {
     setConnecting(true);
     try {
       const resp = await fetch(`${API_BASE}/auth/okx/init?lang=${lang}`);
-      if (!resp.ok) throw new Error("Failed to initialize OAuth");
-      const params = await resp.json();
-      await loadOKXSDK();
-      if (!window.OKEXOAuthSDK) throw new Error("OKX SDK unavailable");
-      window.OKEXOAuthSDK.authorize({
-        response_type: params.response_type,
-        access_type: params.access_type,
-        client_id: params.client_id,
-        redirect_uri: encodeURIComponent(params.redirect_uri),
-        scope: params.scope,
-        state: params.state,
-      });
-    } catch {
+      if (!resp.ok) throw new Error(`init failed: ${resp.status}`);
+      const p = await resp.json();
+      const qs = new URLSearchParams({
+        client_id: p.client_id,
+        response_type: p.response_type,
+        access_type: p.access_type,
+        scope: p.scope,
+        redirect_uri: p.redirect_uri,
+        state: p.state,
+      }).toString();
+      window.location.assign(`${OKX_OAUTH_BASE}?${qs}`);
+    } catch (e) {
+      console.error("OKX OAuth init failed:", e);
       setConnecting(false);
     }
   };
@@ -379,7 +354,7 @@ export default function TradingSettings({ lang = "en" }: Props) {
     return (
       <div class="card-enterprise rounded-xl p-6 text-center">
         <p class="text-[--color-text-muted] mb-4">{t.notConnected}</p>
-        <OKXSDKConnectButton lang={lang} label={t.connect} />
+        <OKXDirectConnectButton lang={lang} label={t.connect} />
       </div>
     );
   }


### PR DESCRIPTION
## Summary

SDK 분석 결과: `OKEXOAuthSDK.authorize()` 내부에서 `window.location.assign()` 이 실행되어야 하는데 실패 (Connecting → Connect OKX 로 원복).

SDK 소스 역분석:
```js
// OKEXOAuthSDK.authorize() 내부 실제 코드:
window.location.assign(domain + "/account/oauth" + fixParams(omit(params, ['domain'])))
```

SDK 제거하고 동일한 URL을 직접 구성:
- `OKXConnectButton.tsx`: SDK 로딩 코드 전면 제거, `fetch /auth/okx/init` → `URLSearchParams` → `window.location.assign()`
- `TradingSettings.tsx`: 동일 패턴 적용

## Test plan
- [ ] "Connect OKX" 클릭 → `https://www.okx.com/account/oauth?client_id=...&state=...` 로 이동
- [ ] OKX 로그인 → 허가 → `api.pruviq.com/auth/okx/callback?code=...` 콜백
- [ ] 대시보드 "OKX Connected ✓" 표시
- [ ] Build: 2520 pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)