### PR TITLE
fix: auto-fix #990 (+1 related)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,35 @@ import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
 import preact from '@astrojs/preact';
+import fs from 'node:fs';
+import nodePath from 'node:path';
+
+/** Discover Korean path prefixes from src/pages/ko/ at build time */
+function discoverKoPathPrefixes() {
+  const koDir = nodePath.resolve('src/pages/ko');
+  if (!fs.existsSync(koDir)) return ['/'];
+  const prefixes = new Set();
+  /** @param {string} dir */
+  function walk(dir) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = nodePath.join(dir, entry.name);
+      if (entry.isDirectory()) { walk(full); continue; }
+      if (!entry.name.endsWith('.astro')) continue;
+      const rel = nodePath.relative(koDir, full).replace(/\\/g, '/');
+      const name = nodePath.basename(rel, '.astro');
+      const dirPart = nodePath.dirname(rel);
+      if (name === 'index' || name.startsWith('[')) {
+        prefixes.add(dirPart === '.' ? '/' : `/${dirPart}/`);
+      } else {
+        prefixes.add(dirPart === '.' ? `/${name}` : `/${dirPart}/${name}`);
+      }
+    }
+  }
+  walk(koDir);
+  return [...prefixes];
+}
+
+const koPathPrefixes = discoverKoPathPrefixes();
 
 // https://astro.build/config
 export default defineConfig({
@@ -39,8 +68,6 @@ export default defineConfig({
         const enUrl = `https://pruviq.com${basePath}`;
         const koUrl = `https://pruviq.com/ko${basePath === '/' ? '/' : basePath}`;
 
-        // Only emit ko hreflang for paths known to have Korean versions
-        const koPathPrefixes = ['/', '/about', '/api', '/fees', '/simulate', '/strategies', '/coins/', '/blog/', '/market', '/compare/', '/leaderboard', '/changelog', '/privacy', '/terms', '/methodology', '/signals', '/learn', '/best-crypto-backtesting', '/crypto-trading-simulator', '/why-backtests-fail'];
         const hasKoVersion = koPathPrefixes.some(prefix => basePath === prefix || basePath.startsWith(prefix));
 
         item.links = [

--- a/scripts/check-seo.js
+++ b/scripts/check-seo.js
@@ -49,13 +49,12 @@ function hasMetaDescription(html) {
     }
 
     if (problems.length > 0) {
-      console.error(`SEO check warning: ${problems.length} HTML files missing title or meta description (non-fatal):`);
+      console.error(`SEO check: ${problems.length} HTML files missing title or meta description:`);
       for (const p of problems.slice(0, 50)) {
         console.error(` - ${p.file}    title:${p.titleOk ? 'OK' : 'MISSING'}    description:${p.descOk ? 'OK' : 'MISSING'}`);
       }
       if (problems.length > 50) console.error(`... and ${problems.length - 50} more`);
-      // Non-fatal in CI: treat as warning so the job doesn't block merges
-      process.exit(0);
+      process.exit(1);
     }
 
     console.log('SEO check passed: all HTML files have a <title> and meta description.');


### PR DESCRIPTION
## Auto-fix for 2 issue(s)

#990: [claude-auto][P2] `astro.config.mjs:43` — `koPathPrefixes` hardcoded; new pages silently skip Ko
#991: [claude-auto][P2] `scripts/check-seo.js:58` — SEO CI check is non-blocking; pages ship with empt

### Changes
```
 astro.config.mjs     | 31 +++++++++++++++++++++++++++++--
 scripts/check-seo.js |  5 ++---
 2 files changed, 31 insertions(+), 5 deletions(-)
```

### Safety Checks
- Files changed: **2** (limit: 20)
- Lines changed: **36** (limit: 1500)

---
*Auto-generated by JEPO auto-fix agent. Requires auto-test pass before merge.*