### PR TITLE
fix: auto-executor safety guards + env var hardening

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -1703,7 +1703,7 @@ _news_cache: Optional[dict] = None
 BINANCE_SPOT_URL = "https://api.binance.com/api/v3/ticker/24hr"
 BINANCE_FUTURES_URL = "https://fapi.binance.com/fapi/v1/ticker/24hr"
 # DO server proxy via Tailscale for Korean IP bypass (fapi v1 geo-blocked from KR)
-BINANCE_PROXY_URL = "http://100.122.203.78:9090/fapi/v1/ticker/24hr"
+BINANCE_PROXY_URL = os.environ.get("BINANCE_PROXY_URL", "http://100.122.203.78:9090/fapi/v1/ticker/24hr")
 _binance_proxy_key = os.environ.get("BINANCE_PROXY_KEY", "")
 BINANCE_PROXY_HEADERS = {"X-Proxy-Key": _binance_proxy_key} if _binance_proxy_key else {}
 _live_spot_cache: Optional[dict] = None
@@ -3838,7 +3838,7 @@ async def generate_bot(req: GenerateBotRequest):
 # Email Subscription
 # ---------------------------------------------------------------------------
 
-SUBSCRIBERS_FILE = Path("/Users/jepo/pruviq-data/subscribers.json")
+SUBSCRIBERS_FILE = Path(os.environ.get("SUBSCRIBERS_FILE", "/Users/jepo/pruviq-data/subscribers.json"))
 
 
 @app.post("/api/subscribe")

--- a/backend/okx/auto_executor.py
+++ b/backend/okx/auto_executor.py
@@ -93,6 +93,34 @@ async def _try_execute(
     if settings["coins"] and coin not in settings["coins"]:
         return None
 
+    # ── Safety: daily trade limit ──
+    daily_stats = get_daily_stats(session_id)
+    max_daily = settings.get("max_daily_trades", 20)
+    if daily_stats["trades_today"] >= max_daily:
+        logger.warning(
+            "Session %s daily trade limit reached (%d/%d)",
+            session_id[:8], daily_stats["trades_today"], max_daily,
+        )
+        return None
+
+    # ── Safety: daily loss limit ──
+    daily_loss_limit = settings.get("daily_loss_limit_usdt", 200)
+    if daily_stats["pnl_today"] <= -daily_loss_limit:
+        logger.warning(
+            "Session %s daily loss limit hit ($%.2f / limit $%.2f)",
+            session_id[:8], daily_stats["pnl_today"], daily_loss_limit,
+        )
+        return None
+
+    # ── Safety: 3 consecutive losses → pause ──
+    recent_trades = get_trade_log(session_id, limit=3)
+    if len(recent_trades) >= 3 and all(t["pnl_usdt"] < 0 for t in recent_trades[:3]):
+        logger.warning(
+            "Session %s paused: 3 consecutive losses detected",
+            session_id[:8],
+        )
+        return None
+
     # ── Execute ──
     token = await get_valid_token(session_id)
     async with OKXClient(token) as client:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ fastapi>=0.115.0
 uvicorn[standard]>=0.30.0
 pydantic>=2.0.0
 defusedxml>=0.7.0
+cryptography>=41.0.0


### PR DESCRIPTION
## Summary
- **[C-1] 오토 트레이딩 안전장치 실제 작동**: `_try_execute()` 진입 전 3가지 가드 추가
  - `max_daily_trades` 초과 시 중단
  - `daily_loss_limit_usdt` 도달 시 중단  
  - 최근 3거래 모두 손실이면 일시 중단 (연속손실 감지)
- **[H-2] `cryptography` requirements 누락 수정**: `okx/storage.py` Fernet 의존성 명시
- **[H-3, H-4] 하드코딩 경로/IP 환경변수화**: `SUBSCRIBERS_FILE`, `BINANCE_PROXY_URL`

## Test plan
- [ ] build: 2520 pages ✅
- [ ] `max_daily_trades=1` 설정 후 두 번째 신호 → `None` 반환 확인
- [ ] `pnl_today <= -daily_loss_limit` 조건 → 거래 중단 확인
- [ ] 최근 3 trades 모두 pnl < 0 → pause 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)