### PR TITLE
fix(ci): backend-deploy workflow targets DO server, not Mac Mini

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -1,4 +1,4 @@
-name: "Backend Deploy: Mac Mini Auto-Restart"
+name: "Backend Deploy: DigitalOcean Auto-Restart"
 
 on:
   push:
@@ -11,47 +11,56 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  restart:
-    name: Restart uvicorn on Mac Mini
-    runs-on: [self-hosted, mac-mini-m4]
-    timeout-minutes: 5
+  deploy-do:
+    name: Deploy to DO (167.172.81.145) via Mac runner SSH
+    # Mac runner already has an id_ed25519 key that can reach root@DO on :2222
+    # (see scripts/backup_do_server.sh). No extra secret needed.
+    runs-on: [self-hosted, mac-mini-m4-ops]
+    timeout-minutes: 6
 
     steps:
-      - name: Pull latest code
+      - name: Pull latest code on DO (pruviq user, safe.directory preconfigured)
         run: |
-          cd ~/pruviq
-          git fetch origin main
-          git reset --hard origin/main
+          ssh -p 2222 -o ConnectTimeout=10 -o IdentitiesOnly=yes \
+              -i $HOME/.ssh/id_ed25519 root@167.172.81.145 \
+              "sudo -u pruviq bash -c 'cd /opt/pruviq/current && git fetch origin main --quiet && git reset --hard origin/main'"
 
-      - name: Install dependencies if requirements changed
+      - name: Install deps if requirements changed
         run: |
-          cd ~/pruviq/backend
-          if git diff HEAD~1 --name-only 2>/dev/null | grep -q "requirements.txt"; then
-            echo "requirements.txt changed, installing..."
-            .venv/bin/pip install -q -r requirements.txt
-          else
-            echo "No dependency changes"
-          fi
-
-      - name: Restart uvicorn via launchd
-        run: |
-          launchctl bootout "gui/$(id -u)" ~/Library/LaunchAgents/com.pruviq.api.plist 2>/dev/null || true
-          pkill -9 -f "uvicorn api.main" 2>/dev/null || true
-          sleep 3
-          launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.pruviq.api.plist
-          echo "uvicorn restart initiated"
-
-      - name: Wait for API to be ready
-        run: |
-          for i in 1 2 3 4 5; do
-            sleep 20
-            coins=$(curl -s -m 5 http://localhost:8080/health 2>/dev/null \
-              | python3 -c "import sys,json; print(json.load(sys.stdin).get('coins_loaded',0))" 2>/dev/null || echo "0")
-            echo "Attempt $i: coins=$coins"
-            if [ "$coins" -gt 400 ] 2>/dev/null; then
-              echo "Backend ready: $coins coins loaded"
-              exit 0
+          ssh -p 2222 -o IdentitiesOnly=yes -i $HOME/.ssh/id_ed25519 root@167.172.81.145 "
+            if sudo -u pruviq bash -c 'cd /opt/pruviq/current && git diff HEAD~1 --name-only' 2>/dev/null | grep -q backend/requirements.txt; then
+              echo 'requirements changed, installing...'
+              sudo -u pruviq /opt/pruviq/app/.venv/bin/pip install -q -r /opt/pruviq/current/backend/requirements.txt
+            else
+              echo 'no dependency changes'
             fi
-          done
-          echo "WARNING: Backend took longer than expected to load — check logs"
-          exit 0
+          "
+
+      - name: Restart pruviq-api.service
+        run: |
+          ssh -p 2222 -o IdentitiesOnly=yes -i $HOME/.ssh/id_ed25519 root@167.172.81.145 \
+              "systemctl restart pruviq-api.service"
+
+      - name: Wait for health
+        run: |
+          ssh -p 2222 -o IdentitiesOnly=yes -i $HOME/.ssh/id_ed25519 root@167.172.81.145 "
+            for i in 1 2 3 4 5 6 7 8 9 10; do
+              sleep 5
+              coins=\$(curl -sf -m 5 http://127.0.0.1:8080/health 2>/dev/null \
+                | python3 -c 'import sys,json; print(json.load(sys.stdin).get(\"coins_loaded\",0))' 2>/dev/null || echo 0)
+              echo \"attempt \$i: coins=\$coins\"
+              if [ \"\$coins\" -gt 400 ] 2>/dev/null; then
+                echo 'backend ready'
+                exit 0
+              fi
+            done
+            echo 'WARNING: backend slow to load — check journalctl -u pruviq-api'
+            exit 1
+          "
+
+      - name: Post-deploy sanity via public endpoint
+        run: |
+          sleep 5
+          status=$(curl -sf -m 10 -o /dev/null -w "%{http_code}" https://api.pruviq.com/health)
+          echo "api.pruviq.com/health → $status"
+          [ "$status" = "200" ] || exit 1


### PR DESCRIPTION
## Summary
Phase 4 DO cutover moved pruviq-api to DigitalOcean, but backend-deploy.yml still restarted **Mac Mini** uvicorn on every \`backend/**\` push. Result: PRs #1075 (httpx + Pillow) and #1078 (systemd timers) merged to main but DO was never reloaded — required manual ssh + git pull + restart.

## Fix
Reuse the existing \`mac-mini-m4-ops\` self-hosted runner but deploy via SSH to DO. The runner already has an id_ed25519 key for \`root@167.172.81.145:2222\` (see \`scripts/backup_do_server.sh\`). **No new secrets required.**

## Pipeline
1. \`pruviq user git fetch + reset --hard origin/main\` (safe.directory preconfigured)
2. \`pip install\` if \`requirements.txt\` changed
3. \`systemctl restart pruviq-api.service\`
4. Poll /health via loopback until coins_loaded>400
5. Verify public \`api.pruviq.com/health\`

## Not automerging
This is a CI infra file — CLAUDE.md rule blocks automerge. **Owner to review & merge manually.**

## Test plan
- [ ] Owner merges
- [ ] Next backend/** PR triggers this workflow
- [ ] DO \`systemctl status pruviq-api\` shows recent restart
- [ ] \`api.pruviq.com/health\` returns 200 with fresh \`uptime_seconds\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)