### PR TITLE
feat: percent position sizing + confirm modal improvements

### DIFF
--- a/backend/okx/auto_executor.py
+++ b/backend/okx/auto_executor.py
@@ -176,6 +176,23 @@ async def _try_execute(
 
     token = await get_valid_token(session_id)
     async with OKXClient(token, session_id=session_id) as client:
+        # ── Percent-of-balance position sizing ──
+        if settings.get("position_size_mode") == "percent":
+            pct = settings.get("position_size_pct", 5)
+            balances = await client.get_balance("USDT")
+            avail = float(balances[0].avail_bal) if balances else 0
+            if avail <= 0:
+                logger.warning(
+                    "Session %s: zero USDT balance — skipping percent sizing",
+                    session_id[:8],
+                )
+                return None
+            position_size = avail * pct / 100
+            logger.info(
+                "Percent sizing: %.1f%% of $%.2f = $%.2f for session %s",
+                pct, avail, position_size, session_id[:8],
+            )
+
         # Check concurrent position limit
         positions = await client.get_positions()
         open_count = sum(1 for p in positions if float(p.pos or 0) != 0)

--- a/src/components/OKXExecuteButton.tsx
+++ b/src/components/OKXExecuteButton.tsx
@@ -33,6 +33,10 @@ const labels = {
     direction: "Direction",
     symbol: "Symbol",
     slTp: "SL / TP",
+    positionSize: "Position Size",
+    leverage: "Leverage",
+    marginMode: "Margin Mode",
+    estFee: "Est. Fee (0.02%)",
     features: [
       "Automated SL/TP from simulation",
       "No API key sharing (OAuth)",
@@ -58,6 +62,10 @@ const labels = {
     direction: "방향",
     symbol: "심볼",
     slTp: "SL / TP",
+    positionSize: "포지션 크기",
+    leverage: "레버리지",
+    marginMode: "마진 모드",
+    estFee: "예상 수수료 (0.02%)",
     features: [
       "시뮬레이션 기반 자동 SL/TP",
       "API 키 공유 불필요 (OAuth)",
@@ -84,9 +92,24 @@ export default function OKXExecuteButton({
   >("idle");
   const [userSettings, setUserSettings] = useState<{
     position_size_usdt: number;
+    position_size_mode: "fixed" | "percent";
+    position_size_pct: number;
     leverage: number;
     td_mode: string;
-  }>({ position_size_usdt: 100, leverage: 1, td_mode: "isolated" });
+  }>({
+    position_size_usdt: 100,
+    position_size_mode: "fixed",
+    position_size_pct: 5,
+    leverage: 1,
+    td_mode: "isolated",
+  });
+  const [availBalance, setAvailBalance] = useState<number | null>(null);
+
+  // Effective position size in USDT (respects fixed vs percent mode)
+  const effectivePositionUsdt =
+    userSettings.position_size_mode === "percent" && availBalance !== null
+      ? Math.max(1, (availBalance * userSettings.position_size_pct) / 100)
+      : userSettings.position_size_usdt;
 
   useEffect(() => {
     fetch(`${API_BASE}/auth/okx/status`, { credentials: "include" })
@@ -94,21 +117,36 @@ export default function OKXExecuteButton({
       .then((d) => {
         setConnected(d.connected);
         if (d.connected) {
-          // Fetch user settings to use their configured position size and leverage
-          return fetch(`${API_BASE}/settings/trading`, {
-            credentials: "include",
-          });
-        }
-        return null;
-      })
-      .then((r) => r?.json())
-      .then((d) => {
-        if (d?.settings) {
-          setUserSettings({
-            position_size_usdt: d.settings.position_size_usdt ?? 100,
-            leverage: d.settings.leverage ?? 1,
-            td_mode: d.settings.td_mode ?? "isolated",
-          });
+          // Fetch settings + balance in parallel
+          Promise.all([
+            fetch(`${API_BASE}/settings/trading`, {
+              credentials: "include",
+            }).then((r) => r.json()),
+            fetch(`${API_BASE}/execute/balance`, {
+              credentials: "include",
+            }).then((r) => r.json()),
+          ])
+            .then(([settingsData, balanceData]) => {
+              if (settingsData?.settings) {
+                setUserSettings({
+                  position_size_usdt:
+                    settingsData.settings.position_size_usdt ?? 100,
+                  position_size_mode:
+                    settingsData.settings.position_size_mode ?? "fixed",
+                  position_size_pct:
+                    settingsData.settings.position_size_pct ?? 5,
+                  leverage: settingsData.settings.leverage ?? 1,
+                  td_mode: settingsData.settings.td_mode ?? "isolated",
+                });
+              }
+              const usdt = balanceData?.balances?.find(
+                (b: { ccy: string }) => b.ccy === "USDT",
+              );
+              if (usdt) {
+                setAvailBalance(parseFloat(usdt.avail_bal ?? "0"));
+              }
+            })
+            .catch(() => {});
         }
       })
       .catch(() => setConnected(false));
@@ -128,7 +166,7 @@ export default function OKXExecuteButton({
           symbol,
           sl_pct: slPct,
           tp_pct: tpPct,
-          position_size_usdt: userSettings.position_size_usdt,
+          position_size_usdt: effectivePositionUsdt,
           leverage: userSettings.leverage,
           td_mode: userSettings.td_mode,
         }),
@@ -242,6 +280,43 @@ export default function OKXExecuteButton({
                 <span class="font-mono">
                   {slPct}% / {tpPct}%
                 </span>
+              </div>
+              <div class="border-t border-[--color-border] pt-2 mt-2 space-y-2">
+                <div class="flex justify-between">
+                  <span class="text-[--color-text-muted]">
+                    {t.positionSize}
+                  </span>
+                  <span class="font-mono font-bold">
+                    ${effectivePositionUsdt.toFixed(0)} USDT
+                    {userSettings.position_size_mode === "percent" && (
+                      <span class="text-[--color-text-muted] font-normal ml-1">
+                        ({userSettings.position_size_pct}%)
+                      </span>
+                    )}
+                  </span>
+                </div>
+                <div class="flex justify-between">
+                  <span class="text-[--color-text-muted]">{t.leverage}</span>
+                  <span class="font-mono font-bold">
+                    {userSettings.leverage}x
+                  </span>
+                </div>
+                <div class="flex justify-between">
+                  <span class="text-[--color-text-muted]">{t.marginMode}</span>
+                  <span class="font-mono capitalize">
+                    {userSettings.td_mode}
+                  </span>
+                </div>
+                <div class="flex justify-between text-[--color-text-muted]">
+                  <span>{t.estFee}</span>
+                  <span class="font-mono">
+                    ~$
+                    {(
+                      (effectivePositionUsdt * userSettings.leverage * 0.0002) /
+                      1
+                    ).toFixed(3)}
+                  </span>
+                </div>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary

- **auto_executor.py**: `position_size_mode=percent` → fetches live USDT balance from OKX, calculates `position_size = avail_bal * pct / 100` before sizing contracts. Previously ignored, always used fixed USDT.
- **OKXExecuteButton.tsx**: fetches `/settings/trading` + `/execute/balance` in parallel on load; `effectivePositionUsdt` respects fixed vs percent mode when sending order; confirm modal now shows:
  - Position Size in USDT (with `(5%)` label when percent mode)
  - Leverage
  - Margin Mode
  - Estimated Fee (notional × 0.02%)

## Test plan

- [ ] Set position_size_mode=percent (5%) in TradingSettings → trigger auto signal → check log: `Percent sizing: 5.0% of $X = $Y`
- [ ] Open OKXExecuteButton modal → confirm position size / leverage / margin mode / est. fee all visible
- [ ] Percent mode: modal shows `$50 USDT (5%)` when balance is $1000

🤖 Generated with [Claude Code](https://claude.com/claude-code)