### PR TITLE
fix(api): RANKING_DIR env override (unblocks production /rankings/daily + E2E)

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -3670,7 +3670,10 @@ async def export_csv(hash: str):
 # Daily Rankings
 # ---------------------------------------------------------------------------
 
-RANKING_DIR = "/Users/jepo/Desktop/autotrader/data/daily_rankings"
+RANKING_DIR = os.environ.get(
+    "RANKING_DIR",
+    "/Users/jepo/Desktop/autotrader/data/daily_rankings",
+)
 
 _rankings_cache: dict = {}
 _RANKINGS_CACHE_TTL = 60


### PR DESCRIPTION
## Root cause
\`RANKING_DIR\` was hardcoded to a Mac filesystem path. After Phase 4 cutover the API runs on DO where that path doesn't exist — every \`/rankings/daily\` request returned 404, and the E2E \`Rankings_daily_structure\` test logged 6 failures on every PR (blocking automerge for PRs #1082, #1083, #1087).

## Fix

- \`RANKING_DIR = os.environ.get("RANKING_DIR", <mac_default>)\`. Mac rollback path still works.
- DO \`/opt/pruviq/shared/.env\` now has \`RANKING_DIR=/opt/pruviq/data/rankings\`.
- Mac → DO rsync: 38 ranking JSON files (12MB, covers 7d/30d/365d × top30/top50/top100/btc).

## Verification
- DO local: \`curl http://127.0.0.1:8080/rankings/daily\` → 200 + 3KB body (post-hotpatch).
- Next backend/** merge (this one) will auto-redeploy via backend-deploy.yml (#1079).
- E2E will pass once main redeploys to DO.

## Test plan
- [x] \`api.pruviq.com/rankings/daily\` returns 200
- [ ] E2E Rankings_daily_structure passes on next run
- [ ] Mac rollback still works (default path intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)