### PR TITLE
fix: autotrader separation + backend auto-deploy workflow

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -1,0 +1,57 @@
+name: "Backend Deploy: Mac Mini Auto-Restart"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+
+concurrency:
+  group: backend-deploy
+  cancel-in-progress: false
+
+jobs:
+  restart:
+    name: Restart uvicorn on Mac Mini
+    runs-on: [self-hosted, mac-mini-m4]
+    timeout-minutes: 5
+
+    steps:
+      - name: Pull latest code
+        run: |
+          cd ~/pruviq
+          git fetch origin main
+          git reset --hard origin/main
+
+      - name: Install dependencies if requirements changed
+        run: |
+          cd ~/pruviq/backend
+          if git diff HEAD~1 --name-only 2>/dev/null | grep -q "requirements.txt"; then
+            echo "requirements.txt changed, installing..."
+            .venv/bin/pip install -q -r requirements.txt
+          else
+            echo "No dependency changes"
+          fi
+
+      - name: Restart uvicorn via launchd
+        run: |
+          launchctl bootout "gui/$(id -u)" ~/Library/LaunchAgents/com.pruviq.api.plist 2>/dev/null || true
+          pkill -9 -f "uvicorn api.main" 2>/dev/null || true
+          sleep 3
+          launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.pruviq.api.plist
+          echo "uvicorn restart initiated"
+
+      - name: Wait for API to be ready
+        run: |
+          for i in 1 2 3 4 5; do
+            sleep 20
+            coins=$(curl -s -m 5 http://localhost:8080/health 2>/dev/null \
+              | python3 -c "import sys,json; print(json.load(sys.stdin).get('coins_loaded',0))" 2>/dev/null || echo "0")
+            echo "Attempt $i: coins=$coins"
+            if [ "$coins" -gt 400 ] 2>/dev/null; then
+              echo "Backend ready: $coins coins loaded"
+              exit 0
+            fi
+          done
+          echo "WARNING: Backend took longer than expected to load — check logs"
+          exit 0

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -30,6 +30,9 @@ from fastapi.responses import JSONResponse, Response
 
 _admin_key_raw = os.environ.get("ADMIN_API_KEY", "")
 ADMIN_API_KEY: Optional[str] = _admin_key_raw if len(_admin_key_raw) >= 32 else None
+_internal_key_raw = os.environ.get("INTERNAL_API_KEY", "")
+INTERNAL_API_KEY: Optional[str] = _internal_key_raw if len(_internal_key_raw) >= 32 else None
+OKX_AUTO_TRADE_LOCAL = os.environ.get("OKX_AUTO_TRADE_LOCAL", "true").lower() == "true"
 COINGECKO_API_KEY = os.environ.get("COINGECKO_API_KEY", "")
 CG_HEADERS = {"x-cg-demo-api-key": COINGECKO_API_KEY} if COINGECKO_API_KEY else {}
 
@@ -41,6 +44,9 @@ logger = logging.getLogger("pruviq")
 
 if ADMIN_API_KEY is None:
     logger.warning("ADMIN_API_KEY too short or missing — /admin/refresh disabled")
+
+if INTERNAL_API_KEY is None:
+    logger.warning("INTERNAL_API_KEY too short or missing — /internal/signals disabled")
 
 # Add backend to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -281,20 +287,28 @@ async def lifespan(app: FastAPI):
     # IMPORTANT: Deploy with --workers 1 (global cache not shared across processes)
     refresh_task = asyncio.create_task(_background_refresh())
     market_task = asyncio.create_task(_background_market_refresh())
-    okx_auto_task = asyncio.create_task(_okx_auto_trading_loop())
+    if OKX_AUTO_TRADE_LOCAL:
+        okx_auto_task = asyncio.create_task(_okx_auto_trading_loop())
+        print("OKX auto-trading loop started (local mode)")
+    else:
+        okx_auto_task = None
+        print("OKX auto-trading loop SKIPPED (OKX_AUTO_TRADE_LOCAL=false — DO server handles it)")
     okx_token_task = asyncio.create_task(_okx_token_refresh_loop())
     print(f"Background data refresh scheduled every {REFRESH_INTERVAL}s")
     print(f"Background market refresh scheduled every {MARKET_REFRESH_INTERVAL}s")
-    print("OKX auto-trading loop started")
 
     yield
 
     indicator_task.cancel()
     refresh_task.cancel()
     market_task.cancel()
-    okx_auto_task.cancel()
+    if okx_auto_task is not None:
+        okx_auto_task.cancel()
     okx_token_task.cancel()
-    for t in (indicator_task, refresh_task, market_task, okx_auto_task, okx_token_task):
+    _tasks = [indicator_task, refresh_task, market_task, okx_token_task]
+    if okx_auto_task is not None:
+        _tasks.append(okx_auto_task)
+    for t in _tasks:
         try:
             await t
         except asyncio.CancelledError:
@@ -641,6 +655,44 @@ async def signals_live(top_n: int = 30):
 
     signals = await asyncio.to_thread(_scan)
     return signals
+
+
+@app.get("/internal/signals")
+async def internal_signals(
+    x_internal_key: str = Header(default="", alias="X-Internal-Key"),
+):
+    """Internal endpoint exposing live scanner signals for the DO auto-trading worker.
+
+    Authentication: Requires `X-Internal-Key` header matching INTERNAL_API_KEY env var
+    (length >= 32). Returns 403 if key is missing, too short, or mismatched.
+
+    Response shape:
+        {"signals": [...], "ts": <unix seconds>}
+
+    When `_signal_scanner` is not yet initialized OR scan returns no signals,
+    `signals` is an empty list (ts still populated).
+
+    Consumed by: `backend/okx/server.py` polling loop (OKX_AUTO_TRADE_LOCAL=false mode).
+    """
+    if INTERNAL_API_KEY is None:
+        raise HTTPException(
+            status_code=403,
+            detail="INTERNAL_API_KEY not configured on server",
+        )
+    if not x_internal_key or not hmac.compare_digest(x_internal_key, INTERNAL_API_KEY):
+        raise HTTPException(status_code=403, detail="invalid X-Internal-Key")
+
+    ts = int(time.time())
+    if _signal_scanner is None:
+        return {"signals": [], "ts": ts}
+
+    try:
+        signals = await asyncio.to_thread(_signal_scanner.scan)
+    except Exception as e:
+        logger.warning(f"/internal/signals scan failed: {e}")
+        raise HTTPException(status_code=500, detail=f"scan failed: {e}")
+
+    return {"signals": signals or [], "ts": ts}
 
 
 @app.get("/signals/history")

--- a/backend/okx/server.py
+++ b/backend/okx/server.py
@@ -11,15 +11,103 @@ Usage:
 """
 from __future__ import annotations
 
+import asyncio
+import logging
+import os
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from router import router as okx_router
 
+logger = logging.getLogger("pruviq-okx")
+
+# Signal polling config (optional — only active if both env vars are set)
+OKX_SIGNAL_SOURCE_URL = os.environ.get("OKX_SIGNAL_SOURCE_URL", "").strip()
+INTERNAL_API_KEY = os.environ.get("INTERNAL_API_KEY", "").strip()
+SIGNAL_POLL_INTERVAL = int(os.environ.get("OKX_SIGNAL_POLL_INTERVAL", "300"))  # 5 min default
+SIGNAL_POLL_TIMEOUT = float(os.environ.get("OKX_SIGNAL_POLL_TIMEOUT", "15"))
+
+
+async def _signal_polling_loop() -> None:
+    """Poll Mac Mini `/internal/signals` every `SIGNAL_POLL_INTERVAL` seconds.
+
+    Runs only when OKX_SIGNAL_SOURCE_URL and INTERNAL_API_KEY are both set.
+    Forwards signals to `process_signals` (auto_executor). Errors are logged
+    at WARNING and the loop continues — one bad poll should not kill the worker.
+    """
+    # Lazy import so the module stays importable in environments without httpx
+    import httpx
+    from auto_executor import process_signals
+
+    # Small startup delay so broker health endpoints come up first
+    await asyncio.sleep(30)
+
+    headers = {"X-Internal-Key": INTERNAL_API_KEY}
+    logger.warning(
+        "Signal polling loop starting: url=%s interval=%ss",
+        OKX_SIGNAL_SOURCE_URL,
+        SIGNAL_POLL_INTERVAL,
+    )
+
+    async with httpx.AsyncClient(timeout=SIGNAL_POLL_TIMEOUT) as client:
+        while True:
+            try:
+                resp = await client.get(OKX_SIGNAL_SOURCE_URL, headers=headers)
+                if resp.status_code != 200:
+                    logger.warning(
+                        "Signal poll non-200: status=%s body=%s",
+                        resp.status_code,
+                        resp.text[:300],
+                    )
+                else:
+                    data = resp.json()
+                    signals = data.get("signals", []) if isinstance(data, dict) else []
+                    if signals:
+                        logger.warning("Signal poll: %d signals received", len(signals))
+                        try:
+                            await process_signals(signals)
+                        except Exception as e:
+                            logger.warning("process_signals failed: %s", e)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.warning("Signal poll error: %s", e)
+
+            await asyncio.sleep(SIGNAL_POLL_INTERVAL)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Start the signal polling loop iff both env vars are configured."""
+    poll_task: asyncio.Task | None = None
+    if OKX_SIGNAL_SOURCE_URL and INTERNAL_API_KEY and len(INTERNAL_API_KEY) >= 32:
+        poll_task = asyncio.create_task(_signal_polling_loop())
+        logger.warning("Signal polling task scheduled")
+    else:
+        logger.warning(
+            "Signal polling DISABLED: OKX_SIGNAL_SOURCE_URL=%s INTERNAL_API_KEY_set=%s",
+            bool(OKX_SIGNAL_SOURCE_URL),
+            len(INTERNAL_API_KEY) >= 32,
+        )
+
+    try:
+        yield
+    finally:
+        if poll_task is not None:
+            poll_task.cancel()
+            try:
+                await poll_task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+
 app = FastAPI(
     title="PRUVIQ OKX Broker",
     version="0.1.0",
     description="PRUVIQ → OKX trade execution via OAuth Broker",
+    lifespan=lifespan,
 )
 
 app.add_middleware(
@@ -38,4 +126,5 @@ async def health():
         "status": "ok",
         "service": "pruviq-okx-broker",
         "version": "0.1.0",
+        "signal_polling": bool(OKX_SIGNAL_SOURCE_URL and len(INTERNAL_API_KEY) >= 32),
     }


### PR DESCRIPTION
## Summary

시스템 무결성 감사(ultraplan) 결과 식별된 구조적 결함 2건 수정.

### 1. Autotrader 분리 인프라 구축

**문제**: `_okx_auto_trading_loop`가 PRUVIQ 시뮬레이션 API(`main.py`) 안에서 실행 중 — "autotrader 완전 독립" 원칙 위반. API 재시작 시 거래 루프도 중단됨.

**수정**:
- `GET /internal/signals` 엔드포인트 추가 (`X-Internal-Key` HMAC 인증)
- `OKX_AUTO_TRADE_LOCAL=false` 설정 시 Mac Mini 로컬 루프 비활성화 (기본값 `true` = 현재 동작 유지)
- DO 서버 `server.py`: `OKX_SIGNAL_SOURCE_URL` + `INTERNAL_API_KEY` 설정 시 신호 폴링 루프 자동 활성화

**마이그레이션 단계** (이 PR 머지 후):
1. Mac Mini `.env`에 `INTERNAL_API_KEY=<32자 이상>` 추가
2. DO 서버 `.env`에 `OKX_SIGNAL_SOURCE_URL=https://api.pruviq.com/internal/signals` + `INTERNAL_API_KEY=<동일값>` 추가
3. Mac Mini: `OKX_AUTO_TRADE_LOCAL=false` 설정
4. 재시작 → DO 서버가 신호 실행 담당

### 2. 백엔드 자동 배포 workflow

**문제**: `backend/**` 변경 PR 머지 후 Mac Mini에서 수동으로 `git pull + start-backend.command` 실행해야 함.

**수정**: `.github/workflows/backend-deploy.yml`
- `backend/**` 변경 감지 시 `mac-mini-m4` self-hosted runner에서 자동 실행
- git pull → requirements 변경 시 pip install → launchd 재시작 → API 준비 확인

## Test plan

- [ ] `INTERNAL_API_KEY` 미설정 시 `/internal/signals` → 403 확인
- [ ] `OKX_AUTO_TRADE_LOCAL=true` (기본) → 기존 동작 유지 확인
- [ ] backend-deploy workflow: `backend/` 변경 PR 머지 시 자동 실행 확인
- [ ] 빌드 2526 pages, qa-redirects PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)