### PR TITLE
fix: wrap _signal_scanner.scan() in asyncio.to_thread — unblock event loop

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -155,7 +155,7 @@ async def _okx_auto_trading_loop():
         try:
             from okx.auto_executor import process_signals
             if _signal_scanner is not None:
-                signals = _signal_scanner.scan()
+                signals = await asyncio.to_thread(_signal_scanner.scan)
                 if signals:
                     await process_signals(signals)
         except asyncio.CancelledError:

--- a/backend/okx/reconciler.py
+++ b/backend/okx/reconciler.py
@@ -100,12 +100,12 @@ async def reconcile_positions(session_id: str) -> None:
     if not okx_inst_ids:
         return
 
-    expected = _expected_inst_ids(session_id)
+    expected = await asyncio.to_thread(_expected_inst_ids, session_id)
     orphans = okx_inst_ids - expected
     if not orphans:
         return
 
-    settings = get_settings(session_id)
+    settings = await asyncio.to_thread(get_settings, session_id)
     chat_id = settings.get("alert_telegram_chat_id", "")
     for inst_id in orphans:
         logger.error(
@@ -128,7 +128,7 @@ def _has_position(pos_str: str) -> bool:
 async def reconcile_all_sessions() -> None:
     """Reconcile every auto-enabled session in turn."""
     try:
-        sessions = get_auto_sessions()  # list[str] of session_ids
+        sessions = await asyncio.to_thread(get_auto_sessions)
     except Exception as e:
         logger.error("Reconcile: get_auto_sessions failed: %s", e)
         return


### PR DESCRIPTION
## Root Cause

\`_signal_scanner.scan()\` was called **synchronously** inside \`_okx_auto_trading_loop\` (main.py:158). This CPU-bound scan of 535 coins takes ~30 seconds and blocked the entire asyncio event loop — causing HTTP requests to time out during each scan window.

\`OKX_AUTO_TRADE_LOCAL\` defaults to \`"true"\`, so the loop always ran even if not explicitly set in \`.env\`.

## Fix

- \`backend/api/main.py\`: \`signals = await asyncio.to_thread(_signal_scanner.scan)\` (matches the existing pattern in \`_prewarm_signals\`)
- \`backend/okx/reconciler.py\`: wrapped \`_expected_inst_ids()\`, \`get_settings()\`, \`get_auto_sessions()\` with \`asyncio.to_thread\` (sync SQLite calls from async context)

## Test plan
- [ ] \`git pull\` + \`~/Desktop/start-backend.command\` on Mac Mini
- [ ] \`curl http://localhost:8080/health\` responds 200 immediately
- [ ] Backend stays responsive after 30s (first scan cycle in thread, not event loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)