### PR TITLE
fix: simulator QA — signal warmup, health retry, CLS, preset reflect

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -280,6 +280,18 @@ async def lifespan(app: FastAPI):
     if data_manager.coin_count > 0:
         _signal_scanner = SignalScanner(data_manager, top_n=50)
         print(f"SignalScanner initialized (top_n=50, {data_manager.coin_count} coins)")
+
+        # Pre-warm signal cache in background — first scan takes ~30s (CPU-bound).
+        # Without this, the first /signals/live request times out on the frontend.
+        async def _prewarm_signals():
+            try:
+                await asyncio.to_thread(_signal_scanner.scan)
+                n = len(_signal_scanner._cache)
+                print(f"Signal cache pre-warmed: {n} active signals")
+            except Exception as e:
+                print(f"WARNING: Signal cache pre-warm failed: {e}")
+
+        asyncio.create_task(_prewarm_signals())
     else:
         print("WARNING: SignalScanner NOT initialized — 0 coins loaded")
 

--- a/src/components/LiveStats.tsx
+++ b/src/components/LiveStats.tsx
@@ -57,7 +57,8 @@ function AnimatedNumber({
     const duration = 1200;
     const steps = 30;
     let step = 0;
-    setDisplay(0);
+    // Don't reset to 0 if already showing the correct value — prevents CLS flash
+    if (display !== value) setDisplay(0);
 
     const timer = setInterval(() => {
       step++;

--- a/src/components/SimulatorPage.tsx
+++ b/src/components/SimulatorPage.tsx
@@ -602,18 +602,30 @@ export default function SimulatorPage({ lang = "en" }: Props) {
     let cancelled = false;
 
     async function init() {
-      try {
-        const healthRes = await fetch(`${API_URL}/health`, {
-          signal: AbortSignal.timeout(5000),
-        });
-        if (healthRes.ok) {
-          const h = await healthRes.json();
-          setCoinsLoaded(h.coins_loaded || h.coin_count || 0);
-          setApiReady(true);
-        } else {
-          setDemoMode(true);
+      // Retry health check up to 3× — backend may still be warming up after restart
+      let healthOk = false;
+      for (let attempt = 0; attempt < 3 && !cancelled; attempt++) {
+        try {
+          const healthRes = await fetch(`${API_URL}/health`, {
+            signal: AbortSignal.timeout(8000),
+          });
+          if (healthRes.ok) {
+            const h = await healthRes.json();
+            if (!cancelled) {
+              setCoinsLoaded(h.coins_loaded || h.coin_count || 0);
+              setApiReady(true);
+            }
+            healthOk = true;
+            break;
+          }
+        } catch {
+          // retry
         }
-      } catch {
+        if (attempt < 2 && !cancelled) {
+          await new Promise((r) => setTimeout(r, 3000));
+        }
+      }
+      if (!healthOk && !cancelled) {
         setDemoMode(true);
       }
 
@@ -1150,6 +1162,8 @@ export default function SimulatorPage({ lang = "en" }: Props) {
     const pending = (window as any).__pruviq_pending_strategy;
     if (pending && apiReady && !isRunning && !result) {
       delete (window as any).__pruviq_pending_strategy;
+      // Mark strategy as active so preset bar reflects the current strategy
+      setActivePreset(pending);
 
       // Call /simulate with strategy ID directly (matching Standard mode behavior)
       setIsRunning(true);
@@ -1300,7 +1314,17 @@ export default function SimulatorPage({ lang = "en" }: Props) {
                   : undefined
               }
             >
-              {<><span class="block text-base leading-none mb-0.5" aria-hidden="true">{t.mobileIcon[tab]}</span><span class="block text-[10px]">{t.mobile[tab]}</span></>}
+              {
+                <>
+                  <span
+                    class="block text-base leading-none mb-0.5"
+                    aria-hidden="true"
+                  >
+                    {t.mobileIcon[tab]}
+                  </span>
+                  <span class="block text-[10px]">{t.mobile[tab]}</span>
+                </>
+              }
             </button>
           ))}
         </div>

--- a/src/components/ui/CountUp.tsx
+++ b/src/components/ui/CountUp.tsx
@@ -27,7 +27,8 @@ export default function CountUp({
   duration = 1500,
   locale,
 }: CountUpProps) {
-  const [current, setCurrent] = useState(0);
+  // Start at target so SSR/initial render shows the correct value (prevents CLS)
+  const [current, setCurrent] = useState(target);
   const [started, setStarted] = useState(false);
   const ref = useRef<HTMLSpanElement>(null);
 
@@ -36,16 +37,23 @@ export default function CountUp({
     const el = ref.current;
     if (!el) return;
 
-    // Respect reduced motion
+    // Respect reduced motion — keep target value as-is
     const prefersReduced = window.matchMedia(
       "(prefers-reduced-motion: reduce)",
     ).matches;
     if (prefersReduced) {
       setCurrent(target);
-      setStarted(true);
       return;
     }
 
+    // If already visible (above-the-fold), skip animation to prevent CLS
+    const rect = el.getBoundingClientRect();
+    if (rect.top < window.innerHeight && rect.bottom > 0) {
+      setCurrent(target);
+      return;
+    }
+
+    // Animate when scrolled into view
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {


### PR DESCRIPTION
## Summary

- **P1-A**: `SignalScanner.scan()` pre-warmed during startup via `asyncio.to_thread` — eliminates 30s warmup delay on first `/signals/live` request
- **P1-B**: Health check retries 3× (8s timeout each, 3s backoff) before enabling demo mode — fixes false "API unavailable" on `/ko/simulate/` after backend restart
- **P2**: `setActivePreset(pending)` added before `/simulate` auto-run from `?strategy=` URL — preset bar now reflects strategy coming from Signals Verify
- **P3**: `CountUp` initializes to `target` (not 0) and skips animation when already in viewport; `AnimatedNumber` no longer resets display to 0 on hydration — eliminates CLS flash on homepage stats

## Test plan
- [ ] `/signals/verify` loads without "warming up" immediately after backend restart
- [ ] `/ko/simulate/` loads correctly (not demo mode) when backend is up
- [ ] Click "Verify →" on a signal → simulator highlights the correct strategy
- [ ] Homepage stats bar shows correct numbers without flash (0 → target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)