### PR TITLE
feat(site+api): Trust Dashboard (Moat-1) — public execution-quality metrics

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -4233,3 +4233,93 @@ async def unsubscribe_email(email: str, token: str):
         "<a href=\"https://pruviq.com\">Back to PRUVIQ</a>"
         "</body></html>"
     )
+
+
+# ── Trust Dashboard (Moat-1) — anonymized execution quality metrics ─────────
+
+_trust_cache: dict = {"ts": 0.0, "data": None}
+_TRUST_CACHE_TTL = 60.0
+
+
+def _compute_trust_metrics_sync() -> dict:
+    """Aggregate trade_log across ALL sessions — no session_id in output."""
+    from okx.storage import _get_conn as _okx_get_conn
+    now = time.time()
+    cutoff_24h = now - 24 * 3600
+    cutoff_7d = now - 7 * 24 * 3600
+
+    try:
+        with _okx_get_conn() as conn:
+            rows = conn.execute(
+                "SELECT signal, result, created_at FROM trade_log "
+                "WHERE created_at >= ? ORDER BY created_at DESC LIMIT 500",
+                (cutoff_7d,),
+            ).fetchall()
+    except Exception as e:
+        logger.warning("trust metrics: trade_log fetch failed: %s", e)
+        return {"trades_24h": 0, "trades_7d": 0, "error": "no data"}
+
+    slippages: list[float] = []
+    with_sl_tp = 0
+    count_24h = 0
+    for signal_json, result_json, created_at in rows:
+        try:
+            signal = json.loads(signal_json) if signal_json else {}
+            result = json.loads(result_json) if result_json else {}
+        except Exception:
+            continue
+        if created_at >= cutoff_24h:
+            count_24h += 1
+        fill = result.get("fill_price")
+        entry = signal.get("entry_price") or signal.get("signal_price")
+        if fill and entry:
+            try:
+                slippages.append((float(fill) - float(entry)) / float(entry) * 100.0)
+            except (ValueError, ZeroDivisionError):
+                pass
+        if result.get("algo"):
+            with_sl_tp += 1
+
+    def _median(xs: list[float]) -> float | None:
+        if not xs:
+            return None
+        ys = sorted(xs)
+        n = len(ys)
+        mid = n // 2
+        return ys[mid] if n % 2 == 1 else (ys[mid - 1] + ys[mid]) / 2.0
+
+    def _p90(xs: list[float]) -> float | None:
+        if not xs:
+            return None
+        ys = sorted(abs(x) for x in xs)
+        idx = max(0, int(len(ys) * 0.9) - 1)
+        return ys[idx]
+
+    abs_slips = [abs(s) for s in slippages]
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "trades_7d": len(rows),
+        "trades_24h": count_24h,
+        "sample_with_fill_price": len(slippages),
+        "slippage_median_pct": round(_median(abs_slips), 4) if abs_slips else None,
+        "slippage_p90_pct": round(_p90(slippages), 4) if slippages else None,
+        "sl_tp_set_rate": round(with_sl_tp / len(rows) * 100, 2) if rows else None,
+        "notes": (
+            "Slippage = |fill − signal_price| / signal_price. "
+            "sl_tp_set_rate = % of logged trades where the OKX SL/TP algo order was accepted. "
+            "Sample excludes trades executed before fill-price logging was added."
+        ),
+    }
+
+
+@app.get("/trust/metrics")
+async def trust_metrics() -> dict:
+    """Public execution-quality metrics. Never exposes per-user data."""
+    now = time.time()
+    cached = _trust_cache.get("data")
+    if cached and (now - _trust_cache["ts"]) < _TRUST_CACHE_TTL:
+        return cached
+    data = await asyncio.to_thread(_compute_trust_metrics_sync)
+    _trust_cache["data"] = data
+    _trust_cache["ts"] = now
+    return data

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -2068,6 +2068,32 @@ export const en = {
   "404.back_home": "Back to Home",
   "404.open_simulator": "Open Simulator",
   "404.or_try": "Or try these",
+  // Trust Dashboard
+  "trust.meta_title": "Trust Dashboard — PRUVIQ",
+  "trust.meta_desc":
+    "PRUVIQ publishes anonymized execution-quality metrics for every auto-trade: slippage, SL/TP set-rate, 24h/7d trade counts. Evidence, not claims.",
+  "trust.moat_label": "Moat #1",
+  "trust.heading": "Trust Dashboard",
+  "trust.intro":
+    "Every auto-execution logs the gap between its signal price and its actual fill price. We publish the aggregate. No per-user attribution — just evidence.",
+  "trust.trades_24h": "Trades (24h)",
+  "trust.trades_7d": "Trades (7d)",
+  "trust.slippage_median": "Slippage median",
+  "trust.slippage_p90": "Slippage p90",
+  "trust.slippage_formula": "|fill − signal| / signal",
+  "trust.slippage_p90_note": "worst 10% bound",
+  "trust.sl_tp_rate": "SL / TP set-rate",
+  "trust.sl_tp_note":
+    "% of logged trades where OKX accepted our stop-loss + take-profit algo order. Misses trigger the emergency-close path (autotrader lesson L1+).",
+  "trust.loading": "loading…",
+  "trust.unavailable": "metrics temporarily unavailable",
+  "trust.updated": "updated",
+  "trust.why_title": "Why we publish this.",
+  "trust.why_body":
+    "Every crypto autotrade platform claims \"precise execution.\" We let you check. Slippage over 0.5% triggers an immediate position close by design. If that number walks up over time, you'll see it here first.",
+  "trust.what_not_title": "What this isn't.",
+  "trust.what_not_body":
+    "Not a leaderboard. Not individual user returns. No clickbait.",
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -2019,4 +2019,30 @@ export const ko: Record<TranslationKey, string> = {
   "404.back_home": "홈으로 돌아가기",
   "404.open_simulator": "시뮬레이터 열기",
   "404.or_try": "이것도 살펴보세요",
+  // Trust Dashboard
+  "trust.meta_title": "신뢰 대시보드 — 프루빅(PRUVIQ)",
+  "trust.meta_desc":
+    "PRUVIQ는 모든 자동매매의 익명화된 실행 품질 지표를 공개합니다: 슬리피지, SL/TP 설정률, 24시간/7일 거래 수. 주장이 아닌 증거.",
+  "trust.moat_label": "Moat #1",
+  "trust.heading": "신뢰 대시보드",
+  "trust.intro":
+    "모든 자동 실행은 신호 가격과 실제 체결 가격 사이의 차이를 기록합니다. 집계 데이터를 공개합니다. 개인별 귀속 없이 — 오직 증거만.",
+  "trust.trades_24h": "거래 수 (24시간)",
+  "trust.trades_7d": "거래 수 (7일)",
+  "trust.slippage_median": "슬리피지 중앙값",
+  "trust.slippage_p90": "슬리피지 p90",
+  "trust.slippage_formula": "|체결가 − 신호가| / 신호가",
+  "trust.slippage_p90_note": "상위 10% 경계",
+  "trust.sl_tp_rate": "SL / TP 설정률",
+  "trust.sl_tp_note":
+    "OKX가 손절/익절 알고 주문을 수락한 거래의 비율. 실패 시 긴급 청산 경로가 작동합니다 (오토트레이더 교훈 L1+).",
+  "trust.loading": "로딩 중…",
+  "trust.unavailable": "지표를 일시적으로 사용할 수 없습니다",
+  "trust.updated": "업데이트",
+  "trust.why_title": "왜 이것을 공개하는가.",
+  "trust.why_body":
+    "모든 크립토 자동매매 플랫폼이 \"정밀한 실행\"을 주장합니다. 우리는 직접 확인할 수 있게 합니다. 슬리피지가 0.5%를 초과하면 설계상 즉시 포지션을 청산합니다. 이 수치가 시간이 지나면서 올라간다면, 여기서 가장 먼저 확인할 수 있습니다.",
+  "trust.what_not_title": "이것은 무엇이 아닌가.",
+  "trust.what_not_body":
+    "리더보드가 아닙니다. 개인 수익률이 아닙니다. 낚시성 콘텐츠 없음.",
 };

--- a/src/pages/trust.astro
+++ b/src/pages/trust.astro
@@ -1,0 +1,100 @@
+---
+// Trust Dashboard (Moat-1 of wondrous-weaving-galaxy plan).
+// Shows anonymized execution-quality metrics. No per-user attribution.
+// Backend: /trust/metrics on api.pruviq.com.
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout
+  title="Trust Dashboard — PRUVIQ"
+  description="PRUVIQ publishes anonymized execution-quality metrics for every auto-trade: slippage, SL/TP set-rate, 24h/7d trade counts. Evidence, not claims."
+>
+  <main class="max-w-4xl mx-auto px-4 py-16 md:py-24">
+    <header class="mb-12 text-center">
+      <p class="font-mono text-[--color-accent] text-xs tracking-widest uppercase mb-4">Moat #1</p>
+      <h1 class="text-4xl md:text-5xl font-extrabold tracking-tight mb-4">Trust Dashboard</h1>
+      <p class="text-lg text-[--color-text-secondary] max-w-2xl mx-auto">
+        Every auto-execution logs the gap between its signal price and its actual fill price.
+        We publish the aggregate. No per-user attribution — just evidence.
+      </p>
+    </header>
+
+    <section id="metrics" class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-12">
+      <div class="card-enterprise rounded-2xl p-6">
+        <p class="text-xs font-mono text-[--color-text-muted] uppercase mb-2">Trades (24h)</p>
+        <p class="text-4xl font-extrabold" data-metric="trades_24h">—</p>
+      </div>
+      <div class="card-enterprise rounded-2xl p-6">
+        <p class="text-xs font-mono text-[--color-text-muted] uppercase mb-2">Trades (7d)</p>
+        <p class="text-4xl font-extrabold" data-metric="trades_7d">—</p>
+      </div>
+      <div class="card-enterprise rounded-2xl p-6">
+        <p class="text-xs font-mono text-[--color-text-muted] uppercase mb-2">Slippage median</p>
+        <p class="text-4xl font-extrabold" data-metric="slippage_median_pct">—</p>
+        <p class="text-xs text-[--color-text-muted] mt-2">|fill − signal| / signal</p>
+      </div>
+      <div class="card-enterprise rounded-2xl p-6">
+        <p class="text-xs font-mono text-[--color-text-muted] uppercase mb-2">Slippage p90</p>
+        <p class="text-4xl font-extrabold" data-metric="slippage_p90_pct">—</p>
+        <p class="text-xs text-[--color-text-muted] mt-2">worst 10% bound</p>
+      </div>
+      <div class="card-enterprise rounded-2xl p-6 md:col-span-2">
+        <p class="text-xs font-mono text-[--color-text-muted] uppercase mb-2">SL / TP set-rate</p>
+        <p class="text-4xl font-extrabold" data-metric="sl_tp_set_rate">—</p>
+        <p class="text-xs text-[--color-text-muted] mt-2">
+          % of logged trades where OKX accepted our stop-loss + take-profit algo order.
+          Misses trigger the emergency-close path (autotrader lesson L1+).
+        </p>
+      </div>
+    </section>
+
+    <p class="text-xs text-[--color-text-muted] text-center font-mono" data-metric="generated_at">
+      loading…
+    </p>
+
+    <footer class="mt-16 text-sm text-[--color-text-muted] space-y-3 max-w-3xl mx-auto">
+      <p>
+        <strong class="text-[--color-text]">Why we publish this.</strong>
+        Every crypto autotrade platform claims "precise execution." We let you check.
+        Slippage over 0.5% triggers an immediate position close by design
+        (<code class="text-xs px-1 bg-[--color-bg-muted] rounded">_MAX_SLIPPAGE</code> in our executor).
+        If that number walks up over time, you'll see it here first.
+      </p>
+      <p>
+        <strong class="text-[--color-text]">What this isn't.</strong>
+        Not a leaderboard. Not individual user returns. No clickbait.
+      </p>
+    </footer>
+  </main>
+
+  <script is:inline>
+    (async () => {
+      try {
+        const resp = await fetch('https://api.pruviq.com/trust/metrics', { cache: 'no-store' });
+        if (!resp.ok) throw new Error('HTTP ' + resp.status);
+        const data = await resp.json();
+        document.querySelectorAll('[data-metric]').forEach((el) => {
+          const key = el.getAttribute('data-metric');
+          if (!key) return;
+          const v = data[key];
+          if (v === null || v === undefined) {
+            el.textContent = 'N/A';
+            return;
+          }
+          if (key === 'slippage_median_pct' || key === 'slippage_p90_pct') {
+            el.textContent = Number(v).toFixed(3) + '%';
+          } else if (key === 'sl_tp_set_rate') {
+            el.textContent = Number(v).toFixed(1) + '%';
+          } else if (key === 'generated_at') {
+            el.textContent = 'updated ' + String(v).replace('T', ' ');
+          } else {
+            el.textContent = String(v);
+          }
+        });
+      } catch (e) {
+        const genEl = document.querySelector('[data-metric="generated_at"]');
+        if (genEl) genEl.textContent = 'metrics temporarily unavailable';
+      }
+    })();
+  </script>
+</Layout>

--- a/src/pages/trust.astro
+++ b/src/pages/trust.astro
@@ -3,66 +3,64 @@
 // Shows anonymized execution-quality metrics. No per-user attribution.
 // Backend: /trust/metrics on api.pruviq.com.
 import Layout from '../layouts/Layout.astro';
+import { useTranslations } from '../i18n/index';
+
+const t = useTranslations('en');
 ---
 
 <Layout
-  title="Trust Dashboard — PRUVIQ"
-  description="PRUVIQ publishes anonymized execution-quality metrics for every auto-trade: slippage, SL/TP set-rate, 24h/7d trade counts. Evidence, not claims."
+  title={t('trust.meta_title')}
+  description={t('trust.meta_desc')}
 >
   <main class="max-w-4xl mx-auto px-4 py-16 md:py-24">
     <header class="mb-12 text-center">
-      <p class="font-mono text-[--color-accent] text-xs tracking-widest uppercase mb-4">Moat #1</p>
-      <h1 class="text-4xl md:text-5xl font-extrabold tracking-tight mb-4">Trust Dashboard</h1>
+      <p class="font-mono text-[--color-accent] text-xs tracking-widest uppercase mb-4">{t('trust.moat_label')}</p>
+      <h1 class="text-4xl md:text-5xl font-extrabold tracking-tight mb-4">{t('trust.heading')}</h1>
       <p class="text-lg text-[--color-text-secondary] max-w-2xl mx-auto">
-        Every auto-execution logs the gap between its signal price and its actual fill price.
-        We publish the aggregate. No per-user attribution — just evidence.
+        {t('trust.intro')}
       </p>
     </header>
 
     <section id="metrics" class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-12">
       <div class="card-enterprise rounded-2xl p-6">
-        <p class="text-xs font-mono text-[--color-text-muted] uppercase mb-2">Trades (24h)</p>
+        <p class="text-xs font-mono text-[--color-text-muted] uppercase mb-2">{t('trust.trades_24h')}</p>
         <p class="text-4xl font-extrabold" data-metric="trades_24h">—</p>
       </div>
       <div class="card-enterprise rounded-2xl p-6">
-        <p class="text-xs font-mono text-[--color-text-muted] uppercase mb-2">Trades (7d)</p>
+        <p class="text-xs font-mono text-[--color-text-muted] uppercase mb-2">{t('trust.trades_7d')}</p>
         <p class="text-4xl font-extrabold" data-metric="trades_7d">—</p>
       </div>
       <div class="card-enterprise rounded-2xl p-6">
-        <p class="text-xs font-mono text-[--color-text-muted] uppercase mb-2">Slippage median</p>
+        <p class="text-xs font-mono text-[--color-text-muted] uppercase mb-2">{t('trust.slippage_median')}</p>
         <p class="text-4xl font-extrabold" data-metric="slippage_median_pct">—</p>
-        <p class="text-xs text-[--color-text-muted] mt-2">|fill − signal| / signal</p>
+        <p class="text-xs text-[--color-text-muted] mt-2">{t('trust.slippage_formula')}</p>
       </div>
       <div class="card-enterprise rounded-2xl p-6">
-        <p class="text-xs font-mono text-[--color-text-muted] uppercase mb-2">Slippage p90</p>
+        <p class="text-xs font-mono text-[--color-text-muted] uppercase mb-2">{t('trust.slippage_p90')}</p>
         <p class="text-4xl font-extrabold" data-metric="slippage_p90_pct">—</p>
-        <p class="text-xs text-[--color-text-muted] mt-2">worst 10% bound</p>
+        <p class="text-xs text-[--color-text-muted] mt-2">{t('trust.slippage_p90_note')}</p>
       </div>
       <div class="card-enterprise rounded-2xl p-6 md:col-span-2">
-        <p class="text-xs font-mono text-[--color-text-muted] uppercase mb-2">SL / TP set-rate</p>
+        <p class="text-xs font-mono text-[--color-text-muted] uppercase mb-2">{t('trust.sl_tp_rate')}</p>
         <p class="text-4xl font-extrabold" data-metric="sl_tp_set_rate">—</p>
         <p class="text-xs text-[--color-text-muted] mt-2">
-          % of logged trades where OKX accepted our stop-loss + take-profit algo order.
-          Misses trigger the emergency-close path (autotrader lesson L1+).
+          {t('trust.sl_tp_note')}
         </p>
       </div>
     </section>
 
     <p class="text-xs text-[--color-text-muted] text-center font-mono" data-metric="generated_at">
-      loading…
+      {t('trust.loading')}
     </p>
 
     <footer class="mt-16 text-sm text-[--color-text-muted] space-y-3 max-w-3xl mx-auto">
       <p>
-        <strong class="text-[--color-text]">Why we publish this.</strong>
-        Every crypto autotrade platform claims "precise execution." We let you check.
-        Slippage over 0.5% triggers an immediate position close by design
-        (<code class="text-xs px-1 bg-[--color-bg-muted] rounded">_MAX_SLIPPAGE</code> in our executor).
-        If that number walks up over time, you'll see it here first.
+        <strong class="text-[--color-text]">{t('trust.why_title')}</strong>
+        {t('trust.why_body')}
       </p>
       <p>
-        <strong class="text-[--color-text]">What this isn't.</strong>
-        Not a leaderboard. Not individual user returns. No clickbait.
+        <strong class="text-[--color-text]">{t('trust.what_not_title')}</strong>
+        {t('trust.what_not_body')}
       </p>
     </footer>
   </main>
@@ -86,14 +84,16 @@ import Layout from '../layouts/Layout.astro';
           } else if (key === 'sl_tp_set_rate') {
             el.textContent = Number(v).toFixed(1) + '%';
           } else if (key === 'generated_at') {
-            el.textContent = 'updated ' + String(v).replace('T', ' ');
+            el.textContent = String(v).replace('T', ' ');
           } else {
             el.textContent = String(v);
           }
         });
       } catch (e) {
         const genEl = document.querySelector('[data-metric="generated_at"]');
-        if (genEl) genEl.textContent = 'metrics temporarily unavailable';
+        if (genEl) genEl.textContent = document.documentElement.lang === 'ko'
+          ? '\uc9c0\ud45c\ub97c \uc77c\uc2dc\uc801\uc73c\ub85c \uc0ac\uc6a9\ud560 \uc218 \uc5c6\uc2b5\ub2c8\ub2e4'
+          : 'metrics temporarily unavailable';
       }
     })();
   </script>


### PR DESCRIPTION
Ships the first of the four Moats from wondrous-weaving-galaxy plan. Auto-executor already records (signal_price, fill_price, SL/TP accepted) per trade; this PR exposes the aggregate publicly so users can hold PRUVIQ accountable instead of trusting a marketing claim.

## Backend
\`GET /trust/metrics\` returns anonymized aggregates across all sessions (last 7d, 500-row cap, 60s cache):
- trades_24h, trades_7d
- slippage_median_pct, slippage_p90_pct
- sl_tp_set_rate
- sample_with_fill_price

No session_id, no per-user attribution, ever.

## Frontend
\`/trust\` — 5 metric cards + explanatory footer. Inline \`<script>\` fetches the API. Graceful "metrics temporarily unavailable" fallback if the API is down.

## Not in this PR (deliberate scope cap)
- Moat-2 Merkle audit log (commit-hash scheme design pending)
- Moat-3 Data Freshness SLO header (middleware work)
- Moat-4 Leader Epoch flag (single-writer metadata)

## Test plan
- [ ] DO auto-redeploys via backend-deploy.yml
- [ ] \`curl https://api.pruviq.com/trust/metrics\` → JSON with null metrics (no trades yet)
- [ ] \`https://pruviq.com/trust\` renders with "N/A" placeholders until first trade logged
- [ ] After a real trade: slippage metrics populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)