### PR TITLE
fix: hero desktop top padding — md:pt-36 → md:pt-20

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,7 +35,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
     <div class="absolute inset-0 hidden md:flex items-center justify-center pointer-events-none" aria-hidden="true">
       <img src="/images/simulator-preview.png" alt="" class="w-[80%] max-w-4xl opacity-[0.04] blur-[1px] select-none" loading="eager" />
     </div>
-    <div class="relative max-w-7xl mx-auto px-6 pt-24 pb-28 md:pt-36 md:pb-44 hero-enter">
+    <div class="relative max-w-7xl mx-auto px-6 pt-24 pb-28 md:pt-20 md:pb-44 hero-enter">
       <div class="grid md:grid-cols-[3fr_2fr] gap-12 md:gap-16 items-start">
         <!-- Left: Text + CTA -->
         <div>

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -35,7 +35,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
     <div class="absolute inset-0 hidden md:flex items-center justify-center pointer-events-none" aria-hidden="true">
       <img src="/images/simulator-preview.png" alt="" class="w-[80%] max-w-4xl opacity-[0.04] blur-[1px] select-none" loading="eager" />
     </div>
-    <div class="relative max-w-7xl mx-auto px-6 pt-24 pb-28 md:pt-36 md:pb-44 hero-enter">
+    <div class="relative max-w-7xl mx-auto px-6 pt-24 pb-28 md:pt-20 md:pb-44 hero-enter">
       <div class="grid md:grid-cols-[3fr_2fr] gap-12 md:gap-16 items-start">
         <!-- Left: Text + CTA -->
         <div>


### PR DESCRIPTION
## Summary
- 홈 hero 데스크탑 상단 여백 144px → 80px으로 축소
- 기존 `md:pt-36` (144px)이 다른 페이지(~77px)의 2배였음
- EN/KO 양쪽 수정

(build: 2522 pages, qa-redirects: PASS)