### PR TITLE
fix: OKX connect button stuck at 연결 중... (fetch timeout)

### DIFF
--- a/src/components/OKXConnectButton.tsx
+++ b/src/components/OKXConnectButton.tsx
@@ -82,7 +82,10 @@ export default function OKXConnectButton({
       }
     }
 
-    fetch(`${API_BASE}/auth/okx/status`, { credentials: "include" })
+    fetch(`${API_BASE}/auth/okx/status`, {
+      credentials: "include",
+      signal: AbortSignal.timeout(8000),
+    })
       .then((r) => r.json())
       .then((d) => {
         setConnected(d.connected);

--- a/src/components/TradingSettings.tsx
+++ b/src/components/TradingSettings.tsx
@@ -213,13 +213,17 @@ export default function TradingSettings({ lang = "en" }: Props) {
   });
 
   useEffect(() => {
-    fetch(`${API_BASE}/auth/okx/status`, { credentials: "include" })
+    fetch(`${API_BASE}/auth/okx/status`, {
+      credentials: "include",
+      signal: AbortSignal.timeout(8000),
+    })
       .then((r) => r.json())
       .then((d) => {
         setConnected(d.connected);
         if (d.connected) {
           return fetch(`${API_BASE}/settings/trading`, {
             credentials: "include",
+            signal: AbortSignal.timeout(8000),
           });
         }
         setLoading(false);


### PR DESCRIPTION
## 문제
OKXConnectButton과 TradingSettings의 `/auth/okx/status` fetch에 타임아웃이 없었음.
백엔드가 시작 직후 느릴 때 fetch가 무한 대기 → `loading: true` 상태 유지 → "연결 중..." 버튼이 영구히 stuck.

## 수정
`AbortSignal.timeout(8000)` 추가 — AutoTradingStatus가 이미 사용하던 방식과 동일하게 통일.
8초 초과 시 catch로 빠지며 `setLoading(false)` 호출 → 연결 안 됨 상태로 정상 표시.

## 영향 범위
- `OKXConnectButton.tsx`: status fetch
- `TradingSettings.tsx`: status fetch + settings fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)