### PR TITLE
fix: mobile menu scroll — max-height via CSS rule

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -473,7 +473,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
       </div>
 
       <!-- 모바일 메뉴 (nav 안 in-flow — 화면 좌우 딱 맞음) -->
-      <div id="mobile-menu" class="hidden md:hidden border-t border-[--color-border] overflow-y-auto" style="max-height:calc(100dvh - 3.5rem);" aria-hidden="true">
+      <div id="mobile-menu" class="hidden md:hidden border-t border-[--color-border]" aria-hidden="true">
         <div class="flex flex-col px-4 py-3 gap-1 text-sm">
 
           <!-- 언어 전환 — 맨 위 -->

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1196,6 +1196,8 @@ textarea:focus-visible {
 /* bg-color via CSS rule (inline style var() doesn't resolve in Tailwind v4 @layer theme context) */
 #mobile-menu {
   background-color: var(--color-bg);
+  max-height: calc(100dvh - 3.5rem);
+  overflow-y: auto;
 }
 
 /* ─── Mobile menu slide-in animation ─── */


### PR DESCRIPTION
## Summary
- 모바일 메뉴 하단 잘림 해결
- 원인: inline style `max-height: calc(100dvh - 3.5rem)` 미적용 (computed: none)
- 수정: `#mobile-menu` CSS 룰로 이동 (bg-color fix와 동일 패턴)
- Layout.astro에서 중복 인라인 스타일 및 `overflow-y-auto` Tailwind 클래스 제거

(build: 2522 pages)