### PR TITLE
fix: OKX token exchange — JSON body + term_id

### DIFF
--- a/backend/okx/oauth.py
+++ b/backend/okx/oauth.py
@@ -82,16 +82,22 @@ async def exchange_code(code: str, state: str) -> tuple[str, str, str]:
         raise ValueError("Invalid or expired CSRF state")
     redirect_url, lang = csrf_result
 
+    # OKX SDK token endpoint requires JSON body + term_id (UUID)
     data = {
         "client_id": OKX_CLIENT_ID,
         "client_secret": OKX_CLIENT_SECRET,
         "code": code,
         "grant_type": "authorization_code",
         "redirect_uri": OKX_REDIRECT_URI,
+        "term_id": secrets.token_hex(16),  # UUID-like identifier required by OKX SDK API
     }
 
     async with httpx.AsyncClient() as client:
-        resp = await client.post(OKX_OAUTH_TOKEN, data=data, timeout=15)
+        resp = await client.post(
+            OKX_OAUTH_TOKEN,
+            json=data,  # OKX SDK endpoint requires Content-Type: application/json
+            timeout=15,
+        )
         resp.raise_for_status()
         token_data = resp.json()
 


### PR DESCRIPTION
## 버그 추적 결과 (전체 흐름)

| 단계 | 오류 | 원인 | 수정 |
|------|------|------|------|
| 1. authorize URL | 404 | `/api/v5/oauth/authorize` 없음 | `/account/oauth` (PR#963) |
| 2. token URL | 405 | `/api/v5/oauth/token` 없음 | `/v5/users/oauth/sdk/token` (PR#964) |
| **3. token body** | **415+53010** | **form-encoded, term_id 없음** | **JSON + term_id (이번 PR)** |

## 변경 내용

`backend/okx/oauth.py`:
- `client.post(data=data)` → `client.post(json=data)` (Content-Type: application/json)
- `term_id: secrets.token_hex(16)` 추가 (OKX SDK 필수 파라미터)

## ⚠️ 머지 후 백엔드 재시작 필수

```
cd ~/pruviq/backend
pkill -f uvicorn
nohup .venv/bin/uvicorn api.main:app --host 0.0.0.0 --port 8080 >> ~/pruviq-api.log 2>> ~/pruviq-api-error.log &
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)