### PR TITLE
fix: hero grid items-start — align badge with simulator image

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -36,7 +36,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       <img src="/images/simulator-preview.png" alt="" class="w-[80%] max-w-4xl opacity-[0.04] blur-[1px] select-none" loading="eager" />
     </div>
     <div class="relative max-w-7xl mx-auto px-6 pt-24 pb-28 md:pt-36 md:pb-44 hero-enter">
-      <div class="grid md:grid-cols-[3fr_2fr] gap-12 md:gap-16 items-center">
+      <div class="grid md:grid-cols-[3fr_2fr] gap-12 md:gap-16 items-start">
         <!-- Left: Text + CTA -->
         <div>
           <HeroBadge stat={simulationsRun} label="simulations run" />

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -36,7 +36,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       <img src="/images/simulator-preview.png" alt="" class="w-[80%] max-w-4xl opacity-[0.04] blur-[1px] select-none" loading="eager" />
     </div>
     <div class="relative max-w-7xl mx-auto px-6 pt-24 pb-28 md:pt-36 md:pb-44 hero-enter">
-      <div class="grid md:grid-cols-[3fr_2fr] gap-12 md:gap-16 items-center">
+      <div class="grid md:grid-cols-[3fr_2fr] gap-12 md:gap-16 items-start">
         <!-- Left: Text + CTA -->
         <div>
           <HeroBadge stat={simulationsRun} label="시뮬레이션 실행" cta="무료 체험 →" />


### PR DESCRIPTION
## Problem
On desktop, the "12,847 simulations run · Try free →" badge appeared lower than the simulator image on the right side.

**Root cause**: `items-center` on the hero grid — when the right column (BrowserFrame + SimulatorPreview) is taller than the left column text, the left column gets vertically centered, pushing the badge downward.

## Fix
`items-center` → `items-start` on both EN and KO homepage hero grids. Both columns now start at the top of the grid row, keeping badge and simulator image top-aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)