### PR TITLE
fix: auto-fix #967 (+1 related)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -49,20 +49,18 @@ export default defineConfig({
           { url: enUrl, lang: 'x-default' },
         ];
 
-        // lastmod — build date for all pages (SSG rebuilds everything)
-        item.lastmod = new Date().toISOString().slice(0, 10);
-
         // Priority + crawl frequency by page type
         // @ts-ignore — EnumChangefreq accepts these string values at runtime
         const p = basePath;
+        const today = new Date().toISOString().slice(0, 10);
         if (p === '/') {
-          item.priority = 1.0; item.changefreq = /** @type {any} */ ('daily');
+          item.priority = 1.0; item.changefreq = /** @type {any} */ ('daily'); item.lastmod = today;
         } else if (['/simulate', '/strategies', '/market', '/leaderboard'].includes(p)) {
-          item.priority = 0.9; item.changefreq = /** @type {any} */ ('daily');
+          item.priority = 0.9; item.changefreq = /** @type {any} */ ('daily'); item.lastmod = today;
         } else if (p === '/strategies/ranking') {
-          item.priority = 0.9; item.changefreq = /** @type {any} */ ('daily');
+          item.priority = 0.9; item.changefreq = /** @type {any} */ ('daily'); item.lastmod = today;
         } else if (p.startsWith('/strategies/') || p.startsWith('/coins/')) {
-          item.priority = 0.8; item.changefreq = /** @type {any} */ ('weekly');
+          item.priority = 0.8; item.changefreq = /** @type {any} */ ('weekly'); item.lastmod = today;
         } else if (p.startsWith('/compare/') || p.startsWith('/vs/') || p.startsWith('/vs-')) {
           item.priority = 0.7; item.changefreq = /** @type {any} */ ('monthly');
         } else if (p.startsWith('/blog/')) {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -71,7 +71,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
         <div class="relative">
           <BrowserFrame
             src="/images/simulator-preview.png"
-            alt="PRUVIQ Strategy Simulator — simulate {coinsAnalyzed} coins in seconds"
+            alt={`PRUVIQ Strategy Simulator — simulate ${coinsAnalyzed} coins in seconds`}
             url="pruviq.com/simulate"
           >
             <SimulatorPreview client:visible />


### PR DESCRIPTION
## Auto-fix for 2 issue(s)

#967: [claude-auto][P2] `src/pages/index.astro:74` — BrowserFrame `alt` prop emits literal `{coinsAnal
#968: [claude-auto][P2] `astro.config.mjs:53` — All 2,500+ pages always get today's date as `lastmod` 

### Changes
```
 astro.config.mjs      | 12 +++++-------
 src/pages/index.astro |  2 +-
 2 files changed, 6 insertions(+), 8 deletions(-)
```

### Safety Checks
- Files changed: **2** (limit: 20)
- Lines changed: **14** (limit: 1500)

---
*Auto-generated by JEPO auto-fix agent. Requires auto-test pass before merge.*