### PR TITLE
fix: automerge stuck — add Visual Regression to trigger list

### DIFF
--- a/.github/workflows/automerge-on-label.yml
+++ b/.github/workflows/automerge-on-label.yml
@@ -9,6 +9,7 @@ on:
       - "E2E Tests"
       - "Accessibility"
       - "Lighthouse Audit"
+      - "Visual Regression"
     types: [completed]
   workflow_dispatch: {}
 


### PR DESCRIPTION
## 원인
`automerge-on-label.yml`의 `workflow_run.workflows` 트리거에 `Visual Regression`이 빠져 있었음.

**흐름:**
1. E2E 완료 → automerge 실행 → visual-regression 아직 돌고 있음 → `allCompleted=false` → 머지 안 함
2. visual-regression 완료 → 트리거 목록에 없으니 automerge 재실행 없음 → PR 영구 대기

## 수정
`"Visual Regression"` 추가 → visual-regression 완료 시 automerge 재시도

🤖 Generated with [Claude Code](https://claude.com/claude-code)