### PR TITLE
fix: service reliability — P0-P2 backend+frontend fixes

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -411,6 +411,18 @@ async def rate_limit_middleware(request: Request, call_next):
                 content={"detail": f"Rate limit exceeded. Retry after {retry_after}s."},
                 headers={"Retry-After": str(retry_after)},
             )
+    # Light rate limit: /api/subscribe and /auth/okx/init (10 req/min per IP)
+    if request.url.path in ("/api/subscribe", "/auth/okx/init"):
+        client_ip = get_client_ip(request)
+        key = f"light:{client_ip}:{request.url.path}"
+        now = time.time()
+        if not hasattr(rate_limit_middleware, "_store"):
+            rate_limit_middleware._store = {}
+        timestamps = [t for t in rate_limit_middleware._store.get(key, []) if now - t < 60]
+        if len(timestamps) >= 10:
+            return JSONResponse(status_code=429, content={"detail": "Too many requests."})
+        timestamps.append(now)
+        rate_limit_middleware._store[key] = timestamps
     return await call_next(request)
 
 
@@ -617,9 +629,9 @@ async def signals_live(top_n: int = 30):
     """
     import asyncio
 
-    global _signal_scanner
     if _signal_scanner is None:
-        _signal_scanner = SignalScanner(data_manager, top_n=min(top_n, 50))
+        logger.warning("/signals/live: scanner not ready yet — startup still in progress")
+        return []
 
     def _scan():
         return _signal_scanner.scan()
@@ -631,9 +643,9 @@ async def signals_live(top_n: int = 30):
 @app.get("/signals/history")
 async def signals_history(hours: int = 24):
     """Return signal history for the last N hours (max 72)."""
-    global _signal_scanner
     if _signal_scanner is None:
-        _signal_scanner = SignalScanner(data_manager)
+        logger.warning("/signals/history: scanner not ready yet — startup still in progress")
+        return []
 
     return _signal_scanner.get_history(min(hours, 72))
 
@@ -3854,7 +3866,6 @@ SUBSCRIBERS_FILE = Path(os.environ.get("SUBSCRIBERS_FILE", "/Users/jepo/pruviq-d
 async def subscribe_email(req: SubscribeRequest):
     """Subscribe an email to weekly strategy alerts."""
     import re
-    import fcntl
 
     # Validate email format
     if not re.match(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$', req.email):

--- a/backend/okx/auto_executor.py
+++ b/backend/okx/auto_executor.py
@@ -133,8 +133,10 @@ async def _try_execute(
         return None
 
     # ── Deduplication: skip already-executed signals ──
-    if signal_time and is_signal_executed(session_id, strategy_id, coin, signal_time):
-        logger.debug("Signal already executed: %s/%s @ %s", strategy_id, coin, signal_time)
+    # Fallback to hourly key when signal_time is missing (prevents double-execution)
+    dedup_time = signal_time or time.strftime("%Y-%m-%dT%H:00:00")
+    if is_signal_executed(session_id, strategy_id, coin, dedup_time):
+        logger.debug("Signal already executed: %s/%s @ %s", strategy_id, coin, dedup_time)
         return None
 
     # ── Safety: daily trade limit ──
@@ -319,8 +321,7 @@ async def _try_execute(
     estimated_loss = -(position_size * sl_pct / 100)
     trade_created_at = result["timestamp"]
     log_trade(session_id, signal, result, pnl=estimated_loss)
-    if signal_time:
-        mark_signal_executed(session_id, strategy_id, coin, signal_time)
+    mark_signal_executed(session_id, strategy_id, coin, dedup_time)
 
     logger.warning(
         "Auto-executed: %s %s %s sz=%s fillPx=%.6f SL=%s TP=%s session=%s",

--- a/backend/okx/pnl_sync.py
+++ b/backend/okx/pnl_sync.py
@@ -68,10 +68,12 @@ async def sync_realized_pnl(session_id: str, inst_id: str, trade_created_at: flo
         except Exception as e:
             logger.error("PnL sync attempt %d failed: %s", i + 1, e)
 
+    # Reset estimated PnL to 0 — consecutive-loss guard should not fire on stale estimates
     logger.warning(
-        "PnL sync: no closed position found for session=%s inst=%s after 3 attempts",
+        "PnL sync: no closed position found for session=%s inst=%s after 3 attempts — resetting pnl to 0",
         session_id[:8], inst_id,
     )
+    _update_trade_pnl(session_id, inst_id, trade_created_at, 0.0)
 
 
 def _update_trade_pnl(

--- a/src/components/OKXConnectButton.tsx
+++ b/src/components/OKXConnectButton.tsx
@@ -4,6 +4,7 @@
  * Mirrors OKX JS SDK behavior (domain + /account/oauth + queryString) without loading SDK.
  */
 import { useState, useEffect } from "preact/hooks";
+import { API_BASE_URL as API_BASE } from "../config/api";
 
 interface Props {
   lang?: "en" | "ko";
@@ -11,7 +12,6 @@ interface Props {
   showCard?: boolean;
 }
 
-const API_BASE = "https://api.pruviq.com";
 const OKX_OAUTH_BASE = "https://www.okx.com/api/v5/oauth/authorize";
 
 const labels = {

--- a/src/components/OKXExecuteButton.tsx
+++ b/src/components/OKXExecuteButton.tsx
@@ -3,6 +3,7 @@
  * Broker tag ensures commission tracking on every order.
  */
 import { useState, useEffect } from "preact/hooks";
+import { API_BASE_URL as API_BASE } from "../config/api";
 
 interface Props {
   strategy?: string;
@@ -12,8 +13,6 @@ interface Props {
   tpPct?: number;
   lang?: "en" | "ko";
 }
-
-const API_BASE = "https://api.pruviq.com";
 
 const labels = {
   en: {

--- a/src/components/TradingSettings.tsx
+++ b/src/components/TradingSettings.tsx
@@ -9,12 +9,11 @@
  * - Empty strategies/coins → "all signals" warning shown
  */
 import { useState, useEffect, useMemo } from "preact/hooks";
+import { API_BASE_URL as API_BASE } from "../config/api";
 
 interface Props {
   lang?: "en" | "ko";
 }
-
-const API_BASE = "https://api.pruviq.com";
 // Must match backend okx/config.py OKX_OAUTH_AUTHORIZE
 const OKX_OAUTH_BASE = "https://www.okx.com/api/v5/oauth/authorize";
 


### PR DESCRIPTION
## Summary

- **P0-3** `pnl_sync.py`: After 3 failed position-history polls, reset pnl to `0.0` instead of leaving the estimated negative value — prevents stale data from falsely triggering the consecutive-loss guard
- **P1-1/P1-2** `main.py`: Light rate limit (10 req/min per IP) on `/api/subscribe` and `/auth/okx/init` — prevents abuse of public endpoints
- **P1-3** `auto_executor.py`: Dedup fallback to hourly bucket key when `signal_time` is missing — prevents double-execution of signals without timestamps
- **P1-4** `main.py`: Remove unused `import fcntl` from `/api/subscribe` handler (Linux-only, no-op on Mac but wrong)
- **P2-2** `OKXConnectButton/ExecuteButton/TradingSettings`: Import `API_BASE` from `config/api.ts` (single source of truth, env-overridable via `PUBLIC_PRUVIQ_API_URL`)
- **P2-4** `main.py`: Remove lazy scanner re-init in `/signals/live` and `/signals/history` — scanner is initialized at startup; re-init creates a different `top_n` instance than the auto-executor uses

## Test plan
- [x] `npm run build` — 2526 pages, 0 errors
- [ ] Mac Mini: `git pull` + `~/Desktop/start-backend.command` after merge (backend changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)