### PR TITLE
fix: OKX OAuth CSRF TTL 30min + error UI feedback

### DIFF
--- a/backend/okx/storage.py
+++ b/backend/okx/storage.py
@@ -110,7 +110,7 @@ def delete_session(session_id: str) -> None:
 
 # ── CSRF States ─────────────────────────────────────────────
 
-CSRF_TTL = 600  # 10 minutes
+CSRF_TTL = 1800  # 30 minutes
 
 
 def save_csrf_state(state: str, redirect_url: str, lang: str = "en") -> None:

--- a/src/components/OKXConnectButton.tsx
+++ b/src/components/OKXConnectButton.tsx
@@ -56,17 +56,30 @@ export default function OKXConnectButton({
   const [connected, setConnected] = useState(false);
   const [loading, setLoading] = useState(true);
   const [connecting, setConnecting] = useState(false);
+  const [error, setError] = useState("");
 
   useEffect(() => {
-    // Handle OAuth callback result (?okx=success)
+    // Handle OAuth callback result (?okx=success|error)
     const params = new URLSearchParams(window.location.search);
-    if (params.get("okx") === "success") {
-      setConnected(true);
-      setLoading(false);
+    const okxParam = params.get("okx");
+    if (okxParam) {
       const url = new URL(window.location.href);
       url.searchParams.delete("okx");
       window.history.replaceState({}, "", url.toString());
-      return;
+      if (okxParam === "success") {
+        setConnected(true);
+        setLoading(false);
+        return;
+      }
+      if (okxParam === "error") {
+        setError(
+          lang === "ko"
+            ? "OKX 연결 실패. 다시 시도해주세요."
+            : "OKX connection failed. Please try again.",
+        );
+        setLoading(false);
+        return;
+      }
     }
 
     fetch(`${API_BASE}/auth/okx/status`, { credentials: "include" })
@@ -177,13 +190,20 @@ export default function OKXConnectButton({
 
   // Simple button
   return (
-    <button
-      class={`btn btn-primary ${sizeClasses[size]}`}
-      onClick={handleConnect}
-      disabled={connecting}
-      aria-label={connecting ? t.connecting : t.connect}
-    >
-      {connecting ? t.connecting : `${t.connect} →`}
-    </button>
+    <div class="flex flex-col gap-1">
+      {error && (
+        <p class="text-xs text-[--color-down]" role="alert">
+          {error}
+        </p>
+      )}
+      <button
+        class={`btn btn-primary ${sizeClasses[size]}`}
+        onClick={handleConnect}
+        disabled={connecting}
+        aria-label={connecting ? t.connecting : t.connect}
+      >
+        {connecting ? t.connecting : `${t.connect} →`}
+      </button>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- CSRF state TTL 10분 → 30분 (OKX 인증 페이지에 10분+ 머무는 경우 대응)
- \`?okx=error\` 처리: 연결 실패 시 유저에게 에러 메시지 표시
- EN/KO 양쪽 에러 문구 추가

## Test plan
- [ ] Connect OKX → Confirm → \`okx=error\` 시 에러 메시지 확인
- [ ] build: 2520 pages ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)