### PR TITLE
fix: autotrading arch v2 — industry-standard SL/TP (avgPx) + full Telegram alerts

### DIFF
--- a/backend/okx/auto_executor.py
+++ b/backend/okx/auto_executor.py
@@ -1,25 +1,28 @@
 """
 Auto-execution worker — monitors signals and executes trades for subscribed users.
 
+Industry standard architecture (3commas/Bybit/OKX bot benchmark):
+  - Mark price fetched at execution time (not signal time) for contract sizing
+  - SL/TP calculated from ACTUAL FILL PRICE (avgPx) after order confirmation
+  - All events notify user via Telegram: entry, SL/TP set, limit hits, failures
+
 Safety guards:
-  - Max $500 per trade (configurable per user)
+  - Max $5000 per trade (configurable per user)
   - Max 20 trades/day (configurable)
   - Daily loss limit (configurable, default $200)
   - Master switch per user
   - Anomaly detection: pauses if 3 consecutive losses
-
-Usage:
-  Called from main.py background task, runs every signal scan cycle.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from typing import Optional
 
 from .client import OKXClient
 from .oauth import get_valid_token, is_authenticated
-from .orders import _pruviq_to_okx_inst_id, _calc_sl_tp_prices
+from .orders import _pruviq_to_okx_inst_id, _calc_sl_tp_prices, _calc_contract_sz
 from .settings import (
     get_auto_sessions,
     get_alert_sessions,
@@ -30,11 +33,18 @@ from .settings import (
     log_trade,
     mark_signal_executed,
 )
-from .notifications import send_signal_alert
+from .notifications import (
+    send_signal_alert,
+    send_trade_executed,
+    send_execution_failed,
+    send_safety_limit,
+)
 from .pnl_sync import sync_realized_pnl
-from .orders import _pruviq_to_okx_inst_id as _to_inst_id, _calc_contract_sz, _calc_sl_tp_prices
 
 logger = logging.getLogger("okx_auto_executor")
+
+# How long to wait for market order fill before querying avgPx (seconds)
+_FILL_WAIT_S = 1.5
 
 
 async def process_signals(signals: list[dict]) -> list[dict]:
@@ -89,7 +99,6 @@ async def process_signals(signals: list[dict]) -> list[dict]:
             continue
         settings = get_settings(session_id)
         for signal in signals:
-            # Apply same strategy/coin filters as auto mode
             if settings["strategies"] and signal["strategy"] not in settings["strategies"]:
                 continue
             if settings["coins"] and signal["coin"] not in settings["coins"]:
@@ -113,6 +122,7 @@ async def _try_execute(
     strategy_id = signal["strategy"]
     coin = signal["coin"]
     signal_time = signal.get("signal_time", "")
+    chat_id = settings.get("alert_telegram_chat_id", "")
 
     # ── Filter: strategy subscribed? ──
     if settings["strategies"] and strategy_id not in settings["strategies"]:
@@ -135,6 +145,12 @@ async def _try_execute(
             "Session %s daily trade limit reached (%d/%d)",
             session_id[:8], daily_stats["trades_today"], max_daily,
         )
+        if chat_id:
+            asyncio.create_task(send_safety_limit(chat_id, "daily_trades", {
+                "trades_today": daily_stats["trades_today"],
+                "max_daily": max_daily,
+                "coin": coin, "strategy": strategy_id,
+            }))
         return None
 
     # ── Safety: daily loss limit ──
@@ -144,12 +160,15 @@ async def _try_execute(
             "Session %s daily loss limit hit ($%.2f / limit $%.2f)",
             session_id[:8], daily_stats["pnl_today"], daily_loss_limit,
         )
+        if chat_id:
+            asyncio.create_task(send_safety_limit(chat_id, "daily_loss", {
+                "pnl_today": daily_stats["pnl_today"],
+                "limit": daily_loss_limit,
+                "coin": coin, "strategy": strategy_id,
+            }))
         return None
 
     # ── Safety: consecutive loss guard ──
-    # pnl_sync.py updates pnl_usdt to actual realized values after position close.
-    # Initial estimate is worst-case (SL scenario), so guard uses actual values
-    # once sync completes (typically within 30-120s of trade close).
     recent_trades = get_trade_log(session_id, limit=3)
     if len(recent_trades) >= 3:
         if all(t["pnl_usdt"] < 0 for t in recent_trades[:3]):
@@ -157,25 +176,34 @@ async def _try_execute(
                 "Session %s: 3 consecutive losses — auto-pausing",
                 session_id[:8],
             )
+            if chat_id:
+                asyncio.create_task(send_safety_limit(chat_id, "consecutive_loss", {
+                    "count": 3, "coin": coin, "strategy": strategy_id,
+                }))
             return None
 
     # ── Execute ──
     inst_id = _pruviq_to_okx_inst_id(coin)
     side = "sell" if signal["direction"] == "short" else "buy"
-    entry_price = signal.get("entry_price", 0)
-
-    if not entry_price or entry_price <= 0:
-        logger.warning("No entry price for signal %s/%s", strategy_id, coin)
-        return None
-
-    position_size = settings["position_size_usdt"]
-    leverage = settings["leverage"]
-    td_mode = settings.get("td_mode", "isolated")
     sl_pct = signal.get("sl_pct", 10)
     tp_pct = signal.get("tp_pct", 8)
+    leverage = settings["leverage"]
+    td_mode = settings.get("td_mode", "isolated")
 
     token = await get_valid_token(session_id)
     async with OKXClient(token, session_id=session_id) as client:
+
+        # ── Industry standard: fetch LIVE mark price at execution time ──
+        # Signal entry_price is from historical OHLCV (up to 5min stale).
+        # Mark price ensures correct contract sizing and SL/TP reference.
+        try:
+            mark_price = await client.get_mark_price(inst_id)
+        except Exception as e:
+            logger.error("Failed to get mark price for %s: %s — skipping", inst_id, e)
+            if chat_id:
+                asyncio.create_task(send_execution_failed(chat_id, signal, f"mark price fetch failed: {e}"))
+            return None
+
         # ── Percent-of-balance position sizing ──
         if settings.get("position_size_mode") == "percent":
             pct = settings.get("position_size_pct", 5)
@@ -186,14 +214,18 @@ async def _try_execute(
                     "Session %s: zero USDT balance — skipping percent sizing",
                     session_id[:8],
                 )
+                if chat_id:
+                    asyncio.create_task(send_execution_failed(chat_id, signal, "insufficient USDT balance"))
                 return None
             position_size = avail * pct / 100
             logger.info(
                 "Percent sizing: %.1f%% of $%.2f = $%.2f for session %s",
                 pct, avail, position_size, session_id[:8],
             )
+        else:
+            position_size = settings["position_size_usdt"]
 
-        # Check concurrent position limit
+        # ── Check concurrent position limit ──
         positions = await client.get_positions()
         open_count = sum(1 for p in positions if float(p.pos or 0) != 0)
         if open_count >= settings["max_concurrent"]:
@@ -203,23 +235,45 @@ async def _try_execute(
             )
             return None
 
-        # Correct OKX SWAP contract size (integer, uses ctVal)
+        # ── Contract size using live mark price ──
         try:
-            sz = await _calc_contract_sz(client, inst_id, position_size, leverage, entry_price)
+            sz = await _calc_contract_sz(client, inst_id, position_size, leverage, mark_price)
         except ValueError as e:
             logger.warning("Position too small for auto-execute: %s", e)
+            if chat_id:
+                asyncio.create_task(send_execution_failed(chat_id, signal, f"position too small: {e}"))
             return None
 
-        # Set leverage before placing order
+        # ── Set leverage ──
         await client.set_leverage(inst_id=inst_id, lever=leverage, mgn_mode=td_mode)
 
-        # Market order
+        # ── Market order ──
         order = await client.place_order(inst_id=inst_id, side=side, sz=sz, td_mode=td_mode)
         ord_id = order.get("ordId", "")
-        logger.warning("← Auto order placed ordId=%s %s %s sz=%s", ord_id, side, inst_id, sz)
+        if not ord_id:
+            logger.error("Auto order returned no ordId — signal %s/%s", strategy_id, coin)
+            if chat_id:
+                asyncio.create_task(send_execution_failed(chat_id, signal, "order returned no ordId"))
+            return None
 
-        # SL/TP — if fails, close naked position immediately
-        sl_price, tp_price = _calc_sl_tp_prices(entry_price, signal["direction"], sl_pct, tp_pct)
+        # ── Industry standard: wait for fill, then query actual avgPx ──
+        # Bybit/OKX bots wait ~1-2s then query fill price for SL/TP accuracy.
+        await asyncio.sleep(_FILL_WAIT_S)
+        fill_price = mark_price  # fallback
+        try:
+            fill_price = await client.get_order_fill_price(inst_id, ord_id)
+            logger.warning(
+                "← Fill confirmed: ordId=%s avgPx=%.6f (markPx was %.6f)",
+                ord_id, fill_price, mark_price,
+            )
+        except Exception as e:
+            logger.warning(
+                "Could not get fill price for %s — using mark price %.6f: %s",
+                ord_id, mark_price, e,
+            )
+
+        # ── SL/TP calculated from ACTUAL FILL PRICE (industry standard) ──
+        sl_price, tp_price = _calc_sl_tp_prices(fill_price, signal["direction"], sl_pct, tp_pct)
         close_side = "buy" if signal["direction"] == "short" else "sell"
 
         try:
@@ -231,6 +285,8 @@ async def _try_execute(
                 tp_trigger_px=tp_price,
                 td_mode=td_mode,
             )
+            algo_id = (algo.get("data") or [{}])[0].get("algoId", "")
+            logger.warning("← SL/TP set: SL=%s TP=%s algoId=%s", sl_price, tp_price, algo_id)
         except Exception as algo_err:
             logger.error(
                 "CRITICAL: SL/TP failed after auto-order %s (%s) — closing: %s",
@@ -238,16 +294,9 @@ async def _try_execute(
             )
             try:
                 await client.close_position(inst_id, mgn_mode=td_mode)
-                # Notify user via Telegram if alert_telegram_chat_id set
-                chat_id = settings.get("alert_telegram_chat_id", "")
                 if chat_id:
-                    await send_signal_alert(chat_id, {
-                        "strategy": strategy_id, "coin": coin,
-                        "direction": "CLOSED",
-                        "entry_price": entry_price,
-                        "sl_pct": sl_pct, "tp_pct": tp_pct,
-                        "strategy_name": f"⚠️ SL/TP FAILED — {strategy_id} position closed",
-                    })
+                    asyncio.create_task(send_execution_failed(chat_id, signal,
+                        f"⚠️ SL/TP FAILED — position closed. ordId={ord_id}"))
             except Exception as close_err:
                 logger.error("EMERGENCY CLOSE FAILED for %s: %s", inst_id, close_err)
             return None
@@ -258,6 +307,7 @@ async def _try_execute(
         "coin": coin,
         "direction": signal["direction"],
         "size": sz,
+        "fill_price": fill_price,
         "sl": sl_price,
         "tp": tp_price,
         "order": order,
@@ -265,20 +315,23 @@ async def _try_execute(
         "timestamp": time.time(),
     }
 
-    # Log trade with estimated worst-case PnL (SL hit scenario)
-    # pnl_sync.py will update this to actual realized PnL once position closes
+    # Log trade: estimated worst-case PnL (SL hit), pnl_sync updates to actual later
     estimated_loss = -(position_size * sl_pct / 100)
     trade_created_at = result["timestamp"]
     log_trade(session_id, signal, result, pnl=estimated_loss)
     if signal_time:
         mark_signal_executed(session_id, strategy_id, coin, signal_time)
+
     logger.warning(
-        "Auto-executed: %s %s %s sz=%s for session %s (est_pnl=%.2f)",
-        side, inst_id, strategy_id, sz, session_id[:8], estimated_loss,
+        "Auto-executed: %s %s %s sz=%s fillPx=%.6f SL=%s TP=%s session=%s",
+        side, inst_id, strategy_id, sz, fill_price, sl_price, tp_price, session_id[:8],
     )
 
+    # ── Telegram: trade entry confirmation (industry standard) ──
+    if chat_id:
+        asyncio.create_task(send_trade_executed(chat_id, signal, fill_price, sz, sl_price, tp_price))
+
     # Fire-and-forget: sync actual realized PnL once position closes
-    import asyncio
     asyncio.create_task(sync_realized_pnl(session_id, inst_id, trade_created_at))
 
     return result

--- a/backend/okx/client.py
+++ b/backend/okx/client.py
@@ -295,3 +295,20 @@ class OKXClient:
         })
         logger.warning("← close-position done instId=%s", inst_id)
         return result
+
+    async def get_order_fill_price(self, inst_id: str, ord_id: str) -> float:
+        """
+        Query actual fill price (avgPx) for a completed market order.
+        Industry standard: SL/TP must be set relative to actual fill, not signal price.
+        Raises ValueError if order not yet filled or avgPx unavailable.
+        """
+        data = await self._get("/api/v5/trade/order", {"instId": inst_id, "ordId": ord_id})
+        orders = data.get("data", [])
+        if not orders:
+            raise ValueError(f"Order {ord_id} not found")
+        avg_px = orders[0].get("avgPx", "")
+        if not avg_px or float(avg_px) <= 0:
+            raise ValueError(f"Order {ord_id} avgPx not available yet (state={orders[0].get('state')})")
+        px = float(avg_px)
+        logger.warning("← order fill ordId=%s avgPx=%.6f state=%s", ord_id, px, orders[0].get("state"))
+        return px

--- a/backend/okx/notifications.py
+++ b/backend/okx/notifications.py
@@ -85,6 +85,122 @@ async def send_reauth_alert(chat_id: str) -> bool:
         return False
 
 
+async def _send(chat_id: str, msg: str, preview: bool = False) -> bool:
+    """Internal helper: send HTML message to Telegram chat."""
+    if not TELEGRAM_TOKEN or not chat_id:
+        return False
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.post(
+                f"https://api.telegram.org/bot{TELEGRAM_TOKEN}/sendMessage",
+                json={
+                    "chat_id": chat_id,
+                    "text": msg,
+                    "parse_mode": "HTML",
+                    "disable_web_page_preview": not preview,
+                },
+            )
+            return resp.status_code == 200
+    except Exception as e:
+        logger.error("Telegram send failed: %s", e)
+        return False
+
+
+async def send_trade_executed(
+    chat_id: str,
+    signal: dict,
+    fill_price: float,
+    sz: str,
+    sl_price: str,
+    tp_price: str,
+) -> bool:
+    """
+    Trade entry confirmation — sent after every successful auto-execution.
+    Industry standard: users must be notified of every entry with fill details.
+    """
+    direction = signal.get("direction", "").upper()
+    emoji = "🔴" if direction == "SHORT" else "🟢"
+    coin = signal.get("coin", "")
+    strategy = signal.get("strategy_name", signal.get("strategy", ""))
+    sl_pct = signal.get("sl_pct", 0)
+    tp_pct = signal.get("tp_pct", 0)
+
+    if fill_price < 1:
+        price_str = f"${fill_price:.6f}"
+    else:
+        price_str = f"${fill_price:,.2f}"
+
+    msg = (
+        f"{emoji} <b>PRUVIQ 자동매매 체결</b>\n"
+        f"<b>{strategy}</b> · {coin} · {direction}\n"
+        f"\n"
+        f"체결가: <b>{price_str}</b> ({sz} contracts)\n"
+        f"SL: {sl_price} (-{sl_pct}%) | TP: {tp_price} (+{tp_pct}%)\n"
+        f"\n"
+        f'<a href="{SITE_URL}/ko/dashboard">대시보드 →</a>'
+    )
+    logger.warning("→ Telegram trade-executed chat_id=%s %s %s", chat_id, coin, direction)
+    return await _send(chat_id, msg)
+
+
+async def send_execution_failed(chat_id: str, signal: dict, reason: str) -> bool:
+    """
+    Execution failure alert — sent when auto-trade fails for any reason.
+    Industry standard: users must know when their bot fails to execute.
+    """
+    coin = signal.get("coin", "")
+    strategy = signal.get("strategy_name", signal.get("strategy", ""))
+    direction = signal.get("direction", "").upper()
+
+    msg = (
+        f"⚠️ <b>PRUVIQ 자동매매 실패</b>\n"
+        f"{strategy} · {coin} · {direction}\n"
+        f"\n"
+        f"사유: <code>{reason}</code>\n"
+        f"\n"
+        f'<a href="{SITE_URL}/ko/dashboard">대시보드 확인 →</a>'
+    )
+    logger.warning("→ Telegram execution-failed chat_id=%s reason=%s", chat_id, reason)
+    return await _send(chat_id, msg)
+
+
+async def send_safety_limit(chat_id: str, limit_type: str, ctx: dict) -> bool:
+    """
+    Safety limit hit — daily trades, daily loss, consecutive losses.
+    Industry standard: circuit breaker events must be communicated to user.
+    """
+    if limit_type == "daily_trades":
+        msg = (
+            f"🛑 <b>PRUVIQ 일일 거래 한도 도달</b>\n"
+            f"오늘 거래: {ctx.get('trades_today')} / {ctx.get('max_daily')}회\n"
+            f"오늘 자동매매가 중단됩니다.\n"
+            f"\n"
+            f'<a href="{SITE_URL}/ko/dashboard">설정 변경 →</a>'
+        )
+    elif limit_type == "daily_loss":
+        msg = (
+            f"🛑 <b>PRUVIQ 일일 손실 한도 도달</b>\n"
+            f"오늘 손익: ${ctx.get('pnl_today', 0):.2f} / -${ctx.get('limit', 0):.0f}\n"
+            f"오늘 자동매매가 중단됩니다.\n"
+            f"\n"
+            f'<a href="{SITE_URL}/ko/dashboard">설정 변경 →</a>'
+        )
+    elif limit_type == "consecutive_loss":
+        msg = (
+            f"⏸️ <b>PRUVIQ 연속 손실 감지 — 자동 일시정지</b>\n"
+            f"연속 {ctx.get('count', 3)}회 손실 발생\n"
+            f"자동매매가 일시 중단되었습니다.\n"
+            f"활성화하려면 설정에서 다시 켜주세요.\n"
+            f"\n"
+            f'<a href="{SITE_URL}/ko/dashboard">대시보드 →</a>'
+        )
+    else:
+        return False
+
+    logger.warning("→ Telegram safety-limit chat_id=%s type=%s", chat_id, limit_type)
+    return await _send(chat_id, msg)
+
+
 async def send_signal_alert(chat_id: str, signal: dict) -> bool:
     """
     Send a signal alert to a user's personal Telegram chat.

--- a/backend/src/strategies/volume_profile.py
+++ b/backend/src/strategies/volume_profile.py
@@ -123,3 +123,17 @@ class VolumeProfileStrategy:
             return True
 
         return False
+
+    def check_signal(self, df, idx: int):
+        """
+        Signal scanner interface — returns 'long', 'short', or None.
+        Wraps entry_signal() for both directions.
+        """
+        if idx < 0 or idx >= len(df):
+            return None
+        row = df.iloc[idx]
+        if self.entry_signal(row, "short"):
+            return "short"
+        if self.entry_signal(row, "long"):
+            return "long"
+        return None

--- a/src/components/TradingSettings.tsx
+++ b/src/components/TradingSettings.tsx
@@ -9,7 +9,8 @@ interface Props {
 }
 
 const API_BASE = "https://api.pruviq.com";
-const OKX_OAUTH_BASE = "https://www.okx.com/account/oauth";
+// Must match backend okx/config.py OKX_OAUTH_AUTHORIZE
+const OKX_OAUTH_BASE = "https://www.okx.com/api/v5/oauth/authorize";
 
 function OKXDirectConnectButton({
   lang,


### PR DESCRIPTION
## 업계 표준 벤치마킹 기반 아키텍처 수정 (3commas/Bybit/OKX bot 기준)

### 🔴 Bug 1 (CRITICAL): SL/TP 기준가격 — signal 시점 → 실제 체결가(avgPx)

**기존**: signal.entry_price (OHLCV 히스토리, 최대 5분 전 캔들 open) → SL/TP 오염
**수정**:
1. 주문 직전 OKX mark_price 실시간 fetch → contract size 계산
2. place_order → 1.5초 대기 → `GET /api/v5/trade/order` avgPx 조회
3. **avgPx 기준으로 SL/TP 계산** (Bybit/OKX/3commas 표준)
4. avgPx 조회 실패 시 mark_price fallback

### 🔴 Bug 2: VolumeProfileStrategy.check_signal() 없음 → 5분마다 에러 스팸
- `check_signal()` 추가: entry_signal() 래핑, 'long'/'short'/None 반환
- signal scanner 에러 제거 → 실제 에러 로그 가시성 확보

### 🔴 Bug 3: OAuth URL 불일치
- TradingSettings: `/account/oauth` → `/api/v5/oauth/authorize` (백엔드 config 일치)

### 🟡 Bug 4: Telegram 이벤트 전체 커버 (업계 표준)
| 이벤트 | 기존 | 수정 |
|--------|------|------|
| 거래 체결 | ❌ 없음 | ✅ send_trade_executed() — fill price, contracts, SL/TP |
| 실행 실패 | ❌ 없음 | ✅ send_execution_failed() — 사유 포함 |
| 일일 거래 한도 | ❌ 없음 | ✅ send_safety_limit("daily_trades") |
| 일일 손실 한도 | ❌ 없음 | ✅ send_safety_limit("daily_loss") |
| 연속 손실 일시정지 | ❌ 없음 | ✅ send_safety_limit("consecutive_loss") |
| SL/TP 실패 | ✅ 있음 | ✅ 유지 |
| 재인증 만료 | ✅ 있음 | ✅ 유지 |

## 머지 후 Mac Mini
```bash
git pull && ~/Desktop/start-backend.command
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)