### PR TITLE
fix: auto-fix #1062 (+1 related)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -96,7 +96,7 @@ export default defineConfig({
         } else if (p.startsWith('/compare/') || p.startsWith('/vs/') || p.startsWith('/vs-')) {
           item.priority = 0.7; item.changefreq = /** @type {any} */ ('monthly');
         } else if (p.startsWith('/blog/')) {
-          item.priority = 0.6; item.changefreq = /** @type {any} */ ('monthly');
+          item.priority = 0.6; item.changefreq = /** @type {any} */ ('monthly'); item.lastmod = today;
         } else if (['/fees', '/learn', '/about', '/api'].includes(p)) {
           item.priority = 0.6; item.changefreq = /** @type {any} */ ('monthly');
         } else {

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -9,6 +9,7 @@ interface Props {
   title: string;
   description: string;
   date: string;
+  updatedDate?: string;
   category: string;
   author?: string;
   image?: string;
@@ -21,7 +22,7 @@ interface Props {
 
 const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
-const { title, description, date, category, author = 'PRUVIQ Research', image, body, tags = [], postId, noAlternate = false, isKorean } = Astro.props;
+const { title, description, date, updatedDate, category, author = 'PRUVIQ Research', image, body, tags = [], postId, noAlternate = false, isKorean } = Astro.props;
 
 const categoryLabels: Record<string, string> = {
   market: 'MARKET ANALYSIS',
@@ -57,6 +58,7 @@ const shareUrlEnc = encodeURIComponent(shareUrl);
     "headline": title,
     "description": description,
     "datePublished": date,
+    "dateModified": updatedDate || date,
     "author": {
       "@type": "Organization",
       "name": author,


### PR DESCRIPTION
## Auto-fix for 2 issue(s)

#1062: [claude-auto][P2] `src/layouts/BlogPost.astro:59` — Article JSON-LD emits without `dateModified`
#1063: [claude-auto][P2] `astro.config.mjs:98-99` — Blog article pages are the only tracked content typ

### Changes
```
 astro.config.mjs           | 2 +-
 src/layouts/BlogPost.astro | 4 +++-
 2 files changed, 4 insertions(+), 2 deletions(-)
```

### Safety Checks
- Files changed: **2** (limit: 20)
- Lines changed: **6** (limit: 1500)

---
*Auto-generated by JEPO auto-fix agent. Requires auto-test pass before merge.*