### PR TITLE
fix(okx): reconciler loop + pnl_sync silent reset bug

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -180,6 +180,28 @@ async def _okx_token_refresh_loop():
         await asyncio.sleep(12 * 3600)  # 12 hours
 
 
+async def _okx_reconcile_loop():
+    """Reconcile OKX live positions vs DB trade_log every 5 minutes (P0-2)."""
+    try:
+        from okx.reconciler import reconcile_loop
+        await reconcile_loop()
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.error(f"OKX reconcile loop terminated: {e}")
+
+
+async def _okx_pnl_retry_loop():
+    """Retry pnl_sync for trade_log rows flagged pnl_synced=0 every 30 min (P0-3)."""
+    try:
+        from okx.pnl_sync import retry_failed_pnl_sync_loop
+        await retry_failed_pnl_sync_loop()
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.error(f"OKX pnl retry loop terminated: {e}")
+
+
 async def _background_refresh():
     """Periodically refresh data from Binance."""
     while True:
@@ -304,9 +326,13 @@ async def lifespan(app: FastAPI):
     market_task = asyncio.create_task(_background_market_refresh())
     if OKX_AUTO_TRADE_LOCAL:
         okx_auto_task = asyncio.create_task(_okx_auto_trading_loop())
-        print("OKX auto-trading loop started (local mode)")
+        okx_reconcile_task = asyncio.create_task(_okx_reconcile_loop())
+        okx_pnl_retry_task = asyncio.create_task(_okx_pnl_retry_loop())
+        print("OKX auto-trading + reconciler + pnl retry loops started (local mode)")
     else:
         okx_auto_task = None
+        okx_reconcile_task = None
+        okx_pnl_retry_task = None
         print("OKX auto-trading loop SKIPPED (OKX_AUTO_TRADE_LOCAL=false — DO server handles it)")
     okx_token_task = asyncio.create_task(_okx_token_refresh_loop())
     print(f"Background data refresh scheduled every {REFRESH_INTERVAL}s")
@@ -319,10 +345,18 @@ async def lifespan(app: FastAPI):
     market_task.cancel()
     if okx_auto_task is not None:
         okx_auto_task.cancel()
+    if okx_reconcile_task is not None:
+        okx_reconcile_task.cancel()
+    if okx_pnl_retry_task is not None:
+        okx_pnl_retry_task.cancel()
     okx_token_task.cancel()
     _tasks = [indicator_task, refresh_task, market_task, okx_token_task]
     if okx_auto_task is not None:
         _tasks.append(okx_auto_task)
+    if okx_reconcile_task is not None:
+        _tasks.append(okx_reconcile_task)
+    if okx_pnl_retry_task is not None:
+        _tasks.append(okx_pnl_retry_task)
     for t in _tasks:
         try:
             await t

--- a/backend/okx/pnl_sync.py
+++ b/backend/okx/pnl_sync.py
@@ -8,10 +8,19 @@ once a position closes, then updates the trade_log record.
 This enables:
   1. Accurate daily P&L reporting
   2. Correct consecutive-loss guard behavior
+
+Failure handling (P0-3, 2026-04-16):
+  - After 3 failed poll attempts, the row is flagged `pnl_synced=0` and the
+    estimated pnl_usdt is left UNCHANGED. Previously this path reset pnl to 0,
+    which corrupted the consecutive-loss guard (zeros no longer count as losses)
+    and silently inflated daily P&L reporting.
+  - A background task (`retry_failed_pnl_sync`) re-attempts every 30 minutes so
+    pnl_synced=0 rows eventually converge to truth without dropping bars.
 """
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import time
 
@@ -21,14 +30,21 @@ from .storage import _get_conn
 
 logger = logging.getLogger("okx_pnl_sync")
 
+# Retry interval for sessions/trades whose realized PnL could not be confirmed
+# within the initial 3-attempt window (30s/60s/120s). Runs in main.py lifespan.
+_RETRY_INTERVAL_S = 30 * 60  # 30 minutes
+_RETRY_LOOKBACK_S = 7 * 24 * 3600  # only retry rows from last 7 days
+_RETRY_HISTORY_LIMIT = "50"
+
 
 async def sync_realized_pnl(session_id: str, inst_id: str, trade_created_at: float) -> None:
     """
     Poll positions-history to find actual realized PnL for a recently closed trade.
-    Updates trade_log.pnl_usdt with the real value.
+    Updates trade_log.pnl_usdt with the real value and sets pnl_synced=1 on success.
 
     Called asynchronously after a trade is logged (fire-and-forget).
-    Polls up to 3 times (at 30s, 60s, 120s) then gives up.
+    Polls up to 3 times (at 30s, 60s, 120s); on failure leaves pnl_usdt untouched
+    and sets pnl_synced=0 for the retry loop to pick up.
     """
     if not is_authenticated(session_id):
         return
@@ -44,7 +60,7 @@ async def sync_realized_pnl(session_id: str, inst_id: str, trade_created_at: flo
                 return
 
             token = await get_valid_token(session_id)
-            async with OKXClient(token) as client:
+            async with OKXClient(token, session_id=session_id) as client:
                 history = await client.get_positions_history(limit="20")
 
             # Find matching closed position by instId and close time after trade creation
@@ -68,12 +84,15 @@ async def sync_realized_pnl(session_id: str, inst_id: str, trade_created_at: flo
         except Exception as e:
             logger.error("PnL sync attempt %d failed: %s", i + 1, e)
 
-    # Reset estimated PnL to 0 — consecutive-loss guard should not fire on stale estimates
+    # P0-3 fix (2026-04-16): do NOT reset pnl_usdt to 0 — that corrupted the
+    # consecutive-loss guard. Flag the row and let retry_failed_pnl_sync()
+    # converge it later. The estimated worst-case pnl remains in place until
+    # we get ground truth from OKX.
     logger.warning(
-        "PnL sync: no closed position found for session=%s inst=%s after 3 attempts — resetting pnl to 0",
+        "pnl_sync 실패 3회, 추정값 유지: session=%s inst=%s trade_id=? flagging pnl_synced=0",
         session_id[:8], inst_id,
     )
-    _update_trade_pnl(session_id, inst_id, trade_created_at, 0.0)
+    _flag_pnl_unsynced(session_id, inst_id, trade_created_at)
 
 
 def _update_trade_pnl(
@@ -82,7 +101,7 @@ def _update_trade_pnl(
     trade_created_at: float,
     realized_pnl: float,
 ) -> None:
-    """Update trade_log.pnl_usdt for the trade closest to trade_created_at."""
+    """Update trade_log.pnl_usdt + mark pnl_synced=1 for the trade closest to trade_created_at."""
     with _get_conn() as conn:
         # Find the trade log entry closest to trade_created_at (within 60s window)
         row = conn.execute(
@@ -109,7 +128,147 @@ def _update_trade_pnl(
             return
 
         conn.execute(
-            "UPDATE trade_log SET pnl_usdt = ? WHERE id = ?",
+            "UPDATE trade_log SET pnl_usdt = ?, pnl_synced = 1 WHERE id = ?",
             (realized_pnl, row[0]),
         )
-        logger.info("PnL sync: updated trade_log id=%d pnl=%.4f", row[0], realized_pnl)
+        logger.info("PnL sync: updated trade_log id=%d pnl=%.4f pnl_synced=1", row[0], realized_pnl)
+
+
+def _flag_pnl_unsynced(
+    session_id: str,
+    inst_id: str,
+    trade_created_at: float,
+) -> None:
+    """
+    Mark trade_log.pnl_synced=0 for the trade closest to trade_created_at.
+    Leaves pnl_usdt (the estimated worst-case) untouched so the consecutive-loss
+    guard still treats the trade as a loss until actual PnL is confirmed.
+    """
+    with _get_conn() as conn:
+        row = conn.execute(
+            """
+            SELECT id FROM trade_log
+            WHERE session_id = ?
+              AND created_at >= ?
+              AND created_at <= ?
+              AND json_extract(signal, '$.coin') LIKE ?
+            ORDER BY ABS(created_at - ?) ASC
+            LIMIT 1
+            """,
+            (
+                session_id,
+                trade_created_at - 10,
+                trade_created_at + 60,
+                f"%{inst_id.split('-')[0]}%",
+                trade_created_at,
+            ),
+        ).fetchone()
+
+        if not row:
+            logger.warning("pnl_sync 실패 3회: no matching trade_log row for inst=%s", inst_id)
+            return
+
+        conn.execute(
+            "UPDATE trade_log SET pnl_synced = 0 WHERE id = ?",
+            (row[0],),
+        )
+        logger.warning("pnl_sync 실패 3회, 추정값 유지: trade_id=%s inst=%s", row[0], inst_id)
+
+
+# ── Retry loop ─────────────────────────────────────────────
+
+async def retry_failed_pnl_sync() -> None:
+    """
+    Re-attempt PnL sync for all trade_log rows where pnl_synced=0.
+
+    A single pass iterates recent (<7 days) unsynced rows, groups by session,
+    fetches positions-history per session once, then matches each unsynced row
+    against the history. Successful matches update both pnl_usdt and pnl_synced=1.
+    """
+    from .orders import _pruviq_to_okx_inst_id
+
+    cutoff = time.time() - _RETRY_LOOKBACK_S
+    with _get_conn() as conn:
+        rows = conn.execute(
+            """
+            SELECT id, session_id, signal, created_at
+            FROM trade_log
+            WHERE pnl_synced = 0 AND created_at >= ?
+            ORDER BY created_at ASC
+            """,
+            (cutoff,),
+        ).fetchall()
+
+    if not rows:
+        return
+
+    # Group by session_id so we only call positions-history once per session
+    by_session: dict[str, list[tuple]] = {}
+    for row in rows:
+        by_session.setdefault(row[1], []).append(row)
+
+    logger.warning(
+        "pnl_sync retry: %d unsynced rows across %d sessions",
+        len(rows), len(by_session),
+    )
+
+    for session_id, session_rows in by_session.items():
+        if not is_authenticated(session_id):
+            continue
+        try:
+            token = await get_valid_token(session_id)
+            async with OKXClient(token, session_id=session_id) as client:
+                history = await client.get_positions_history(limit=_RETRY_HISTORY_LIMIT)
+        except Exception as e:
+            logger.error("pnl_sync retry: fetch history failed for %s: %s", session_id[:8], e)
+            continue
+
+        for row_id, _, signal_json, created_at in session_rows:
+            try:
+                signal = json.loads(signal_json)
+            except Exception:
+                continue
+            coin = signal.get("coin", "")
+            if not coin:
+                continue
+            inst_id = _pruviq_to_okx_inst_id(coin)
+
+            matched = False
+            for pos in history:
+                if pos.get("instId", "") != inst_id:
+                    continue
+                u_time_ms = int(pos.get("uTime", "0"))
+                u_time_s = u_time_ms / 1000
+                if u_time_s < created_at:
+                    continue
+                realized_pnl = float(pos.get("realizedPnl", "0"))
+                with _get_conn() as conn:
+                    conn.execute(
+                        "UPDATE trade_log SET pnl_usdt = ?, pnl_synced = 1 WHERE id = ?",
+                        (realized_pnl, row_id),
+                    )
+                logger.warning(
+                    "pnl_sync retry: id=%d session=%s inst=%s realized=%.4f OK",
+                    row_id, session_id[:8], inst_id, realized_pnl,
+                )
+                matched = True
+                break
+
+            if not matched:
+                logger.info(
+                    "pnl_sync retry: id=%d session=%s inst=%s still unsynced",
+                    row_id, session_id[:8], inst_id,
+                )
+
+
+async def retry_failed_pnl_sync_loop() -> None:
+    """Background loop: re-run pnl_sync every 30 minutes for pnl_synced=0 rows."""
+    logger.info("pnl_sync retry loop started (interval=%ds)", _RETRY_INTERVAL_S)
+    while True:
+        await asyncio.sleep(_RETRY_INTERVAL_S)
+        try:
+            await retry_failed_pnl_sync()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error("pnl_sync retry loop error: %s", e)

--- a/backend/okx/reconciler.py
+++ b/backend/okx/reconciler.py
@@ -1,0 +1,158 @@
+"""
+Position reconciliation loop.
+
+Every 5 minutes, compare OKX-side open positions (pos != 0) against the recent
+trade_log for each auto-enabled session. Flag "orphan" positions — live on OKX
+but absent from our records — because those are the scariest class of bug
+before live money: a stop-loss we never tracked, a trade from a stale deploy,
+or a manual OKX action the bot is unaware of.
+
+Design decisions (P0-2, 2026-04-16):
+  - trade_log has no `status` column, so we treat recent trades (last 24h) as
+    the "expected" set. This avoids an invasive schema change pre-live-money.
+  - We only ALERT (log + Telegram). We do NOT auto-disable, auto-close, or
+    auto-reconcile — those require more testing than a P0 hotfix deserves.
+  - "Closed in OKX but open in DB" is intentionally NOT handled here: pnl_sync
+    already covers that path, and without a status column we'd produce false
+    positives (e.g. successful trade + realized pnl already recorded).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+
+from .client import OKXClient
+from .oauth import get_valid_token, is_authenticated
+from .orders import _pruviq_to_okx_inst_id
+from .settings import get_auto_sessions, get_settings
+from .storage import _get_conn
+
+logger = logging.getLogger("okx_reconciler")
+
+RECONCILE_INTERVAL = 300  # 5 minutes
+_TRADE_LOOKBACK_S = 24 * 3600  # treat last 24h of trade_log as expected positions
+
+
+def _expected_inst_ids(session_id: str) -> set[str]:
+    """Derive the set of inst_ids this session should plausibly have open."""
+    cutoff = time.time() - _TRADE_LOOKBACK_S
+    with _get_conn() as conn:
+        rows = conn.execute(
+            "SELECT signal FROM trade_log WHERE session_id = ? AND created_at >= ?",
+            (session_id, cutoff),
+        ).fetchall()
+
+    inst_ids: set[str] = set()
+    for (signal_json,) in rows:
+        try:
+            signal = json.loads(signal_json)
+        except Exception:
+            continue
+        coin = signal.get("coin", "")
+        if not coin:
+            continue
+        try:
+            inst_ids.add(_pruviq_to_okx_inst_id(coin))
+        except Exception:
+            continue
+    return inst_ids
+
+
+async def _send_orphan_alert(chat_id: str, session_id: str, inst_id: str) -> None:
+    """Notify user via Telegram about an orphan position. Fire-and-forget."""
+    if not chat_id:
+        return
+    try:
+        # Build a synthetic signal dict so send_execution_failed can render cleanly.
+        synthetic_signal = {
+            "coin": inst_id,
+            "strategy": "reconciler",
+            "direction": "",
+        }
+        from .notifications import send_execution_failed
+        reason = (
+            f"Orphan position detected: {inst_id} live on OKX but not tracked in "
+            f"trade_log (session {session_id[:8]}). Manual review required."
+        )
+        await send_execution_failed(chat_id, synthetic_signal, reason)
+    except Exception as e:
+        logger.error("Orphan alert Telegram send failed for %s: %s", session_id[:8], e)
+
+
+async def reconcile_positions(session_id: str) -> None:
+    """Reconcile a single session's OKX positions vs recent trade_log."""
+    if not is_authenticated(session_id):
+        return
+
+    try:
+        token = await get_valid_token(session_id)
+        async with OKXClient(token, session_id=session_id) as client:
+            okx_positions = await client.get_positions()
+    except Exception as e:
+        logger.error("Reconcile: fetch positions failed for %s: %s", session_id[:8], e)
+        return
+
+    okx_inst_ids = {
+        p.inst_id for p in okx_positions if _has_position(p.pos)
+    }
+    if not okx_inst_ids:
+        return
+
+    expected = _expected_inst_ids(session_id)
+    orphans = okx_inst_ids - expected
+    if not orphans:
+        return
+
+    settings = get_settings(session_id)
+    chat_id = settings.get("alert_telegram_chat_id", "")
+    for inst_id in orphans:
+        logger.error(
+            "Reconcile: ORPHAN POSITION %s on OKX not in DB (session=%s)",
+            inst_id, session_id[:8],
+        )
+        await _send_orphan_alert(chat_id, session_id, inst_id)
+
+
+def _has_position(pos_str: str) -> bool:
+    """OKX returns pos as a string; treat '0', '', None as no-position."""
+    if not pos_str:
+        return False
+    try:
+        return float(pos_str) != 0
+    except (ValueError, TypeError):
+        return False
+
+
+async def reconcile_all_sessions() -> None:
+    """Reconcile every auto-enabled session in turn."""
+    try:
+        sessions = get_auto_sessions()  # list[str] of session_ids
+    except Exception as e:
+        logger.error("Reconcile: get_auto_sessions failed: %s", e)
+        return
+
+    for session_id in sessions:
+        try:
+            await reconcile_positions(session_id)
+        except Exception as e:
+            logger.error("Reconcile: session %s failed: %s", session_id[:8], e)
+
+
+async def reconcile_loop() -> None:
+    """Background loop: reconcile every RECONCILE_INTERVAL seconds."""
+    logger.info(
+        "Position reconcile loop started (interval=%ds, lookback=%ds)",
+        RECONCILE_INTERVAL, _TRADE_LOOKBACK_S,
+    )
+    # Defer first pass so startup completes before we hit OKX APIs.
+    await asyncio.sleep(60)
+    while True:
+        try:
+            await reconcile_all_sessions()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error("Reconcile loop error: %s", e)
+        await asyncio.sleep(RECONCILE_INTERVAL)

--- a/backend/okx/settings.py
+++ b/backend/okx/settings.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sqlite3
 import time
 from typing import Any
 
@@ -43,14 +44,23 @@ def _ensure_table() -> None:
         """)
         conn.execute("""
             CREATE TABLE IF NOT EXISTS trade_log (
-                id         INTEGER PRIMARY KEY AUTOINCREMENT,
-                session_id TEXT NOT NULL,
-                signal     TEXT NOT NULL,
-                result     TEXT NOT NULL,
-                pnl_usdt   REAL DEFAULT 0,
-                created_at REAL NOT NULL
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id  TEXT NOT NULL,
+                signal      TEXT NOT NULL,
+                result      TEXT NOT NULL,
+                pnl_usdt    REAL DEFAULT 0,
+                created_at  REAL NOT NULL,
+                pnl_synced  INTEGER DEFAULT 1
             )
         """)
+        # Additive migration: add pnl_synced column for tables created before this field existed.
+        # SQLite does not support "IF NOT EXISTS" on ALTER TABLE ADD COLUMN, so we catch the
+        # OperationalError("duplicate column name") that is raised when the column already exists.
+        try:
+            conn.execute("ALTER TABLE trade_log ADD COLUMN pnl_synced INTEGER DEFAULT 1")
+        except sqlite3.OperationalError as e:
+            if "duplicate column" not in str(e).lower():
+                raise
         # Signal deduplication: prevents the same signal from executing twice
         # across 5-minute auto-trading loop cycles
         conn.execute("""


### PR DESCRIPTION
## Summary
- New backend/okx/reconciler.py: every 5min compare OKX live positions vs DB trade_log, alert on orphan positions
- pnl_sync.py: remove silent pnl=0 reset after 3 failures (was corrupting consecutive-loss guard)
- Add pnl_synced flag + retry mechanism
- Register reconcile_loop in main.py lifespan

## Test plan
- [x] Python AST check on all modified files (PASS)
- [ ] npm run build 0 errors
- [x] reconcile_loop imported correctly in main.py (line 186, task created line 329)

🤖 Generated with [Claude Code](https://claude.com/claude-code)