### PR TITLE
fix: show field2 selector in ConditionRow instead of blank value

### DIFF
--- a/src/components/ConditionRow.tsx
+++ b/src/components/ConditionRow.tsx
@@ -144,7 +144,7 @@ export default function ConditionRow({
             </option>
           ))}
         </select>
-        {/* Value */}
+        {/* Value / Field2 */}
         {booleanFields.has(c.field) ? (
           <select
             value={String(c.value)}
@@ -160,6 +160,23 @@ export default function ConditionRow({
           >
             <option value="true">true</option>
             <option value="false">false</option>
+          </select>
+        ) : c.field2 !== undefined ? (
+          <select
+            value={c.field2}
+            onChange={(e: Event) =>
+              onUpdate(c.id, "field2", (e.target as HTMLSelectElement).value)
+            }
+            class="w-20 px-1 py-2 min-h-[44px] bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
+            aria-label="Comparison field"
+          >
+            {displayFields
+              .filter((f) => !booleanFields.has(f))
+              .map((f) => (
+                <option key={f} value={f} title={fieldDescriptions[f] || f}>
+                  {fieldLabels[f] || f}
+                </option>
+              ))}
           </select>
         ) : (
           <input


### PR DESCRIPTION
## Summary
- Cross-field conditions (ema_fast < ema_slow) showed a blank number input because ConditionRow only handled numeric/boolean values
- Now renders a field selector dropdown when `c.field2` is set, showing non-boolean fields
- User can see and change the comparison field directly in the UI
- Build: 2526 pages, 0 errors

## Test plan
- [ ] Expert mode default state: EMA Fast condition shows "EMA Slow (ema_slow)" in dropdown instead of blank
- [ ] Can change the field2 dropdown to another field
- [ ] Boolean conditions (is_squeeze, bearish) still show true/false select
- [ ] Numeric conditions still show number input