### PR TITLE
fix: OKX OAuth standard FD Broker endpoints

### DIFF
--- a/backend/okx/config.py
+++ b/backend/okx/config.py
@@ -19,8 +19,8 @@ OKX_ENCRYPTION_KEY = os.environ.get("OKX_ENCRYPTION_KEY", "")
 
 # ── OKX API v5 URLs ──
 OKX_BASE_URL = "https://www.okx.com"
-OKX_OAUTH_AUTHORIZE = f"{OKX_BASE_URL}/account/oauth/authorize"
-OKX_OAUTH_TOKEN = f"{OKX_BASE_URL}/v5/users/oauth/sdk/token"
+OKX_OAUTH_AUTHORIZE = f"{OKX_BASE_URL}/api/v5/oauth/authorize"
+OKX_OAUTH_TOKEN = f"{OKX_BASE_URL}/api/v5/oauth/token"
 
 # ── Demo mode (testnet headers) ──
 OKX_DEMO_MODE = os.environ.get("OKX_DEMO_MODE", "false").lower() == "true"

--- a/backend/okx/oauth.py
+++ b/backend/okx/oauth.py
@@ -91,7 +91,7 @@ async def exchange_code(code: str, state: str, domain: str = "") -> tuple[str, s
         "redirect_uri": OKX_REDIRECT_URI,
     }
 
-    logger.warning("OKX token request → url=%s data=%s", OKX_OAUTH_TOKEN, {k: v for k, v in data.items() if k != "client_secret"})
+    logger.debug("OKX token request → url=%s", OKX_OAUTH_TOKEN)
 
     async with httpx.AsyncClient() as client:
         resp = await client.post(
@@ -99,7 +99,7 @@ async def exchange_code(code: str, state: str, domain: str = "") -> tuple[str, s
             json=data,
             timeout=15,
         )
-        logger.warning("OKX token response → status=%s body=%s", resp.status_code, resp.text[:500])
+        logger.debug("OKX token response → status=%s", resp.status_code)
         resp.raise_for_status()
         token_data = resp.json()
 

--- a/backend/okx/oauth.py
+++ b/backend/okx/oauth.py
@@ -71,7 +71,7 @@ def generate_oauth_params(redirect_after: str = "", lang: str = "en") -> dict:
     }
 
 
-async def exchange_code(code: str, state: str) -> tuple[str, str, str]:
+async def exchange_code(code: str, state: str, domain: str = "") -> tuple[str, str, str]:  # domain param kept for router compat
     """
     Exchange authorization code for access + refresh tokens.
     Validates CSRF state, stores encrypted tokens in SQLite.
@@ -82,22 +82,24 @@ async def exchange_code(code: str, state: str) -> tuple[str, str, str]:
         raise ValueError("Invalid or expired CSRF state")
     redirect_url, lang = csrf_result
 
-    # OKX SDK token endpoint requires JSON body + term_id (UUID)
+    # Standard FD Broker OAuth token exchange (RFC 6749)
     data = {
         "client_id": OKX_CLIENT_ID,
         "client_secret": OKX_CLIENT_SECRET,
         "code": code,
         "grant_type": "authorization_code",
         "redirect_uri": OKX_REDIRECT_URI,
-        "term_id": secrets.token_hex(16),  # UUID-like identifier required by OKX SDK API
     }
+
+    logger.warning("OKX token request → url=%s data=%s", OKX_OAUTH_TOKEN, {k: v for k, v in data.items() if k != "client_secret"})
 
     async with httpx.AsyncClient() as client:
         resp = await client.post(
             OKX_OAUTH_TOKEN,
-            json=data,  # OKX SDK endpoint requires Content-Type: application/json
+            json=data,
             timeout=15,
         )
+        logger.warning("OKX token response → status=%s body=%s", resp.status_code, resp.text[:500])
         resp.raise_for_status()
         token_data = resp.json()
 

--- a/backend/okx/router.py
+++ b/backend/okx/router.py
@@ -93,10 +93,11 @@ async def oauth_start(
 async def oauth_callback(
     code: str = Query(..., description="OKX authorization code"),
     state: str = Query(..., description="CSRF state token"),
+    domain: str = Query("", description="OKX SDK domain parameter"),
 ):
     """Step 2: Exchange code for tokens, set session cookie, redirect to frontend."""
     try:
-        session_id, redirect_url, lang = await exchange_code(code, state)
+        session_id, redirect_url, lang = await exchange_code(code, state, domain)
     except ValueError as e:
         logger.warning("OAuth callback rejected: %s", e)
         return RedirectResponse(

--- a/src/components/OKXConnectButton.tsx
+++ b/src/components/OKXConnectButton.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 const API_BASE = "https://api.pruviq.com";
-const OKX_OAUTH_BASE = "https://www.okx.com/account/oauth";
+const OKX_OAUTH_BASE = "https://www.okx.com/api/v5/oauth/authorize";
 
 const labels = {
   en: {


### PR DESCRIPTION
## Summary
- Auth URL: `/account/oauth` → `/api/v5/oauth/authorize` (FD Broker 표준)
- Token URL: `/v5/users/oauth/sdk/token` → `/api/v5/oauth/token` (FD Broker 표준)
- Token body: term_id/scope/domain 제거 → 표준 RFC 6749 5필드만
- 53010 "code error" 근본 원인: JS SDK 전용 엔드포인트를 FD Broker에 사용

## Test plan
- [ ] build: 2520 pages ✓
- [ ] Connect OKX → 새 auth URL로 redirect 확인
- [ ] 토큰 교환 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)