### PR TITLE
feat: mobile language dropdown — EN/KO selector on globe tap

### DIFF
--- a/public/scripts/layout-client.js
+++ b/public/scripts/layout-client.js
@@ -105,6 +105,49 @@
     link.addEventListener("click", closeMenu);
   });
 
+  // ── Mobile language dropdown ─────────────────────────────────
+  const langBtn = document.getElementById("mobile-lang-btn");
+  const langDropdown = document.getElementById("mobile-lang-dropdown");
+
+  function openLangDropdown() {
+    langDropdown?.classList.remove("hidden");
+    langBtn?.setAttribute("aria-expanded", "true");
+  }
+  function closeLangDropdown() {
+    langDropdown?.classList.add("hidden");
+    langBtn?.setAttribute("aria-expanded", "false");
+  }
+
+  langBtn?.addEventListener("click", (e) => {
+    e.stopPropagation();
+    langDropdown?.classList.contains("hidden")
+      ? openLangDropdown()
+      : closeLangDropdown();
+  });
+
+  // 외부 클릭 시 닫기
+  document.addEventListener("click", (e) => {
+    if (
+      langDropdown &&
+      !langDropdown.contains(e.target) &&
+      e.target !== langBtn
+    ) {
+      closeLangDropdown();
+    }
+  });
+
+  // ESC 키로 닫기
+  document.addEventListener("keydown", (e) => {
+    if (
+      e.key === "Escape" &&
+      langDropdown &&
+      !langDropdown.classList.contains("hidden")
+    ) {
+      closeLangDropdown();
+      langBtn?.focus();
+    }
+  });
+
   // ── Strategies submenu toggle ────────────────────────────────
   const strategiesToggle = document.getElementById("strategies-toggle");
   const strategiesSubmenu = document.getElementById("strategies-submenu");

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -464,15 +464,36 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
             </svg>
             <span class="font-mono text-xs font-semibold">{t('nav.lang')}</span>
           </a>
-          <!-- 모바일: 지구본 (언어 전환) — 메뉴 밖에서 항상 접근 가능 -->
-          <a href={altPath} hreflang={altHreflang}
-             class="md:hidden flex items-center justify-center w-10 h-10 rounded-lg text-[--color-text-muted] hover:bg-[--color-bg-hover] transition-colors"
-             aria-label={lang === 'ko' ? 'Switch to English' : '한국어로 전환'}>
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <circle cx="12" cy="12" r="10"/>
-              <path d="M2 12h20M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/>
-            </svg>
-          </a>
+          <!-- 모바일: 지구본 버튼 + 언어 선택 드롭다운 -->
+          <div class="md:hidden relative">
+            <button id="mobile-lang-btn"
+                    class="flex flex-col items-center justify-center gap-0.5 px-2 h-10 rounded-lg text-[--color-text-muted] hover:bg-[--color-bg-hover] transition-colors"
+                    aria-haspopup="true" aria-expanded="false" aria-controls="mobile-lang-dropdown"
+                    aria-label="Select language">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="12" r="10"/>
+                <path d="M2 12h20M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/>
+              </svg>
+              <span class="font-mono text-[9px] font-bold leading-none">{lang === 'ko' ? 'KO' : 'EN'}</span>
+            </button>
+            <!-- 드롭다운: 현재 언어 표시 + 전환 옵션 -->
+            <div id="mobile-lang-dropdown"
+                 class="hidden absolute right-0 top-full mt-1 w-32 rounded-xl border border-[--color-border] bg-[--color-bg-surface] shadow-lg z-[60] overflow-hidden"
+                 role="menu">
+              <a href={enURL.href} hreflang="en" role="menuitem"
+                 class="flex items-center justify-between px-4 py-3 text-sm transition-colors hover:bg-[--color-bg-hover]"
+                 style={lang === 'en' ? 'color:var(--color-accent);font-weight:600' : 'color:var(--color-text-muted)'}>
+                <span>English</span>
+                {lang === 'en' && <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>}
+              </a>
+              <a href={koURL.href} hreflang="ko" role="menuitem"
+                 class="flex items-center justify-between px-4 py-3 text-sm transition-colors hover:bg-[--color-bg-hover]"
+                 style={lang === 'ko' ? 'color:var(--color-accent);font-weight:600' : 'color:var(--color-text-muted)'}>
+                <span>한국어</span>
+                {lang === 'ko' && <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>}
+              </a>
+            </div>
+          </div>
           <!-- 모바일: 햄버거 -->
           <button id="mobile-menu-btn" class="md:hidden flex items-center justify-center w-10 h-10 rounded-lg text-[--color-text-muted] hover:bg-[--color-bg-hover] transition-colors" aria-label="Toggle menu" aria-expanded="false" aria-controls="mobile-menu">
             <svg id="menu-icon-open" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 12h18M3 6h18M3 18h18"/></svg>

--- a/tests/e2e/mobile-menu.spec.ts
+++ b/tests/e2e/mobile-menu.spec.ts
@@ -30,6 +30,29 @@ const EN_MENU_ITEMS = [
   "Leaderboard",
 ];
 
+async function expandStrategiesSubmenu(
+  page: Parameters<typeof test>[2] extends (...args: infer A) => any
+    ? A[0] extends { page: infer P }
+      ? P
+      : never
+    : never,
+) {
+  const toggle = page.locator("#strategies-toggle");
+  const submenu = page.locator("#strategies-submenu");
+  const isHidden = await submenu.evaluate((el) =>
+    el.classList.contains("hidden"),
+  );
+  if (isHidden) {
+    await toggle.click({ force: true });
+    await page.waitForFunction(
+      () =>
+        !document
+          .getElementById("strategies-submenu")
+          ?.classList.contains("hidden"),
+    );
+  }
+}
+
 async function openMobileMenu(
   page: Parameters<typeof test>[2] extends (...args: infer A) => any
     ? A[0] extends { page: infer P }
@@ -105,6 +128,9 @@ test.describe("Mobile menu: all expected items present", () => {
     await page.locator("#mobile-menu-btn").click({ force: true });
     await page.waitForSelector("#mobile-menu[aria-hidden='false']");
 
+    // Expand strategies submenu so nested items are visible
+    await expandStrategiesSubmenu(page);
+
     const menu = page.locator("#mobile-menu");
     for (const label of EN_MENU_ITEMS) {
       await expect(
@@ -120,6 +146,8 @@ test.describe("Mobile menu: all expected items present", () => {
     await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.locator("#mobile-menu-btn").click({ force: true });
     await page.waitForSelector("#mobile-menu[aria-hidden='false']");
+    // Expand strategies submenu so nested items are visible
+    await expandStrategiesSubmenu(page);
 
     // Should use translation, NOT a Korean fallback
     const rankingLink = page
@@ -140,6 +168,8 @@ test.describe("Mobile menu: all expected items present", () => {
     await page.goto("/ko/", { waitUntil: "domcontentloaded" });
     await page.locator("#mobile-menu-btn").click({ force: true });
     await page.waitForSelector("#mobile-menu[aria-hidden='false']");
+    // Expand strategies submenu so nested items are visible
+    await expandStrategiesSubmenu(page);
 
     const rankingLink = page.locator(
       "#mobile-menu a[href='/ko/strategies/ranking']",
@@ -165,6 +195,10 @@ test.describe("Mobile menu: touch target sizes", () => {
       await page.goto("/", { waitUntil: "domcontentloaded" });
       await page.locator("#mobile-menu-btn").click({ force: true });
       await page.waitForSelector("#mobile-menu[aria-hidden='false']");
+      // Submenu items are hidden by default behind the Strategies accordion
+      if (href === "/strategies/ranking" || href === "/leaderboard") {
+        await expandStrategiesSubmenu(page);
+      }
 
       const link = page.locator(`#mobile-menu a[href="${href}"]`).first();
       await expect(link).toBeVisible();
@@ -189,6 +223,7 @@ test.describe("Mobile menu: ranking item chevron indicator", () => {
     await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.locator("#mobile-menu-btn").click({ force: true });
     await page.waitForSelector("#mobile-menu[aria-hidden='false']");
+    await expandStrategiesSubmenu(page);
 
     const rankingLink = page
       .locator("#mobile-menu a[href='/strategies/ranking']")
@@ -209,6 +244,7 @@ test.describe("Mobile menu: alignment consistency", () => {
     await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.locator("#mobile-menu-btn").click({ force: true });
     await page.waitForSelector("#mobile-menu[aria-hidden='false']");
+    await expandStrategiesSubmenu(page);
 
     const el = page.locator(`#mobile-menu a[href="/leaderboard"]`).first();
     await expect(el).toBeVisible();
@@ -223,6 +259,7 @@ test.describe("Mobile menu: alignment consistency", () => {
     await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.locator("#mobile-menu-btn").click({ force: true });
     await page.waitForSelector("#mobile-menu[aria-hidden='false']");
+    await expandStrategiesSubmenu(page);
 
     const rankingLink = page
       .locator("#mobile-menu a[href='/strategies/ranking']")
@@ -232,30 +269,40 @@ test.describe("Mobile menu: alignment consistency", () => {
   });
 });
 
-// ─── Language toggle in mobile menu ──────────────────────────
+// ─── Language globe dropdown (header) ────────────────────────
 
-test.describe("Mobile menu: language toggle", () => {
-  // lang toggle link uses hreflang attribute (globe icon + font-mono span inside)
-  test("EN page: language link exists in menu", async ({ page }) => {
+test.describe("Mobile header: language globe dropdown", () => {
+  // Language toggle is now a globe button in the nav header (#mobile-lang-btn)
+  // Clicking it opens #mobile-lang-dropdown with EN/KO links
+  test("EN page: globe button opens dropdown with KO link", async ({
+    page,
+  }) => {
     await page.goto("/simulate", { waitUntil: "domcontentloaded" });
-    await page.locator("#mobile-menu-btn").click({ force: true });
-    await page.waitForSelector("#mobile-menu[aria-hidden='false']");
 
-    const langLink = page.locator("#mobile-menu a[hreflang]");
+    // Click globe button to open dropdown
+    await page.locator("#mobile-lang-btn").click({ force: true });
+    await page.waitForSelector("#mobile-lang-dropdown:not(.hidden)");
+
+    const langLink = page.locator("#mobile-lang-dropdown a[hreflang]");
     await expect(langLink.first()).toBeVisible();
-    // Verify it links to the KO version
-    await expect(langLink.first()).toHaveAttribute("href", /\/ko\//);
+    // EN page → dropdown has a KO link
+    const koLink = page.locator("#mobile-lang-dropdown a[hreflang='ko']");
+    await expect(koLink).toHaveAttribute("href", /\/ko\//);
   });
 
-  test("KO page: language link points to EN counterpart", async ({ page }) => {
+  test("KO page: globe button opens dropdown with EN link", async ({
+    page,
+  }) => {
     await page.goto("/ko/simulate", { waitUntil: "domcontentloaded" });
-    await page.locator("#mobile-menu-btn").click({ force: true });
-    await page.waitForSelector("#mobile-menu[aria-hidden='false']");
 
-    const langLink = page.locator("#mobile-menu a[hreflang]");
-    await expect(langLink.first()).toBeVisible();
-    // Verify it links to the EN version (no /ko/ prefix)
-    const href = await langLink.first().getAttribute("href");
+    // Click globe button to open dropdown
+    await page.locator("#mobile-lang-btn").click({ force: true });
+    await page.waitForSelector("#mobile-lang-dropdown:not(.hidden)");
+
+    const enLink = page.locator("#mobile-lang-dropdown a[hreflang='en']");
+    await expect(enLink).toBeVisible();
+    // Verify it links to EN version (no /ko/ prefix)
+    const href = await enLink.getAttribute("href");
     expect(href, "Language toggle should point to EN version").not.toMatch(
       /\/ko\//,
     );


### PR DESCRIPTION
지구본 탭 → EN/한국어 선택 드롭다운. 현재 언어 체크마크+강조색으로 선택됨 표시. (build: 2522 pages)