### PR TITLE
fix: lang dropdown bg — global.css rule (var() inline style not applied)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -478,7 +478,6 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
             <!-- 드롭다운: 현재 언어 표시 + 전환 옵션 -->
             <div id="mobile-lang-dropdown"
                  class="hidden absolute right-0 top-full mt-1 w-36 rounded-xl shadow-lg z-[60] overflow-hidden"
-                 style="background-color: var(--color-bg-surface); border: 1px solid var(--color-border);"
                  role="menu">
               <a href={enURL.href} hreflang="en" role="menuitem"
                  class="flex items-center justify-between px-4 py-3 text-sm transition-colors hover:bg-[--color-bg-hover]"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1200,6 +1200,12 @@ textarea:focus-visible {
   overflow-y: auto;
 }
 
+/* ─── Language dropdown ─── */
+#mobile-lang-dropdown {
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+}
+
 /* ─── Mobile menu slide-in animation ─── */
 #mobile-menu:not(.hidden) {
   animation: mobileMenuIn 0.2s ease-out forwards;


### PR DESCRIPTION
## Summary
- Astro SSG inline `style="background-color: var(--color-bg-surface)"` not applied by browser (same issue as #mobile-menu fix)
- Fix: add `#mobile-lang-dropdown { background-color: var(--color-bg-surface); }` as non-layered CSS rule in global.css
- Remove redundant inline style from Layout.astro