### PR TITLE
fix: simulator integrity — fee configurable, leverage PnL, data_range, survivor bias

### DIFF
--- a/backend/api/data_manager.py
+++ b/backend/api/data_manager.py
@@ -161,8 +161,11 @@ class DataManager:
         return resampled
 
     def data_range(self) -> str:
-        """Overall data range."""
+        """Overall data range across all loaded coins."""
         if not self._coin_info:
             return "N/A"
-        first = self._coin_info[0]
-        return f"{first['date_from']} ~ {first['date_to']}"
+        dates_from = [c["date_from"] for c in self._coin_info if c.get("date_from")]
+        dates_to = [c["date_to"] for c in self._coin_info if c.get("date_to")]
+        if not dates_from:
+            return "N/A"
+        return f"{min(dates_from)} ~ {max(dates_to)}"

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -280,6 +280,18 @@ async def lifespan(app: FastAPI):
     if data_manager.coin_count > 0:
         _signal_scanner = SignalScanner(data_manager, top_n=50)
         print(f"SignalScanner initialized (top_n=50, {data_manager.coin_count} coins)")
+
+        # Pre-warm signal cache in background — first scan takes ~30s (CPU-bound).
+        # Without this, the first /signals/live request times out on the frontend.
+        async def _prewarm_signals():
+            try:
+                await asyncio.to_thread(_signal_scanner.scan)
+                n = len(_signal_scanner._cache)
+                print(f"Signal cache pre-warmed: {n} active signals")
+            except Exception as e:
+                print(f"WARNING: Signal cache pre-warm failed: {e}")
+
+        asyncio.create_task(_prewarm_signals())
     else:
         print("WARNING: SignalScanner NOT initialized — 0 coins loaded")
 

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -765,7 +765,7 @@ async def hot_strategies():
                             sl_pct=float(defaults["sl"]) / 100,
                             tp_pct=float(defaults["tp"]) / 100,
                             max_bars=48,
-                            fee_pct=0.0008,
+                            fee_pct=0.0005,
                             slippage_pct=0.0002,
                             direction=direction,
                             market_type="futures",
@@ -917,18 +917,20 @@ async def simulate(req: SimulationRequest):
                     actual_date_max = df_max
 
             dyn_slip = _get_dynamic_slippage(sym)
+            effective_fee = req.fee_pct if req.fee_pct is not None else cost_model.fee_pct
             result = run_fast(
                 df, strategy, sym,
                 sl_pct=req.sl_pct / 100,
                 tp_pct=req.tp_pct / 100,
                 max_bars=req.max_bars,
-                fee_pct=cost_model.fee_pct,
+                fee_pct=effective_fee,
                 slippage_pct=dyn_slip,
                 direction=run_dir,
                 market_type=req.market_type,
                 strategy_id=strategy_id,
                 funding_rate_8h=getattr(cost_model, 'funding_rate_8h', 0.0001),
                 timeframe=timeframe,
+                leverage=float(req.leverage),
             )
 
             # Collect per-coin stats

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -26,6 +26,8 @@ class SimulationRequest(BaseModel):
     avoid_hours: Optional[List[int]] = Field(default=None, description="UTC hours to avoid entering trades (0-23). null = use strategy default")
     avoid_months: Optional[List[int]] = Field(default=None, description="Months to avoid entering trades (1-12). null = no month filter")
     min_vol_regime: Optional[float] = Field(default=None, description="Minimum ATR ratio (current ATR / 14-period ATR MA) to allow entry. e.g., 0.7 = skip low-volatility periods. null = no filter")
+    fee_pct: Optional[float] = Field(default=None, ge=0.0, le=0.01, description="Fee per side (0.0005 = 0.05%). None = use market_type default")
+    leverage: float = Field(default=1.0, ge=1.0, le=125.0, description="Leverage multiplier for PnL calculation")
 
     @field_validator("avoid_hours")
     @classmethod

--- a/backend/src/simulation/engine.py
+++ b/backend/src/simulation/engine.py
@@ -93,8 +93,8 @@ class CostModel:
 
     @staticmethod
     def futures():
-        """Futures taker fee (0.08%/side) — AutoTrader parity."""
-        return CostModel(fee_pct=0.0008, slippage_pct=0.0002, funding_rate_8h=0.0001)
+        """Futures taker fee (0.05%/side — Binance/OKX standard). User-overridable via API."""
+        return CostModel(fee_pct=0.0005, slippage_pct=0.0002, funding_rate_8h=0.0001)
 
 
 class Strategy(Protocol):

--- a/backend/src/simulation/engine_fast.py
+++ b/backend/src/simulation/engine_fast.py
@@ -1486,7 +1486,7 @@ def run_fast(
     sl_pct: float = 0.10,
     tp_pct: float = 0.08,
     max_bars: int = 48,
-    fee_pct: float = 0.0008,
+    fee_pct: float = 0.0005,
     slippage_pct: float = 0.0002,
     direction: str = "short",
     market_type: str = "futures",
@@ -1495,6 +1495,7 @@ def run_fast(
     timeframe: str = "1H",
     trailing_pct: float = 0.0,
     initial_sl_pct: float = 0.0,
+    leverage: float = 1.0,
 ) -> SimResult:
     """Complete fast simulation pipeline."""
 
@@ -1557,6 +1558,11 @@ def run_fast(
             max_drawdown_pct=0, max_consecutive_losses=0,
             total_fees_pct=0, total_funding_pct=0, tp_count=0, sl_count=0, timeout_count=0,
         )
+
+    # Apply leverage to PnL — multiply net return by leverage multiplier
+    if leverage != 1.0:
+        from dataclasses import replace as _dc_replace
+        trades = [_dc_replace(t, pnl_pct=round(t.pnl_pct * leverage, 4)) for t in trades]
 
     wins = [t for t in trades if t.pnl_pct > 0]
     losses = [t for t in trades if t.pnl_pct <= 0]

--- a/src/components/LiveStats.tsx
+++ b/src/components/LiveStats.tsx
@@ -57,7 +57,8 @@ function AnimatedNumber({
     const duration = 1200;
     const steps = 30;
     let step = 0;
-    setDisplay(0);
+    // Don't reset to 0 if already showing the correct value — prevents CLS flash
+    if (display !== value) setDisplay(0);
 
     const timer = setInterval(() => {
       step++;

--- a/src/components/SimulatorPage.tsx
+++ b/src/components/SimulatorPage.tsx
@@ -602,18 +602,30 @@ export default function SimulatorPage({ lang = "en" }: Props) {
     let cancelled = false;
 
     async function init() {
-      try {
-        const healthRes = await fetch(`${API_URL}/health`, {
-          signal: AbortSignal.timeout(5000),
-        });
-        if (healthRes.ok) {
-          const h = await healthRes.json();
-          setCoinsLoaded(h.coins_loaded || h.coin_count || 0);
-          setApiReady(true);
-        } else {
-          setDemoMode(true);
+      // Retry health check up to 3× — backend may still be warming up after restart
+      let healthOk = false;
+      for (let attempt = 0; attempt < 3 && !cancelled; attempt++) {
+        try {
+          const healthRes = await fetch(`${API_URL}/health`, {
+            signal: AbortSignal.timeout(8000),
+          });
+          if (healthRes.ok) {
+            const h = await healthRes.json();
+            if (!cancelled) {
+              setCoinsLoaded(h.coins_loaded || h.coin_count || 0);
+              setApiReady(true);
+            }
+            healthOk = true;
+            break;
+          }
+        } catch {
+          // retry
         }
-      } catch {
+        if (attempt < 2 && !cancelled) {
+          await new Promise((r) => setTimeout(r, 3000));
+        }
+      }
+      if (!healthOk && !cancelled) {
         setDemoMode(true);
       }
 
@@ -1150,6 +1162,8 @@ export default function SimulatorPage({ lang = "en" }: Props) {
     const pending = (window as any).__pruviq_pending_strategy;
     if (pending && apiReady && !isRunning && !result) {
       delete (window as any).__pruviq_pending_strategy;
+      // Mark strategy as active so preset bar reflects the current strategy
+      setActivePreset(pending);
 
       // Call /simulate with strategy ID directly (matching Standard mode behavior)
       setIsRunning(true);
@@ -1300,7 +1314,17 @@ export default function SimulatorPage({ lang = "en" }: Props) {
                   : undefined
               }
             >
-              {<><span class="block text-base leading-none mb-0.5" aria-hidden="true">{t.mobileIcon[tab]}</span><span class="block text-[10px]">{t.mobile[tab]}</span></>}
+              {
+                <>
+                  <span
+                    class="block text-base leading-none mb-0.5"
+                    aria-hidden="true"
+                  >
+                    {t.mobileIcon[tab]}
+                  </span>
+                  <span class="block text-[10px]">{t.mobile[tab]}</span>
+                </>
+              }
             </button>
           ))}
         </div>

--- a/src/components/SimulatorPage.tsx
+++ b/src/components/SimulatorPage.tsx
@@ -496,6 +496,9 @@ export default function SimulatorPage({ lang = "en" }: Props) {
   const [presetLoading, setPresetLoading] = useState(false);
   const [presetError, setPresetError] = useState<string | null>(null);
 
+  // Fee rate (user-configurable, default 0.05% Binance/OKX taker)
+  const [feePct, setFeePct] = useState(0.05);
+
   // Per-coin USDT + Leverage (compound mode uses total capital)
   const [perCoinUsdt, setPerCoinUsdt] = useState(60);
   const [leverage, setLeverage] = useState(5);
@@ -705,7 +708,14 @@ export default function SimulatorPage({ lang = "en" }: Props) {
         if (["1H", "2H", "4H", "6H", "12H", "1D", "1W"].includes(tf))
           setTimeframe(tf);
       }
-      if (params.has("start")) setStartDate(params.get("start")!);
+      if (params.has("start")) {
+        setStartDate(params.get("start")!);
+      } else {
+        // Default to 1-year lookback
+        const d = new Date();
+        d.setFullYear(d.getFullYear() - 1);
+        setStartDate(d.toISOString().slice(0, 10));
+      }
       if (params.has("end")) setEndDate(params.get("end")!);
       // Auto-select coin from URL (e.g., from /coins/[symbol] CTA)
       // Supports both ?symbol= and ?coin= for backwards compat
@@ -934,6 +944,7 @@ export default function SimulatorPage({ lang = "en" }: Props) {
       per_coin_usd: perCoinUsdt,
       leverage,
       compounding,
+      fee_pct: feePct / 100,
     };
 
     if (coinMode === "top") body.top_n = topN;
@@ -1180,6 +1191,8 @@ export default function SimulatorPage({ lang = "en" }: Props) {
         sl_pct: slPct,
         tp_pct: tpPct,
         top_n: topN,
+        fee_pct: feePct / 100,
+        leverage: leverage,
       };
       if (startDate) body.start_date = startDate;
       if (endDate) body.end_date = endDate;
@@ -1449,6 +1462,8 @@ export default function SimulatorPage({ lang = "en" }: Props) {
               setTpPct={setTpPct}
               leverage={leverage}
               setLeverage={setLeverage}
+              feePct={feePct}
+              setFeePct={setFeePct}
               coinMode={coinMode}
               setCoinMode={setCoinMode}
               topN={topN}

--- a/src/components/StandardPanel.tsx
+++ b/src/components/StandardPanel.tsx
@@ -33,6 +33,8 @@ interface Props {
   setTpPct: (v: number) => void;
   leverage: number;
   setLeverage: (v: number) => void;
+  feePct?: number;
+  setFeePct?: (v: number) => void;
   coinMode: "all" | "top" | "select";
   setCoinMode: (v: "all" | "top" | "select") => void;
   topN: number;
@@ -61,6 +63,9 @@ const L = {
     all: "All",
     period: "Test Period",
     months: "months",
+    fee: "Fee/Side",
+    survivorNote:
+      "Only currently-listed coins. Delisted excluded — results may be overstated.",
     run: "Run Backtest",
     running: "Running...",
     runOn: "Simulate on {n} Coins",
@@ -79,6 +84,9 @@ const L = {
     all: "전체",
     period: "테스트 기간",
     months: "개월",
+    fee: "거래 수수료",
+    survivorNote:
+      "현재 상장 코인만 포함. 상장폐지 코인 제외 — 실제보다 과대평가될 수 있음.",
     run: "백테스트 실행",
     running: "실행 중...",
     runOn: "{n}개 코인으로 시뮬레이션",
@@ -114,6 +122,8 @@ export default function StandardPanel({
   setTpPct,
   leverage,
   setLeverage,
+  feePct = 0.05,
+  setFeePct,
   coinMode,
   setCoinMode,
   topN,
@@ -387,9 +397,49 @@ export default function StandardPanel({
           />
           <div class="flex justify-between text-[9px] text-[--color-text-muted] mt-0.5">
             <span>3</span>
-            <span>12</span>
+            <span>12★</span>
             <span>24</span>
           </div>
+        </div>
+
+        {/* Fee Rate */}
+        {setFeePct && (
+          <div>
+            <label class="text-[11px] text-[--color-text-muted] font-mono mb-1 block">
+              {t.fee}:{" "}
+              <span class="font-bold text-[--color-text]">
+                {feePct.toFixed(2)}%
+              </span>
+            </label>
+            <input
+              type="range"
+              min="0.01"
+              max="0.20"
+              step="0.01"
+              value={feePct}
+              onInput={(e) =>
+                setFeePct(Number((e.target as HTMLInputElement).value))
+              }
+              class="w-full h-1.5"
+            />
+            <div class="flex justify-between text-[9px] text-[--color-text-muted] mt-0.5">
+              <span>0.01%</span>
+              <span>0.05%</span>
+              <span>0.20%</span>
+            </div>
+          </div>
+        )}
+
+        {/* Survivor Bias Disclaimer */}
+        <div
+          class="text-[10px] font-mono px-2 py-1.5 rounded border"
+          style={{
+            background: "rgba(245,158,11,0.06)",
+            borderColor: "rgba(245,158,11,0.25)",
+            color: "rgba(245,158,11,0.8)",
+          }}
+        >
+          ⚠ {t.survivorNote}
         </div>
       </div>
 

--- a/src/components/ui/CountUp.tsx
+++ b/src/components/ui/CountUp.tsx
@@ -27,7 +27,8 @@ export default function CountUp({
   duration = 1500,
   locale,
 }: CountUpProps) {
-  const [current, setCurrent] = useState(0);
+  // Start at target so SSR/initial render shows the correct value (prevents CLS)
+  const [current, setCurrent] = useState(target);
   const [started, setStarted] = useState(false);
   const ref = useRef<HTMLSpanElement>(null);
 
@@ -36,16 +37,23 @@ export default function CountUp({
     const el = ref.current;
     if (!el) return;
 
-    // Respect reduced motion
+    // Respect reduced motion — keep target value as-is
     const prefersReduced = window.matchMedia(
       "(prefers-reduced-motion: reduce)",
     ).matches;
     if (prefersReduced) {
       setCurrent(target);
-      setStarted(true);
       return;
     }
 
+    // If already visible (above-the-fold), skip animation to prevent CLS
+    const rect = el.getBoundingClientRect();
+    if (rect.top < window.innerHeight && rect.bottom > 0) {
+      setCurrent(target);
+      return;
+    }
+
+    // Animate when scrolled into view
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -122,7 +122,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       <div class="hidden md:block absolute top-[2.75rem] left-[calc(33.33%+1rem)] right-[calc(33.33%+1rem)] h-px bg-gradient-to-r from-[--color-accent]/30 via-[--color-accent]/15 to-[--color-accent]/30 step-connect-line reveal" aria-hidden="true"></div>
       <StepCard step={1} title="Pick a Strategy" description="36 presets or build your own with 14 indicators." />
       <StepCard step={2} title="Set Your Risk" description="SL, TP, leverage, time filters. Real fees included." />
-      <StepCard step={3} title="See Real Results" description={`${coinsAnalyzed}+ coins, 2+ years of data. Results in seconds.`} />
+      <StepCard step={3} title="See Real Results" description={`${coinsAnalyzed}+ coins, up to 2+ years of data. Results in seconds.`} />
     </div>
     <div class="text-center mt-14">
       <a href="/simulate" class="btn btn-primary btn-lg">Open Simulator — Free &rarr;</a>


### PR DESCRIPTION
## Summary
- **Fee**: `engine.py` futures fee 0.0008→0.0005 (Binance/OKX taker); user-overridable via new `fee_pct` field in `SimulationRequest`
- **Leverage PnL**: `run_fast()` now applies leverage multiplier to net PnL per trade (`pnl *= leverage`)
- **data_range()**: Fixed to use `min(date_from)` across all coins, not `_coin_info[0]` (was showing 0GUSDT range, not full 2023~ range)
- **Default period**: 1-year lookback set on page init if no URL param
- **Fee slider**: StandardPanel shows fee rate slider (0.01–0.20%, default 0.05%)
- **Survivor bias disclaimer**: ⚠ warning added below fee slider (delisted coins excluded)
- **index.astro**: "2+ years" → "up to 2+ years" for accuracy

## Test plan
- [ ] `/simulate` → Standard mode → fee slider shows 0.05% default
- [ ] Survivor bias ⚠ disclaimer visible below fee slider
- [ ] Default period set to 1 year on page load
- [ ] Backend: `GET /health` data_range shows ~2023-11-07 not 2025-09-17
- [ ] Build: 2526 pages, 0 errors ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)