### PR TITLE
fix(backend): add httpx + Pillow to requirements.txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,5 @@ uvicorn[standard]>=0.30.0
 pydantic>=2.0.0
 defusedxml>=0.7.0
 cryptography>=41.0.0
+httpx>=0.27.0
+Pillow>=10.0.0


### PR DESCRIPTION
## Summary
- Already installed on DO production server but missing from repo
- Prevents crash on fresh DO deploy / container rebuild
- Required by: reconciler.py, pnl_sync.py, telegram_halt.py (httpx); SNS card rendering (Pillow)

## Test plan
- [x] DO server already has these installed in venv — no behavior change
- [ ] CI: backend-ci workflow passes
- [ ] After merge: `ssh do "systemctl restart pruviq-api"` not needed (already installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)