### PR TITLE
fix: remove OKX_BROKER_CODE hardcoded default + rate_limits DDoS cap

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -368,7 +368,10 @@ def check_rate_limit(client_ip: str) -> bool:
         for ip in stale:
             del rate_limits[ip]
 
+    # Hard cap: if dict exceeds 10k IPs (DDoS scenario), reject new IPs
     if client_ip not in rate_limits:
+        if len(rate_limits) >= 10_000:
+            return False
         rate_limits[client_ip] = []
 
     rate_limits[client_ip] = [t for t in rate_limits[client_ip] if now - t < 60]

--- a/backend/okx/config.py
+++ b/backend/okx/config.py
@@ -12,7 +12,10 @@ OKX_CLIENT_SECRET = os.environ.get("OKX_CLIENT_SECRET", "")
 OKX_REDIRECT_URI = os.environ.get(
     "OKX_REDIRECT_URI", "https://api.pruviq.com/auth/okx/callback"
 )
-OKX_BROKER_CODE = os.environ.get("OKX_BROKER_CODE", "c12571e26a02OCDE")
+OKX_BROKER_CODE = os.environ.get("OKX_BROKER_CODE", "")
+if not OKX_BROKER_CODE:
+    import logging as _logging
+    _logging.getLogger("pruviq").warning("OKX_BROKER_CODE env var not set — affiliate revenue tracking disabled")
 
 # ── Encryption ──
 OKX_ENCRYPTION_KEY = os.environ.get("OKX_ENCRYPTION_KEY", "")


### PR DESCRIPTION
## Summary

- **OKX_BROKER_CODE**: 소스코드에 실제 브로커 코드가 기본값으로 하드코딩되어 있었음. 환경변수 미설정 시 실제 브로커 코드로 동작 — 미설정을 감지 불가능한 상태였음. 기본값 제거 + 미설정 시 WARNING 로그.
- **rate_limits DDoS 상한**: 고유 IP 무제한 증가 방지. 10,000 IP 초과 시 신규 IP 거부.

## 감사 결론 (ultraplan)

전체 5개 결함 중 코드 레벨 수정 가능한 2건 처리:

| # | 결함 | 상태 |
|---|------|------|
| 1 | Autotrader=PRUVIQ API 동거 (아키텍처) | 별도 논의 필요 |
| 2 | Mac Mini SPOF (인프라) | 별도 논의 필요 |
| 3 | `/admin/refresh` 미인증 | 오진 — 이미 ADMIN_API_KEY 보호됨 |
| 4 | rate_limits 메모리 상한 없음 | ✅ 이 PR |
| 5 | OKX_BROKER_CODE 하드코딩 | ✅ 이 PR |

## Test plan

- [ ] `OKX_BROKER_CODE` 환경변수 미설정 시 WARNING 로그 확인
- [ ] `OKX_BROKER_CODE` 설정 시 정상 동작 확인
- [ ] 빌드 2526 pages, qa-redirects PASS 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)