### PR TITLE
fix: autotrading hero spacing + dashboard API key label

### DIFF
--- a/src/pages/autotrading/index.astro
+++ b/src/pages/autotrading/index.astro
@@ -10,7 +10,7 @@ import Layout from '../../layouts/Layout.astro';
   <!-- HERO -->
   <section class="relative overflow-hidden hero-bg-depth section-glow-green">
     <div class="absolute left-1/2 top-1/3 -translate-x-1/2 -translate-y-1/2 w-[700px] h-[400px] rounded-full bg-[--color-accent]/[0.05] blur-[140px] pointer-events-none" aria-hidden="true"></div>
-    <div class="relative max-w-4xl mx-auto px-6 pt-24 pb-28 md:pt-36 md:pb-44 text-center hero-enter">
+    <div class="relative max-w-4xl mx-auto px-6 pt-16 pb-20 md:pt-24 md:pb-32 text-center hero-enter">
       <!-- Partner badge -->
       <div class="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-[--color-accent]/30 bg-[--color-accent]/8 mb-8">
         <span class="inline-block w-2 h-2 rounded-full bg-[--color-up] animate-pulse" aria-hidden="true"></span>

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -42,8 +42,8 @@ import LiveTradeHistory from '../components/LiveTradeHistory';
             <p class="text-xl font-bold">Auto</p>
           </div>
           <div class="bg-[--color-bg]/50 rounded-xl p-3 text-center">
-            <p class="text-xs text-[--color-text-muted] mb-1">API Keys</p>
-            <p class="text-xl font-bold text-[--color-up]">None</p>
+            <p class="text-xs text-[--color-text-muted] mb-1">API Key Sharing</p>
+            <p class="text-xl font-bold text-[--color-up]">Not required</p>
           </div>
         </div>
       </div>

--- a/src/pages/ko/autotrading/index.astro
+++ b/src/pages/ko/autotrading/index.astro
@@ -10,7 +10,7 @@ import Layout from '../../../layouts/Layout.astro';
   <!-- HERO -->
   <section class="relative overflow-hidden hero-bg-depth section-glow-green">
     <div class="absolute left-1/2 top-1/3 -translate-x-1/2 -translate-y-1/2 w-[700px] h-[400px] rounded-full bg-[--color-accent]/[0.05] blur-[140px] pointer-events-none" aria-hidden="true"></div>
-    <div class="relative max-w-4xl mx-auto px-6 pt-24 pb-28 md:pt-36 md:pb-44 text-center hero-enter">
+    <div class="relative max-w-4xl mx-auto px-6 pt-16 pb-20 md:pt-24 md:pb-32 text-center hero-enter">
       <!-- Partner badge -->
       <div class="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-[--color-accent]/30 bg-[--color-accent]/8 mb-8">
         <span class="inline-block w-2 h-2 rounded-full bg-[--color-up] animate-pulse" aria-hidden="true"></span>


### PR DESCRIPTION
## Summary
- Autotrading hero (EN + KO): reduce `md:pt-36` (144px) → `md:pt-24` (96px) — hero content was starting too far from the top
- Dashboard EN: "API Keys: None" → "API Key Sharing: Not required" — clarifies our key selling point (no API key sharing via OAuth)

## Test plan
- [x] `npm run build` — 2522 pages, 0 errors
- [x] /autotrading hero content starts higher on page
- [x] /dashboard OKX card shows "Not required" under "API Key Sharing"

🤖 Generated with [Claude Code](https://claude.com/claude-code)