### PR TITLE
fix: redirect /dashboard until public launch

### DIFF
--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -1,4 +1,7 @@
 ---
+// TODO: Dashboard not ready — redirect until public launch
+return Astro.redirect('/', 302);
+
 import Layout from '../layouts/Layout.astro';
 import OKXConnectButton from '../components/OKXConnectButton';
 import TradingSettings from '../components/TradingSettings';


### PR DESCRIPTION
## Summary
- /dashboard는 아직 준비 안 됨 → Astro.redirect('/') 302로 임시 차단
- 재활성화: dashboard.astro에서 return Astro.redirect() 줄 삭제

Build: 2520 pages ✓

🤖 Generated with Claude Code