### PR TITLE
feat: mobile lang button in header + chevron touch target fix

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -464,6 +464,15 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
             </svg>
             <span class="font-mono text-xs font-semibold">{t('nav.lang')}</span>
           </a>
+          <!-- 모바일: 지구본 (언어 전환) — 메뉴 밖에서 항상 접근 가능 -->
+          <a href={altPath} hreflang={altHreflang}
+             class="md:hidden flex items-center justify-center w-10 h-10 rounded-lg text-[--color-text-muted] hover:bg-[--color-bg-hover] transition-colors"
+             aria-label={lang === 'ko' ? 'Switch to English' : '한국어로 전환'}>
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <circle cx="12" cy="12" r="10"/>
+              <path d="M2 12h20M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/>
+            </svg>
+          </a>
           <!-- 모바일: 햄버거 -->
           <button id="mobile-menu-btn" class="md:hidden flex items-center justify-center w-10 h-10 rounded-lg text-[--color-text-muted] hover:bg-[--color-bg-hover] transition-colors" aria-label="Toggle menu" aria-expanded="false" aria-controls="mobile-menu">
             <svg id="menu-icon-open" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 12h18M3 6h18M3 18h18"/></svg>
@@ -475,20 +484,6 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
       <!-- 모바일 메뉴 (nav 안 in-flow — 화면 좌우 딱 맞음) -->
       <div id="mobile-menu" class="hidden md:hidden border-t border-[--color-border]" aria-hidden="true">
         <div class="flex flex-col px-4 py-3 gap-1 text-sm">
-
-          <!-- 언어 전환 — 맨 위 -->
-          <div class="flex items-center justify-between pb-3 mb-1 border-b border-[--color-border]">
-            <span class="text-xs text-[--color-text-muted] font-mono uppercase tracking-wider">Language</span>
-            <a href={altPath} hreflang={altHreflang}
-               class="font-mono text-sm px-4 py-2 border border-[--color-accent]/40 rounded-lg text-[--color-accent] bg-[--color-accent]/5 min-h-[40px] flex items-center font-semibold hover:bg-[--color-accent]/10 transition-colors"
-               aria-label={lang === 'ko' ? 'Switch to English' : '한국어로 전환'}>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-1.5" aria-hidden="true">
-                <circle cx="12" cy="12" r="10"/>
-                <path d="M2 12h20M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/>
-              </svg>
-              {t('nav.lang')}
-            </a>
-          </div>
 
           <!-- 네비게이션 아이템 -->
           {navItems.map(item => (
@@ -503,7 +498,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
                       {item.label}
                     </a>
                     <button id="strategies-toggle"
-                            class="min-h-[48px] px-3 flex items-center justify-center transition-colors"
+                            class="w-12 h-12 flex items-center justify-center rounded-lg transition-colors hover:bg-[--color-bg-hover] shrink-0"
                             aria-expanded={isActive('/strategies') ? "true" : "false"}
                             aria-controls="strategies-submenu"
                             aria-label="Toggle Strategies submenu">


### PR DESCRIPTION
언어 전환 버튼을 모바일 헤더로 이동 + Strategies chevron 터치 영역 48x48px 개선 (build: 2522 pages)