### PR TITLE
feat: platform funnel redesign — nav + deploy button + autotrading sections

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -76,16 +76,15 @@ const autotradingPath = lp('/autotrading');
 
 // Active nav detection
 const navItems = [
-  { href: marketPath, match: '/market', label: t('nav.market') },
   { href: simulatePath, match: '/simulate', label: t('nav.simulate') },
   { href: strategiesPath, match: '/strategies', label: t('nav.strategies') },
   { href: signalsPath, match: '/signals', label: t('nav.signals') },
+  { href: autotradingPath, match: '/autotrading', label: t('nav.autotrading'), badge: 'NEW' },
+  { href: marketPath, match: '/market', label: t('nav.market') },
   { href: coinsPath, match: '/coins', label: t('nav.coins') },
   { href: learnPath, match: '/learn', label: t('nav.learn') },
   { href: feesPath, match: '/fees', label: t('nav.fees') },
   { href: aboutPath, match: '/about', label: t('footer.about') },
-  { href: autotradingPath, match: '/autotrading', label: t('nav.autotrading'), badge: 'NEW' },
-  { href: dashboardPath, match: '/dashboard', label: t('nav.dashboard') },
 ];
 const isActive = (match: string) => basePath.startsWith(match);
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -59,8 +59,8 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
             <a href="/simulate" class="btn btn-primary btn-lg text-center w-full sm:w-auto">
               Open Simulator — Free &rarr;
             </a>
-            <a href="/strategies" class="btn btn-ghost btn-lg text-center w-full sm:w-auto">
-              Explore Strategies
+            <a href="/autotrading" class="btn btn-ghost btn-lg text-center w-full sm:w-auto border-[--color-accent]/30 hover:border-[--color-accent] hover:text-[--color-accent]">
+              Deploy a Bot &rarr;
             </a>
           </div>
           <!-- Trust strip -->
@@ -128,7 +128,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       <a href="/simulate" class="btn btn-primary btn-lg">Open Simulator — Free &rarr;</a>
     </div>
     <!-- Persona entry points -->
-    <div class="mt-14 grid sm:grid-cols-3 gap-5 max-w-3xl mx-auto">
+    <div class="mt-14 grid sm:grid-cols-2 lg:grid-cols-4 gap-5 max-w-4xl mx-auto">
       <a href="/learn" class="card-premium card-hover p-6 text-center group">
         <p class="text-sm text-[--color-text-muted] mb-2 font-mono">New to trading?</p>
         <p class="text-base font-semibold group-hover:text-[--color-accent] transition-colors">Start Learning →</p>
@@ -141,6 +141,28 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
         <p class="text-sm text-[--color-text-muted] mb-2 font-mono">Just exploring?</p>
         <p class="text-base font-semibold group-hover:text-[--color-accent] transition-colors">Explore Strategies →</p>
       </a>
+      <a href="/autotrading" class="card-premium card-hover p-6 text-center group border border-[--color-accent]/20">
+        <p class="text-sm text-[--color-accent] mb-2 font-mono">Ready to automate?</p>
+        <p class="text-base font-semibold group-hover:text-[--color-accent] transition-colors">Deploy a Bot →</p>
+      </a>
+    </div>
+  </section>
+
+  <!-- HOW AUTOTRADING WORKS -->
+  <hr class="section-divider" />
+  <section class="max-w-7xl mx-auto px-6 py-24 md:py-32 section-elevated" aria-labelledby="autotrading-heading">
+    <p class="font-mono text-[--color-accent] text-sm tracking-wider text-center mb-4">AUTOTRADING</p>
+    <h2 id="autotrading-heading" class="text-3xl md:text-4xl lg:text-5xl font-extrabold text-center mb-5">From Verified Strategy to Running Bot</h2>
+    <p class="text-[--color-text-secondary] text-center text-xl mb-14 max-w-xl mx-auto">Backtested. Verified. Executing 24/7 on OKX.</p>
+    <div class="relative grid md:grid-cols-3 gap-8">
+      <div class="hidden md:block absolute top-[2.75rem] left-[calc(33.33%+1rem)] right-[calc(33.33%+1rem)] h-px bg-gradient-to-r from-[--color-accent]/30 via-[--color-accent]/15 to-[--color-accent]/30 reveal" aria-hidden="true"></div>
+      <StepCard step={1} title="Connect OKX" description="OAuth only — no API keys shared, no withdrawal access. Secure by design." />
+      <StepCard step={2} title="Pick a Verified Strategy" description="Only strategies that passed rigorous backtests across 570+ coins are deployable." />
+      <StepCard step={3} title="Bot Trades 24/7" description="Scans signals every 5 minutes. Executes automatically with your risk limits." />
+    </div>
+    <div class="text-center mt-14">
+      <a href="/autotrading" class="btn btn-primary btn-lg">Start Autotrading — Free →</a>
+      <p class="text-xs text-[--color-text-muted] mt-3">Simulation results do not guarantee live trading performance.</p>
     </div>
   </section>
 

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -59,8 +59,8 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
             <a href="/ko/simulate" class="btn btn-primary btn-lg text-center w-full sm:w-auto">
               시뮬레이터 열기 — 무료 &rarr;
             </a>
-            <a href="/ko/strategies" class="btn btn-ghost btn-sm text-center w-full sm:w-auto">
-              전략 탐색하기
+            <a href="/ko/autotrading" class="btn btn-ghost btn-lg text-center w-full sm:w-auto border-[--color-accent]/30 hover:border-[--color-accent] hover:text-[--color-accent]">
+              자동매매 시작 &rarr;
             </a>
           </div>
           <!-- Trust strip -->
@@ -125,7 +125,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       <a href="/ko/simulate" class="btn btn-primary btn-md">시뮬레이터 열기 — 무료 &rarr;</a>
     </div>
     <!-- 페르소나별 진입점 -->
-    <div class="mt-12 grid sm:grid-cols-3 gap-5 max-w-3xl mx-auto">
+    <div class="mt-12 grid sm:grid-cols-2 lg:grid-cols-4 gap-5 max-w-4xl mx-auto">
       <a href="/ko/learn" class="card-premium card-hover p-6 text-center group">
         <p class="text-sm text-[--color-text-muted] mb-2 font-mono">처음이신가요?</p>
         <p class="text-base font-semibold group-hover:text-[--color-accent] transition-colors">학습 시작 →</p>
@@ -138,6 +138,28 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
         <p class="text-sm text-[--color-text-muted] mb-2 font-mono">둘러보는 중?</p>
         <p class="text-base font-semibold group-hover:text-[--color-accent] transition-colors">전략 탐색 →</p>
       </a>
+      <a href="/ko/autotrading" class="card-premium card-hover p-6 text-center group border border-[--color-accent]/20">
+        <p class="text-sm text-[--color-accent] mb-2 font-mono">자동화 준비됐나요?</p>
+        <p class="text-base font-semibold group-hover:text-[--color-accent] transition-colors">자동매매 시작 →</p>
+      </a>
+    </div>
+  </section>
+
+  <!-- HOW AUTOTRADING WORKS -->
+  <hr class="section-divider" />
+  <section class="max-w-7xl mx-auto px-6 py-24 md:py-32 section-elevated" aria-labelledby="autotrading-ko-heading">
+    <p class="font-mono text-[--color-accent] text-sm tracking-wider text-center mb-4">자동매매</p>
+    <h2 id="autotrading-ko-heading" class="text-3xl md:text-4xl lg:text-5xl font-extrabold text-center mb-5">검증된 전략에서 실행 봇까지</h2>
+    <p class="text-[--color-text-secondary] text-center text-xl mb-14 max-w-xl mx-auto">백테스트 완료. 검증됨. OKX에서 24시간 실행.</p>
+    <div class="relative grid md:grid-cols-3 gap-8">
+      <div class="hidden md:block absolute top-[2.75rem] left-[calc(33.33%+1rem)] right-[calc(33.33%+1rem)] h-px bg-gradient-to-r from-[--color-accent]/30 via-[--color-accent]/15 to-[--color-accent]/30 reveal" aria-hidden="true"></div>
+      <StepCard step={1} title="OKX 연결" description="OAuth만 사용 — API 키 공유 없음, 출금 권한 없음. 보안 설계." />
+      <StepCard step={2} title="검증된 전략 선택" description="570개 이상 코인에서 엄격한 백테스트를 통과한 전략만 배포 가능합니다." />
+      <StepCard step={3} title="봇이 24시간 실행" description="5분마다 시그널 스캔. 설정한 리스크 한도 내에서 자동 실행됩니다." />
+    </div>
+    <div class="text-center mt-14">
+      <a href="/ko/autotrading" class="btn btn-primary btn-lg">자동매매 시작 — 무료 →</a>
+      <p class="text-xs text-[--color-text-muted] mt-3">시뮬레이션 성과는 실제 거래 수익을 보장하지 않습니다.</p>
     </div>
   </section>
 

--- a/src/pages/ko/strategies/[id].astro
+++ b/src/pages/ko/strategies/[id].astro
@@ -193,7 +193,7 @@ const statusLabels: Record<string, string> = {
       )}
 
       {demo && strategy.data.status === 'verified' && (
-        <div class="mt-6">
+        <div class="mt-6 space-y-3">
           <OKXExecuteButton
             client:visible
             strategy={strategy.id}
@@ -203,6 +203,14 @@ const statusLabels: Record<string, string> = {
             tpPct={demo.tp}
             lang="ko"
           />
+          <a href="/ko/dashboard"
+             class="flex items-center justify-center gap-2 w-full px-5 py-3 rounded-lg border border-[--color-accent]/30 text-[--color-accent] hover:border-[--color-accent] hover:bg-[--color-accent]/5 transition-all text-sm font-semibold">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z"/>
+            </svg>
+            자동매매 봇으로 실행 — 24시간 자동 →
+          </a>
+          <p class="text-xs text-[--color-text-muted] text-center">OKX 1회 연결 · 5분마다 시그널 스캔 · API 키 불필요</p>
         </div>
       )}
 

--- a/src/pages/strategies/[id].astro
+++ b/src/pages/strategies/[id].astro
@@ -173,7 +173,7 @@ const statusLabels: Record<string, string> = {
       )}
 
       {demo && strategy.data.status === 'verified' && (
-        <div class="mt-6">
+        <div class="mt-6 space-y-3">
           <OKXExecuteButton
             client:visible
             strategy={strategy.id}
@@ -183,6 +183,14 @@ const statusLabels: Record<string, string> = {
             tpPct={demo.tp}
             lang="en"
           />
+          <a href="/dashboard"
+             class="flex items-center justify-center gap-2 w-full px-5 py-3 rounded-lg border border-[--color-accent]/30 text-[--color-accent] hover:border-[--color-accent] hover:bg-[--color-accent]/5 transition-all text-sm font-semibold">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z"/>
+            </svg>
+            Deploy as Bot — Run 24/7 →
+          </a>
+          <p class="text-xs text-[--color-text-muted] text-center">Connect OKX once · bot scans signals every 5 min · no API keys needed</p>
         </div>
       )}
 


### PR DESCRIPTION
## Summary

### Nav 재구성 (PR #973 통합 처리)
- Dashboard 제거 (→ /autotrading 진입 후 /dashboard 접근)
- 순서 변경: `Simulate | Strategies | Signals | Autotrading(NEW) | Market | Coins | Learn | Fees | About`
- 10개 → 9개로 모바일 오버플로우 해소

### Strategy 상세 페이지 — Deploy 버튼
- verified 전략에만 "Deploy as Bot — Run 24/7 →" 버튼 추가
- EN: `/dashboard`, KO: `/ko/dashboard` 연결
- OKXExecuteButton 아래 배치 (단일 실행 → 봇 배포 업셀 플로우)

### 홈페이지 리디자인
- Hero 2번째 CTA: `Explore Strategies` → `Deploy a Bot →` (→ /autotrading)
- 페르소나 카드: 3열 → 4열 (`Ready to automate? Deploy a Bot →` 추가)
- 신규 섹션 `HOW AUTOTRADING WORKS`: Connect OKX → Pick Strategy → Bot Trades 24/7
- KO 미러: 자동매매 3단계 + 법적 고지

## 검증
- build: 2522 pages ✅
- qa-redirects: PASS ✅
- `/strategies/bb-squeeze-short` → Deploy 버튼 표시 ✅
- `/autotrading`, `/ko/autotrading` 페이지 정상 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)