### PR TITLE
feat(okx): max_per_trade_usdt cap + complete .env.example

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -22,6 +22,21 @@ OKX_ENCRYPTION_KEY=
 # Set to "true" to use OKX demo/paper trading environment
 OKX_DEMO_MODE=false
 
+# ── OKX Auto-trading (standalone server mode) ───────────────────────────────
+# Auto-trade mode: true = runs in-process on this API server,
+#                  false = delegates to okx/server.py on a separate host
+OKX_AUTO_TRADE_LOCAL=true
+
+# Signal source URL (only needed when OKX_AUTO_TRADE_LOCAL=false)
+OKX_SIGNAL_SOURCE_URL=https://api.pruviq.com/internal/signals
+OKX_SIGNAL_POLL_INTERVAL=300
+OKX_SIGNAL_POLL_TIMEOUT=15
+
+# Internal API key (≥32 chars) — used by okx/server.py standalone mode to
+# authenticate against the main API when fetching signals.
+# Generate: python3 -c "import secrets; print(secrets.token_urlsafe(32))"
+INTERNAL_API_KEY=
+
 # ── Frontend / Cookie config ─────────────────────────────────────────────────
 # Must match deployed frontend domain
 PRUVIQ_FRONTEND_URL=https://pruviq.com
@@ -34,15 +49,34 @@ PRUVIQ_COOKIE_DOMAIN=.pruviq.com
 TELEGRAM_TOKEN=
 TELEGRAM_CHAT_ID=
 
+# Telegram channel/chat for signal broadcasts (default: @PRUVIQ)
+SIGNAL_TELEGRAM_CHAT_ID=@PRUVIQ
+
+# Public API base URL referenced by scripts (signal_telegram.py etc.)
+PRUVIQ_API_URL=https://api.pruviq.com
+
 # ── Admin ────────────────────────────────────────────────────────────────────
 # Required for /admin/* endpoints (min 32 chars)
 # Generate: python3 -c "import secrets; print(secrets.token_urlsafe(32))"
 ADMIN_API_KEY=
 
+# ── Email (weekly digest / notifications) ────────────────────────────────────
+SENDGRID_API_KEY=
+
+# Secret used to sign unsubscribe links (override the default in production)
+UNSUBSCRIBE_SECRET=change-this-from-default-pruviq-unsub-2026
+
+# Subscribers JSON file path (update for server deployment)
+SUBSCRIBERS_FILE=/opt/pruviq/data/subscribers.json
+
 # ── Optional ─────────────────────────────────────────────────────────────────
 # Binance API (live performance data sync — not required for core features)
 BINANCE_API_KEY=
 BINANCE_SECRET_KEY=
+
+# Binance geo-bypass proxy (set only if running on Korean IP or blocked region)
+# BINANCE_PROXY_URL=http://100.122.203.78:9090/fapi/v1/ticker/24hr
+# BINANCE_PROXY_KEY=
 
 # CoinGecko API key (higher rate limits — free tier works without this)
 COINGECKO_API_KEY=

--- a/backend/okx/auto_executor.py
+++ b/backend/okx/auto_executor.py
@@ -7,7 +7,7 @@ Industry standard architecture (3commas/Bybit/OKX bot benchmark):
   - All events notify user via Telegram: entry, SL/TP set, limit hits, failures
 
 Safety guards:
-  - Max $5000 per trade (configurable per user)
+  - Max $200 per trade (configurable via settings.max_per_trade_usdt, default $200)
   - Max 20 trades/day (configurable)
   - Daily loss limit (configurable, default $200)
   - Master switch per user
@@ -321,6 +321,15 @@ async def _try_execute(
                 mult = float(strategy.get("multiplier", 1.0))
                 signal_size = float(signal.get("position_size_usdt", position_size))
                 position_size = signal_size * mult
+
+        # ── Execution-time safety cap (applies after all sizing paths) ──
+        max_per_trade = float(settings.get("max_per_trade_usdt", 200.0))
+        if position_size > max_per_trade:
+            logger.info(
+                "Position capped at max_per_trade_usdt=%.2f (was %.2f) session=%s",
+                max_per_trade, position_size, session_id[:8],
+            )
+            position_size = max_per_trade
 
         # ── Check concurrent position limit (strategy tightens but cannot loosen) ──
         max_concurrent = settings["max_concurrent"]

--- a/backend/okx/constraints.py
+++ b/backend/okx/constraints.py
@@ -219,6 +219,19 @@ def validate(params: dict, context: dict) -> ConstraintResult:
     if leverage > 125:
         errors.append("OKX 최대 레버리지 125x 초과")
 
+    # 7. Per-trade USD cap (execution-time safety, separate from fixed-mode input cap)
+    if "max_per_trade_usdt" in params:
+        try:
+            max_per_trade = float(params["max_per_trade_usdt"])
+        except (TypeError, ValueError):
+            max_per_trade = 0.0
+        if max_per_trade <= 0:
+            errors.append("max_per_trade_usdt must be > 0")
+        elif max_per_trade > 10000:
+            warnings.append(
+                f"max_per_trade_usdt ${max_per_trade:,.0f} > $10,000 is very high for beta"
+            )
+
     # ── SOFT WARNINGS (allow but caution) ─────────────────────────────
 
     # R:R below 1

--- a/backend/okx/settings.py
+++ b/backend/okx/settings.py
@@ -25,6 +25,7 @@ DEFAULT_SETTINGS: dict[str, Any] = {
     "td_mode": "isolated",     # isolated or cross
     "max_concurrent": 3,       # max open positions
     "max_daily_trades": 20,    # safety limit
+    "max_per_trade_usdt": 200.0,  # hard cap per single trade (execution-time safety)
     "daily_loss_limit_usdt": 200,  # stop trading if daily loss exceeds
     "execution_mode": "manual",    # manual | alert | auto
     "enabled": False,          # master switch
@@ -114,6 +115,11 @@ def save_settings(session_id: str, settings: dict[str, Any]) -> dict[str, Any]:
     if "max_daily_trades" in settings:
         val = int(settings["max_daily_trades"])
         validated["max_daily_trades"] = max(1, min(50, val))
+    if "max_per_trade_usdt" in settings:
+        val = float(settings["max_per_trade_usdt"])
+        if val <= 0:
+            raise ValueError("max_per_trade_usdt must be > 0")
+        validated["max_per_trade_usdt"] = max(1.0, min(10000.0, val))
     if "daily_loss_limit_usdt" in settings:
         val = float(settings["daily_loss_limit_usdt"])
         validated["daily_loss_limit_usdt"] = max(50, min(5000, val))


### PR DESCRIPTION
## Summary
- **P0-6: max_per_trade_usdt execution-time safety cap**
  - `DEFAULT_SETTINGS["max_per_trade_usdt"] = 200.0` — replaces the undocumented hardcoded $5000 ceiling in the old docstring.
  - `save_settings()` validates (raises on <=0, clamps to 1..10000).
  - `constraints.validate()` now returns a hard error on <=0 and a warning on > $10,000 for beta.
  - `auto_executor._try_execute()` enforces the cap on `position_size` after *all* sizing paths (fixed / percent-of-balance / strategy override) so no branch can bypass it. Logs an INFO line when capping fires.
  - Storage design note: settings are a JSON blob in a TEXT column, and `get_settings()` merges against `DEFAULT_SETTINGS`, so existing rows auto-pick up the new key — no `ALTER TABLE` needed.
- **P0-9: backend/.env.example completeness (12 missing vars)**
  - `INTERNAL_API_KEY`, `OKX_AUTO_TRADE_LOCAL`, `OKX_SIGNAL_SOURCE_URL`, `OKX_SIGNAL_POLL_INTERVAL`, `OKX_SIGNAL_POLL_TIMEOUT` (standalone server mode)
  - `BINANCE_PROXY_URL`, `BINANCE_PROXY_KEY` (commented; for geo-restricted hosts)
  - `SENDGRID_API_KEY`, `UNSUBSCRIBE_SECRET`, `SUBSCRIBERS_FILE` (email pipeline)
  - `SIGNAL_TELEGRAM_CHAT_ID`, `PRUVIQ_API_URL` (referenced by `scripts/signal_telegram.py`)

## Test plan
- [x] `python3 -c "import ast; ..."` parses all 3 modified backend files without error
- [x] Smoke test: `constraints.validate({max_per_trade_usdt: 15000, ...})` returns the expected warning; `-1` returns the expected hard error; `200` passes cleanly
- [x] `npm run build` — 2526 pages built in 35.03s, 0 errors
- [ ] After merge on Mac Mini: `git pull` on jepo account + `~/Desktop/start-backend.command` to pick up the new settings field
- [ ] Post-deploy: `GET /settings/trading` for an existing authenticated session should include `max_per_trade_usdt: 200.0` (merged from DEFAULT_SETTINGS for legacy rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)