### PR TITLE
hotfix: remove consecutive-loss guard that always fires after 3 trades

### DIFF
--- a/backend/okx/auto_executor.py
+++ b/backend/okx/auto_executor.py
@@ -24,7 +24,6 @@ from .settings import (
     get_auto_sessions,
     get_daily_stats,
     get_settings,
-    get_trade_log,
     log_trade,
 )
 
@@ -112,14 +111,10 @@ async def _try_execute(
         )
         return None
 
-    # ── Safety: 3 consecutive losses → pause ──
-    recent_trades = get_trade_log(session_id, limit=3)
-    if len(recent_trades) >= 3 and all(t["pnl_usdt"] < 0 for t in recent_trades[:3]):
-        logger.warning(
-            "Session %s paused: 3 consecutive losses detected",
-            session_id[:8],
-        )
-        return None
+    # NOTE: consecutive-loss guard requires actual realized PnL from position
+    # close events (no OKX webhook yet). Currently all logged pnl_usdt values
+    # are worst-case estimates (always negative), so this check would fire
+    # after every 3rd trade. Deferred until position-close tracking is added.
 
     # ── Execute ──
     token = await get_valid_token(session_id)


### PR DESCRIPTION
## 문제
PR #976에서 추가한 연속손실 감지 가드가 **매 3번째 거래마다 항상 발동**하는 버그.

```python
# 원인: estimated_loss = -(position_size * sl_pct / 100) 은 항상 음수
log_trade(session_id, signal, result, pnl=estimated_loss)  # 항상 음수로 기록

# 결과: 3거래 후 모든 pnl_usdt < 0 → 자동 트레이딩 영구 중단
if all(t["pnl_usdt"] < 0 for t in recent_trades[:3]):  # 항상 True
```

## 수정
- 연속손실 가드 제거 (주석으로 이유 명시)
- 사용하지 않는 `get_trade_log` import 제거
- **daily_trades / daily_loss_limit 가드는 정상 — 영향 없음**

## 미구현 사유
연속손실 감지는 실제 청산된 포지션의 PnL이 필요. 현재 OKX position-close 웹훅 없음 → 실현 PnL 추적 불가. 추후 웹훅 연동 시 재구현 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)