### PR TITLE
fix: ConditionRow — field2 selector + missing boolean fields

### DIFF
--- a/src/components/ConditionRow.tsx
+++ b/src/components/ConditionRow.tsx
@@ -28,6 +28,9 @@ export default function ConditionRow({
 }: Props) {
   const fieldDescriptions: Record<string, string> = {
     is_squeeze: "Bollinger Band Squeeze detected",
+    recent_squeeze: "BB Squeeze in last 10 candles (rolling)",
+    bb_expanding: "BB width expanding (curr > prev)",
+    bb_width_above_ma: "BB width above its moving average",
     bb_width_change: "BB width expansion rate (%)",
     vol_ratio: "Volume ratio vs average",
     bearish: "Bearish candle pattern",
@@ -59,6 +62,9 @@ export default function ConditionRow({
 
   const fieldLabels: Record<string, string> = {
     is_squeeze: "BB Squeeze (is_squeeze)",
+    recent_squeeze: "Recent Squeeze (recent_squeeze)",
+    bb_expanding: "BB Expanding (bb_expanding)",
+    bb_width_above_ma: "BB Width > MA (bb_width_above_ma)",
     bb_width_change: "BB Width \u0394% (bb_width_change)",
     vol_ratio: "Volume Ratio (vol_ratio)",
     bearish: "Bearish Pattern (bearish)",
@@ -144,7 +150,7 @@ export default function ConditionRow({
             </option>
           ))}
         </select>
-        {/* Value */}
+        {/* Value / Field2 */}
         {booleanFields.has(c.field) ? (
           <select
             value={String(c.value)}
@@ -160,6 +166,23 @@ export default function ConditionRow({
           >
             <option value="true">true</option>
             <option value="false">false</option>
+          </select>
+        ) : c.field2 !== undefined ? (
+          <select
+            value={c.field2}
+            onChange={(e: Event) =>
+              onUpdate(c.id, "field2", (e.target as HTMLSelectElement).value)
+            }
+            class="w-20 px-1 py-2 min-h-[44px] bg-[--color-bg-tooltip] border border-[--color-border] rounded font-mono text-xs text-[--color-text] outline-none focus:border-[--color-accent]"
+            aria-label="Comparison field"
+          >
+            {displayFields
+              .filter((f) => !booleanFields.has(f))
+              .map((f) => (
+                <option key={f} value={f} title={fieldDescriptions[f] || f}>
+                  {fieldLabels[f] || f}
+                </option>
+              ))}
           </select>
         ) : (
           <input

--- a/src/components/simulator-types.ts
+++ b/src/components/simulator-types.ts
@@ -184,6 +184,9 @@ export const OPS = [
 
 export const booleanFields = new Set([
   "is_squeeze",
+  "recent_squeeze",
+  "bb_expanding",
+  "bb_width_above_ma",
   "uptrend",
   "downtrend",
   "bullish",


### PR DESCRIPTION
## Summary
3개 버그 통합 수정:

1. **field2 conditions 빈 칸 → 필드 셀렉터**: `ema_fast < ema_slow`, `close < bb_mid` 같은 필드-대-필드 비교가 blank number input으로 표시되던 문제. 이제 드롭다운으로 비교 필드를 표시/변경 가능
2. **누락된 boolean fields**: `recent_squeeze`, `bb_expanding`, `bb_width_above_ma`가 booleanFields에 없어서 blank number input으로 표시되던 문제. true/false 셀렉터로 표시
3. **fieldLabels/Descriptions 추가**: 3개 신규 boolean 필드에 읽기 쉬운 라벨과 툴팁 추가

## Verification
브라우저에서 localhost:4321로 직접 확인:
- Volatility Squeeze ↓ 프리셋: 모든 5개 조건 정상 렌더링
- `EMA Fast (ema_fast) < EMA Slow` 드롭다운으로 표시 ✓
- `recent_squeeze = true Prev` boolean select 표시 ✓

Build: 2526 pages, 0 errors

## Test plan
- [ ] Expert mode → Volatility Squeeze ↓ preset: EMA Fast row shows "EMA Slow" dropdown (not blank)
- [ ] bb-squeeze-short preset: recent_squeeze/bb_expanding/bb_width_above_ma show true/false select
- [ ] bb-squeeze-short preset: Close < BB Mid shows field dropdown (not blank)