### PR TITLE
fix: automerge — check_suite trigger (structural fix)

### DIFF
--- a/.github/workflows/automerge-on-label.yml
+++ b/.github/workflows/automerge-on-label.yml
@@ -9,6 +9,7 @@ on:
       - "E2E Tests"
       - "Accessibility"
       - "Lighthouse Audit"
+      - "Visual Regression"
     types: [completed]
   workflow_dispatch: {}
 

--- a/.github/workflows/automerge-on-label.yml
+++ b/.github/workflows/automerge-on-label.yml
@@ -3,14 +3,8 @@ name: Auto-merge labeled PRs
 on:
   pull_request:
     types: [labeled]
-  workflow_run:
-    workflows:
-      - "validate-startup-files"
-      - "E2E Tests"
-      - "Accessibility"
-      - "Lighthouse Audit"
-      - "Visual Regression"
-    types: [completed]
+  check_suite:
+    types: [completed]   # fires on every check completion — no hardcoded workflow list needed
   workflow_dispatch: {}
 
 permissions:
@@ -19,9 +13,9 @@ permissions:
   checks: read
 
 concurrency:
-  # PR별 독립 큐 — 다른 PR 이벤트끼리 서로 CANCEL 안 함
-  # workflow_dispatch는 run_id로 독립 실행
-  group: automerge-${{ github.event.pull_request.number || github.event.workflow_run.head_sha || github.run_id }}
+  # Per-SHA queue — different PRs don't cancel each other
+  # check_suite uses head_sha; workflow_dispatch uses run_id
+  group: automerge-${{ github.event.pull_request.number || github.event.check_suite.head_sha || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -33,7 +27,6 @@ jobs:
         with:
           script: |
             const labelName = 'automerge';
-            const restrictedPrefixes = [];
             const restrictedExactFiles = [
               'astro.config.mjs',
               'wrangler.toml',
@@ -44,10 +37,12 @@ jobs:
             const MIN_CHECK_RUNS = 2;
 
             let pr = null;
+
             if (context.eventName === 'pull_request') {
               pr = context.payload.pull_request;
-            } else if (context.eventName === 'workflow_run') {
-              const headSha = context.payload.workflow_run.head_sha;
+
+            } else if (context.eventName === 'check_suite') {
+              const headSha = context.payload.check_suite.head_sha;
               const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -57,17 +52,16 @@ jobs:
                 core.info(`No PRs associated with commit ${headSha}`);
                 return;
               }
-              // Find an open PR with automerge label
               const candidate = prs.data.find(p =>
                 p.state === 'open' && p.labels.some(l => l.name === labelName)
               );
               if (!candidate) {
-                core.info('No open PRs with automerge label found');
+                core.info('No open PRs with automerge label found for this commit');
                 return;
               }
               pr = candidate;
+
             } else if (context.eventName === 'workflow_dispatch') {
-              // Scan all open PRs for automerge label
               const openPRs = await github.paginate(github.rest.pulls.list, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -82,6 +76,7 @@ jobs:
                 return;
               }
               pr = candidate;
+
             } else {
               core.info(`Unsupported event: ${context.eventName}`);
               return;
@@ -106,17 +101,12 @@ jobs:
 
             const restrictedHits = [];
             for (const f of files) {
-              for (const prefix of restrictedPrefixes) {
-                if (f.filename.startsWith(prefix)) {
-                  restrictedHits.push({ file: f.filename, rule: `prefix: ${prefix}` });
-                }
-              }
               if (restrictedExactFiles.includes(f.filename)) {
-                restrictedHits.push({ file: f.filename, rule: 'infrastructure file' });
+                restrictedHits.push(f.filename);
               }
             }
             if (restrictedHits.length > 0) {
-              const list = restrictedHits.map(h => `- \`${h.file}\` (${h.rule})`).join('\n');
+              const list = restrictedHits.map(f => `- \`${f}\``).join('\n');
               core.info(`Skipping: PR touches restricted files:\n${list}`);
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
@@ -127,7 +117,7 @@ jobs:
               return;
             }
 
-            // Check Runs (not legacy commit statuses) for head SHA
+            // Check all runs for the PR head SHA
             const headSha = pr.head && pr.head.sha ? pr.head.sha : null;
             if (!headSha) {
               core.info('No head SHA found for PR; aborting.');
@@ -141,22 +131,22 @@ jobs:
             });
 
             const checkRuns = checks.data.check_runs.filter(
-              c => c.name !== 'attempt-merge'  // Exclude self
+              c => c.name !== 'attempt-merge'  // exclude self
             );
             const total = checkRuns.length;
             const allCompleted = checkRuns.every(c => c.status === 'completed');
             const allSuccess = checkRuns.every(c => c.conclusion === 'success' || c.conclusion === 'skipped');
 
-            core.info(`Check Runs for ${headSha}: ${total} total, allCompleted=${allCompleted}, allSuccess=${allSuccess}`);
+            core.info(`Check runs for ${headSha}: ${total} total, allCompleted=${allCompleted}, allSuccess=${allSuccess}`);
             checkRuns.forEach(c => core.info(`  - ${c.name}: ${c.status} / ${c.conclusion}`));
 
             if (total < MIN_CHECK_RUNS) {
-              core.info(`Only ${total} check runs found (minimum ${MIN_CHECK_RUNS}). Waiting for more.`);
+              core.info(`Only ${total} check runs (minimum ${MIN_CHECK_RUNS}). Waiting.`);
               return;
             }
 
             if (!allCompleted) {
-              core.info('Some checks still running; will not merge yet.');
+              core.info('Some checks still running; will retry when next check completes.');
               return;
             }
 
@@ -165,7 +155,7 @@ jobs:
               return;
             }
 
-            // All checks green — attempt to merge
+            // All checks green — merge
             try {
               await github.rest.pulls.merge({
                 owner: context.repo.owner,
@@ -175,8 +165,7 @@ jobs:
               });
               core.info(`Successfully merged PR #${prNumber}`);
             } catch (err) {
-              // Use warning instead of setFailed to prevent failure emails.
-              // Merge can fail when PR is behind main (common with data refresh commits).
-              // The next workflow run will retry automatically.
+              // Merge can fail when PR is behind main (data refresh commits).
+              // Next check_suite completion will retry automatically.
               core.warning(`Merge attempt for PR #${prNumber} did not succeed: ${err.message}`);
             }


### PR DESCRIPTION
## 근본 원인
`workflow_run` 트리거는 특정 워크플로우 이름 목록에 의존.
→ 새 워크플로우 추가 시마다 이 목록도 수동 업데이트 필요
→ 누락되면 automerge 영구 대기 (Visual Regression이 그랬음)

## 구조적 수정
`check_suite: completed` — 이름 무관하게 **모든** 체크 완료 시 트리거.
내부 로직(`allCompleted && allSuccess`)은 그대로 → 마지막 체크가 끝나는 순간 자동 머지.

앞으로 워크플로우가 몇 개 추가되더라도 이 파일은 수정 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)