### PR TITLE
feat: SL/TP parameter optimization heatmap

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -430,7 +430,7 @@ async def security_headers_middleware(request: Request, call_next):
 
 @app.middleware("http")
 async def rate_limit_middleware(request: Request, call_next):
-    if request.url.path in ("/simulate", "/simulate/coin", "/simulate/compare", "/simulate/validate", "/backtest", "/export/csv"):
+    if request.url.path in ("/simulate", "/simulate/coin", "/simulate/compare", "/simulate/validate", "/simulate/optimize", "/backtest", "/export/csv"):
         client_ip = get_client_ip(request)
         if not check_rate_limit(client_ip):
             oldest = rate_limits.get(client_ip, [0])[0]
@@ -1855,7 +1855,7 @@ async def simulate_optimize(req: OptimizeRequest):
         )
 
     # Run grid in thread pool
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     pairs = [(sl, tp) for sl in req.sl_steps for tp in req.tp_steps]
     with ThreadPoolExecutor(max_workers=min(len(pairs), 8)) as pool:
         futures_list = [loop.run_in_executor(pool, _run_cell, sl, tp) for sl, tp in pairs]

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -65,6 +65,9 @@ from api.schemas import (
     MonteCarloResult, MCEquityBand,
     TradeItem,
     SubscribeRequest,
+    OptimizeRequest,
+    OptimizeResponse,
+    OptimizeCell,
     VALID_TIMEFRAMES,
 )
 from api.data_manager import DataManager
@@ -1709,6 +1712,167 @@ async def simulate_validate(req: ValidateRequest):
             **{k: v for k, v in mc_result.items() if k != "equity_bands"},
             equity_bands=[MCEquityBand(**b) for b in mc_result["equity_bands"]],
         ),
+    )
+
+
+@app.post("/simulate/optimize", response_model=OptimizeResponse)
+async def simulate_optimize(req: OptimizeRequest):
+    """SL/TP grid search — runs up to 36 simulations with different SL/TP pairs."""
+    if data_manager.coin_count == 0:
+        raise HTTPException(503, "Data not loaded yet. Try again shortly.")
+
+    t_start = time.time()
+
+    if req.direction:
+        req.direction = req.direction.lower()
+
+    timeframe = _validate_timeframe(getattr(req, "timeframe", "1H") or "1H")
+    resampled = _is_resampled(timeframe)
+
+    strategy_id = req.strategy
+    is_both = req.direction == "both"
+    if strategy_id == "bb-squeeze":
+        strategy_id = f"bb-squeeze-{req.direction or 'short'}" if not is_both else "bb-squeeze-short"
+
+    if strategy_id not in STRATEGY_REGISTRY:
+        raise HTTPException(400, f"Unknown strategy: {req.strategy}")
+
+    strategy, default_direction, defaults = get_strategy(strategy_id)
+    direction = req.direction if req.direction is not None else default_direction
+    directions_to_run = ["short", "long"] if is_both else [direction]
+
+    cost_model = CostModel.futures() if req.market_type == "futures" else CostModel.spot()
+
+    # Load coins once — reuse across all grid cells
+    if resampled:
+        coins = _get_resampled_coins(req.symbols, req.top_n, timeframe)
+        if req.symbols and not coins:
+            raise HTTPException(404, "None of the requested symbols found.")
+        has_cache = False
+    else:
+        has_cache = indicator_cache.strategy_count(strategy_id) > 0
+        if req.symbols:
+            requested = [s.strip().upper() for s in req.symbols if s and s.strip()]
+            if has_cache:
+                coins = indicator_cache.get_symbols_for_strategy(strategy_id, requested)
+                cached_syms = {sym for sym, _ in coins}
+                missing = [s for s in requested if s not in cached_syms]
+                if missing:
+                    coins.extend(data_manager.get_symbols(missing))
+            else:
+                coins = data_manager.get_symbols(requested)
+            if not coins:
+                raise HTTPException(404, "None of the requested symbols found.")
+        else:
+            n = _resolve_top_n(req.top_n)
+            coins = indicator_cache.get_top_n_for_strategy(strategy_id, data_manager, n) if has_cache else data_manager.get_top_n(n)
+
+    _cached_syms = set()
+    if has_cache:
+        _cached_syms = {sym for sym, _ in indicator_cache.get_symbols_for_strategy(strategy_id, [s for s, _ in coins])}
+
+    # Pre-compute indicators + date filter once per coin
+    prepared = []
+    for sym, df in coins:
+        if sym not in _cached_syms:
+            df = strategy.calculate_indicators(df.copy())
+        df = filter_df_by_date(df, req.start_date, req.end_date)
+        prepared.append((sym, df))
+
+    data_range = data_manager.data_range()
+    coins_used = len(prepared)
+
+    valid_metrics = {"total_return_pct", "win_rate", "profit_factor", "sharpe_ratio"}
+    metric = req.metric if req.metric in valid_metrics else "total_return_pct"
+
+    def _run_cell(sl_pct: float, tp_pct: float) -> OptimizeCell:
+        all_trades = []
+        for sym, df in prepared:
+            dyn_slip = _get_dynamic_slippage(sym)
+            for run_dir in directions_to_run:
+                result = run_fast(
+                    df, strategy, sym,
+                    sl_pct=sl_pct / 100,
+                    tp_pct=tp_pct / 100,
+                    max_bars=req.max_bars,
+                    fee_pct=cost_model.fee_pct,
+                    slippage_pct=dyn_slip,
+                    direction=run_dir,
+                    market_type=req.market_type,
+                    strategy_id=strategy_id,
+                    funding_rate_8h=getattr(cost_model, "funding_rate_8h", 0.0001),
+                    timeframe=timeframe,
+                    leverage=1.0,
+                )
+                all_trades.extend(result.trades)
+
+        if not all_trades:
+            return OptimizeCell(sl_pct=sl_pct, tp_pct=tp_pct, total_trades=0,
+                                win_rate=0, profit_factor=0, total_return_pct=0,
+                                max_drawdown_pct=0, sharpe_ratio=0)
+
+        n_coins = len(prepared) or 1
+        wins = [t for t in all_trades if t["pnl_pct"] > 0]
+        losses = [t for t in all_trades if t["pnl_pct"] <= 0]
+        gross_profit = sum(t["pnl_pct"] for t in wins) if wins else 0
+        gross_loss = abs(sum(t["pnl_pct"] for t in losses)) if losses else 0
+        total_return = round(sum(t["pnl_pct"] for t in all_trades) / n_coins, 4)
+        win_rate = round(len(wins) / len(all_trades) * 100, 2) if all_trades else 0
+        pf = round(gross_profit / gross_loss, 2) if gross_loss > 0 else (999.99 if gross_profit > 0 else 0)
+
+        # MDD
+        equity = 100.0
+        peak = equity
+        max_dd = 0.0
+        for t in all_trades:
+            equity += t["pnl_pct"] / n_coins
+            peak = max(peak, equity)
+            dd = (peak - equity) / peak * 100 if peak > 0 else 0
+            max_dd = max(max_dd, min(dd, 100.0))
+
+        # Sharpe (daily)
+        from collections import defaultdict as _dd_opt
+        daily = _dd_opt(float)
+        for t in all_trades:
+            day = t.get("exit_time", t["time"])[:10]
+            if day and day != "NaT" and len(day) == 10:
+                daily[day] += t["pnl_pct"]
+        sharpe = 0.0
+        if len(daily) >= 5:
+            dr = np.array(list(daily.values())) / n_coins
+            std = float(np.std(dr, ddof=1))
+            if std > 0:
+                sharpe = round(float(np.mean(dr)) / std * np.sqrt(365), 2)
+
+        return OptimizeCell(
+            sl_pct=sl_pct, tp_pct=tp_pct,
+            total_trades=len(all_trades),
+            win_rate=win_rate,
+            profit_factor=pf,
+            total_return_pct=total_return,
+            max_drawdown_pct=round(max_dd, 2),
+            sharpe_ratio=sharpe,
+        )
+
+    # Run grid in thread pool
+    loop = asyncio.get_event_loop()
+    pairs = [(sl, tp) for sl in req.sl_steps for tp in req.tp_steps]
+    with ThreadPoolExecutor(max_workers=min(len(pairs), 8)) as pool:
+        futures_list = [loop.run_in_executor(pool, _run_cell, sl, tp) for sl, tp in pairs]
+        grid = await asyncio.gather(*futures_list)
+
+    compute_ms = int((time.time() - t_start) * 1000)
+
+    return OptimizeResponse(
+        strategy=req.strategy,
+        direction=direction if not is_both else "both",
+        metric=metric,
+        sl_steps=req.sl_steps,
+        tp_steps=req.tp_steps,
+        grid=list(grid),
+        coins_used=coins_used,
+        data_range=data_range,
+        compute_time_ms=compute_ms,
     )
 
 

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -680,7 +680,79 @@ class GenerateBotRequest(BaseModel):
     backtest_profit_factor: float = 0
 # --- Subscribe Schemas ---
 
+
 class SubscribeRequest(BaseModel):
     """Email subscription request."""
+
     email: str
     lang: str = "en"
+
+
+# --- Parameter Optimization Schemas ---
+
+
+class OptimizeRequest(BaseModel):
+    """SL/TP grid search request."""
+
+    strategy: str = Field(default="bb-squeeze", description="Strategy ID")
+    direction: Optional[str] = Field(default=None, description="long | short | both")
+    sl_steps: List[float] = Field(
+        default=[5.0, 8.0, 10.0, 15.0, 20.0],
+        description="Stop Loss values to sweep (max 6)",
+    )
+    tp_steps: List[float] = Field(
+        default=[5.0, 8.0, 10.0, 15.0, 20.0],
+        description="Take Profit values to sweep (max 6)",
+    )
+    max_bars: int = Field(default=48, ge=6, le=168)
+    market_type: Literal["futures", "spot"] = Field(default="futures")
+    symbols: Optional[List[str]] = Field(default=None)
+    top_n: Optional[int] = Field(
+        default=20,
+        ge=1,
+        le=100,
+        description="Limit coins for speed (default 20)",
+    )
+    start_date: Optional[str] = Field(default=None)
+    end_date: Optional[str] = Field(default=None)
+    timeframe: str = Field(default="1H")
+    metric: str = Field(
+        default="total_return_pct",
+        description="Primary metric: total_return_pct | win_rate | profit_factor | sharpe_ratio",
+    )
+
+    @field_validator("sl_steps", "tp_steps")
+    @classmethod
+    def _limit_steps(cls, v):
+        if len(v) > 6:
+            raise ValueError("Max 6 steps per axis (36 combinations max)")
+        if any(x < 1.0 or x > 30.0 for x in v):
+            raise ValueError("Steps must be between 1.0 and 30.0")
+        return sorted(set(v))
+
+
+class OptimizeCell(BaseModel):
+    """Single cell in the SL/TP optimization grid."""
+
+    sl_pct: float
+    tp_pct: float
+    total_trades: int
+    win_rate: float
+    profit_factor: float
+    total_return_pct: float
+    max_drawdown_pct: float
+    sharpe_ratio: float = 0.0
+
+
+class OptimizeResponse(BaseModel):
+    """SL/TP optimization grid results."""
+
+    strategy: str
+    direction: str
+    metric: str
+    sl_steps: List[float]
+    tp_steps: List[float]
+    grid: List[OptimizeCell]
+    coins_used: int
+    data_range: str
+    compute_time_ms: int

--- a/src/components/BuilderPanel.tsx
+++ b/src/components/BuilderPanel.tsx
@@ -369,6 +369,7 @@ export default function BuilderPanel(props: Props) {
               </label>
               <input
                 type="number"
+                aria-label="Stop Loss %"
                 value={localSl}
                 min={1}
                 max={50}
@@ -393,6 +394,7 @@ export default function BuilderPanel(props: Props) {
               </label>
               <input
                 type="number"
+                aria-label="Take Profit %"
                 value={localTp}
                 min={1}
                 max={50}
@@ -417,6 +419,7 @@ export default function BuilderPanel(props: Props) {
               </label>
               <input
                 type="number"
+                aria-label="Max Bars"
                 value={localMaxBars}
                 min={1}
                 max={168}
@@ -436,6 +439,7 @@ export default function BuilderPanel(props: Props) {
               </label>
               <input
                 type="number"
+                aria-label="Per Coin USD"
                 value={localPerCoin}
                 min={props.compounding ? 100 : 1}
                 max={props.compounding ? 1000000 : 10000}
@@ -458,6 +462,7 @@ export default function BuilderPanel(props: Props) {
               </label>
               <input
                 type="number"
+                aria-label="Leverage"
                 value={localLeverage}
                 min={1}
                 max={125}

--- a/src/components/OptimizePanel.tsx
+++ b/src/components/OptimizePanel.tsx
@@ -1,0 +1,515 @@
+/**
+ * OptimizePanel.tsx – SL/TP grid-search heatmap
+ *
+ * Calls POST /simulate/optimize and renders a color-coded table where
+ * each cell shows the primary metric value for that SL/TP combination.
+ */
+import { useState } from "preact/hooks";
+import { API_BASE_URL } from "../config/api";
+import { COLORS } from "./simulator-types";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface OptimizeCell {
+  sl_pct: number;
+  tp_pct: number;
+  total_trades: number;
+  win_rate: number;
+  profit_factor: number;
+  total_return_pct: number;
+  max_drawdown_pct: number;
+  sharpe_ratio: number;
+}
+
+interface OptimizeResponse {
+  strategy: string;
+  direction: string;
+  metric: string;
+  sl_steps: number[];
+  tp_steps: number[];
+  grid: OptimizeCell[];
+  coins_used: number;
+  data_range: string;
+  compute_time_ms: number;
+}
+
+type MetricKey =
+  | "total_return_pct"
+  | "win_rate"
+  | "profit_factor"
+  | "sharpe_ratio";
+
+interface Props {
+  strategy: string;
+  direction: string;
+  max_bars: number;
+  top_n: number;
+  market_type?: "futures" | "spot";
+  start_date?: string | null;
+  end_date?: string | null;
+  timeframe?: string;
+  lang: "en" | "ko";
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  t: Record<string, any>;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const METRIC_LABELS: Record<MetricKey, { en: string; ko: string }> = {
+  total_return_pct: { en: "Total Return %", ko: "총 수익률 %" },
+  win_rate: { en: "Win Rate %", ko: "승률 %" },
+  profit_factor: { en: "Profit Factor", ko: "손익비" },
+  sharpe_ratio: { en: "Sharpe Ratio", ko: "샤프 비율" },
+};
+
+const DEFAULT_STEPS = [5, 8, 10, 15, 20];
+
+function getMetricValue(cell: OptimizeCell, metric: MetricKey): number {
+  return cell[metric] ?? 0;
+}
+
+function metricLabel(metric: MetricKey, lang: "en" | "ko"): string {
+  return METRIC_LABELS[metric][lang];
+}
+
+function formatMetric(v: number, metric: MetricKey): string {
+  if (metric === "profit_factor") return v === 0 ? "–" : v.toFixed(2);
+  if (metric === "sharpe_ratio") return v === 0 ? "–" : v.toFixed(2);
+  if (metric === "total_return_pct" || metric === "win_rate")
+    return v === 0 ? "–" : v.toFixed(1) + "%";
+  return v.toFixed(2);
+}
+
+/** Map value to a green↔red color.  Higher is always better. */
+function heatColor(v: number, min: number, max: number): string {
+  if (max === min) return "rgba(49,130,246,0.15)";
+  const ratio = Math.max(0, Math.min(1, (v - min) / (max - min)));
+  // ratio=1 → green, ratio=0 → red
+  const r = Math.round(240 * (1 - ratio) + 0 * ratio);
+  const g = Math.round(66 * (1 - ratio) + 192 * ratio);
+  const b = Math.round(81 * (1 - ratio) + 115 * ratio);
+  return `rgba(${r},${g},${b},${0.12 + ratio * 0.28})`;
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export default function OptimizePanel({
+  strategy,
+  direction,
+  max_bars,
+  top_n,
+  market_type = "futures",
+  start_date,
+  end_date,
+  timeframe = "1H",
+  lang,
+  t,
+}: Props) {
+  const [metric, setMetric] = useState<MetricKey>("total_return_pct");
+  const [slSteps, setSlSteps] = useState<number[]>(DEFAULT_STEPS);
+  const [tpSteps, setTpSteps] = useState<number[]>(DEFAULT_STEPS);
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<OptimizeResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // ── Step editor helpers ───────────────────────────────────────────────────
+
+  function toggleStep(
+    arr: number[],
+    setArr: (v: number[]) => void,
+    val: number,
+  ) {
+    if (arr.includes(val)) {
+      if (arr.length <= 2) return; // min 2 steps
+      setArr(arr.filter((x) => x !== val).sort((a, b) => a - b));
+    } else {
+      if (arr.length >= 6) return; // max 6
+      setArr([...arr, val].sort((a, b) => a - b));
+    }
+  }
+
+  const STEP_OPTIONS = [3, 5, 8, 10, 12, 15, 18, 20, 25];
+
+  // ── Run optimization ──────────────────────────────────────────────────────
+
+  async function run() {
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const payload = {
+        strategy,
+        direction: direction === "both" ? "both" : direction,
+        sl_steps: slSteps,
+        tp_steps: tpSteps,
+        max_bars,
+        market_type,
+        top_n: Math.min(top_n, 50),
+        metric,
+        ...(start_date ? { start_date } : {}),
+        ...(end_date ? { end_date } : {}),
+        timeframe,
+      };
+      const res = await fetch(`${API_BASE_URL}/simulate/optimize`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(120_000),
+      });
+      if (!res.ok) {
+        const detail = await res.json().catch(() => ({}));
+        throw new Error(detail?.detail || `HTTP ${res.status}`);
+      }
+      setResult(await res.json());
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  // ── Heatmap rendering ─────────────────────────────────────────────────────
+
+  function renderHeatmap(data: OptimizeResponse) {
+    const { sl_steps, tp_steps, grid } = data;
+    const values = grid.map((c) => getMetricValue(c, metric));
+    const minV = Math.min(...values);
+    const maxV = Math.max(...values);
+
+    // Find best cell
+    const bestIdx = values.reduce((bi, v, i) => (v > values[bi] ? i : bi), 0);
+
+    const colCount = tp_steps.length;
+
+    return (
+      <div class="overflow-x-auto">
+        <table class="w-full text-xs font-mono border-collapse">
+          <thead>
+            <tr>
+              <th class="p-2 text-left text-[--color-text-muted]">
+                {lang === "ko" ? "SL\\ TP→" : "SL\\ TP→"}
+              </th>
+              {tp_steps.map((tp) => (
+                <th
+                  key={tp}
+                  class="p-2 text-center font-semibold"
+                  style={{ color: COLORS.accent }}
+                >
+                  TP {tp}%
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {sl_steps.map((sl, ri) => (
+              <tr key={sl}>
+                <td class="p-2 font-semibold" style={{ color: COLORS.accent }}>
+                  SL {sl}%
+                </td>
+                {tp_steps.map((tp, ci) => {
+                  const idx = ri * colCount + ci;
+                  const cell = grid[idx];
+                  const v = getMetricValue(cell, metric);
+                  const isBest = idx === bestIdx && cell.total_trades > 0;
+                  const noTrades = cell.total_trades === 0;
+                  return (
+                    <td
+                      key={tp}
+                      class="p-2 text-center transition-all"
+                      style={{
+                        background: noTrades
+                          ? "rgba(255,255,255,0.03)"
+                          : heatColor(v, minV, maxV),
+                        border: isBest
+                          ? `1.5px solid ${COLORS.green}`
+                          : "1px solid rgba(255,255,255,0.04)",
+                        borderRadius: "4px",
+                        position: "relative",
+                      }}
+                      title={
+                        noTrades
+                          ? "No trades"
+                          : `Trades: ${cell.total_trades} | WR: ${cell.win_rate.toFixed(1)}% | PF: ${cell.profit_factor.toFixed(2)} | Return: ${cell.total_return_pct.toFixed(1)}% | MDD: ${cell.max_drawdown_pct.toFixed(1)}%`
+                      }
+                    >
+                      {isBest && (
+                        <span
+                          class="absolute top-0.5 right-0.5 text-[8px]"
+                          style={{ color: COLORS.green }}
+                        >
+                          ★
+                        </span>
+                      )}
+                      <span
+                        style={{
+                          color: noTrades
+                            ? "var(--color-text-muted)"
+                            : v >= 0
+                              ? COLORS.green
+                              : COLORS.red,
+                          fontWeight: isBest ? 700 : 400,
+                        }}
+                      >
+                        {noTrades ? "–" : formatMetric(v, metric)}
+                      </span>
+                      {!noTrades && (
+                        <div
+                          class="text-[9px] mt-0.5"
+                          style={{
+                            color: "var(--color-text-muted)",
+                            opacity: 0.7,
+                          }}
+                        >
+                          {cell.total_trades}t
+                        </div>
+                      )}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
+  // ── UI ────────────────────────────────────────────────────────────────────
+
+  return (
+    <div class="space-y-4 p-3 md:p-4">
+      {/* Header */}
+      <div>
+        <h3
+          class="text-sm font-semibold mb-1"
+          style={{ color: "var(--color-text)" }}
+        >
+          {lang === "ko"
+            ? "SL/TP 파라미터 최적화"
+            : "SL/TP Parameter Optimization"}
+        </h3>
+        <p class="text-xs" style={{ color: "var(--color-text-muted)" }}>
+          {lang === "ko"
+            ? "SL/TP 조합별 성과를 비교해 최적 파라미터를 찾습니다 (코인 최대 50개)."
+            : "Compare performance across SL/TP combinations to find the optimal parameters (up to 50 coins)."}
+        </p>
+      </div>
+
+      {/* Config row */}
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {/* Metric selector */}
+        <div>
+          <label
+            class="block text-[11px] mb-1.5 font-medium"
+            style={{ color: "var(--color-text-muted)" }}
+          >
+            {lang === "ko" ? "최적화 기준" : "Optimize by"}
+          </label>
+          <select
+            value={metric}
+            onChange={(e) =>
+              setMetric((e.target as HTMLSelectElement).value as MetricKey)
+            }
+            class="w-full rounded px-2 py-1.5 text-xs font-mono"
+            style={{
+              background: "var(--color-surface)",
+              border: "1px solid var(--color-border)",
+              color: "var(--color-text)",
+            }}
+          >
+            {(Object.keys(METRIC_LABELS) as MetricKey[]).map((k) => (
+              <option key={k} value={k}>
+                {metricLabel(k, lang)}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* SL steps */}
+        <div>
+          <label
+            class="block text-[11px] mb-1.5 font-medium"
+            style={{ color: "var(--color-text-muted)" }}
+          >
+            {lang === "ko"
+              ? `손절 범위 (${slSteps.length}/6)`
+              : `SL steps (${slSteps.length}/6)`}
+          </label>
+          <div class="flex flex-wrap gap-1">
+            {STEP_OPTIONS.map((v) => {
+              const active = slSteps.includes(v);
+              return (
+                <button
+                  key={v}
+                  type="button"
+                  aria-label={`SL ${v}%`}
+                  aria-pressed={active}
+                  onClick={() => toggleStep(slSteps, setSlSteps, v)}
+                  class="px-2 py-0.5 rounded text-[11px] font-mono transition-all"
+                  style={{
+                    background: active
+                      ? COLORS.accentBg
+                      : "var(--color-surface)",
+                    color: active ? COLORS.accent : "var(--color-text-muted)",
+                    border: active
+                      ? `1px solid ${COLORS.accent}`
+                      : "1px solid var(--color-border)",
+                    opacity: !active && slSteps.length >= 6 ? 0.4 : 1,
+                  }}
+                >
+                  {v}%
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* TP steps */}
+        <div>
+          <label
+            class="block text-[11px] mb-1.5 font-medium"
+            style={{ color: "var(--color-text-muted)" }}
+          >
+            {lang === "ko"
+              ? `익절 범위 (${tpSteps.length}/6)`
+              : `TP steps (${tpSteps.length}/6)`}
+          </label>
+          <div class="flex flex-wrap gap-1">
+            {STEP_OPTIONS.map((v) => {
+              const active = tpSteps.includes(v);
+              return (
+                <button
+                  key={v}
+                  type="button"
+                  aria-label={`TP ${v}%`}
+                  aria-pressed={active}
+                  onClick={() => toggleStep(tpSteps, setTpSteps, v)}
+                  class="px-2 py-0.5 rounded text-[11px] font-mono transition-all"
+                  style={{
+                    background: active
+                      ? COLORS.accentBg
+                      : "var(--color-surface)",
+                    color: active ? COLORS.accent : "var(--color-text-muted)",
+                    border: active
+                      ? `1px solid ${COLORS.accent}`
+                      : "1px solid var(--color-border)",
+                    opacity: !active && tpSteps.length >= 6 ? 0.4 : 1,
+                  }}
+                >
+                  {v}%
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* Run button */}
+      <button
+        type="button"
+        onClick={run}
+        disabled={loading}
+        aria-label={lang === "ko" ? "최적화 실행" : "Run optimization"}
+        class="w-full py-2.5 rounded-lg text-sm font-semibold transition-all"
+        style={{
+          background: loading ? "var(--color-surface)" : COLORS.accent,
+          color: loading ? "var(--color-text-muted)" : "#fff",
+          border: `1px solid ${loading ? "var(--color-border)" : COLORS.accent}`,
+          cursor: loading ? "not-allowed" : "pointer",
+        }}
+      >
+        {loading
+          ? lang === "ko"
+            ? `분석 중… (${slSteps.length}×${tpSteps.length} = ${slSteps.length * tpSteps.length}회)`
+            : `Running… (${slSteps.length}×${tpSteps.length} = ${slSteps.length * tpSteps.length} simulations)`
+          : lang === "ko"
+            ? `최적화 실행 (${slSteps.length}×${tpSteps.length} = ${slSteps.length * tpSteps.length}회 시뮬레이션)`
+            : `Run Optimization (${slSteps.length}×${tpSteps.length} = ${slSteps.length * tpSteps.length} simulations)`}
+      </button>
+
+      {/* Error */}
+      {error && (
+        <div
+          role="alert"
+          aria-live="assertive"
+          class="text-xs p-3 rounded"
+          style={{
+            background: COLORS.redBg,
+            color: COLORS.red,
+            border: `1px solid ${COLORS.red}44`,
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {/* Results */}
+      {result && (
+        <div class="space-y-3">
+          {/* Meta */}
+          <div
+            class="flex flex-wrap gap-x-4 gap-y-1 text-[11px]"
+            style={{ color: "var(--color-text-muted)" }}
+          >
+            <span>
+              {lang === "ko" ? "기준 지표" : "Metric"}:{" "}
+              <span style={{ color: COLORS.accent }}>
+                {metricLabel(metric, lang)}
+              </span>
+            </span>
+            <span>
+              {lang === "ko" ? "코인" : "Coins"}:{" "}
+              <span style={{ color: "var(--color-text)" }}>
+                {result.coins_used}
+              </span>
+            </span>
+            <span>
+              {lang === "ko" ? "데이터" : "Data"}:{" "}
+              <span style={{ color: "var(--color-text)" }}>
+                {result.data_range}
+              </span>
+            </span>
+            <span>
+              {lang === "ko" ? "소요" : "Time"}:{" "}
+              <span style={{ color: "var(--color-text)" }}>
+                {(result.compute_time_ms / 1000).toFixed(1)}s
+              </span>
+            </span>
+          </div>
+
+          {/* Heatmap */}
+          {renderHeatmap(result)}
+
+          {/* Legend */}
+          <div
+            class="flex items-center gap-2 text-[10px] pt-1"
+            style={{ color: "var(--color-text-muted)" }}
+          >
+            <div
+              class="w-16 h-3 rounded"
+              style={{
+                background: `linear-gradient(to right, rgba(240,66,81,0.35), rgba(49,130,246,0.2), rgba(0,192,115,0.4))`,
+              }}
+            />
+            <span>{lang === "ko" ? "낮음 → 높음" : "Low → High"}</span>
+            <span class="ml-auto">★ = {lang === "ko" ? "최적" : "Best"}</span>
+            <span class="ml-2 italic">
+              {lang === "ko"
+                ? "셀에 마우스를 올려 상세 지표 확인"
+                : "Hover cells for detail metrics"}
+            </span>
+          </div>
+
+          <p
+            class="text-[9px] mt-1"
+            style={{ color: "var(--color-text-muted)", opacity: 0.5 }}
+          >
+            {lang === "ko"
+              ? "과거 시뮬레이션 결과는 미래 수익을 보장하지 않습니다. 최적화 결과는 과적합(overfitting) 위험이 있습니다."
+              : "Past simulation results do not guarantee future returns. Optimized parameters carry overfitting risk."}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ResultsPanel.tsx
+++ b/src/components/ResultsPanel.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from "preact/hooks";
 import ResultsCard from "./ResultsCard";
 import ResultHero from "./ResultHero";
 import OOSValidation from "./OOSValidation";
+import OptimizePanel from "./OptimizePanel";
 import ExchangeCTA from "./ExchangeCTA";
 import EmailCapture from "./EmailCapture";
 import BotCodeSection from "./BotCodeSection";
@@ -28,7 +29,13 @@ interface HistoryEntry {
   result: BacktestResult;
 }
 
-type ResultTab = "summary" | "equity" | "trades" | "coins" | "validate";
+type ResultTab =
+  | "summary"
+  | "equity"
+  | "trades"
+  | "coins"
+  | "validate"
+  | "optimize";
 
 interface Props {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- i18n dict has mixed value types (string, string[], Record<string,string>)
@@ -91,7 +98,7 @@ export default function ResultsPanel({
       ? ["summary"]
       : simMode === "standard"
         ? ["summary", "equity", "trades", "coins"]
-        : ["summary", "equity", "trades", "coins", "validate"];
+        : ["summary", "equity", "trades", "coins", "validate", "optimize"];
   const [coinSort, setCoinSort] = useState<{ key: string; asc: boolean }>({
     key: "total_return_pct",
     asc: false,
@@ -520,7 +527,11 @@ export default function ResultsPanel({
                     ? t.coinsTab || t.coins || "Coins"
                     : tab === "validate"
                       ? t.validate || "Validate"
-                      : t[tab] || tab}
+                      : tab === "optimize"
+                        ? lang === "ko"
+                          ? "최적화"
+                          : "Optimize"
+                        : t[tab] || tab}
                 </button>
               ))}
             </div>
@@ -1349,6 +1360,24 @@ export default function ResultsPanel({
                 top_n={result.coins_used}
               />
             </div>
+          )}
+
+          {/* Optimize tab */}
+          {resultTab === "optimize" && (
+            <OptimizePanel
+              strategy={activePreset || result.name || "bb-squeeze"}
+              direction={result.direction}
+              max_bars={result.max_bars}
+              top_n={Math.min(result.coins_used || 20, 50)}
+              market_type={
+                ((result as unknown as Record<string, string>).market_type as
+                  | "futures"
+                  | "spot") || "futures"
+              }
+              timeframe={result.timeframe || "1H"}
+              lang={lang}
+              t={t}
+            />
           )}
 
           {/* Coins tab */}

--- a/tests/e2e/simulator-e2e.spec.ts
+++ b/tests/e2e/simulator-e2e.spec.ts
@@ -300,20 +300,25 @@ test.describe("Simulator — Expert Parameter Controls", () => {
     await openSimulator(page, true);
     await switchToExpert(page);
 
-    const inputs = page.locator('input[type="number"]');
-    const count = await inputs.count();
+    // Use aria-labels to target specific parameter inputs (avoids hidden condition inputs)
+    const paramInputs = [
+      page.locator('input[aria-label="Stop Loss %"]'),
+      page.locator('input[aria-label="Take Profit %"]'),
+      page.locator('input[aria-label="Max Bars"]'),
+    ];
 
-    // Fill each input with a test value and verify
-    // Verify at least some number inputs are interactive (fill + read back)
-    const testCount = Math.min(count, 3);
-    for (let i = 0; i < testCount; i++) {
-      const input = inputs.nth(i);
+    for (const input of paramInputs) {
+      if ((await input.count()) === 0) continue;
       const min = await input.getAttribute("min");
       const testVal = min && Number(min) > 10 ? "15" : "10";
+      await input.waitFor({ state: "visible", timeout: 5000 });
       await input.click();
       await input.fill(testVal);
       const actual = await input.inputValue();
-      expect(actual, `Input ${i} should accept value`).toBe(testVal);
+      expect(
+        actual,
+        `${await input.getAttribute("aria-label")} should accept value`,
+      ).toBe(testVal);
     }
   });
 


### PR DESCRIPTION
## Summary

- **Backend**: New `POST /simulate/optimize` endpoint — runs SL/TP grid search (up to 6×6=36 combos) in parallel via asyncio+ThreadPoolExecutor. Coins are loaded once and reused across all grid cells for efficiency.
- **Frontend**: New `OptimizePanel.tsx` with step selector UI and color-coded heatmap table (green↔red heat, ★ best cell, hover tooltip)
- **Integration**: "Optimize" tab added to ResultsPanel (expert mode only)

## Metrics available
`total_return_pct` | `win_rate` | `profit_factor` | `sharpe_ratio`

## Test plan
- [ ] Run simulator in expert mode → confirm "Optimize" tab visible
- [ ] Select SL/TP steps → confirm combination count updates in button label
- [ ] Click Run → confirm heatmap renders with color coding
- [ ] Hover cell → confirm tooltip shows detail metrics
- [ ] Best cell should have ★ marker and green border

🤖 Generated with [Claude Code](https://claude.com/claude-code)