### PR TITLE
fix: timeline dot overlap, about section seam, fees dual CTA

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -320,7 +320,7 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
 
     <!-- Contact + CTA -->
     <section class="reveal mb-8">
-      <div class="text-center py-8 border-t border-[--color-border]">
+      <div class="text-center py-8">
         <p class="font-mono text-[--color-accent] text-xs tracking-wider mb-2">{t('about.contact_tag')}</p>
         <p class="text-[--color-text-muted] text-sm mb-6">{t('about.contact_desc')}</p>
         <div class="flex flex-col sm:flex-row gap-3 justify-center">
@@ -334,10 +334,10 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
     <hr class="section-divider" />
 
     <!-- Explore CTAs -->
-    <section class="reveal pb-8">
+    <section class="reveal pb-8 pt-8">
       <div class="text-center">
-        <p class="text-[--color-text-muted] text-sm mb-4">{t('about.explore_desc')}</p>
-        <div class="flex flex-wrap gap-3 justify-center">
+        <p class="text-[--color-text-muted] text-sm mb-6">{t('about.explore_desc')}</p>
+        <div class="flex flex-wrap gap-4 justify-center">
           <a href="/simulate" class="btn btn-primary btn-md">
             {t('cross.simulate_cta')} &rarr;
           </a>

--- a/src/pages/fees.astro
+++ b/src/pages/fees.astro
@@ -460,9 +460,12 @@ const t = useTranslations('en');
     </div>
   </section>
 
-  <div class="text-center mt-8">
-    <a href="/simulate" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
+  <div class="text-center mt-8 pb-4 flex flex-wrap gap-4 justify-center">
+    <a href="/simulate" class="btn btn-primary btn-md no-underline">
       {t('cross.simulate_cta')} &rarr;
+    </a>
+    <a href="/strategies" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
+      {t('cross.strategies_cta')} &rarr;
     </a>
   </div>
 

--- a/src/pages/ko/about.astro
+++ b/src/pages/ko/about.astro
@@ -290,7 +290,7 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
 
     <!-- Contact + CTA -->
     <section class="reveal mb-8">
-      <div class="text-center py-8 border-t border-[--color-border]">
+      <div class="text-center py-8">
         <p class="font-mono text-[--color-accent] text-xs tracking-wider mb-2">{t('about.contact_tag')}</p>
         <p class="text-[--color-text-muted] text-sm mb-6">{t('about.contact_desc')}</p>
         <div class="flex flex-col sm:flex-row gap-3 justify-center">
@@ -304,10 +304,10 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
     <hr class="section-divider" />
 
     <!-- Explore CTAs -->
-    <section class="reveal pb-8">
+    <section class="reveal pb-8 pt-8">
       <div class="text-center">
-        <p class="text-[--color-text-muted] text-sm mb-4">{t('about.explore_desc')}</p>
-        <div class="flex flex-wrap gap-3 justify-center">
+        <p class="text-[--color-text-muted] text-sm mb-6">{t('about.explore_desc')}</p>
+        <div class="flex flex-wrap gap-4 justify-center">
           <a href="/ko/simulate" class="btn btn-primary btn-md">
             {t('cross.simulate_cta')} &rarr;
           </a>

--- a/src/pages/ko/fees.astro
+++ b/src/pages/ko/fees.astro
@@ -444,9 +444,12 @@ const t = useTranslations('ko');
     </div>
   </section>
 
-  <div class="text-center mt-8">
-    <a href="/ko/simulate" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
+  <div class="text-center mt-8 pb-4 flex flex-wrap gap-4 justify-center">
+    <a href="/ko/simulate" class="btn btn-primary btn-md no-underline">
       {t('cross.simulate_cta')} &rarr;
+    </a>
+    <a href="/ko/strategies" class="btn btn-ghost btn-md hover:border-[--color-accent] transition-colors no-underline">
+      {t('cross.strategies_cta')} &rarr;
     </a>
   </div>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -358,7 +358,7 @@
 }
 .timeline-dot {
   position: absolute;
-  left: calc(0.5rem - 4px);
+  left: calc(-1.5rem - 4.5px);
   top: 0.25rem;
   width: 9px;
   height: 9px;


### PR DESCRIPTION
## Summary
- **Timeline dots**: fixed `.timeline-dot` left position (`calc(0.5rem - 4px)` → `calc(-1.5rem - 4.5px)`) — dots were rendering on top of the first text character instead of in the left margin next to the vertical line
- **About section seam**: removed redundant `border-t` from Contact section inner div (the `<hr>` above already provides the divider, causing a double-line seam)
- **About CTA spacing**: added `pt-8` to Explore CTAs section, increased `gap-3` → `gap-4` between buttons
- **Fees bottom CTA**: added "View All Strategies →" button alongside "Open Simulator →" (both EN and KO), styled as primary/ghost pair

## Test plan
- [ ] `/about` roadmap: dots visible in left margin, no overlap with text
- [ ] `/about` Contact → Explore CTA transition: single divider line, no double-border seam
- [ ] `/about` bottom: two CTA buttons with proper gap
- [ ] `/fees` + `/ko/fees` bottom: two CTA buttons (Open Simulator + View All Strategies)

Build: 2522 pages, qa-redirects: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)