### PR TITLE
fix: unify section borders + globe lang icon + mobile menu overlay

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -14,7 +14,7 @@ export const en = {
   "nav.blog": "Blog",
   "nav.performance": "Performance",
   "nav.ranking": "Daily Strategy Ranking",
-  "nav.lang": "한국어 / KO",
+  "nav.lang": "KO",
 
   // Hero
   "hero.tag": "FREE BACKTESTING TOOL",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -15,7 +15,7 @@ export const ko: Record<TranslationKey, string> = {
   "nav.blog": "블로그",
   "nav.performance": "성과",
   "nav.ranking": "오늘의 전략 랭킹",
-  "nav.lang": "English",
+  "nav.lang": "EN",
 
   // Hero
   "hero.tag": "무료 백테스트 도구",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -452,41 +452,81 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
             <a href={item.href} aria-current={isActive(item.match) ? "page" : undefined} class="transition-colors nav-slide-underline flex items-center gap-1.5" style={isActive(item.match) ? 'color:var(--color-accent);font-weight:500' : 'color:var(--color-text-muted)'}>{item.label}{item.badge && <span class="text-[9px] font-bold px-1 py-0.5 rounded bg-[--color-accent] text-white leading-none tracking-wide">{item.badge}</span>}</a>
           ))}
         </div>
-        <!-- 3열: Lang + Mobile hamburger (우측) -->
-        <div class="flex items-center justify-end gap-3">
-          <a href={altPath} hreflang={altHreflang} class="hidden md:inline-flex font-mono text-sm px-4 py-2 border border-[--color-border] rounded-lg hover:border-[--color-accent] hover:text-[--color-accent] hover:bg-[--color-accent]/5 text-[--color-text-muted] transition-colors" aria-label={lang === 'ko' ? 'Switch to English' : '한국어로 전환'}>{t('nav.lang')}</a>
-          <button id="mobile-menu-btn" class="md:hidden text-[--color-text-muted]" aria-label="Toggle menu" aria-expanded="false" aria-controls="mobile-menu">
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 12h18M3 6h18M3 18h18"/></svg>
+        <!-- 3열: Lang (지구본) + Mobile hamburger (우측) -->
+        <div class="flex items-center justify-end gap-2">
+          <!-- 데스크톱: 지구본 아이콘 + 언어코드 -->
+          <a href={altPath} hreflang={altHreflang}
+             class="hidden md:inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-[--color-border] hover:border-[--color-accent] hover:text-[--color-accent] hover:bg-[--color-accent]/5 text-[--color-text-muted] transition-colors"
+             aria-label={lang === 'ko' ? 'Switch to English' : '한국어로 전환'}>
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <circle cx="12" cy="12" r="10"/>
+              <path d="M2 12h20M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/>
+            </svg>
+            <span class="font-mono text-xs font-semibold">{t('nav.lang')}</span>
+          </a>
+          <!-- 모바일: 햄버거 -->
+          <button id="mobile-menu-btn" class="md:hidden flex items-center justify-center w-10 h-10 rounded-lg text-[--color-text-muted] hover:bg-[--color-bg-hover] transition-colors" aria-label="Toggle menu" aria-expanded="false" aria-controls="mobile-menu">
+            <svg id="menu-icon-open" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 12h18M3 6h18M3 18h18"/></svg>
+            <svg id="menu-icon-close" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="hidden" aria-hidden="true"><path d="M18 6L6 18M6 6l12 12"/></svg>
           </button>
         </div>
       </div>
-      <div id="mobile-menu" class="hidden md:hidden border-t border-[--color-border] bg-[--color-bg] backdrop-blur-sm overflow-y-auto" style="max-height:calc(100dvh - 3.5rem)" aria-hidden="true">
-        <div class="flex flex-col px-4 py-3 gap-1 text-sm">
-          <!-- Language switch — top of mobile menu for discoverability -->
-          <div class="flex items-center justify-between pb-3 mb-1 border-b border-[--color-border]">
-            <span class="text-xs text-[--color-text-muted] font-mono uppercase tracking-wider">Language</span>
-            <a href={altPath} hreflang={altHreflang} class="font-mono text-sm px-4 py-2 border border-[--color-accent]/40 rounded-lg text-[--color-accent] bg-[--color-accent]/5 min-h-[40px] flex items-center font-semibold hover:bg-[--color-accent]/10 transition-colors" aria-label={lang === 'ko' ? 'Switch to English' : '한국어로 전환'}>{t('nav.lang')}</a>
-          </div>
-          {navItems.map(item => (
-            <Fragment>
-              <a href={item.href} aria-current={isActive(item.match) ? "page" : undefined} class="min-h-[48px] flex items-center px-3 rounded-lg text-[15px] font-medium transition-colors hover:bg-[--color-bg-hover]" style={isActive(item.match) ? 'color:var(--color-accent);font-weight:500' : 'color:var(--color-text-muted)'}>{item.label}{item.badge && <span class="ml-1.5 text-[9px] font-bold px-1 py-0.5 rounded bg-[--color-accent] text-white leading-none tracking-wide">{item.badge}</span>}</a>
-              {item.match === '/strategies' && (
-                <div class="flex flex-col ml-3 mb-1 rounded-lg bg-[--color-bg-surface] overflow-hidden">
-                  <a href={rankingPath} aria-current={isActive('/strategies/ranking') ? "page" : undefined} class="min-h-[44px] flex items-center gap-2.5 px-4 text-sm transition-colors hover:bg-[--color-bg-hover]" style={isActive('/strategies/ranking') ? 'color:var(--color-accent);font-weight:500' : 'color:var(--color-text-secondary)'}>
-                    <span class="text-[--color-text-muted] text-xs shrink-0">›</span>
-                    {t('nav.ranking')}
-                  </a>
-                  <a href={leaderboardPath} aria-current={isActive('/leaderboard') ? "page" : undefined} class="min-h-[44px] flex items-center gap-2.5 px-4 text-sm transition-colors hover:bg-[--color-bg-hover]" style={isActive('/leaderboard') ? 'color:var(--color-accent);font-weight:500' : 'color:var(--color-text-secondary)'}>
-                    <span class="text-[--color-text-muted] text-xs shrink-0">›</span>
-                    {t('nav.leaderboard')}
-                  </a>
-                </div>
-              )}
-            </Fragment>
-          ))}
-        </div>
-      </div>
     </nav>
+
+    <!-- 모바일 backdrop (fixed overlay) -->
+    <div id="mobile-backdrop" class="fixed inset-0 z-40 bg-black/50 backdrop-blur-[2px] hidden md:hidden" aria-hidden="true"></div>
+
+    <!-- 모바일 메뉴 (fixed drawer, nav 바 아래부터 풀 높이) -->
+    <div id="mobile-menu" class="fixed left-0 right-0 bottom-0 z-50 bg-[--color-bg] overflow-y-auto hidden md:hidden" style="top:3.5rem; border-top: 1px solid var(--color-border);" aria-hidden="true">
+      <div class="flex flex-col px-4 py-4 gap-1 text-sm">
+
+        <!-- 언어 전환 — 맨 위 고정 -->
+        <a href={altPath} hreflang={altHreflang}
+           class="flex items-center gap-2.5 px-3 py-3 mb-2 rounded-xl border border-[--color-accent]/30 bg-[--color-accent]/5 text-[--color-accent] font-semibold hover:bg-[--color-accent]/10 transition-colors min-h-[48px]"
+           aria-label={lang === 'ko' ? 'Switch to English' : '한국어로 전환'}>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="10"/>
+            <path d="M2 12h20M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/>
+          </svg>
+          <span class="font-mono text-sm">{lang === 'ko' ? 'English' : '한국어'}</span>
+          <span class="ml-auto font-mono text-xs opacity-60">{t('nav.lang')}</span>
+        </a>
+
+        <div class="h-px bg-[--color-border] mb-2"></div>
+
+        <!-- 네비게이션 아이템 -->
+        {navItems.map(item => (
+          <Fragment>
+            <a href={item.href} aria-current={isActive(item.match) ? "page" : undefined}
+               class="min-h-[48px] flex items-center px-3 rounded-lg text-[15px] font-medium transition-colors hover:bg-[--color-bg-hover]"
+               style={isActive(item.match) ? 'color:var(--color-accent);font-weight:500' : 'color:var(--color-text-muted)'}>
+              {item.label}
+              {item.badge && <span class="ml-1.5 text-[9px] font-bold px-1 py-0.5 rounded bg-[--color-accent] text-white leading-none tracking-wide">{item.badge}</span>}
+            </a>
+            {item.match === '/strategies' && (
+              <div class="flex flex-col ml-3 mb-1 rounded-lg bg-[--color-bg-surface] overflow-hidden">
+                <a href={rankingPath} aria-current={isActive('/strategies/ranking') ? "page" : undefined}
+                   class="min-h-[44px] flex items-center gap-2.5 px-4 text-sm transition-colors hover:bg-[--color-bg-hover]"
+                   style={isActive('/strategies/ranking') ? 'color:var(--color-accent);font-weight:500' : 'color:var(--color-text-secondary)'}>
+                  <span class="text-[--color-text-muted] text-xs shrink-0">›</span>
+                  {t('nav.ranking')}
+                </a>
+                <a href={leaderboardPath} aria-current={isActive('/leaderboard') ? "page" : undefined}
+                   class="min-h-[44px] flex items-center gap-2.5 px-4 text-sm transition-colors hover:bg-[--color-bg-hover]"
+                   style={isActive('/leaderboard') ? 'color:var(--color-accent);font-weight:500' : 'color:var(--color-text-secondary)'}>
+                  <span class="text-[--color-text-muted] text-xs shrink-0">›</span>
+                  {t('nav.leaderboard')}
+                </a>
+              </div>
+            )}
+          </Fragment>
+        ))}
+
+        <!-- 하단 여백 (safe area) -->
+        <div class="h-6"></div>
+      </div>
+    </div>
+
     </header>
 
     <CommandPalette lang={lang} client:idle />

--- a/src/pages/api.astro
+++ b/src/pages/api.astro
@@ -25,7 +25,7 @@ const API_BASE = 'https://api.pruviq.com';
   <hr class="section-divider" />
 
   <!-- OVERVIEW -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-12">
+  <section class="reveal pb-12 pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <div class="reveal grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
         <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card]">
@@ -75,7 +75,7 @@ const API_BASE = 'https://api.pruviq.com';
   </nav>
 
   <!-- ENDPOINTS: MARKET DATA -->
-  <section id="market-data" class="reveal pb-12 border-t border-[--color-border] pt-12">
+  <section id="market-data" class="reveal pb-12 pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-6">{t('api.section_market')}</h2>
       <div class="space-y-4 max-w-4xl">
@@ -176,7 +176,7 @@ const API_BASE = 'https://api.pruviq.com';
   <hr class="section-divider" />
 
   <!-- ENDPOINTS: DATA -->
-  <section id="data-retrieval" class="reveal pb-12 border-t border-[--color-border] pt-12">
+  <section id="data-retrieval" class="reveal pb-12 pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-6">{t('api.section_data')}</h2>
       <div class="space-y-4 max-w-4xl">
@@ -330,7 +330,7 @@ const API_BASE = 'https://api.pruviq.com';
   <hr class="section-divider" />
 
   <!-- ENDPOINTS: RANKINGS & SIGNALS -->
-  <section id="signals" class="reveal pb-12 border-t border-[--color-border] pt-12">
+  <section id="signals" class="reveal pb-12 pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-6">{t('api.section_signals')}</h2>
       <div class="space-y-4 max-w-4xl">
@@ -445,7 +445,7 @@ const API_BASE = 'https://api.pruviq.com';
   <hr class="section-divider" />
 
   <!-- ENDPOINTS: SIMULATION -->
-  <section id="simulation" class="reveal pb-12 border-t border-[--color-border] pt-12">
+  <section id="simulation" class="reveal pb-12 pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-6">{t('api.section_simulation')}</h2>
       <div class="space-y-4 max-w-4xl">
@@ -599,7 +599,7 @@ const API_BASE = 'https://api.pruviq.com';
   <hr class="section-divider" />
 
   <!-- ENDPOINTS: STRATEGY BUILDER -->
-  <section id="builder" class="reveal pb-12 border-t border-[--color-border] pt-12">
+  <section id="builder" class="reveal pb-12 pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-6">{t('api.section_builder')}</h2>
       <div class="space-y-4 max-w-4xl">
@@ -739,7 +739,7 @@ const API_BASE = 'https://api.pruviq.com';
   <hr class="section-divider" />
 
   <!-- QUICK START -->
-  <section id="quickstart" class="reveal pb-12 border-t border-[--color-border] pt-12">
+  <section id="quickstart" class="reveal pb-12 pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-2">{t('api.quickstart')}</h2>
       <p class="text-[--color-text-muted] text-sm mb-6">{t('api.quickstart_desc')}</p>
@@ -827,7 +827,7 @@ console.log(\`Trades: \${sim.total_trades}, WR: \${sim.win_rate}%\`);`}</code></
   <hr class="section-divider" />
 
   <!-- SDK / COMING SOON -->
-  <section class="reveal pb-16 border-t border-[--color-border] pt-12">
+  <section class="reveal pb-16 pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] max-w-3xl">
         <h3 class="text-xl font-bold mb-2">{t('api.sdk_title')}</h3>

--- a/src/pages/fees.astro
+++ b/src/pages/fees.astro
@@ -74,7 +74,7 @@ const t = useTranslations('en');
   <hr class="section-divider" />
 
   <!-- INTERACTIVE FEE CALCULATOR -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-12 section-elevated">
+  <section class="reveal pb-12 pt-12 section-elevated">
     <div class="max-w-5xl mx-auto px-4">
       <div class="shadow-[var(--shadow-lg)] rounded-2xl bg-[--color-bg-card] p-6 md:p-8">
         <FeeCalculator client:visible lang="en" />
@@ -83,14 +83,14 @@ const t = useTranslations('en');
       <p class="text-[--color-text-muted] text-xs mt-6">
         {t('fees.disclosure')}
       </p>
-      <a href="/simulate" class="btn btn-primary btn-md w-full sm:w-auto mt-4">{t('fees.ctaSimulate')} &rarr;</a>
+      <a href="/simulate" class="btn btn-primary btn-md w-full sm:w-auto mt-8">{t('fees.ctaSimulate')} &rarr;</a>
     </div>
   </section>
 
   <hr class="section-divider" />
 
   <!-- EXCHANGE COMPARISON CARDS -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-12 section-accent-glow">
+  <section class="reveal pb-12 pt-12 section-accent-glow">
     <div class="max-w-5xl mx-auto px-4">
       <h2 id="compare" class="text-2xl font-bold mb-2">{t('fees.compare_title')}</h2>
       <p class="text-[--color-text-muted] text-sm mb-8">{t('fees.compare_desc')}</p>
@@ -211,7 +211,7 @@ const t = useTranslations('en');
   <hr class="section-divider" />
 
   <!-- BLOCK 1: PROBLEM HOOK -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-12 section-elevated">
+  <section class="reveal pb-12 pt-12 section-elevated">
     <div class="max-w-5xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('fees.trust_tag')}</p>
       <h2 id="savings" class="text-2xl font-bold mb-2">{t('fees.referral.problem.headline')}</h2>
@@ -228,7 +228,7 @@ const t = useTranslations('en');
   <hr class="section-divider" />
 
   <!-- BLOCK 2: EDUCATION / COMPARISON TABLE -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-12 section-accent-glow">
+  <section class="reveal pb-12 pt-12 section-accent-glow">
     <div class="max-w-5xl mx-auto px-4">
       <h2 id="how" class="text-2xl font-bold mb-2">{t('fees.referral.how.headline')}</h2>
       <p class="text-[--color-text-muted] text-sm mb-6 max-w-3xl">{t('fees.referral.how.body')}</p>
@@ -283,7 +283,7 @@ const t = useTranslations('en');
   <hr class="section-divider" />
 
   <!-- BLOCK 3: SCREENSHOT PROOF -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-12 section-elevated">
+  <section class="reveal pb-12 pt-12 section-elevated">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-2">{t('fees.referral.proof.headline')}</h2>
       <p class="text-[--color-text-muted] text-sm mb-6">{t('fees.referral.proof.subheading')}</p>
@@ -311,7 +311,7 @@ const t = useTranslations('en');
   <hr class="section-divider" />
 
   <!-- BLOCK 4: HOW TO VERIFY -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-12 section-accent-glow">
+  <section class="reveal pb-12 pt-12 section-accent-glow">
     <div class="max-w-5xl mx-auto px-4">
       <h2 id="verify" class="text-2xl font-bold mb-2">{t('fees.referral.verify.headline')}</h2>
       <p class="text-[--color-text-muted] text-sm mb-6 max-w-3xl">{t('fees.referral.verify.body')}</p>
@@ -346,7 +346,7 @@ const t = useTranslations('en');
   <hr class="section-divider" />
 
   <!-- BLOCK 5: REFERRAL FAQ -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-12 section-elevated">
+  <section class="reveal pb-12 pt-12 section-elevated">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-6">{t('fees.referral.faq.headline')}</h2>
 
@@ -397,7 +397,7 @@ const t = useTranslations('en');
   <hr class="section-divider" />
 
   <!-- BLOCK 6: FINAL CTA -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-12 section-accent-glow">
+  <section class="reveal pb-12 pt-12 section-accent-glow">
     <div class="max-w-5xl mx-auto px-4 text-center">
       <p class="text-[--color-text-muted] text-sm mb-4">{t('fees.referral.cta.primary')}</p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center mb-6">
@@ -418,7 +418,7 @@ const t = useTranslations('en');
   <hr class="section-divider" />
 
   <!-- EXISTING FAQ (compact) -->
-  <section class="reveal pb-16 border-t border-[--color-border] pt-12 section-elevated">
+  <section class="reveal pb-16 pt-12 section-elevated">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-6">{t('fees.faq_title')}</h2>
 

--- a/src/pages/ko/api.astro
+++ b/src/pages/ko/api.astro
@@ -25,7 +25,7 @@ const API_BASE = 'https://api.pruviq.com';
   <hr class="section-divider" />
 
   <!-- OVERVIEW -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-12">
+  <section class="reveal pb-12 pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <div class="reveal grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
         <div class="border border-[--color-border] rounded-lg p-4 bg-[--color-bg-card]">
@@ -62,7 +62,7 @@ const API_BASE = 'https://api.pruviq.com';
   <hr class="section-divider" />
 
   <!-- ENDPOINTS: MARKET DATA -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-12">
+  <section class="reveal pb-12 pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-6">{t('api.section_market')}</h2>
       <div class="space-y-4 max-w-4xl">
@@ -163,7 +163,7 @@ const API_BASE = 'https://api.pruviq.com';
   <hr class="section-divider" />
 
   <!-- ENDPOINTS: DATA -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-12">
+  <section class="reveal pb-12 pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-6">{t('api.section_data')}</h2>
       <div class="space-y-4 max-w-4xl">
@@ -317,7 +317,7 @@ const API_BASE = 'https://api.pruviq.com';
   <hr class="section-divider" />
 
   <!-- ENDPOINTS: RANKINGS & SIGNALS -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-12">
+  <section class="reveal pb-12 pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-6">{t('api.section_signals')}</h2>
       <div class="space-y-4 max-w-4xl">
@@ -433,7 +433,7 @@ const API_BASE = 'https://api.pruviq.com';
   <hr class="section-divider" />
 
   <!-- ENDPOINTS: SIMULATION -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-12">
+  <section class="reveal pb-12 pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-6">{t('api.section_simulation')}</h2>
       <div class="space-y-4 max-w-4xl">
@@ -587,7 +587,7 @@ const API_BASE = 'https://api.pruviq.com';
   <hr class="section-divider" />
 
   <!-- ENDPOINTS: STRATEGY BUILDER -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-12">
+  <section class="reveal pb-12 pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-6">{t('api.section_builder')}</h2>
       <div class="space-y-4 max-w-4xl">
@@ -727,7 +727,7 @@ const API_BASE = 'https://api.pruviq.com';
   <hr class="section-divider" />
 
   <!-- QUICK START -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-12">
+  <section class="reveal pb-12 pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-2">{t('api.quickstart')}</h2>
       <p class="text-[--color-text-muted] text-sm mb-6">{t('api.quickstart_desc')}</p>
@@ -815,7 +815,7 @@ console.log(\`거래: \${sim.total_trades}, 승률: \${sim.win_rate}%\`);`}</cod
   <hr class="section-divider" />
 
   <!-- SDK / COMING SOON -->
-  <section class="reveal pb-16 border-t border-[--color-border] pt-12">
+  <section class="reveal pb-16 pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <div class="border border-[--color-border] rounded-lg p-6 bg-[--color-bg-card] max-w-3xl">
         <h3 class="text-xl font-bold mb-2">{t('api.sdk_title')}</h3>

--- a/src/pages/ko/fees.astro
+++ b/src/pages/ko/fees.astro
@@ -63,21 +63,21 @@ const t = useTranslations('ko');
   <hr class="section-divider" />
 
   <!-- 인터랙티브 수수료 계산기 -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-12">
+  <section class="reveal pb-12 pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <FeeCalculator client:visible lang="ko" />
       <noscript><p class="text-[--color-text-muted] text-sm py-4">JavaScript를 활성화하면 수수료 계산기를 사용할 수 있습니다.</p></noscript>
       <p class="text-[--color-text-muted] text-xs mt-6">
         {t('fees.disclosure')}
       </p>
-      <a href="/ko/simulate" class="btn btn-primary btn-md w-full sm:w-auto mt-4">{t('fees.ctaSimulate')} &rarr;</a>
+      <a href="/ko/simulate" class="btn btn-primary btn-md w-full sm:w-auto mt-8">{t('fees.ctaSimulate')} &rarr;</a>
     </div>
   </section>
 
   <hr class="section-divider" />
 
   <!-- 거래소 비교 카드 -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-12">
+  <section class="reveal pb-12 pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-2">{t('fees.compare_title')}</h2>
       <p class="text-[--color-text-muted] text-sm mb-8">{t('fees.compare_desc')}</p>
@@ -195,7 +195,7 @@ const t = useTranslations('ko');
   <hr class="section-divider" />
 
   <!-- BLOCK 1: PROBLEM HOOK -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-12">
+  <section class="reveal pb-12 pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('fees.trust_tag')}</p>
       <h2 class="text-2xl font-bold mb-2">{t('fees.referral.problem.headline')}</h2>
@@ -212,7 +212,7 @@ const t = useTranslations('ko');
   <hr class="section-divider" />
 
   <!-- BLOCK 2: EDUCATION / COMPARISON TABLE -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-12">
+  <section class="reveal pb-12 pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-2">{t('fees.referral.how.headline')}</h2>
       <p class="text-[--color-text-muted] text-sm mb-6 max-w-3xl">{t('fees.referral.how.body')}</p>
@@ -267,7 +267,7 @@ const t = useTranslations('ko');
   <hr class="section-divider" />
 
   <!-- BLOCK 3: SCREENSHOT PROOF -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-12">
+  <section class="reveal pb-12 pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-2">{t('fees.referral.proof.headline')}</h2>
       <p class="text-[--color-text-muted] text-sm mb-6">{t('fees.referral.proof.subheading')}</p>
@@ -295,7 +295,7 @@ const t = useTranslations('ko');
   <hr class="section-divider" />
 
   <!-- BLOCK 4: HOW TO VERIFY -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-12">
+  <section class="reveal pb-12 pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-2">{t('fees.referral.verify.headline')}</h2>
       <p class="text-[--color-text-muted] text-sm mb-6 max-w-3xl">{t('fees.referral.verify.body')}</p>
@@ -330,7 +330,7 @@ const t = useTranslations('ko');
   <hr class="section-divider" />
 
   <!-- BLOCK 5: REFERRAL FAQ -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-12">
+  <section class="reveal pb-12 pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-6">{t('fees.referral.faq.headline')}</h2>
 
@@ -381,7 +381,7 @@ const t = useTranslations('ko');
   <hr class="section-divider" />
 
   <!-- BLOCK 6: FINAL CTA -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-12">
+  <section class="reveal pb-12 pt-12">
     <div class="max-w-5xl mx-auto px-4 text-center">
       <p class="text-[--color-text-muted] text-sm mb-4">{t('fees.referral.cta.primary')}</p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center mb-6">
@@ -402,7 +402,7 @@ const t = useTranslations('ko');
   <hr class="section-divider" />
 
   <!-- EXISTING FAQ (compact) -->
-  <section class="reveal pb-16 border-t border-[--color-border] pt-12">
+  <section class="reveal pb-16 pt-12">
     <div class="max-w-5xl mx-auto px-4">
       <h2 class="text-2xl font-bold mb-6">{t('fees.faq_title')}</h2>
 

--- a/src/pages/ko/strategies/[id].astro
+++ b/src/pages/ko/strategies/[id].astro
@@ -218,7 +218,7 @@ const statusLabels: Record<string, string> = {
 
       <hr class="section-divider" />
 
-      <div class="reveal mt-12 border-t border-[--color-border] pt-8 text-center">
+      <div class="reveal mt-4 pt-8 text-center">
         <p class="text-[--color-text-muted] text-sm mb-4">
           {demo ? t('strategies.detail_demo_footer') : t('strategies.detail_nodemo_footer')}
         </p>

--- a/src/pages/ko/strategies/ranking.astro
+++ b/src/pages/ko/strategies/ranking.astro
@@ -220,7 +220,7 @@ if (!ssrRanking) {
   <hr class="section-divider" />
 
   <!-- Footer CTAs -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-8">
+  <section class="reveal pb-12 pt-8">
     <div class="max-w-5xl mx-auto px-4 text-center">
       <p class="text-[--color-text-muted] text-sm mb-4">
         {t('ranking.footer_text')}

--- a/src/pages/strategies/[id].astro
+++ b/src/pages/strategies/[id].astro
@@ -198,7 +198,7 @@ const statusLabels: Record<string, string> = {
 
       <hr class="section-divider" />
 
-      <div class="reveal mt-12 border-t border-[--color-border] pt-8 text-center">
+      <div class="reveal mt-4 pt-8 text-center">
         <p class="text-[--color-text-muted] text-sm mb-4">
           {demo ? t('strategies.detail_demo_footer') : t('strategies.detail_nodemo_footer')}
         </p>

--- a/src/pages/strategies/ranking.astro
+++ b/src/pages/strategies/ranking.astro
@@ -239,7 +239,7 @@ if (!ssrRanking) {
   <hr class="section-divider" />
 
   <!-- Footer CTAs -->
-  <section class="reveal pb-12 border-t border-[--color-border] pt-8">
+  <section class="reveal pb-12 pt-8">
     <div class="max-w-5xl mx-auto px-4 text-center">
       <p class="text-[--color-text-muted] text-sm mb-4">
         {t('ranking.footer_text')}

--- a/src/scripts/layout-client.js
+++ b/src/scripts/layout-client.js
@@ -36,24 +36,44 @@
 
   const menuBtn = document.getElementById("mobile-menu-btn");
   const mobileMenu = document.getElementById("mobile-menu");
+  const mobileBackdrop = document.getElementById("mobile-backdrop");
+  const iconOpen = document.getElementById("menu-icon-open");
+  const iconClose = document.getElementById("menu-icon-close");
+
+  function openMenu() {
+    mobileMenu?.classList.remove("hidden");
+    mobileBackdrop?.classList.remove("hidden");
+    mobileMenu?.setAttribute("aria-hidden", "false");
+    mobileBackdrop?.setAttribute("aria-hidden", "false");
+    menuBtn?.setAttribute("aria-expanded", "true");
+    iconOpen?.classList.add("hidden");
+    iconClose?.classList.remove("hidden");
+    // 배경 스크롤 잠금
+    document.body.style.overflow = "hidden";
+  }
 
   function closeMenu() {
     mobileMenu?.classList.add("hidden");
+    mobileBackdrop?.classList.add("hidden");
     mobileMenu?.setAttribute("aria-hidden", "true");
+    mobileBackdrop?.setAttribute("aria-hidden", "true");
     menuBtn?.setAttribute("aria-expanded", "false");
+    iconOpen?.classList.remove("hidden");
+    iconClose?.classList.add("hidden");
+    // 배경 스크롤 복원
+    document.body.style.overflow = "";
   }
 
   menuBtn?.addEventListener("click", () => {
-    const isHidden = mobileMenu?.classList.toggle("hidden");
-    menuBtn.setAttribute("aria-expanded", String(!isHidden));
-    mobileMenu?.setAttribute("aria-hidden", String(!!isHidden));
-    // Scroll menu into view without stealing focus (avoids outline on first link)
-    if (!isHidden) {
-      mobileMenu?.scrollIntoView({ block: "nearest" });
-    }
+    const isHidden = mobileMenu?.classList.contains("hidden");
+    if (isHidden) openMenu();
+    else closeMenu();
   });
 
-  // Escape key closes menu
+  // backdrop 클릭 시 닫기
+  mobileBackdrop?.addEventListener("click", closeMenu);
+
+  // Escape 키로 닫기
   document.addEventListener("keydown", (e) => {
     if (
       e.key === "Escape" &&
@@ -65,7 +85,7 @@
     }
   });
 
-  // Focus trap when menu is open
+  // Focus trap
   mobileMenu?.addEventListener("keydown", (e) => {
     if (e.key !== "Tab") return;
     const focusable = mobileMenu.querySelectorAll("a, button");
@@ -81,11 +101,9 @@
     }
   });
 
-  // Close menu when clicking a link inside it
+  // 링크 클릭 시 닫기
   mobileMenu?.querySelectorAll("a").forEach((link) => {
-    link.addEventListener("click", () => {
-      closeMenu();
-    });
+    link.addEventListener("click", closeMenu);
   });
 
   // Hide sticky banners when hero section is in viewport (M3)

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1193,6 +1193,22 @@ textarea:focus-visible {
 }
 
 /* ─── Divider line ─── */
+/* ─── Mobile menu slide-in animation ─── */
+#mobile-menu:not(.hidden) {
+  animation: mobileMenuIn 0.2s ease-out forwards;
+}
+@keyframes mobileMenuIn {
+  from { opacity: 0; transform: translateY(-6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+#mobile-backdrop:not(.hidden) {
+  animation: backdropIn 0.2s ease-out forwards;
+}
+@keyframes backdropIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
 .section-divider {
   height: 1px;
   background: linear-gradient(90deg, transparent 5%, rgba(44,181,232,0.3) 30%, rgba(44,181,232,0.5) 50%, rgba(44,181,232,0.3) 70%, transparent 95%);

--- a/tests/e2e/mobile-menu.spec.ts
+++ b/tests/e2e/mobile-menu.spec.ts
@@ -235,14 +235,13 @@ test.describe("Mobile menu: alignment consistency", () => {
 // ─── Language toggle in mobile menu ──────────────────────────
 
 test.describe("Mobile menu: language toggle", () => {
-  // lang toggle link is the only a.font-mono in #mobile-menu (unique class)
-  // Uses text "KO" on EN pages, "EN" on KO pages (from t('nav.lang'))
+  // lang toggle link uses hreflang attribute (globe icon + font-mono span inside)
   test("EN page: language link exists in menu", async ({ page }) => {
     await page.goto("/simulate", { waitUntil: "domcontentloaded" });
     await page.locator("#mobile-menu-btn").click({ force: true });
     await page.waitForSelector("#mobile-menu[aria-hidden='false']");
 
-    const langLink = page.locator("#mobile-menu a.font-mono");
+    const langLink = page.locator("#mobile-menu a[hreflang]");
     await expect(langLink.first()).toBeVisible();
     // Verify it links to the KO version
     await expect(langLink.first()).toHaveAttribute("href", /\/ko\//);
@@ -253,7 +252,7 @@ test.describe("Mobile menu: language toggle", () => {
     await page.locator("#mobile-menu-btn").click({ force: true });
     await page.waitForSelector("#mobile-menu[aria-hidden='false']");
 
-    const langLink = page.locator("#mobile-menu a.font-mono");
+    const langLink = page.locator("#mobile-menu a[hreflang]");
     await expect(langLink.first()).toBeVisible();
     // Verify it links to the EN version (no /ko/ prefix)
     const href = await langLink.first().getAttribute("href");


### PR DESCRIPTION
## Summary

### 1. 이중선 제거 (fees / api / ranking / strategies)
- `<hr class="section-divider">` 바로 다음 `<section>` 에서 `border-t border-[--color-border]` 제거 — 그라디언트 선 + 흰 선 이중 표시 해소
- 적용 파일: `fees.astro`, `ko/fees.astro`, `api.astro`, `ko/api.astro`, `strategies/ranking.astro`, `ko/strategies/ranking.astro`, `strategies/[id].astro`, `ko/strategies/[id].astro`
- `fees.astro`: CTA 버튼 `mt-4` → `mt-8` (너무 붙어있던 간격 해소)

### 2. 언어 버튼 → 지구본 아이콘
- 데스크톱: 텍스트 버튼 → 🌐 SVG 아이콘 + "KO"/"EN" 코드 (compact)
- 모바일 메뉴: 지구본 + 전체 언어명 + 코드 표시
- i18n: `nav.lang` "한국어 / KO" → "KO", "English" → "EN"

### 3. 모바일 메뉴 근본 재설계 (fixed overlay)
- **Before**: block element → 페이지 아래로 밀림, 짧은 화면에서 하단 잘림
- **After**: `position: fixed`, `top: 3.5rem`, `bottom: 0` → 뷰포트 전체 커버, 독립 스크롤
- 반투명 backdrop 추가 (클릭 시 닫기)
- 햄버거 ↔ X 아이콘 전환
- `body.overflow = hidden` 스크롤 잠금
- 슬라이드 인 애니메이션 (200ms ease-out)
- 확장성: nav 아이템 아무리 추가해도 스크롤로 접근 가능

## Test plan
- [ ] `/fees`: 섹션 구분이 section-divider 하나만 있는지 (이중선 없음)
- [ ] 모바일: 햄버거 탭 → X 아이콘으로 바뀌고 overlay 등장, 배경 dim
- [ ] 모바일: backdrop 탭 → 메뉴 닫힘
- [ ] 모바일: 지구본+KO/EN 버튼 탭 → 언어 전환
- [ ] 데스크톱: 우상단 🌐 KO/EN 버튼 확인

Build: 2522 pages, qa-redirects: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)