### PR TITLE
fix: hide autotrading/dashboard until beta validated

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -79,7 +79,7 @@ const navItems = [
   { href: simulatePath, match: '/simulate', label: t('nav.simulate') },
   { href: strategiesPath, match: '/strategies', label: t('nav.strategies') },
   { href: signalsPath, match: '/signals', label: t('nav.signals') },
-  { href: autotradingPath, match: '/autotrading', label: t('nav.autotrading'), badge: 'NEW' },
+  // { href: autotradingPath, match: '/autotrading', label: t('nav.autotrading'), badge: 'NEW' },  // hidden: beta testing
   { href: marketPath, match: '/market', label: t('nav.market') },
   { href: coinsPath, match: '/coins', label: t('nav.coins') },
   { href: learnPath, match: '/learn', label: t('nav.learn') },

--- a/src/pages/autotrading/index.astro
+++ b/src/pages/autotrading/index.astro
@@ -1,4 +1,6 @@
 ---
+// Autotrading is in beta — hidden from public until backend is validated
+return Astro.redirect('/', 302);
 import Layout from '../../layouts/Layout.astro';
 ---
 

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -1,4 +1,6 @@
 ---
+// Dashboard is in beta — hidden from public until backend is validated
+return Astro.redirect('/', 302);
 import Layout from '../layouts/Layout.astro';
 import OKXConnectButton from '../components/OKXConnectButton';
 import AutoTradingStatus from '../components/AutoTradingStatus';

--- a/src/pages/ko/autotrading/index.astro
+++ b/src/pages/ko/autotrading/index.astro
@@ -1,4 +1,6 @@
 ---
+// Autotrading is in beta — hidden from public until backend is validated
+return Astro.redirect('/ko/', 302);
 import Layout from '../../../layouts/Layout.astro';
 ---
 

--- a/src/pages/ko/dashboard.astro
+++ b/src/pages/ko/dashboard.astro
@@ -1,4 +1,6 @@
 ---
+// Dashboard is in beta — hidden from public until backend is validated
+return Astro.redirect('/ko/', 302);
 import Layout from '../../layouts/Layout.astro';
 import OKXConnectButton from '../../components/OKXConnectButton';
 import AutoTradingStatus from '../../components/AutoTradingStatus';


### PR DESCRIPTION
## Summary
- Nav에서 Autotrading 항목 주석 처리 (NEW 배지 포함)
- `/autotrading`, `/ko/autotrading` → 홈으로 302 redirect
- `/dashboard`, `/ko/dashboard` → 홈으로 302 redirect

## Re-enable 조건
1. Mac Mini `git pull` + 서버 재시작
2. OKX Demo 모드로 실제 주문 1회 검증 (avgPx, SL/TP 확인)
3. Layout.astro 주석 해제 + redirect 4개 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)