### PR TITLE
feat: launch autotrading dashboard for all OKX users

### DIFF
--- a/src/components/LivePositions.tsx
+++ b/src/components/LivePositions.tsx
@@ -1,0 +1,303 @@
+/**
+ * LivePositions.tsx
+ * Displays open OKX positions for the authenticated user.
+ * Polls GET /execute/positions every 30s (credentials: include).
+ * 401 → prompt to connect OKX. Empty → "No open positions".
+ */
+import { useState, useEffect, useCallback } from "preact/hooks";
+import { API_BASE_URL } from "../config/api";
+
+interface Position {
+  instId: string;
+  pos: string;
+  avgPx: string;
+  markPx: string;
+  upl: string;
+  uplRatio: string;
+}
+
+interface ApiResponse {
+  data: Position[];
+}
+
+interface Props {
+  lang?: "en" | "ko";
+}
+
+const POLL_INTERVAL_MS = 30_000;
+
+const i18n = {
+  en: {
+    title: "Live Positions",
+    connect_prompt: "Connect OKX to see positions",
+    no_positions: "No open positions",
+    col_instrument: "Instrument",
+    col_side: "Side",
+    col_size: "Size",
+    col_avg_entry: "Avg Entry",
+    col_mark_price: "Mark Price",
+    col_upl: "Unrealized P&L",
+    updated: "Auto-refreshes every 30s",
+    error: "Failed to load positions",
+    retry: "Retry →",
+  },
+  ko: {
+    title: "실시간 포지션",
+    connect_prompt: "포지션을 보려면 OKX를 연결하세요",
+    no_positions: "오픈 포지션 없음",
+    col_instrument: "종목",
+    col_side: "방향",
+    col_size: "수량",
+    col_avg_entry: "평균 진입가",
+    col_mark_price: "마크 가격",
+    col_upl: "미실현 손익",
+    updated: "30초마다 자동 갱신",
+    error: "포지션 로드 실패",
+    retry: "다시 시도 →",
+  },
+} as const;
+
+function formatPrice(raw: string): string {
+  const n = parseFloat(raw);
+  if (isNaN(n)) return raw;
+  if (n === 0) return "0";
+  if (Math.abs(n) < 1) return n.toFixed(6);
+  if (Math.abs(n) < 100) return n.toFixed(4);
+  return n.toLocaleString(undefined, { maximumFractionDigits: 2 });
+}
+
+function formatUpl(raw: string): string {
+  const n = parseFloat(raw);
+  if (isNaN(n)) return raw;
+  const sign = n >= 0 ? "+" : "";
+  return `${sign}${n.toFixed(4)} USDT`;
+}
+
+function formatUplRatio(raw: string): string {
+  const n = parseFloat(raw);
+  if (isNaN(n)) return "";
+  const pct = (n * 100).toFixed(2);
+  const sign = n >= 0 ? "+" : "";
+  return `${sign}${pct}%`;
+}
+
+function inferSide(pos: string): string {
+  const n = parseFloat(pos);
+  if (isNaN(n) || n === 0) return "—";
+  return n > 0 ? "LONG" : "SHORT";
+}
+
+function SkeletonRow() {
+  return (
+    <tr class="border-b border-[--color-border]">
+      {[1, 2, 3, 4, 5, 6].map((i) => (
+        <td key={i} class="px-4 py-3">
+          <div class="h-4 rounded bg-[--color-bg-elevated] animate-pulse w-20" />
+        </td>
+      ))}
+    </tr>
+  );
+}
+
+export default function LivePositions({ lang = "en" }: Props) {
+  const t = i18n[lang] ?? i18n.en;
+
+  const [positions, setPositions] = useState<Position[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [unauthed, setUnauthed] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<string>("");
+
+  const fetchPositions = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE_URL}/execute/positions`, {
+        credentials: "include",
+        signal: AbortSignal.timeout(15_000),
+      });
+
+      if (res.status === 401) {
+        setUnauthed(true);
+        setLoading(false);
+        return;
+      }
+
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+      const body: ApiResponse = await res.json();
+      setPositions(body.data ?? []);
+      setLastUpdated(new Date().toLocaleTimeString());
+      setError(null);
+      setUnauthed(false);
+    } catch (e) {
+      if (e instanceof DOMException && e.name === "AbortError") return;
+      setError(t.error);
+    } finally {
+      setLoading(false);
+    }
+  }, [t.error]);
+
+  useEffect(() => {
+    fetchPositions();
+    const interval = setInterval(fetchPositions, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [fetchPositions]);
+
+  return (
+    <div class="card-enterprise rounded-xl p-5">
+      {/* Header */}
+      <div class="flex items-center justify-between mb-4">
+        <div class="flex items-center gap-2">
+          <span
+            class="w-2 h-2 rounded-full bg-[--color-up] animate-pulse"
+            aria-hidden="true"
+          />
+          <h2 class="font-bold text-sm">{t.title}</h2>
+        </div>
+        {lastUpdated && (
+          <p class="text-xs text-[--color-text-muted]">{t.updated}</p>
+        )}
+      </div>
+
+      {/* Unauthenticated */}
+      {unauthed && (
+        <div class="flex items-center justify-center gap-2 py-10 text-[--color-text-muted]">
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            aria-hidden="true"
+          >
+            <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+            <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+          </svg>
+          <p class="text-sm">{t.connect_prompt}</p>
+        </div>
+      )}
+
+      {/* Error */}
+      {!unauthed && error && (
+        <div class="flex flex-col items-center gap-3 py-10">
+          <p
+            class="text-sm text-[--color-down]"
+            role="alert"
+            aria-live="assertive"
+          >
+            {error}
+          </p>
+          <button
+            onClick={() => {
+              setLoading(true);
+              setError(null);
+              fetchPositions();
+            }}
+            class="text-xs text-[--color-accent] hover:underline cursor-pointer"
+          >
+            {t.retry}
+          </button>
+        </div>
+      )}
+
+      {/* Table */}
+      {!unauthed && !error && (
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm" role="table" aria-label={t.title}>
+            <thead>
+              <tr class="border-b border-[--color-border]">
+                {[
+                  t.col_instrument,
+                  t.col_side,
+                  t.col_size,
+                  t.col_avg_entry,
+                  t.col_mark_price,
+                  t.col_upl,
+                ].map((col) => (
+                  <th
+                    key={col}
+                    scope="col"
+                    class="px-4 py-2 text-left text-xs font-semibold text-[--color-text-muted] whitespace-nowrap"
+                  >
+                    {col}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {loading && (
+                <>
+                  <SkeletonRow />
+                  <SkeletonRow />
+                  <SkeletonRow />
+                </>
+              )}
+
+              {!loading && positions.length === 0 && (
+                <tr>
+                  <td
+                    colSpan={6}
+                    class="px-4 py-10 text-center text-sm text-[--color-text-muted]"
+                  >
+                    {t.no_positions}
+                  </td>
+                </tr>
+              )}
+
+              {!loading &&
+                positions.map((p, idx) => {
+                  const uplNum = parseFloat(p.upl);
+                  const isPositive = !isNaN(uplNum) && uplNum >= 0;
+                  const uplColor = isNaN(uplNum)
+                    ? "text-[--color-text-secondary]"
+                    : isPositive
+                      ? "text-[--color-up]"
+                      : "text-[--color-down]";
+                  const side = inferSide(p.pos);
+                  const sideColor =
+                    side === "LONG"
+                      ? "text-[--color-up]"
+                      : side === "SHORT"
+                        ? "text-[--color-down]"
+                        : "text-[--color-text-muted]";
+
+                  return (
+                    <tr
+                      key={`${p.instId}-${idx}`}
+                      class="border-b border-[--color-border] hover:bg-[--color-bg-elevated] transition-colors"
+                    >
+                      <td class="px-4 py-3 font-mono font-semibold whitespace-nowrap">
+                        {p.instId}
+                      </td>
+                      <td
+                        class={`px-4 py-3 font-mono text-xs font-bold ${sideColor}`}
+                      >
+                        {side}
+                      </td>
+                      <td class="px-4 py-3 font-mono text-[--color-text-secondary]">
+                        {p.pos}
+                      </td>
+                      <td class="px-4 py-3 font-mono text-[--color-text-secondary]">
+                        ${formatPrice(p.avgPx)}
+                      </td>
+                      <td class="px-4 py-3 font-mono text-[--color-text-secondary]">
+                        ${formatPrice(p.markPx)}
+                      </td>
+                      <td
+                        class={`px-4 py-3 font-mono font-semibold ${uplColor}`}
+                      >
+                        <div>{formatUpl(p.upl)}</div>
+                        <div class="text-xs opacity-75">
+                          {formatUplRatio(p.uplRatio)}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/LiveTradeHistory.tsx
+++ b/src/components/LiveTradeHistory.tsx
@@ -1,0 +1,307 @@
+/**
+ * LiveTradeHistory.tsx
+ * Displays the last 20 auto-traded orders for the authenticated user.
+ * Fetches GET /settings/trades?limit=20 (credentials: include) on mount.
+ * 401 → prompt to connect OKX. Empty → "No trades yet" message.
+ */
+import { useState, useEffect, useCallback } from "preact/hooks";
+import { API_BASE_URL } from "../config/api";
+
+interface TradeSignal {
+  strategy: string;
+  coin: string;
+  direction: "long" | "short" | string;
+}
+
+interface TradeResult {
+  order: string;
+  algo: string;
+  timestamp: string;
+}
+
+interface Trade {
+  signal: TradeSignal;
+  result: TradeResult;
+  pnl_usdt: number;
+  timestamp: number;
+}
+
+interface TradesResponse {
+  trades: Trade[];
+}
+
+interface Props {
+  lang?: "en" | "ko";
+}
+
+const i18n = {
+  en: {
+    title: "Trade History",
+    connect_prompt: "Connect OKX to see trade history",
+    no_trades: "No trades yet. Auto-trading will log here.",
+    col_time: "Time",
+    col_strategy: "Strategy",
+    col_coin: "Coin",
+    col_direction: "Direction",
+    col_pnl: "Est. P&L",
+    error: "Failed to load trade history",
+    retry: "Retry →",
+    just_now: "just now",
+    min_ago: "{n} min ago",
+    hour_ago: "{n}h ago",
+    day_ago: "{n}d ago",
+  },
+  ko: {
+    title: "거래 내역",
+    connect_prompt: "거래 내역을 보려면 OKX를 연결하세요",
+    no_trades: "아직 거래 없음. 자동매매 시작 후 여기에 기록됩니다.",
+    col_time: "시간",
+    col_strategy: "전략",
+    col_coin: "코인",
+    col_direction: "방향",
+    col_pnl: "예상 손익",
+    error: "거래 내역 로드 실패",
+    retry: "다시 시도 →",
+    just_now: "방금",
+    min_ago: "{n}분 전",
+    hour_ago: "{n}시간 전",
+    day_ago: "{n}일 전",
+  },
+} as const;
+
+type I18nKey = keyof (typeof i18n)["en"];
+
+function useTimeAgo(t: (typeof i18n)["en"] | (typeof i18n)["ko"]) {
+  return (ts: number): string => {
+    const diffMs = Date.now() - ts;
+    const diffMin = Math.floor(diffMs / 60_000);
+    if (diffMin < 1) return t.just_now;
+    if (diffMin < 60) return t.min_ago.replace("{n}", String(diffMin));
+    const diffHour = Math.floor(diffMin / 60);
+    if (diffHour < 24) return t.hour_ago.replace("{n}", String(diffHour));
+    const diffDay = Math.floor(diffHour / 24);
+    return t.day_ago.replace("{n}", String(diffDay));
+  };
+}
+
+function formatPnl(pnl: number): string {
+  const sign = pnl >= 0 ? "+" : "";
+  return `${sign}${pnl.toFixed(2)} USDT`;
+}
+
+function SkeletonRow() {
+  return (
+    <tr class="border-b border-[--color-border]">
+      {[1, 2, 3, 4, 5].map((i) => (
+        <td key={i} class="px-4 py-3">
+          <div class="h-4 rounded bg-[--color-bg-elevated] animate-pulse w-20" />
+        </td>
+      ))}
+    </tr>
+  );
+}
+
+export default function LiveTradeHistory({ lang = "en" }: Props) {
+  const t = i18n[lang] ?? i18n.en;
+  const timeAgo = useTimeAgo(t);
+
+  const [trades, setTrades] = useState<Trade[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [unauthed, setUnauthed] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchTrades = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE_URL}/settings/trades?limit=20`, {
+        credentials: "include",
+        signal: AbortSignal.timeout(15_000),
+      });
+
+      if (res.status === 401) {
+        setUnauthed(true);
+        setLoading(false);
+        return;
+      }
+
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+      const body: TradesResponse = await res.json();
+      setTrades(body.trades ?? []);
+      setError(null);
+      setUnauthed(false);
+    } catch (e) {
+      if (e instanceof DOMException && e.name === "AbortError") return;
+      setError(t.error);
+    } finally {
+      setLoading(false);
+    }
+  }, [t.error]);
+
+  useEffect(() => {
+    fetchTrades();
+  }, [fetchTrades]);
+
+  return (
+    <div class="card-enterprise rounded-xl p-5">
+      {/* Header */}
+      <div class="flex items-center gap-2 mb-4">
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          class="text-[--color-accent]"
+          aria-hidden="true"
+        >
+          <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+        </svg>
+        <h2 class="font-bold text-sm">{t.title}</h2>
+      </div>
+
+      {/* Unauthenticated */}
+      {unauthed && (
+        <div class="flex items-center justify-center gap-2 py-10 text-[--color-text-muted]">
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            aria-hidden="true"
+          >
+            <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+            <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+          </svg>
+          <p class="text-sm">{t.connect_prompt}</p>
+        </div>
+      )}
+
+      {/* Error */}
+      {!unauthed && error && (
+        <div class="flex flex-col items-center gap-3 py-10">
+          <p
+            class="text-sm text-[--color-down]"
+            role="alert"
+            aria-live="assertive"
+          >
+            {error}
+          </p>
+          <button
+            onClick={() => {
+              setLoading(true);
+              setError(null);
+              fetchTrades();
+            }}
+            class="text-xs text-[--color-accent] hover:underline cursor-pointer"
+          >
+            {t.retry}
+          </button>
+        </div>
+      )}
+
+      {/* Table */}
+      {!unauthed && !error && (
+        <div class="overflow-x-auto max-h-[480px] overflow-y-auto">
+          <table class="w-full text-sm" role="table" aria-label={t.title}>
+            <thead class="sticky top-0 bg-[--color-bg-card] z-10">
+              <tr class="border-b border-[--color-border]">
+                {(
+                  [
+                    "col_time",
+                    "col_strategy",
+                    "col_coin",
+                    "col_direction",
+                    "col_pnl",
+                  ] as I18nKey[]
+                ).map((col) => (
+                  <th
+                    key={col}
+                    scope="col"
+                    class="px-4 py-2 text-left text-xs font-semibold text-[--color-text-muted] whitespace-nowrap"
+                  >
+                    {t[col]}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {loading && (
+                <>
+                  <SkeletonRow />
+                  <SkeletonRow />
+                  <SkeletonRow />
+                </>
+              )}
+
+              {!loading && trades.length === 0 && (
+                <tr>
+                  <td
+                    colSpan={5}
+                    class="px-4 py-10 text-center text-sm text-[--color-text-muted]"
+                  >
+                    {t.no_trades}
+                  </td>
+                </tr>
+              )}
+
+              {!loading &&
+                trades.map((trade, idx) => {
+                  const dir = trade.signal.direction;
+                  const isLong =
+                    typeof dir === "string" && dir.toLowerCase() === "long";
+                  const isShort =
+                    typeof dir === "string" && dir.toLowerCase() === "short";
+
+                  const dirColor = isLong
+                    ? "text-[--color-up]"
+                    : isShort
+                      ? "text-[--color-down]"
+                      : "text-[--color-text-secondary]";
+
+                  const pnlColor =
+                    trade.pnl_usdt >= 0
+                      ? "text-[--color-up]"
+                      : "text-[--color-down]";
+
+                  // Use result.timestamp (ISO string) if available, else fall back to unix ms
+                  const tsMs = trade.result.timestamp
+                    ? new Date(trade.result.timestamp).getTime()
+                    : trade.timestamp;
+
+                  return (
+                    <tr
+                      key={`${trade.signal.coin}-${trade.signal.strategy}-${idx}`}
+                      class="border-b border-[--color-border] hover:bg-[--color-bg-elevated] transition-colors"
+                    >
+                      <td class="px-4 py-3 font-mono text-xs text-[--color-text-muted] whitespace-nowrap">
+                        {timeAgo(tsMs)}
+                      </td>
+                      <td class="px-4 py-3 text-xs text-[--color-text-secondary] whitespace-nowrap">
+                        {trade.signal.strategy}
+                      </td>
+                      <td class="px-4 py-3 font-mono font-semibold whitespace-nowrap">
+                        {trade.signal.coin}
+                      </td>
+                      <td
+                        class={`px-4 py-3 font-mono text-xs font-bold ${dirColor}`}
+                      >
+                        {dir.toUpperCase()}
+                      </td>
+                      <td
+                        class={`px-4 py-3 font-mono font-semibold whitespace-nowrap ${pnlColor}`}
+                      >
+                        {formatPnl(trade.pnl_usdt)}
+                      </td>
+                    </tr>
+                  );
+                })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TradingSettings.tsx
+++ b/src/components/TradingSettings.tsx
@@ -169,7 +169,6 @@ interface Settings {
 export default function TradingSettings({ lang = "en" }: Props) {
   const t = labels[lang];
   const [connected, setConnected] = useState(false);
-  const [isAdmin, setIsAdmin] = useState(false);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState<"idle" | "saving" | "saved">("idle");
   const [settings, setSettings] = useState<Settings>({
@@ -190,27 +189,11 @@ export default function TradingSettings({ lang = "en" }: Props) {
   });
 
   useEffect(() => {
-    // Check for admin key in localStorage or URL param
-    const params = new URLSearchParams(window.location.search);
-    const urlKey = params.get("admin_key");
-    if (urlKey) {
-      localStorage.setItem("pruviq_admin_key", urlKey);
-      // Clean URL
-      const url = new URL(window.location.href);
-      url.searchParams.delete("admin_key");
-      window.history.replaceState({}, "", url.toString());
-    }
-    const adminKey = localStorage.getItem("pruviq_admin_key") || "";
-
-    fetch(`${API_BASE}/auth/okx/status`, {
-      credentials: "include",
-      headers: adminKey ? { "x-admin-key": adminKey } : {},
-    })
+    fetch(`${API_BASE}/auth/okx/status`, { credentials: "include" })
       .then((r) => r.json())
       .then((d) => {
         setConnected(d.connected);
-        setIsAdmin(d.admin || false);
-        if (d.connected && d.admin) {
+        if (d.connected) {
           return fetch(`${API_BASE}/settings/trading`, {
             credentials: "include",
           });
@@ -270,83 +253,6 @@ export default function TradingSettings({ lang = "en" }: Props) {
   if (loading) {
     return (
       <div class="text-center py-8 text-[--color-text-muted]">Loading...</div>
-    );
-  }
-
-  // Non-admin: Coming Soon
-  if (!isAdmin) {
-    const comingSoon =
-      lang === "ko"
-        ? {
-            title: "자동매매 — 준비 중",
-            desc: "전략 선택, 포지션 설정, 원클릭 자동 실행 기능이 곧 출시됩니다.",
-            features: [
-              "7개 검증 전략 자동 실행",
-              "포지션 크기 + 레버리지 설정",
-              "실시간 포지션 모니터링",
-              "OAuth 보안 — API 키 불필요",
-            ],
-            notify: "출시 알림 받기",
-          }
-        : {
-            title: "Auto-Trading — Coming Soon",
-            desc: "Strategy selection, position configuration, and one-click auto-execution launching soon.",
-            features: [
-              "7 verified strategies auto-execution",
-              "Position size + leverage config",
-              "Real-time position monitoring",
-              "OAuth security — no API keys",
-            ],
-            notify: "Get notified at launch",
-          };
-    return (
-      <div class="card-enterprise rounded-xl p-8 text-center">
-        <div class="w-16 h-16 rounded-2xl bg-[--color-accent]/10 flex items-center justify-center mx-auto mb-4">
-          <svg
-            class="w-8 h-8 text-[--color-accent]"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              d="M13 10V3L4 14h7v7l9-11h-7z"
-            />
-          </svg>
-        </div>
-        <h3 class="text-xl font-bold mb-2">{comingSoon.title}</h3>
-        <p class="text-sm text-[--color-text-muted] mb-4">{comingSoon.desc}</p>
-        <ul class="space-y-2 mb-6 text-left max-w-xs mx-auto">
-          {comingSoon.features.map((f) => (
-            <li class="flex items-center gap-2 text-sm text-[--color-text-secondary]">
-              <svg
-                class="w-4 h-4 text-[--color-up] shrink-0"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                stroke-width="2.5"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M5 13l4 4L19 7"
-                />
-              </svg>
-              {f}
-            </li>
-          ))}
-        </ul>
-        <a
-          href="https://t.me/PRUVIQ"
-          target="_blank"
-          rel="noopener"
-          class="btn btn-primary btn-md"
-        >
-          {comingSoon.notify} →
-        </a>
-      </div>
     );
   }
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1510,6 +1510,7 @@ export const en = {
   "nav.weekly": "Weekly",
   "nav.signals": "Signals",
   "nav.dashboard": "Dashboard",
+  "nav.autotrading": "Autotrading",
 
   // Metric explanation tooltips
   "metric.sharpe_desc":

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -1476,6 +1476,7 @@ export const ko: Record<TranslationKey, string> = {
   "nav.weekly": "주간",
   "nav.signals": "시그널",
   "nav.dashboard": "대시보드",
+  "nav.autotrading": "자동매매",
 
   // Metric explanation tooltips
   "metric.sharpe_desc":

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -72,6 +72,7 @@ const builderPath = lp('/builder');
 const performancePath = lp('/performance');
 const blogPath = lp('/blog');
 const dashboardPath = lp('/dashboard');
+const autotradingPath = lp('/autotrading');
 
 // Active nav detection
 const navItems = [
@@ -83,6 +84,7 @@ const navItems = [
   { href: learnPath, match: '/learn', label: t('nav.learn') },
   { href: feesPath, match: '/fees', label: t('nav.fees') },
   { href: aboutPath, match: '/about', label: t('footer.about') },
+  { href: autotradingPath, match: '/autotrading', label: t('nav.autotrading'), badge: 'NEW' },
   { href: dashboardPath, match: '/dashboard', label: t('nav.dashboard') },
 ];
 const isActive = (match: string) => basePath.startsWith(match);
@@ -448,7 +450,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
               </div>
             </div>
           ) : (
-            <a href={item.href} aria-current={isActive(item.match) ? "page" : undefined} class="transition-colors nav-slide-underline" style={isActive(item.match) ? 'color:var(--color-accent);font-weight:500' : 'color:var(--color-text-muted)'}>{item.label}</a>
+            <a href={item.href} aria-current={isActive(item.match) ? "page" : undefined} class="transition-colors nav-slide-underline flex items-center gap-1.5" style={isActive(item.match) ? 'color:var(--color-accent);font-weight:500' : 'color:var(--color-text-muted)'}>{item.label}{item.badge && <span class="text-[9px] font-bold px-1 py-0.5 rounded bg-[--color-accent] text-white leading-none tracking-wide">{item.badge}</span>}</a>
           ))}
         </div>
         <!-- 3열: Lang + Mobile hamburger (우측) -->

--- a/src/pages/autotrading/index.astro
+++ b/src/pages/autotrading/index.astro
@@ -1,0 +1,280 @@
+---
+import Layout from '../../layouts/Layout.astro';
+---
+
+<Layout
+  title="Autotrading — Verified Strategies Running 24/7 | PRUVIQ"
+  description="PRUVIQ backtests 570+ coins. Only verified strategies deploy. Connect your OKX account and let your bot execute automatically with proven risk limits."
+>
+
+  <!-- HERO -->
+  <section class="relative overflow-hidden hero-bg-depth section-glow-green">
+    <div class="absolute left-1/2 top-1/3 -translate-x-1/2 -translate-y-1/2 w-[700px] h-[400px] rounded-full bg-[--color-accent]/[0.05] blur-[140px] pointer-events-none" aria-hidden="true"></div>
+    <div class="relative max-w-4xl mx-auto px-6 pt-24 pb-28 md:pt-36 md:pb-44 text-center hero-enter">
+      <!-- Partner badge -->
+      <div class="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-[--color-accent]/30 bg-[--color-accent]/8 mb-8">
+        <span class="inline-block w-2 h-2 rounded-full bg-[--color-up] animate-pulse" aria-hidden="true"></span>
+        <span class="font-mono text-xs font-bold tracking-widest text-[--color-accent] uppercase">OKX Official Broker Partner</span>
+      </div>
+
+      <h1 class="text-5xl md:text-6xl lg:text-7xl font-extrabold tracking-[-0.04em] leading-[1.05] text-balance mb-8">
+        Verified Strategies,<br/>
+        <span class="gradient-text-shimmer">Running 24/7</span>
+      </h1>
+
+      <p class="text-xl md:text-2xl text-[--color-text-secondary] leading-relaxed max-w-2xl mx-auto mb-10">
+        PRUVIQ backtests <strong class="text-[--color-text]">570+ coins</strong>. Only verified strategies deploy. Your bot executes automatically on OKX.
+      </p>
+
+      <div class="flex flex-col sm:flex-row gap-4 justify-center">
+        <a href="/dashboard" class="btn btn-primary btn-lg text-center">
+          Connect OKX &amp; Deploy &rarr;
+        </a>
+        <a href="/strategies" class="btn btn-ghost btn-lg text-center">
+          See verified strategies &rarr;
+        </a>
+      </div>
+
+      <p class="text-[10px] text-[--color-text-muted]/50 mt-6 font-mono">
+        Simulation results do not guarantee live trading performance.
+      </p>
+    </div>
+  </section>
+
+  <!-- HOW IT WORKS -->
+  <hr class="section-divider" />
+  <section class="max-w-7xl mx-auto px-6 py-24 md:py-32 section-elevated" aria-labelledby="how-it-works-heading">
+    <p class="font-mono text-[--color-accent] text-sm tracking-wider text-center mb-4 uppercase">How It Works</p>
+    <h2 id="how-it-works-heading" class="text-3xl md:text-4xl lg:text-5xl font-extrabold text-center mb-5">Three Steps to Automated Trading</h2>
+    <p class="text-[--color-text-secondary] text-center text-xl mb-16 max-w-xl mx-auto">From verified strategy to 24/7 execution.</p>
+
+    <div class="relative grid md:grid-cols-3 gap-8">
+      <!-- Connecting line (desktop) -->
+      <div class="hidden md:block absolute top-[2.75rem] left-[calc(33.33%+1rem)] right-[calc(33.33%+1rem)] h-px bg-gradient-to-r from-[--color-accent]/30 via-[--color-accent]/15 to-[--color-accent]/30" aria-hidden="true"></div>
+
+      <!-- Step 1 -->
+      <div class="card-enterprise p-8 border-t-2 border-t-[--color-accent]/40">
+        <div class="flex items-center justify-center w-12 h-12 rounded-full border-2 border-[--color-accent]/40 bg-[--color-accent]/10 font-mono font-bold text-[--color-accent] text-lg mb-6" aria-label="Step 1">
+          1
+        </div>
+        <h3 class="font-bold text-xl mb-3">PRUVIQ Verifies</h3>
+        <p class="text-[--color-text-muted] leading-relaxed">
+          We test strategies across 570+ coins and real market conditions. Only strategies with proven edge are deployable.
+        </p>
+      </div>
+
+      <!-- Step 2 -->
+      <div class="card-enterprise p-8 border-t-2 border-t-[--color-accent]/40">
+        <div class="flex items-center justify-center w-12 h-12 rounded-full border-2 border-[--color-accent]/40 bg-[--color-accent]/10 font-mono font-bold text-[--color-accent] text-lg mb-6" aria-label="Step 2">
+          2
+        </div>
+        <h3 class="font-bold text-xl mb-3">You Connect</h3>
+        <p class="text-[--color-text-muted] leading-relaxed">
+          Link your OKX account via OAuth. No API keys shared. No withdrawal access. Secure by design.
+        </p>
+      </div>
+
+      <!-- Step 3 -->
+      <div class="card-enterprise p-8 border-t-2 border-t-[--color-accent]/40">
+        <div class="flex items-center justify-center w-12 h-12 rounded-full border-2 border-[--color-accent]/40 bg-[--color-accent]/10 font-mono font-bold text-[--color-accent] text-lg mb-6" aria-label="Step 3">
+          3
+        </div>
+        <h3 class="font-bold text-xl mb-3">Bot Executes 24/7</h3>
+        <p class="text-[--color-text-muted] leading-relaxed">
+          Your bot scans signals every 5 minutes and executes trades automatically with your configured risk limits.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- DEPLOYABLE STRATEGIES -->
+  <hr class="section-divider" />
+  <section class="py-24 md:py-32 section-accent-glow" aria-labelledby="strategies-heading">
+    <div class="max-w-7xl mx-auto px-6">
+      <p class="font-mono text-[--color-up] text-sm tracking-wider text-center mb-4 uppercase">Deployable Strategies</p>
+      <h2 id="strategies-heading" class="text-3xl md:text-4xl lg:text-5xl font-extrabold text-center mb-5">Only Backtested, Verified</h2>
+      <p class="text-[--color-text-secondary] text-center text-xl mb-16 max-w-xl mx-auto">
+        Only backtested, verified strategies can be deployed.
+      </p>
+
+      <div class="grid md:grid-cols-3 gap-6">
+
+        <!-- BB Squeeze Short -->
+        <div class="card-enterprise p-6 border border-[--color-border] hover:border-[--color-up]/40 transition-colors">
+          <div class="flex items-center justify-between mb-4">
+            <h3 class="font-bold text-lg">BB Squeeze Short</h3>
+            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-[--color-up]/30 bg-[--color-up]/10 text-[--color-up] font-mono text-xs font-bold" aria-label="Status: Verified">
+              <span class="w-1.5 h-1.5 rounded-full bg-[--color-up]" aria-hidden="true"></span>
+              VERIFIED
+            </span>
+          </div>
+          <div class="grid grid-cols-2 gap-4 mb-6">
+            <div>
+              <p class="text-[--color-text-muted] text-xs font-mono mb-1">WIN RATE</p>
+              <p class="text-2xl font-extrabold text-[--color-up]">62%</p>
+            </div>
+            <div>
+              <p class="text-[--color-text-muted] text-xs font-mono mb-1">TRADES</p>
+              <p class="text-2xl font-extrabold">147</p>
+            </div>
+          </div>
+          <a href="/dashboard" class="btn btn-ghost w-full text-center text-sm min-h-[44px] flex items-center justify-center">
+            Deploy &rarr;
+          </a>
+        </div>
+
+        <!-- ATR Breakout -->
+        <div class="card-enterprise p-6 border border-[--color-border] hover:border-[--color-up]/40 transition-colors">
+          <div class="flex items-center justify-between mb-4">
+            <h3 class="font-bold text-lg">ATR Breakout</h3>
+            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-[--color-up]/30 bg-[--color-up]/10 text-[--color-up] font-mono text-xs font-bold" aria-label="Status: Verified">
+              <span class="w-1.5 h-1.5 rounded-full bg-[--color-up]" aria-hidden="true"></span>
+              VERIFIED
+            </span>
+          </div>
+          <div class="grid grid-cols-2 gap-4 mb-6">
+            <div>
+              <p class="text-[--color-text-muted] text-xs font-mono mb-1">WIN RATE</p>
+              <p class="text-2xl font-extrabold text-[--color-up]">58%</p>
+            </div>
+            <div>
+              <p class="text-[--color-text-muted] text-xs font-mono mb-1">TRADES</p>
+              <p class="text-2xl font-extrabold">203</p>
+            </div>
+          </div>
+          <a href="/dashboard" class="btn btn-ghost w-full text-center text-sm min-h-[44px] flex items-center justify-center">
+            Deploy &rarr;
+          </a>
+        </div>
+
+        <!-- Donchian Breakout -->
+        <div class="card-enterprise p-6 border border-[--color-border] hover:border-[--color-up]/40 transition-colors">
+          <div class="flex items-center justify-between mb-4">
+            <h3 class="font-bold text-lg">Donchian Breakout</h3>
+            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-[--color-up]/30 bg-[--color-up]/10 text-[--color-up] font-mono text-xs font-bold" aria-label="Status: Verified">
+              <span class="w-1.5 h-1.5 rounded-full bg-[--color-up]" aria-hidden="true"></span>
+              VERIFIED
+            </span>
+          </div>
+          <div class="grid grid-cols-2 gap-4 mb-6">
+            <div>
+              <p class="text-[--color-text-muted] text-xs font-mono mb-1">WIN RATE</p>
+              <p class="text-2xl font-extrabold text-[--color-up]">61%</p>
+            </div>
+            <div>
+              <p class="text-[--color-text-muted] text-xs font-mono mb-1">TRADES</p>
+              <p class="text-2xl font-extrabold">89</p>
+            </div>
+          </div>
+          <a href="/dashboard" class="btn btn-ghost w-full text-center text-sm min-h-[44px] flex items-center justify-center">
+            Deploy &rarr;
+          </a>
+        </div>
+
+      </div>
+
+      <div class="text-center mt-10">
+        <a href="/strategies" class="btn btn-ghost btn-sm font-mono">View all verified strategies &rarr;</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- TRUST & SAFETY -->
+  <hr class="section-divider" />
+  <section class="py-24 md:py-32 section-elevated" aria-labelledby="trust-heading">
+    <div class="max-w-4xl mx-auto px-6">
+      <p class="font-mono text-[--color-accent] text-sm tracking-wider text-center mb-4 uppercase">Trust &amp; Safety</p>
+      <h2 id="trust-heading" class="text-3xl md:text-4xl font-extrabold text-center mb-16">Built for Security</h2>
+
+      <div class="grid sm:grid-cols-2 gap-5">
+
+        <div class="card-enterprise p-6 flex items-start gap-4">
+          <div class="w-10 h-10 rounded-xl bg-[--color-up]/15 flex items-center justify-center shrink-0" aria-hidden="true">
+            <svg class="w-5 h-5 text-[--color-up]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
+            </svg>
+          </div>
+          <div>
+            <h3 class="font-bold text-base mb-1">OKX Official Broker Partner</h3>
+            <p class="text-[--color-text-muted] text-sm">20% fee discount for PRUVIQ users via official broker partnership.</p>
+          </div>
+        </div>
+
+        <div class="card-enterprise p-6 flex items-start gap-4">
+          <div class="w-10 h-10 rounded-xl bg-[--color-up]/15 flex items-center justify-center shrink-0" aria-hidden="true">
+            <svg class="w-5 h-5 text-[--color-up]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
+            </svg>
+          </div>
+          <div>
+            <h3 class="font-bold text-base mb-1">OAuth Only — No API Keys</h3>
+            <p class="text-[--color-text-muted] text-sm">No API keys shared. No withdrawal access. Secure OAuth connection only.</p>
+          </div>
+        </div>
+
+        <div class="card-enterprise p-6 flex items-start gap-4">
+          <div class="w-10 h-10 rounded-xl bg-[--color-up]/15 flex items-center justify-center shrink-0" aria-hidden="true">
+            <svg class="w-5 h-5 text-[--color-up]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M7.864 4.243A7.5 7.5 0 0119.5 10.5c0 2.92-.556 5.709-1.568 8.268M5.742 6.364A7.465 7.465 0 004.5 10.5a7.464 7.464 0 01-1.15 3.993m1.989 3.559A11.209 11.209 0 008.25 10.5a3.75 3.75 0 117.5 0c0 .527-.021 1.049-.064 1.565M12 10.5a14.94 14.94 0 01-3.6 9.75m6.633-4.596a18.666 18.666 0 01-2.485 5.33" />
+            </svg>
+          </div>
+          <div>
+            <h3 class="font-bold text-base mb-1">AES-256 Encrypted Token Storage</h3>
+            <p class="text-[--color-text-muted] text-sm">All OAuth tokens stored with AES-256 encryption at rest.</p>
+          </div>
+        </div>
+
+        <div class="card-enterprise p-6 flex items-start gap-4">
+          <div class="w-10 h-10 rounded-xl bg-[--color-up]/15 flex items-center justify-center shrink-0" aria-hidden="true">
+            <svg class="w-5 h-5 text-[--color-up]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5M9 11.25v1.5M12 9v3.75m3-6v6" />
+            </svg>
+          </div>
+          <div>
+            <h3 class="font-bold text-base mb-1">Daily Loss Limits &amp; Position Size Limits</h3>
+            <p class="text-[--color-text-muted] text-sm">Configurable daily loss limits and per-position size limits protect your capital.</p>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- Disclaimer -->
+      <div class="mt-10 px-6 py-5 rounded-xl border border-[--color-verified-border] bg-[--color-verified-subtle]">
+        <p class="text-sm text-[--color-text-muted] leading-relaxed">
+          <strong class="text-[--color-verified]">Risk Disclosure:</strong> Simulation results do not guarantee live trading performance. Past backtests are not a promise of future returns. Autotrading involves significant risk of loss. Only trade with funds you can afford to lose.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <hr class="section-divider" />
+  <section class="relative pt-24 pb-20 md:pt-32 md:pb-28 overflow-hidden section-glow-cyan" aria-labelledby="autotrading-cta-heading">
+    <div class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[400px] rounded-full bg-[--color-accent]/[0.06] blur-[120px] pointer-events-none" aria-hidden="true"></div>
+    <div class="relative max-w-4xl mx-auto px-6 text-center">
+      <p class="font-mono text-[--color-accent] text-sm mb-5 tracking-wider uppercase">Get Started</p>
+      <h2 id="autotrading-cta-heading" class="text-4xl md:text-6xl font-extrabold mb-8">
+        <span class="gradient-text-shimmer">Ready to Automate?</span>
+      </h2>
+      <p class="text-[--color-text-secondary] text-xl md:text-2xl mb-10 max-w-xl mx-auto">
+        Connect your OKX account and deploy a verified strategy in minutes.
+      </p>
+
+      <div class="flex flex-wrap gap-3 justify-center mb-10 font-mono text-xs">
+        <span class="px-4 py-2 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5">OKX Official Partner</span>
+        <span class="px-4 py-2 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5">OAuth Only</span>
+        <span class="px-4 py-2 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5">No Withdrawal Access</span>
+        <span class="px-4 py-2 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5">20% Fee Discount</span>
+      </div>
+
+      <a href="/dashboard" class="btn btn-primary btn-lg">
+        Connect OKX &amp; Start &rarr;
+      </a>
+
+      <p class="text-[--color-text-muted] text-xs mt-8 max-w-lg mx-auto">
+        Simulation results do not guarantee live trading performance. Past backtests are not a promise of future returns.
+      </p>
+    </div>
+  </section>
+
+</Layout>

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -1,17 +1,19 @@
 ---
-// TODO: Dashboard not ready — redirect until public launch
-return Astro.redirect('/', 302);
-
 import Layout from '../layouts/Layout.astro';
 import OKXConnectButton from '../components/OKXConnectButton';
 import TradingSettings from '../components/TradingSettings';
+import LivePositions from '../components/LivePositions';
+import LiveTradeHistory from '../components/LiveTradeHistory';
 ---
 
 <Layout title="Dashboard — PRUVIQ" description="Manage your OKX connection and auto-trading settings.">
 
   <main class="max-w-4xl mx-auto px-4 py-12 md:py-20">
-    <h1 class="text-3xl md:text-4xl font-bold mb-2">Dashboard</h1>
-    <p class="text-[--color-text-muted] mb-8">Manage your exchange connection and auto-trading.</p>
+    <div class="flex items-center justify-between mb-2 flex-wrap gap-3">
+      <h1 class="text-3xl md:text-4xl font-bold">Dashboard</h1>
+      <a href="/autotrading" class="text-sm text-[--color-text-muted] hover:text-[--color-accent] transition-colors">← About Autotrading</a>
+    </div>
+    <p class="text-[--color-text-muted] mb-8">Manage your OKX connection and auto-trading bots.</p>
 
     <!-- OKX Connection Card -->
     <section class="mb-8">
@@ -19,7 +21,9 @@ import TradingSettings from '../components/TradingSettings';
         <div class="flex items-center justify-between mb-4 flex-wrap gap-4">
           <div class="flex items-center gap-3">
             <div class="w-12 h-12 rounded-xl bg-[--color-accent]/10 flex items-center justify-center">
-              <span class="text-2xl font-bold text-[--color-accent]">O</span>
+              <svg class="w-7 h-7 text-[--color-accent]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+              </svg>
             </div>
             <div>
               <h2 class="text-xl font-bold">OKX Broker</h2>
@@ -45,9 +49,19 @@ import TradingSettings from '../components/TradingSettings';
       </div>
     </section>
 
-    <!-- Trading Settings -->
+    <!-- Auto-Trading Settings -->
     <section class="mb-8">
       <TradingSettings client:load lang="en" />
+    </section>
+
+    <!-- Live Positions -->
+    <section class="mb-8">
+      <LivePositions client:load lang="en" />
+    </section>
+
+    <!-- Trade History -->
+    <section class="mb-8">
+      <LiveTradeHistory client:load lang="en" />
     </section>
 
     <!-- Security Info -->
@@ -70,6 +84,11 @@ import TradingSettings from '../components/TradingSettings';
         </div>
       </div>
     </section>
+
+    <!-- Risk Disclaimer -->
+    <p class="text-xs text-[--color-text-disabled] text-center mt-8">
+      Auto-trading executes real trades with real money. Simulation results do not guarantee live trading performance.
+    </p>
   </main>
 
 </Layout>

--- a/src/pages/ko/autotrading/index.astro
+++ b/src/pages/ko/autotrading/index.astro
@@ -1,0 +1,280 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+---
+
+<Layout
+  title="자동매매 — 검증된 전략, 24시간 자동 실행 | PRUVIQ"
+  description="프루빅이 570개 이상의 코인으로 전략을 검증합니다. 검증된 전략만 배포 가능합니다. OKX 계정을 연결하고 자동으로 거래를 실행하세요."
+>
+
+  <!-- HERO -->
+  <section class="relative overflow-hidden hero-bg-depth section-glow-green">
+    <div class="absolute left-1/2 top-1/3 -translate-x-1/2 -translate-y-1/2 w-[700px] h-[400px] rounded-full bg-[--color-accent]/[0.05] blur-[140px] pointer-events-none" aria-hidden="true"></div>
+    <div class="relative max-w-4xl mx-auto px-6 pt-24 pb-28 md:pt-36 md:pb-44 text-center hero-enter">
+      <!-- Partner badge -->
+      <div class="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-[--color-accent]/30 bg-[--color-accent]/8 mb-8">
+        <span class="inline-block w-2 h-2 rounded-full bg-[--color-up] animate-pulse" aria-hidden="true"></span>
+        <span class="font-mono text-xs font-bold tracking-widest text-[--color-accent] uppercase">OKX 공식 브로커 파트너</span>
+      </div>
+
+      <h1 class="text-5xl md:text-6xl lg:text-7xl font-extrabold tracking-[-0.04em] leading-[1.05] text-balance mb-8">
+        검증된 전략,<br/>
+        <span class="gradient-text-shimmer">24시간 자동 실행</span>
+      </h1>
+
+      <p class="text-xl md:text-2xl text-[--color-text-secondary] leading-relaxed max-w-2xl mx-auto mb-10">
+        프루빅이 <strong class="text-[--color-text]">570개 이상의 코인</strong>으로 전략을 검증합니다. 검증된 전략만 배포 가능합니다.
+      </p>
+
+      <div class="flex flex-col sm:flex-row gap-4 justify-center">
+        <a href="/ko/dashboard" class="btn btn-primary btn-lg text-center">
+          OKX 연결 후 시작 &rarr;
+        </a>
+        <a href="/ko/strategies" class="btn btn-ghost btn-lg text-center">
+          검증된 전략 보기 &rarr;
+        </a>
+      </div>
+
+      <p class="text-[10px] text-[--color-text-muted]/50 mt-6 font-mono">
+        시뮬레이션 성과는 실제 거래 수익을 보장하지 않습니다.
+      </p>
+    </div>
+  </section>
+
+  <!-- HOW IT WORKS -->
+  <hr class="section-divider" />
+  <section class="max-w-7xl mx-auto px-6 py-24 md:py-32 section-elevated" aria-labelledby="how-it-works-ko-heading">
+    <p class="font-mono text-[--color-accent] text-sm tracking-wider text-center mb-4 uppercase">작동 방식</p>
+    <h2 id="how-it-works-ko-heading" class="text-3xl md:text-4xl lg:text-5xl font-extrabold text-center mb-5">자동매매, 3단계로 시작</h2>
+    <p class="text-[--color-text-secondary] text-center text-xl mb-16 max-w-xl mx-auto">검증된 전략부터 24시간 자동 실행까지.</p>
+
+    <div class="relative grid md:grid-cols-3 gap-8">
+      <!-- Connecting line (desktop) -->
+      <div class="hidden md:block absolute top-[2.75rem] left-[calc(33.33%+1rem)] right-[calc(33.33%+1rem)] h-px bg-gradient-to-r from-[--color-accent]/30 via-[--color-accent]/15 to-[--color-accent]/30" aria-hidden="true"></div>
+
+      <!-- Step 1 -->
+      <div class="card-enterprise p-8 border-t-2 border-t-[--color-accent]/40">
+        <div class="flex items-center justify-center w-12 h-12 rounded-full border-2 border-[--color-accent]/40 bg-[--color-accent]/10 font-mono font-bold text-[--color-accent] text-lg mb-6" aria-label="1단계">
+          1
+        </div>
+        <h3 class="font-bold text-xl mb-3">프루빅이 검증</h3>
+        <p class="text-[--color-text-muted] leading-relaxed">
+          570개 이상의 코인과 실제 시장 조건으로 전략을 테스트합니다. 검증된 우위를 가진 전략만 배포 가능합니다.
+        </p>
+      </div>
+
+      <!-- Step 2 -->
+      <div class="card-enterprise p-8 border-t-2 border-t-[--color-accent]/40">
+        <div class="flex items-center justify-center w-12 h-12 rounded-full border-2 border-[--color-accent]/40 bg-[--color-accent]/10 font-mono font-bold text-[--color-accent] text-lg mb-6" aria-label="2단계">
+          2
+        </div>
+        <h3 class="font-bold text-xl mb-3">OKX 연결</h3>
+        <p class="text-[--color-text-muted] leading-relaxed">
+          OAuth로 OKX 계정을 연결하세요. API 키 공유 없음. 출금 권한 없음. 보안 설계.
+        </p>
+      </div>
+
+      <!-- Step 3 -->
+      <div class="card-enterprise p-8 border-t-2 border-t-[--color-accent]/40">
+        <div class="flex items-center justify-center w-12 h-12 rounded-full border-2 border-[--color-accent]/40 bg-[--color-accent]/10 font-mono font-bold text-[--color-accent] text-lg mb-6" aria-label="3단계">
+          3
+        </div>
+        <h3 class="font-bold text-xl mb-3">봇이 24시간 실행</h3>
+        <p class="text-[--color-text-muted] leading-relaxed">
+          봇이 5분마다 신호를 스캔하고, 설정된 리스크 한도 내에서 자동으로 거래를 실행합니다.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- DEPLOYABLE STRATEGIES -->
+  <hr class="section-divider" />
+  <section class="py-24 md:py-32 section-accent-glow" aria-labelledby="strategies-ko-heading">
+    <div class="max-w-7xl mx-auto px-6">
+      <p class="font-mono text-[--color-up] text-sm tracking-wider text-center mb-4 uppercase">배포 가능 전략</p>
+      <h2 id="strategies-ko-heading" class="text-3xl md:text-4xl lg:text-5xl font-extrabold text-center mb-5">백테스트 검증 완료</h2>
+      <p class="text-[--color-text-secondary] text-center text-xl mb-16 max-w-xl mx-auto">
+        백테스트로 검증된 전략만 배포할 수 있습니다.
+      </p>
+
+      <div class="grid md:grid-cols-3 gap-6">
+
+        <!-- BB Squeeze Short -->
+        <div class="card-enterprise p-6 border border-[--color-border] hover:border-[--color-up]/40 transition-colors">
+          <div class="flex items-center justify-between mb-4">
+            <h3 class="font-bold text-lg">BB 스퀴즈 숏</h3>
+            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-[--color-up]/30 bg-[--color-up]/10 text-[--color-up] font-mono text-xs font-bold" aria-label="상태: 검증됨">
+              <span class="w-1.5 h-1.5 rounded-full bg-[--color-up]" aria-hidden="true"></span>
+              검증됨
+            </span>
+          </div>
+          <div class="grid grid-cols-2 gap-4 mb-6">
+            <div>
+              <p class="text-[--color-text-muted] text-xs font-mono mb-1">승률</p>
+              <p class="text-2xl font-extrabold text-[--color-up]">62%</p>
+            </div>
+            <div>
+              <p class="text-[--color-text-muted] text-xs font-mono mb-1">거래 횟수</p>
+              <p class="text-2xl font-extrabold">147</p>
+            </div>
+          </div>
+          <a href="/ko/dashboard" class="btn btn-ghost w-full text-center text-sm min-h-[44px] flex items-center justify-center">
+            배포하기 &rarr;
+          </a>
+        </div>
+
+        <!-- ATR Breakout -->
+        <div class="card-enterprise p-6 border border-[--color-border] hover:border-[--color-up]/40 transition-colors">
+          <div class="flex items-center justify-between mb-4">
+            <h3 class="font-bold text-lg">ATR 브레이크아웃</h3>
+            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-[--color-up]/30 bg-[--color-up]/10 text-[--color-up] font-mono text-xs font-bold" aria-label="상태: 검증됨">
+              <span class="w-1.5 h-1.5 rounded-full bg-[--color-up]" aria-hidden="true"></span>
+              검증됨
+            </span>
+          </div>
+          <div class="grid grid-cols-2 gap-4 mb-6">
+            <div>
+              <p class="text-[--color-text-muted] text-xs font-mono mb-1">승률</p>
+              <p class="text-2xl font-extrabold text-[--color-up]">58%</p>
+            </div>
+            <div>
+              <p class="text-[--color-text-muted] text-xs font-mono mb-1">거래 횟수</p>
+              <p class="text-2xl font-extrabold">203</p>
+            </div>
+          </div>
+          <a href="/ko/dashboard" class="btn btn-ghost w-full text-center text-sm min-h-[44px] flex items-center justify-center">
+            배포하기 &rarr;
+          </a>
+        </div>
+
+        <!-- Donchian Breakout -->
+        <div class="card-enterprise p-6 border border-[--color-border] hover:border-[--color-up]/40 transition-colors">
+          <div class="flex items-center justify-between mb-4">
+            <h3 class="font-bold text-lg">돈치안 브레이크아웃</h3>
+            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-[--color-up]/30 bg-[--color-up]/10 text-[--color-up] font-mono text-xs font-bold" aria-label="상태: 검증됨">
+              <span class="w-1.5 h-1.5 rounded-full bg-[--color-up]" aria-hidden="true"></span>
+              검증됨
+            </span>
+          </div>
+          <div class="grid grid-cols-2 gap-4 mb-6">
+            <div>
+              <p class="text-[--color-text-muted] text-xs font-mono mb-1">승률</p>
+              <p class="text-2xl font-extrabold text-[--color-up]">61%</p>
+            </div>
+            <div>
+              <p class="text-[--color-text-muted] text-xs font-mono mb-1">거래 횟수</p>
+              <p class="text-2xl font-extrabold">89</p>
+            </div>
+          </div>
+          <a href="/ko/dashboard" class="btn btn-ghost w-full text-center text-sm min-h-[44px] flex items-center justify-center">
+            배포하기 &rarr;
+          </a>
+        </div>
+
+      </div>
+
+      <div class="text-center mt-10">
+        <a href="/ko/strategies" class="btn btn-ghost btn-sm font-mono">검증된 전략 전체 보기 &rarr;</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- TRUST & SAFETY -->
+  <hr class="section-divider" />
+  <section class="py-24 md:py-32 section-elevated" aria-labelledby="trust-ko-heading">
+    <div class="max-w-4xl mx-auto px-6">
+      <p class="font-mono text-[--color-accent] text-sm tracking-wider text-center mb-4 uppercase">신뢰 &amp; 보안</p>
+      <h2 id="trust-ko-heading" class="text-3xl md:text-4xl font-extrabold text-center mb-16">보안을 위해 설계됨</h2>
+
+      <div class="grid sm:grid-cols-2 gap-5">
+
+        <div class="card-enterprise p-6 flex items-start gap-4">
+          <div class="w-10 h-10 rounded-xl bg-[--color-up]/15 flex items-center justify-center shrink-0" aria-hidden="true">
+            <svg class="w-5 h-5 text-[--color-up]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
+            </svg>
+          </div>
+          <div>
+            <h3 class="font-bold text-base mb-1">OKX 공식 브로커 파트너</h3>
+            <p class="text-[--color-text-muted] text-sm">공식 브로커 파트너십으로 PRUVIQ 사용자에게 수수료 20% 할인 제공.</p>
+          </div>
+        </div>
+
+        <div class="card-enterprise p-6 flex items-start gap-4">
+          <div class="w-10 h-10 rounded-xl bg-[--color-up]/15 flex items-center justify-center shrink-0" aria-hidden="true">
+            <svg class="w-5 h-5 text-[--color-up]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
+            </svg>
+          </div>
+          <div>
+            <h3 class="font-bold text-base mb-1">OAuth만 사용 — API 키 없음</h3>
+            <p class="text-[--color-text-muted] text-sm">API 키 공유 없음. 출금 권한 없음. 안전한 OAuth 연결만 사용.</p>
+          </div>
+        </div>
+
+        <div class="card-enterprise p-6 flex items-start gap-4">
+          <div class="w-10 h-10 rounded-xl bg-[--color-up]/15 flex items-center justify-center shrink-0" aria-hidden="true">
+            <svg class="w-5 h-5 text-[--color-up]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M7.864 4.243A7.5 7.5 0 0119.5 10.5c0 2.92-.556 5.709-1.568 8.268M5.742 6.364A7.465 7.465 0 004.5 10.5a7.464 7.464 0 01-1.15 3.993m1.989 3.559A11.209 11.209 0 008.25 10.5a3.75 3.75 0 117.5 0c0 .527-.021 1.049-.064 1.565M12 10.5a14.94 14.94 0 01-3.6 9.75m6.633-4.596a18.666 18.666 0 01-2.485 5.33" />
+            </svg>
+          </div>
+          <div>
+            <h3 class="font-bold text-base mb-1">AES-256 암호화 토큰 저장</h3>
+            <p class="text-[--color-text-muted] text-sm">모든 OAuth 토큰은 AES-256 암호화로 저장됩니다.</p>
+          </div>
+        </div>
+
+        <div class="card-enterprise p-6 flex items-start gap-4">
+          <div class="w-10 h-10 rounded-xl bg-[--color-up]/15 flex items-center justify-center shrink-0" aria-hidden="true">
+            <svg class="w-5 h-5 text-[--color-up]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5M9 11.25v1.5M12 9v3.75m3-6v6" />
+            </svg>
+          </div>
+          <div>
+            <h3 class="font-bold text-base mb-1">일일 손실 한도 &amp; 포지션 크기 한도</h3>
+            <p class="text-[--color-text-muted] text-sm">설정 가능한 일일 손실 한도와 포지션별 크기 한도로 자본을 보호합니다.</p>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- 법적 고지 -->
+      <div class="mt-10 px-6 py-5 rounded-xl border border-[--color-verified-border] bg-[--color-verified-subtle]">
+        <p class="text-sm text-[--color-text-muted] leading-relaxed">
+          <strong class="text-[--color-verified]">위험 고지:</strong> 본 서비스는 투자 자문업이 아닙니다. 시뮬레이션 성과는 실제 거래 수익을 보장하지 않습니다. 자동매매는 상당한 손실 위험을 수반합니다. 잃어도 되는 자금으로만 거래하십시오.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <hr class="section-divider" />
+  <section class="relative pt-24 pb-20 md:pt-32 md:pb-28 overflow-hidden section-glow-cyan" aria-labelledby="autotrading-ko-cta-heading">
+    <div class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[400px] rounded-full bg-[--color-accent]/[0.06] blur-[120px] pointer-events-none" aria-hidden="true"></div>
+    <div class="relative max-w-4xl mx-auto px-6 text-center">
+      <p class="font-mono text-[--color-accent] text-sm mb-5 tracking-wider uppercase">시작하기</p>
+      <h2 id="autotrading-ko-cta-heading" class="text-4xl md:text-6xl font-extrabold mb-8">
+        <span class="gradient-text-shimmer">자동매매를 시작할 준비가 되셨나요?</span>
+      </h2>
+      <p class="text-[--color-text-secondary] text-xl md:text-2xl mb-10 max-w-xl mx-auto">
+        OKX 계정을 연결하고 몇 분 안에 검증된 전략을 배포하세요.
+      </p>
+
+      <div class="flex flex-wrap gap-3 justify-center mb-10 font-mono text-xs">
+        <span class="px-4 py-2 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5">OKX 공식 파트너</span>
+        <span class="px-4 py-2 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5">OAuth만 사용</span>
+        <span class="px-4 py-2 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5">출금 권한 없음</span>
+        <span class="px-4 py-2 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5">수수료 20% 할인</span>
+      </div>
+
+      <a href="/ko/dashboard" class="btn btn-primary btn-lg">
+        OKX 연결 후 시작 &rarr;
+      </a>
+
+      <p class="text-[--color-text-muted] text-xs mt-8 max-w-lg mx-auto">
+        본 서비스는 투자 자문업이 아닙니다. 시뮬레이션 성과는 실제 거래 수익을 보장하지 않습니다.
+      </p>
+    </div>
+  </section>
+
+</Layout>

--- a/src/pages/ko/dashboard.astro
+++ b/src/pages/ko/dashboard.astro
@@ -2,25 +2,32 @@
 import Layout from '../../layouts/Layout.astro';
 import OKXConnectButton from '../../components/OKXConnectButton';
 import TradingSettings from '../../components/TradingSettings';
+import LivePositions from '../../components/LivePositions';
+import LiveTradeHistory from '../../components/LiveTradeHistory';
 ---
 
-<Layout title="대시보드 — PRUVIQ" description="OKX 연결 및 자동매매 설정을 관리하세요.">
+<Layout title="대시보드 — PRUVIQ" description="OKX 연결 및 자동매매 설정을 관리합니다." lang="ko">
 
   <main class="max-w-4xl mx-auto px-4 py-12 md:py-20">
-    <h1 class="text-3xl md:text-4xl font-bold mb-2">대시보드</h1>
-    <p class="text-[--color-text-muted] mb-8">거래소 연결 및 자동매매를 관리하세요.</p>
+    <div class="flex items-center justify-between mb-2 flex-wrap gap-3">
+      <h1 class="text-3xl md:text-4xl font-bold">대시보드</h1>
+      <a href="/ko/autotrading" class="text-sm text-[--color-text-muted] hover:text-[--color-accent] transition-colors">← 자동매매 소개</a>
+    </div>
+    <p class="text-[--color-text-muted] mb-8">OKX 연결 및 자동매매 봇을 관리합니다.</p>
 
-    <!-- OKX Connection Card -->
+    <!-- OKX 연결 카드 -->
     <section class="mb-8">
       <div class="card-enterprise rounded-2xl p-6 md:p-8">
         <div class="flex items-center justify-between mb-4 flex-wrap gap-4">
           <div class="flex items-center gap-3">
             <div class="w-12 h-12 rounded-xl bg-[--color-accent]/10 flex items-center justify-center">
-              <span class="text-2xl font-bold text-[--color-accent]">O</span>
+              <svg class="w-7 h-7 text-[--color-accent]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+              </svg>
             </div>
             <div>
               <h2 class="text-xl font-bold">OKX 브로커</h2>
-              <p class="text-sm text-[--color-text-muted]">공식 브로커 파트너 — 20% 수수료 할인</p>
+              <p class="text-sm text-[--color-text-muted]">공식 브로커 파트너 — 수수료 20% 할인</p>
             </div>
           </div>
           <OKXConnectButton client:load lang="ko" size="md" />
@@ -42,19 +49,29 @@ import TradingSettings from '../../components/TradingSettings';
       </div>
     </section>
 
-    <!-- Trading Settings -->
+    <!-- 자동매매 설정 -->
     <section class="mb-8">
       <TradingSettings client:load lang="ko" />
     </section>
 
-    <!-- Security Info -->
+    <!-- 오픈 포지션 -->
+    <section class="mb-8">
+      <LivePositions client:load lang="ko" />
+    </section>
+
+    <!-- 거래 내역 -->
+    <section class="mb-8">
+      <LiveTradeHistory client:load lang="ko" />
+    </section>
+
+    <!-- 보안 정보 -->
     <section>
       <div class="card-enterprise rounded-xl p-5">
         <h3 class="font-bold mb-3">보안</h3>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-3 text-xs">
           <div class="flex items-center gap-2 text-[--color-text-muted]">
             <span class="w-2 h-2 rounded-full bg-[--color-up]"></span>
-            OAuth — API 키 공유 없음
+            OAuth — API 키 미공유
           </div>
           <div class="flex items-center gap-2 text-[--color-text-muted]">
             <span class="w-2 h-2 rounded-full bg-[--color-up]"></span>
@@ -62,11 +79,16 @@ import TradingSettings from '../../components/TradingSettings';
           </div>
           <div class="flex items-center gap-2 text-[--color-text-muted]">
             <span class="w-2 h-2 rounded-full bg-[--color-up]"></span>
-            AES-256 암호화 토큰 저장
+            AES-256 암호화 토큰
           </div>
         </div>
       </div>
     </section>
+
+    <!-- 법적 고지 -->
+    <p class="text-xs text-[--color-text-disabled] text-center mt-8">
+      본 서비스는 투자 자문업이 아닙니다. 자동매매는 실제 자금으로 거래를 실행합니다. 시뮬레이션 성과는 실제 거래 수익을 보장하지 않습니다.
+    </p>
   </main>
 
 </Layout>


### PR DESCRIPTION
## 근본 원인 수정 3개

### 1. `dashboard.astro` redirect 제거
`return Astro.redirect('/', 302)` — 모든 사용자가 대시보드에 접근 불가했던 직접 원인.

### 2. `TradingSettings.tsx` isAdmin 게이트 제거
- `if (!isAdmin) → Coming Soon` 블록 완전 제거
- 설정 fetch를 `connected && admin` → `connected` 로 확장
- OKX 연결된 모든 사용자가 자동매매 설정 가능

### 3. Nav + i18n: Autotrading 진입점 추가
- `nav.autotrading: "Autotrading" / "자동매매"` 키 추가
- Primary nav에 NEW 배지와 함께 노출

## 신규 파일
| 파일 | 역할 |
|------|------|
| `LivePositions.tsx` | 실시간 오픈 포지션 (30초 폴링) |
| `LiveTradeHistory.tsx` | 거래 내역 (최근 20건) |
| `autotrading/index.astro` | 자동매매 랜딩 (EN) |
| `ko/autotrading/index.astro` | 자동매매 랜딩 (KO + 법적 고지) |
| `ko/dashboard.astro` | 한국어 대시보드 (법적 고지 포함) |

## 검증
- build: 2522 pages ✅
- qa-redirects: PASS ✅
- `/dashboard` → 실제 페이지 (redirect 없음) ✅
- `/autotrading` → 신규 랜딩 페이지 ✅
- `/ko/dashboard` + `/ko/autotrading` → 한국어 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)