### PR TITLE
fix: mobile nav lang button to top + section-divider consistent margin

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -460,11 +460,16 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
           </button>
         </div>
       </div>
-      <div id="mobile-menu" class="hidden md:hidden border-t border-[--color-border] bg-[--color-bg] backdrop-blur-sm" aria-hidden="true">
-        <div class="flex flex-col px-4 py-4 gap-1 text-sm">
+      <div id="mobile-menu" class="hidden md:hidden border-t border-[--color-border] bg-[--color-bg] backdrop-blur-sm overflow-y-auto" style="max-height:calc(100dvh - 3.5rem)" aria-hidden="true">
+        <div class="flex flex-col px-4 py-3 gap-1 text-sm">
+          <!-- Language switch — top of mobile menu for discoverability -->
+          <div class="flex items-center justify-between pb-3 mb-1 border-b border-[--color-border]">
+            <span class="text-xs text-[--color-text-muted] font-mono uppercase tracking-wider">Language</span>
+            <a href={altPath} hreflang={altHreflang} class="font-mono text-sm px-4 py-2 border border-[--color-accent]/40 rounded-lg text-[--color-accent] bg-[--color-accent]/5 min-h-[40px] flex items-center font-semibold hover:bg-[--color-accent]/10 transition-colors" aria-label={lang === 'ko' ? 'Switch to English' : '한국어로 전환'}>{t('nav.lang')}</a>
+          </div>
           {navItems.map(item => (
             <Fragment>
-              <a href={item.href} aria-current={isActive(item.match) ? "page" : undefined} class="min-h-[48px] flex items-center px-3 rounded-lg text-[15px] font-medium transition-colors hover:bg-[--color-bg-hover]" style={isActive(item.match) ? 'color:var(--color-accent);font-weight:500' : 'color:var(--color-text-muted)'}>{item.label}</a>
+              <a href={item.href} aria-current={isActive(item.match) ? "page" : undefined} class="min-h-[48px] flex items-center px-3 rounded-lg text-[15px] font-medium transition-colors hover:bg-[--color-bg-hover]" style={isActive(item.match) ? 'color:var(--color-accent);font-weight:500' : 'color:var(--color-text-muted)'}>{item.label}{item.badge && <span class="ml-1.5 text-[9px] font-bold px-1 py-0.5 rounded bg-[--color-accent] text-white leading-none tracking-wide">{item.badge}</span>}</a>
               {item.match === '/strategies' && (
                 <div class="flex flex-col ml-3 mb-1 rounded-lg bg-[--color-bg-surface] overflow-hidden">
                   <a href={rankingPath} aria-current={isActive('/strategies/ranking') ? "page" : undefined} class="min-h-[44px] flex items-center gap-2.5 px-4 text-sm transition-colors hover:bg-[--color-bg-hover]" style={isActive('/strategies/ranking') ? 'color:var(--color-accent);font-weight:500' : 'color:var(--color-text-secondary)'}>
@@ -479,9 +484,6 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
               )}
             </Fragment>
           ))}
-          <div class="border-t border-[--color-border] mt-2 pt-2">
-            <a href={altPath} hreflang={altHreflang} class="font-mono text-xs px-3 py-2 border border-[--color-border] rounded-lg text-[--color-text-muted] w-fit min-h-[44px] flex items-center hover:border-[--color-accent] hover:text-[--color-accent] transition-colors" aria-label={lang === 'ko' ? 'Switch to English' : '한국어로 전환'}>{t('nav.lang')}</a>
-          </div>
         </div>
       </div>
     </nav>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -319,7 +319,7 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
     <hr class="section-divider" />
 
     <!-- Contact + CTA -->
-    <section class="reveal mb-8">
+    <section class="reveal mb-12">
       <div class="text-center py-8">
         <p class="font-mono text-[--color-accent] text-xs tracking-wider mb-2">{t('about.contact_tag')}</p>
         <p class="text-[--color-text-muted] text-sm mb-6">{t('about.contact_desc')}</p>

--- a/src/pages/ko/about.astro
+++ b/src/pages/ko/about.astro
@@ -289,7 +289,7 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
     <hr class="section-divider" />
 
     <!-- Contact + CTA -->
-    <section class="reveal mb-8">
+    <section class="reveal mb-12">
       <div class="text-center py-8">
         <p class="font-mono text-[--color-accent] text-xs tracking-wider mb-2">{t('about.contact_tag')}</p>
         <p class="text-[--color-text-muted] text-sm mb-6">{t('about.contact_desc')}</p>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1197,7 +1197,7 @@ textarea:focus-visible {
   height: 1px;
   background: linear-gradient(90deg, transparent 5%, rgba(44,181,232,0.3) 30%, rgba(44,181,232,0.5) 50%, rgba(44,181,232,0.3) 70%, transparent 95%);
   border: none;
-  margin: 0;
+  margin: 2rem 0;
   position: relative;
 }
 .section-divider::after {


### PR DESCRIPTION
## Summary
- **모바일 언어 전환**: EN/KO 버튼을 모바일 메뉴 맨 위로 이동 (기존: 8개 nav 아이템 아래에 숨겨져 있어서 발견 불가). 액센트 색상으로 눈에 잘 띄게 스타일링
- **모바일 메뉴 스크롤**: `overflow-y-auto` + `max-height: calc(100dvh - 3.5rem)` 추가 — 작은 화면에서도 메뉴 전체 접근 가능
- **section-divider 마진 통일**: `margin: 0` → `margin: 2rem 0` — 모든 페이지에서 섹션 구분선 위아래 일관된 여백
- **about 페이지 spacing 통일**: Contact 섹션 `mb-8` → `mb-12` (EN + KO)

## Test plan
- [ ] 모바일에서 햄버거 클릭 → 상단에 EN/KO 버튼 즉시 노출
- [ ] EN 페이지에서 KO 전환, KO에서 EN 전환 동작 확인
- [ ] `/about` 각 섹션 구분선 위아래 일관된 간격 확인
- [ ] 작은 화면(375px)에서 모바일 메뉴 스크롤 가능 확인

Build: 2522 pages, qa-redirects: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)