### PR TITLE
fix: auto-fix #1042 (+1 related)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -53,6 +53,9 @@ export default defineConfig({
         }
       },
       filter(page) {
+        const pathname = new URL(page).pathname;
+        const coinMatch = pathname.match(/^(?:\/ko)?\/coins\/([^/]+)\/?$/);
+        if (coinMatch && !coinMatch[1].endsWith('usdt')) return false;
         return !(/\/learn\/.+/.test(page)) && !page.includes('/demo/') && !page.includes('/builder/') && !page.includes('/404');
       },
       serialize(item) {

--- a/src/pages/ko/strategies/[id].astro
+++ b/src/pages/ko/strategies/[id].astro
@@ -60,7 +60,7 @@ const statusLabels: Record<string, string> = {
 };
 ---
 
-<Layout title={`${strategy.data.name} - PRUVIQ`} description={strategy.data.description} type="article" date={strategy.data.dateAdded} noAlternate={!isKorean}>
+<Layout title={`${strategy.data.name} - PRUVIQ`} description={strategy.data.description} type="article" date={strategy.data.dateAdded} noAlternate={!isKorean} skipArticleLD>
   <script type="application/ld+json" set:html={JSON.stringify({
     "@context": "https://schema.org",
     "@type": "TechArticle",

--- a/src/pages/strategies/[id].astro
+++ b/src/pages/strategies/[id].astro
@@ -44,7 +44,7 @@ const statusLabels: Record<string, string> = {
 };
 ---
 
-<Layout title={`${strategy.data.name} - PRUVIQ`} description={strategy.data.description} type="article" date={strategy.data.dateAdded}>
+<Layout title={`${strategy.data.name} - PRUVIQ`} description={strategy.data.description} type="article" date={strategy.data.dateAdded} skipArticleLD>
   <!-- TechArticle schema with dynamic dateModified -->
   <script type="application/ld+json" set:html={JSON.stringify({
     "@context": "https://schema.org",


### PR DESCRIPTION
## Auto-fix for 2 issue(s)

#1042: [claude-auto][P2] `astro.config.mjs:55-57` — ~577 non-canonical coin URLs included in sitemap; G
#1043: [claude-auto][P2] `src/pages/strategies/[id].astro:47` and `src/pages/ko/strategies/[id].astro:63`

### Changes
```
 astro.config.mjs                   | 3 +++
 src/pages/ko/strategies/[id].astro | 2 +-
 src/pages/strategies/[id].astro    | 2 +-
 3 files changed, 5 insertions(+), 2 deletions(-)
```

### Safety Checks
- Files changed: **3** (limit: 20)
- Lines changed: **7** (limit: 1500)

---
*Auto-generated by JEPO auto-fix agent. Requires auto-test pass before merge.*