### PR TITLE
chore(vision-qa): upgrade model to claude-opus-4-7

### DIFF
--- a/.github/workflows/vision-qa.yml
+++ b/.github/workflows/vision-qa.yml
@@ -84,7 +84,7 @@ jobs:
         env:
           VISION_DIR: test-results/vision
           # Claude CLI 인증 사용 (ANTHROPIC_API_KEY 불필요 — Claude Code OAuth)
-          CLAUDE_MODEL: claude-sonnet-4-6
+          CLAUDE_MODEL: claude-opus-4-7
         timeout-minutes: 8
 
       - name: Step 2b — QA Score 산출

--- a/scripts/vision-analyze.ts
+++ b/scripts/vision-analyze.ts
@@ -16,7 +16,7 @@ import path from "path";
 
 const VISION_DIR = process.env.VISION_DIR ?? "test-results/vision";
 const REPORT_PATH = path.join(VISION_DIR, "vision-report.json");
-const CLAUDE_MODEL = process.env.CLAUDE_MODEL ?? "claude-sonnet-4-6";
+const CLAUDE_MODEL = process.env.CLAUDE_MODEL ?? "claude-opus-4-7";
 
 // QA 지식 베이스 로드 (tests/harness/qa-knowledge.md)
 const QA_KNOWLEDGE_PATH = path.join(


### PR DESCRIPTION
## Summary
- Vision QA 스크립트/워크플로우 기본 모델 `claude-sonnet-4-6` → `claude-opus-4-7`
- 근거: Opus 4.7 Vision 정확도 54.5% → 98.5% (Anthropic 공식 발표, 2026-04-16)
- 비용: 일 1회 크론(`30 1 * * *`) — 절대 증가분 무시 가능

## Changes
- `scripts/vision-analyze.ts:19` — 기본값 갱신
- `.github/workflows/vision-qa.yml:87` — `CLAUDE_MODEL` env 동일 반영

## Test plan
- [ ] CI green
- [ ] 다음 스케줄(UTC 01:30) Vision QA 잡이 Opus 4.7로 실행되는지 actions 로그 확인
- [ ] `vision-report.json`의 `model` 필드가 `claude-opus-4-7`인지 확인