### PR TITLE
feat(infra): Phase 5-A — DO systemd timers for 5 PRUVIQ cron jobs

### DIFF
--- a/backend/deploy/systemd/README.md
+++ b/backend/deploy/systemd/README.md
@@ -1,0 +1,104 @@
+# PRUVIQ systemd units (DO server)
+
+Source of truth for systemd services/timers deployed on DO `167.172.81.145`.
+Migration from Mac Mini cron (2026-04-17).
+
+## Layout
+
+```
+backend/deploy/systemd/
+├── pruviq-<name>.service   Oneshot/simple service unit
+├── pruviq-<name>.timer     Timer that triggers the service
+├── pruviq-alert@.service   OnFailure handler template (instantiated with unit name)
+└── bin/
+    ├── <name>.sh           DO-native wrapper script
+    └── alert-failure.sh    Telegram failure notifier
+```
+
+## Conventions
+
+- Unit naming: `pruviq-<dash-separated-name>.{service,timer}`
+- `User=pruviq` / `Group=pruviq` — no root services
+- `EnvironmentFile=/opt/pruviq/shared/.env` — single secret source
+- `WorkingDirectory=/opt/pruviq/current` — symlink to active release
+- `OnFailure=pruviq-alert@%n.service` — auto-Telegram on failure
+- `RandomizedDelaySec=30` on timers — prevent thundering herd
+- `Persistent=true` on timers — catch up missed runs after reboot
+
+## Deploy procedure (one unit)
+
+```bash
+# 1. Copy wrapper to /opt/pruviq/bin/
+scp -P 2222 backend/deploy/systemd/bin/<name>.sh \
+    root@167.172.81.145:/opt/pruviq/bin/
+
+# 2. Copy unit files to /etc/systemd/system/
+scp -P 2222 backend/deploy/systemd/pruviq-<name>.{service,timer} \
+    root@167.172.81.145:/etc/systemd/system/
+
+# 3. On DO: make wrapper executable, reload systemd, enable timer
+ssh -p 2222 root@167.172.81.145 "
+  chown pruviq:pruviq /opt/pruviq/bin/<name>.sh
+  chmod +x /opt/pruviq/bin/<name>.sh
+  systemctl daemon-reload
+  # Manual run first (service, not timer)
+  systemctl start pruviq-<name>.service
+  journalctl -u pruviq-<name>.service --since '2 min ago' -n 50
+  # If OK, enable timer
+  systemctl enable --now pruviq-<name>.timer
+  systemctl list-timers pruviq-*
+"
+
+# 4. Disable Mac cron line (comment with # MIGRATED-TO-DO prefix)
+ssh jepo@macmini.local "crontab -l | sed 's|^.*<script_name>.*$|# MIGRATED-TO-DO &|' | crontab -"
+
+# 5. Wait for next DO timer fire, verify journal:
+ssh -p 2222 root@167.172.81.145 "journalctl -u pruviq-<name>.service -n 30 --no-pager"
+```
+
+## Dedup window policy
+
+Pattern depends on duplicate impact:
+
+- **Idempotent / silent duplicate** (sim_audit, monitor, update_ohlcv):
+  DO enable → verify → Mac disable. Accept one double-fire.
+- **User-visible duplicate** (signal_telegram → @PRUVIQ channel):
+  Mac disable FIRST → accept brief gap → DO enable. Never double-post.
+
+## KST → UTC cron mapping
+
+Mac crontab is implicit KST (macOS system timezone). DO systemd is UTC. Convert:
+
+| Mac cron | Desc | DO OnCalendar |
+|----------|------|---------------|
+| `*/5 * * * *` | monitor | `*:0/5` |
+| `*/10 * * * *` | staleness-watch | `*:0/10` |
+| `*/15 * * * *` | macmini_health | (Mac 전용) |
+| `*/20 * * * *` | refresh_static | `*:0/20` |
+| `*/30 * * * *` | jepo_healthcheck | (Mac 전용) |
+| `0 * * * *` | monitor --full | `*:00:00` |
+| `5 * * * *` | signal_telegram | `*:05:00` |
+| `0 */6 * * *` | sim_audit | `00,06,12,18:00:00` |
+| `15 */4 * * *` | update_ohlcv | `00/4:15:00` |
+| `0 4 * * *` KST | update_pruviq_performance | `*-*-* 19:00:00` UTC (prev day) |
+| `30 2 * * *` KST | full_pipeline | `*-*-* 17:30:00` UTC (prev day) |
+| `0 5 * * *` KST | backup_do_server | (Mac 전용, 역방향 백업) |
+| `0 6 * * *` KST | backup-critical-data | (Mac 전용) |
+| `0 7 * * *` KST | doc-sync-check | (Mac 전용, ~/.claude) |
+| `0 3 1,20 * *` KST | refresh_threads_token | (Mac 전용, SNS 토큰) |
+| `0 4 5,25 * *` KST | refresh_instagram_token | (Mac 전용, SNS 토큰) |
+| `0 5 1,15 * *` KST | refresh_tokens | (Mac 전용, SNS 토큰) |
+| `0 * * * *` KST | social/health_check | (Mac 전용, SNS) |
+
+## Migration status
+
+| Unit | Status | Mac cron disabled? |
+|------|--------|--------------------|
+| pruviq-sim-audit | ⏳ first end-to-end | — |
+| pruviq-monitor | pending | — |
+| pruviq-staleness-watch | pending | — |
+| pruviq-refresh-static | pending (5-B: needs Node) | — |
+| pruviq-signal-telegram | pending | — |
+| pruviq-update-ohlcv | pending | — |
+| pruviq-full-pipeline | pending (5-B: needs git push key) | — |
+| pruviq-update-performance | pending (5-B: needs git push key) | — |

--- a/backend/deploy/systemd/bin/alert-failure.sh
+++ b/backend/deploy/systemd/bin/alert-failure.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# PRUVIQ — OnFailure handler for systemd units.
+# Invoked by pruviq-alert@UNIT.service when a timer service fails.
+set -uo pipefail
+
+UNIT="${1:-unknown}"
+HOST=$(hostname)
+JOURNAL_TAIL=$(journalctl -u "$UNIT" -n 20 --no-pager 2>/dev/null | tail -15)
+
+if [ -n "${TELEGRAM_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
+    curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_TOKEN}/sendMessage" \
+        -d chat_id="${TELEGRAM_CHAT_ID}" \
+        -d text="🚨 PRUVIQ systemd FAIL on ${HOST}
+Unit: ${UNIT}
+
+Journal tail:
+${JOURNAL_TAIL}" >/dev/null 2>&1 || true
+fi

--- a/backend/deploy/systemd/bin/monitor.sh
+++ b/backend/deploy/systemd/bin/monitor.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# PRUVIQ — Health Monitor (DO-native)
+# Called by pruviq-monitor.timer (every 5 min) and pruviq-monitor-full.timer (hourly --full).
+# Uses systemd journal for logs (no file log). Telegram alert with 30-min cooldown.
+set -uo pipefail
+
+FULL_CHECK=false
+[ "${1:-}" = "--full" ] && FULL_CHECK=true
+
+STATE_FILE="/tmp/pruviq-monitor-state"
+ISSUES=()
+
+notify() {
+    [ -z "${TELEGRAM_TOKEN:-}" ] && return 0
+    [ -z "${TELEGRAM_CHAT_ID:-}" ] && return 0
+    curl -sf -m 10 -X POST "https://api.telegram.org/bot${TELEGRAM_TOKEN}/sendMessage" \
+        -d chat_id="${TELEGRAM_CHAT_ID}" \
+        -d text="$1" \
+        -d parse_mode="Markdown" >/dev/null 2>&1 || true
+}
+
+# 30-min cooldown via mtime
+should_alert() {
+    local key="$1"
+    local marker="${STATE_FILE}-${key}"
+    if [ -f "$marker" ]; then
+        local age=$(( $(date +%s) - $(stat -c %Y "$marker") ))
+        [ "$age" -lt 1800 ] && return 1
+    fi
+    touch "$marker"
+    return 0
+}
+
+# 1. Local API health
+API_RESP=$(curl -s -m 10 http://127.0.0.1:8080/health 2>/dev/null || echo '{"error":true}')
+API_OK=$(echo "$API_RESP" | python3 -c 'import json,sys; d=json.load(sys.stdin); print("ok" if d.get("status")=="ok" else "fail")' 2>/dev/null || echo "fail")
+[ "$API_OK" != "ok" ] && ISSUES+=("API down: 127.0.0.1:8080")
+
+# 2. API response time
+if [ "$API_OK" = "ok" ]; then
+    RT=$(curl -s -m 10 -o /dev/null -w "%{time_total}" http://127.0.0.1:8080/health 2>/dev/null || echo "99")
+    RT_MS=$(awk "BEGIN{printf \"%d\", ${RT} * 1000}")
+    [ "${RT_MS:-0}" -gt 5000 ] && ISSUES+=("API slow: ${RT_MS}ms")
+fi
+
+# Full check: external endpoints + tunnel + disk
+if [ "$FULL_CHECK" = true ]; then
+    SITE=$(curl -s -m 15 -o /dev/null -w "%{http_code}" https://pruviq.com 2>/dev/null || echo "000")
+    [ "$SITE" != "200" ] && ISSUES+=("pruviq.com HTTP $SITE")
+
+    API_EXT=$(curl -s -m 15 -o /dev/null -w "%{http_code}" https://api.pruviq.com/health 2>/dev/null || echo "000")
+    [ "$API_EXT" != "200" ] && ISSUES+=("api.pruviq.com HTTP $API_EXT")
+
+    if ! systemctl is-active --quiet pruviq-cloudflared.service; then
+        ISSUES+=("pruviq-cloudflared.service not active")
+    fi
+
+    DISK=$(df -h / | tail -1 | awk '{print $5}' | tr -d '%')
+    [ "${DISK:-0}" -gt 90 ] && ISSUES+=("Disk usage ${DISK}%")
+
+    echo "full_check: site=$SITE api_ext=$API_EXT disk=${DISK}%"
+fi
+
+if [ ${#ISSUES[@]} -gt 0 ]; then
+    MSG="🚨 *PRUVIQ Alert (DO)*"
+    for issue in "${ISSUES[@]}"; do
+        MSG="${MSG}
+• ${issue}"
+    done
+    if should_alert "issues"; then
+        notify "$MSG"
+        echo "ALERT sent: ${#ISSUES[@]} issues"
+    else
+        echo "ALERT suppressed (cooldown): ${#ISSUES[@]} issues"
+    fi
+    exit 1
+else
+    echo "OK: all checks passed"
+    # Clear cooldown markers on recovery
+    rm -f "${STATE_FILE}-"*
+fi

--- a/backend/deploy/systemd/bin/signal-telegram.sh
+++ b/backend/deploy/systemd/bin/signal-telegram.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# PRUVIQ — Signal Telegram (DO-native, every hour :05)
+# Posts new signals to @PRUVIQ channel. Dedup via state file.
+set -uo pipefail
+
+# Use local loopback; signal_telegram.py respects PRUVIQ_API_URL env
+export PRUVIQ_API_URL="${PRUVIQ_API_URL:-http://127.0.0.1:8080}"
+export SIGNAL_TELEGRAM_CHAT_ID="${SIGNAL_TELEGRAM_CHAT_ID:-@PRUVIQ}"
+
+exec /opt/pruviq/app/.venv/bin/python /opt/pruviq/current/backend/scripts/signal_telegram.py

--- a/backend/deploy/systemd/bin/sim_audit.sh
+++ b/backend/deploy/systemd/bin/sim_audit.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# PRUVIQ — Simulator Audit (DO-native, runs every 6h via pruviq-sim-audit.timer)
+#
+# Runs tests/sim_audit.py, posts Telegram alert only if FAIL detected.
+# Uses TELEGRAM_TOKEN (main bot) since TELEGRAM_ALERT_BOT_TOKEN is Mac-only.
+set -uo pipefail
+
+REPO_DIR="/opt/pruviq/current"
+VENV="/opt/pruviq/app/.venv/bin/python"
+LATEST="/tmp/pruviq-sim-audit-latest.txt"
+
+cd "$REPO_DIR"
+"$VENV" tests/sim_audit.py quick 2>&1 | tee "$LATEST"
+
+FAILS=$(grep -c FAIL "$LATEST" 2>/dev/null || echo 0)
+if [ "$FAILS" -gt 0 ]; then
+    SUMMARY=$(grep -E 'SUMMARY|FAIL' "$LATEST" | head -10)
+    if [ -n "${TELEGRAM_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
+        curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_TOKEN}/sendMessage" \
+            -d chat_id="${TELEGRAM_CHAT_ID}" \
+            -d text="⚠️ PRUVIQ Simulator QA FAIL (${FAILS} failures):
+${SUMMARY}" >/dev/null 2>&1 || true
+    fi
+    exit 1
+fi
+exit 0

--- a/backend/deploy/systemd/bin/staleness-watch.sh
+++ b/backend/deploy/systemd/bin/staleness-watch.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# PRUVIQ — Data Staleness Watchdog (DO-native, every 10 min)
+# Checks live API data freshness, auto-triggers refresh if stale.
+set -uo pipefail
+
+STALE_HOURS="${STALE_HOURS:-1}"
+# Check CF-served static data (fast, edge-cached).
+# /market/live on local API is too slow (572-coin live fetch, ~30s).
+SITE_URL="${STALENESS_URL:-https://pruviq.com/data/market.json}"
+STATE_FILE="/tmp/pruviq-staleness-alerted-$(date -u +%Y%m%d).json"
+
+notify() {
+    [ -z "${TELEGRAM_TOKEN:-}" ] && return 0
+    [ -z "${TELEGRAM_CHAT_ID:-}" ] && return 0
+    curl -sf -m 10 -X POST "https://api.telegram.org/bot${TELEGRAM_TOKEN}/sendMessage" \
+        -d chat_id="${TELEGRAM_CHAT_ID}" \
+        -d text="$1" >/dev/null 2>&1 || true
+}
+
+[ ! -f "$STATE_FILE" ] && echo '{}' > "$STATE_FILE"
+
+already_alerted() {
+    python3 -c "
+import json,sys
+try:
+    with open('$STATE_FILE') as f:
+        d=json.load(f)
+    sys.exit(0 if '$1' in d else 1)
+except: sys.exit(1)
+"
+}
+
+mark_alerted() {
+    python3 -c "
+import json
+with open('$STATE_FILE') as f: d=json.load(f)
+d['$1']=True
+with open('$STATE_FILE','w') as f: json.dump(d,f)
+" 2>/dev/null || true
+}
+
+generated=$(curl -sf -m 15 "$SITE_URL" 2>/dev/null | python3 -c "
+import sys,json
+from datetime import datetime,timezone
+try:
+    d=json.load(sys.stdin)
+    ts=d.get('generated','')
+    if ts:
+        dt=datetime.fromisoformat(ts.replace('Z','+00:00'))
+        age_h=(datetime.now(timezone.utc)-dt).total_seconds()/3600
+        print(f'{age_h:.2f}')
+    else:
+        print('ERROR')
+except:
+    print('ERROR')
+" 2>/dev/null)
+
+if [ -z "$generated" ] || [ "$generated" = "ERROR" ]; then
+    if ! already_alerted "fetch_failed"; then
+        notify "🚨 PRUVIQ: Cannot fetch data from $SITE_URL"
+        mark_alerted "fetch_failed"
+    fi
+    echo "fetch failed"
+    exit 1
+fi
+
+echo "age=${generated}h threshold=${STALE_HOURS}h"
+
+state=$(python3 -c "
+a=${generated}; t=${STALE_HOURS}
+print('STALE' if a>=t else ('WARN' if a>=t*0.75 else 'OK'))
+")
+
+if [ "$state" = "STALE" ]; then
+    if ! already_alerted "market_stale"; then
+        notify "🚨 PRUVIQ: Data STALE ${generated}h old (limit ${STALE_HOURS}h). Triggering refresh via systemd..."
+        mark_alerted "market_stale"
+        # Trigger refresh (systemd unit will exist once Phase 5-B deploys)
+        systemctl start pruviq-refresh-static.service 2>&1 || \
+            notify "⚠️ PRUVIQ: auto-refresh unit not yet installed (Phase 5-B pending)"
+    fi
+fi

--- a/backend/deploy/systemd/bin/update-ohlcv.sh
+++ b/backend/deploy/systemd/bin/update-ohlcv.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# PRUVIQ — OHLCV Update (DO-native, every 4h at :15)
+# Fetches latest OHLCV from Binance (via DO proxy) into /opt/pruviq/data/futures/
+set -uo pipefail
+
+DATA_DIR="${PRUVIQ_DATA_DIR:-/opt/pruviq/data/futures}"
+
+mkdir -p "$DATA_DIR"
+exec /opt/pruviq/app/.venv/bin/python \
+    /opt/pruviq/current/backend/scripts/update_ohlcv.py \
+    --data-dir "$DATA_DIR"

--- a/backend/deploy/systemd/pruviq-alert@.service
+++ b/backend/deploy/systemd/pruviq-alert@.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=PRUVIQ Unit Failure Alert for %i
+
+[Service]
+Type=oneshot
+User=pruviq
+Group=pruviq
+EnvironmentFile=/opt/pruviq/shared/.env
+ExecStart=/opt/pruviq/bin/alert-failure.sh %i

--- a/backend/deploy/systemd/pruviq-monitor-full.service
+++ b/backend/deploy/systemd/pruviq-monitor-full.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=PRUVIQ Health Monitor (hourly full check — site, tunnel, disk)
+After=network-online.target pruviq-api.service
+Wants=network-online.target
+OnFailure=pruviq-alert@%n.service
+
+[Service]
+Type=oneshot
+User=pruviq
+Group=pruviq
+WorkingDirectory=/opt/pruviq/current
+EnvironmentFile=/opt/pruviq/shared/.env
+ExecStart=/opt/pruviq/bin/monitor.sh --full
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=60

--- a/backend/deploy/systemd/pruviq-monitor-full.timer
+++ b/backend/deploy/systemd/pruviq-monitor-full.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=PRUVIQ Health Monitor Full timer (hourly)
+Requires=pruviq-monitor-full.service
+
+[Timer]
+OnCalendar=hourly
+RandomizedDelaySec=30
+Persistent=true
+Unit=pruviq-monitor-full.service
+
+[Install]
+WantedBy=timers.target

--- a/backend/deploy/systemd/pruviq-monitor.service
+++ b/backend/deploy/systemd/pruviq-monitor.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=PRUVIQ Health Monitor (5min quick check)
+After=network-online.target pruviq-api.service
+Wants=network-online.target
+OnFailure=pruviq-alert@%n.service
+
+[Service]
+Type=oneshot
+User=pruviq
+Group=pruviq
+WorkingDirectory=/opt/pruviq/current
+EnvironmentFile=/opt/pruviq/shared/.env
+ExecStart=/opt/pruviq/bin/monitor.sh
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=60

--- a/backend/deploy/systemd/pruviq-monitor.timer
+++ b/backend/deploy/systemd/pruviq-monitor.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=PRUVIQ Health Monitor timer (every 5 min)
+Requires=pruviq-monitor.service
+
+[Timer]
+OnCalendar=*:0/5
+RandomizedDelaySec=30
+Persistent=true
+Unit=pruviq-monitor.service
+
+[Install]
+WantedBy=timers.target

--- a/backend/deploy/systemd/pruviq-signal-telegram.service
+++ b/backend/deploy/systemd/pruviq-signal-telegram.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=PRUVIQ Telegram Signal Poster (hourly, max 5/hr)
+After=network-online.target pruviq-api.service
+Wants=network-online.target
+OnFailure=pruviq-alert@%n.service
+
+[Service]
+Type=oneshot
+User=pruviq
+Group=pruviq
+WorkingDirectory=/opt/pruviq/current
+EnvironmentFile=/opt/pruviq/shared/.env
+ExecStart=/opt/pruviq/bin/signal-telegram.sh
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=120

--- a/backend/deploy/systemd/pruviq-signal-telegram.timer
+++ b/backend/deploy/systemd/pruviq-signal-telegram.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=PRUVIQ Telegram Signal timer (every hour at :05)
+Requires=pruviq-signal-telegram.service
+
+[Timer]
+OnCalendar=*:05
+RandomizedDelaySec=30
+Persistent=true
+Unit=pruviq-signal-telegram.service
+
+[Install]
+WantedBy=timers.target

--- a/backend/deploy/systemd/pruviq-sim-audit.service
+++ b/backend/deploy/systemd/pruviq-sim-audit.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=PRUVIQ Simulator Audit (6h QA check)
+After=network-online.target pruviq-api.service
+Wants=network-online.target
+OnFailure=pruviq-alert@%n.service
+
+[Service]
+Type=oneshot
+User=pruviq
+Group=pruviq
+WorkingDirectory=/opt/pruviq/current
+EnvironmentFile=/opt/pruviq/shared/.env
+ExecStart=/opt/pruviq/bin/sim_audit.sh
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=300
+
+[Install]
+WantedBy=multi-user.target

--- a/backend/deploy/systemd/pruviq-sim-audit.timer
+++ b/backend/deploy/systemd/pruviq-sim-audit.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=PRUVIQ Simulator Audit timer (every 6h)
+Requires=pruviq-sim-audit.service
+
+[Timer]
+OnCalendar=*-*-* 00,06,12,18:00:00
+RandomizedDelaySec=30
+Persistent=true
+Unit=pruviq-sim-audit.service
+
+[Install]
+WantedBy=timers.target

--- a/backend/deploy/systemd/pruviq-staleness-watch.service
+++ b/backend/deploy/systemd/pruviq-staleness-watch.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=PRUVIQ Data Staleness Watchdog (10min)
+After=network-online.target pruviq-api.service
+Wants=network-online.target
+OnFailure=pruviq-alert@%n.service
+
+[Service]
+Type=oneshot
+User=pruviq
+Group=pruviq
+WorkingDirectory=/opt/pruviq/current
+EnvironmentFile=/opt/pruviq/shared/.env
+ExecStart=/opt/pruviq/bin/staleness-watch.sh
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=60

--- a/backend/deploy/systemd/pruviq-staleness-watch.timer
+++ b/backend/deploy/systemd/pruviq-staleness-watch.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=PRUVIQ Staleness Watchdog timer (every 10 min)
+Requires=pruviq-staleness-watch.service
+
+[Timer]
+OnCalendar=*:0/10
+RandomizedDelaySec=30
+Persistent=true
+Unit=pruviq-staleness-watch.service
+
+[Install]
+WantedBy=timers.target

--- a/backend/deploy/systemd/pruviq-update-ohlcv.service
+++ b/backend/deploy/systemd/pruviq-update-ohlcv.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=PRUVIQ OHLCV Data Update (4h interval, 572 coins from Binance)
+After=network-online.target pruviq-api.service
+Wants=network-online.target
+OnFailure=pruviq-alert@%n.service
+
+[Service]
+Type=oneshot
+User=pruviq
+Group=pruviq
+WorkingDirectory=/opt/pruviq/current
+EnvironmentFile=/opt/pruviq/shared/.env
+ExecStart=/opt/pruviq/bin/update-ohlcv.sh
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=1800
+Nice=10
+IOSchedulingClass=best-effort
+IOSchedulingPriority=5

--- a/backend/deploy/systemd/pruviq-update-ohlcv.timer
+++ b/backend/deploy/systemd/pruviq-update-ohlcv.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=PRUVIQ OHLCV Update timer (every 4h at :15)
+Requires=pruviq-update-ohlcv.service
+
+[Timer]
+OnCalendar=*-*-* 00/4:15:00
+RandomizedDelaySec=60
+Persistent=true
+Unit=pruviq-update-ohlcv.service
+
+[Install]
+WantedBy=timers.target

--- a/tests/sim_audit.py
+++ b/tests/sim_audit.py
@@ -6,13 +6,16 @@ Usage: python3 sim_audit.py [full|layer0|layer1|layer2|layer3|quick]
 
 import json
 import math
+import os
 import sys
 import time
 from pathlib import Path
 from urllib.request import Request, urlopen
 from urllib.error import URLError, HTTPError
 
-API_BASE = "https://api.pruviq.com"
+# PRUVIQ_API_URL overrides; useful when running on DO server to avoid
+# CF tunnel roundtrip (/market/live etc. are ~30s via tunnel, instant locally).
+API_BASE = os.getenv("PRUVIQ_API_URL", "https://api.pruviq.com")
 LOCAL_BASE = "http://localhost:8080"
 TOLERANCE = 0.01  # 0.01% tolerance
 GT_PATH = Path(__file__).parent / "ground_truth" / "formulas.json"


### PR DESCRIPTION
## Summary
Migrates 5 Mac Mini crontab entries to DigitalOcean systemd timers.
Part of the Mac → DO migration (wondrous-weaving-galaxy plan, Phase 5).

## What's migrated
| Unit | Timer | Replaces Mac cron |
|------|-------|-------------------|
| pruviq-monitor | every 5 min | \`*/5 monitor.sh\` |
| pruviq-monitor-full | hourly | \`0 * monitor.sh --full\` |
| pruviq-staleness-watch | every 10 min | \`*/10 pruviq-staleness-watch.sh\` |
| pruviq-signal-telegram | hourly :05 | \`5 * signal_telegram.py\` |
| pruviq-update-ohlcv | every 4h :15 | \`15 */4 update_ohlcv.py\` |

## Design (see backend/deploy/systemd/README.md)
- \`User=pruviq\` / \`Group=pruviq\` — no root services
- \`EnvironmentFile=/opt/pruviq/shared/.env\` — single secret source
- \`WorkingDirectory=/opt/pruviq/current\` — symlink to active release
- \`OnFailure=pruviq-alert@%n.service\` — auto-Telegram on failure
- \`RandomizedDelaySec=30\` — thundering herd prevention
- \`Persistent=true\` — catch up missed runs after reboot

## Status
- DO server: all 5 timers enabled + active (\`systemctl list-timers 'pruviq-*'\`)
- Mac crontab: 5 corresponding lines commented with \`# MIGRATED-TO-DO 2026-04-17:\`
- Manual verification: monitor.service → OK (all checks passed, 1s), staleness-watch.service → OK (detected stale data, triggered alert)
- sim_audit.py: code fix to respect \`PRUVIQ_API_URL\` env so DO runs hit localhost instead of CF tunnel

## Out of scope (future PRs)
- **Phase 5-B**: refresh_static, full_pipeline, update_pruviq_performance need Node.js + \`CLOUDFLARE_API_TOKEN\` + git deploy key on DO
- **Phase 5-C**: Mac-only cron (SNS, macmini health, backup) stays on Mac
- polkit rule for pruviq user to trigger pruviq-refresh-static from staleness-watch (Phase 5-B)

## Test plan
- [x] Manual service runs verified on DO
- [x] Timers fire on schedule (monitor fired at 00:00 UTC, OK)
- [x] OnFailure chain triggers Telegram (verified via sim_audit timeout)
- [ ] Wait for first signal-telegram fire at :05 UTC, verify single post (no duplicate)
- [ ] Wait for first update-ohlcv fire at :15 UTC, verify no Mac duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)