### PR TITLE
fix: OKX OAuth form-encoded token + homepage hero seam

### DIFF
--- a/backend/okx/oauth.py
+++ b/backend/okx/oauth.py
@@ -96,10 +96,10 @@ async def exchange_code(code: str, state: str, domain: str = "") -> tuple[str, s
     async with httpx.AsyncClient() as client:
         resp = await client.post(
             OKX_OAUTH_TOKEN,
-            json=data,
+            data=data,  # RFC 6749: application/x-www-form-urlencoded
             timeout=15,
         )
-        logger.debug("OKX token response → status=%s", resp.status_code)
+        logger.warning("OKX token → status=%s body=%s", resp.status_code, resp.text[:300])
         resp.raise_for_status()
         token_data = resp.json()
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -36,7 +36,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       <img src="/images/simulator-preview.png" alt="" class="w-[80%] max-w-4xl opacity-[0.04] blur-[1px] select-none" loading="eager" />
     </div>
     <div class="relative max-w-7xl mx-auto px-6 pt-24 pb-28 md:pt-36 md:pb-44 hero-enter">
-      <div class="grid md:grid-cols-2 gap-12 md:gap-16 items-center">
+      <div class="grid md:grid-cols-[3fr_2fr] gap-12 md:gap-16 items-center">
         <!-- Left: Text + CTA -->
         <div>
           <HeroBadge stat={simulationsRun} label="simulations run" />
@@ -110,15 +110,8 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
     <p class="text-xs text-[--color-text-muted] font-mono text-center mt-3 opacity-60">Updated live · Last simulation: 2 min ago</p>
   </div>
 
-  <!-- Decorative wave transition -->
-  <div class="relative h-16 md:h-24 -mb-1 overflow-hidden pointer-events-none" aria-hidden="true">
-    <svg viewBox="0 0 1440 96" class="absolute bottom-0 w-full" preserveAspectRatio="none">
-      <path d="M0,96 L0,40 C240,80 480,0 720,40 C960,80 1200,10 1440,50 L1440,96 Z" fill="rgba(255,255,255,0.015)" />
-      <path d="M0,96 L0,60 C360,20 720,80 1080,30 C1260,10 1380,40 1440,35 L1440,96 Z" fill="rgba(255,255,255,0.01)" />
-    </svg>
-  </div>
-
   <!-- HOW IT WORKS -->
+  <hr class="section-divider" />
   <section class="max-w-7xl mx-auto px-6 py-24 md:py-32 section-elevated">
     <p class="font-mono text-[--color-accent] text-sm tracking-wider text-center mb-4">HOW IT WORKS</p>
     <h2 class="text-3xl md:text-4xl lg:text-5xl font-extrabold text-center mb-5">Three Steps to Verified Results</h2>


### PR DESCRIPTION
## Summary
- `oauth.py`: switch from `json=` to `data=` — OKX `/api/v5/oauth/token` requires RFC 6749 form-encoded body, not JSON (was causing 524 Cloudflare timeout)
- `oauth.py`: upgrade token response log to `warning` level with response body for debugging
- `index.astro`: hero grid `md:grid-cols-2` → `md:grid-cols-[3fr_2fr]` (matches Korean homepage ratio, text column gets more space)
- `index.astro`: remove wave SVG divider, replace with `<hr class="section-divider" />` before HOW IT WORKS — eliminates awkward blank seam

## Test plan
- [ ] OKX Connect → OKX auth page → callback → dashboard shows "OKX Connected ✓"
- [ ] English homepage: stats section → HOW IT WORKS transition looks clean (no empty gap)
- [ ] Build: 2520 pages, 0 errors ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)