### PR TITLE
fix: auto-fix #1053 (+1 related)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -89,7 +89,9 @@ export default defineConfig({
           item.priority = 0.9; item.changefreq = /** @type {any} */ ('daily'); item.lastmod = today;
         } else if (p === '/strategies/ranking') {
           item.priority = 0.9; item.changefreq = /** @type {any} */ ('daily'); item.lastmod = today;
-        } else if (p.startsWith('/strategies/') || p.startsWith('/coins/')) {
+        } else if (p.startsWith('/coins/')) {
+          item.priority = 0.8; item.changefreq = /** @type {any} */ ('daily'); item.lastmod = today;
+        } else if (p.startsWith('/strategies/')) {
           item.priority = 0.8; item.changefreq = /** @type {any} */ ('weekly'); item.lastmod = today;
         } else if (p.startsWith('/compare/') || p.startsWith('/vs/') || p.startsWith('/vs-')) {
           item.priority = 0.7; item.changefreq = /** @type {any} */ ('monthly');

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -184,7 +184,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <meta property="og:locale" content={lang === 'ko' ? 'ko_KR' : 'en_US'} />
     {!noAlternate && <meta property="og:locale:alternate" content={lang === 'ko' ? 'en_US' : 'ko_KR'} />}
     <meta property="og:image" content={ogImage} />
-    <meta property="og:image:alt" content="PRUVIQ — Free Crypto Strategy Backtester" />
+    <meta property="og:image:alt" content={Astro.props.ogImage ? title : "PRUVIQ — Free Crypto Strategy Backtester"} />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <!-- Twitter -->
@@ -192,7 +192,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImage} />
-    <meta name="twitter:image:alt" content="PRUVIQ — Free Crypto Strategy Backtester" />
+    <meta name="twitter:image:alt" content={Astro.props.ogImage ? title : "PRUVIQ — Free Crypto Strategy Backtester"} />
     <meta name="twitter:site" content="@pruviq" />
     <title>{title}</title>
     <!-- JSON-LD Organization -->


### PR DESCRIPTION
## Auto-fix for 2 issue(s)

#1053: [claude-auto][P2] `src/layouts/Layout.astro:187,195` — `og:image:alt` and `twitter:image:alt` ar
#1054: [claude-auto][P2] `astro.config.mjs:93` — `changefreq: 'weekly'` on coin detail pages contradict

### Changes
```
 astro.config.mjs         | 4 +++-
 src/layouts/Layout.astro | 4 ++--
 2 files changed, 5 insertions(+), 3 deletions(-)
```

### Safety Checks
- Files changed: **2** (limit: 20)
- Lines changed: **8** (limit: 1500)

---
*Auto-generated by JEPO auto-fix agent. Requires auto-test pass before merge.*