### PR TITLE
feat(api): Moat-3 — X-Data-Age-Seconds response header

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -523,6 +523,43 @@ async def rate_limit_middleware(request: Request, call_next):
     return await call_next(request)
 
 
+# ── Data Freshness SLO (Moat-3) ──────────────────────────────────────
+# Advertise how old the canonical market snapshot is on every response. A
+# monitoring system can alert on max_over_time(data_age[10m]) > 900, and
+# the UI can show a staleness indicator so users never trust a frozen number.
+#
+# Single source: public/data/market.json mtime. refresh_static refreshes
+# this file every 20 minutes; anything > ~1h is almost certainly the refresh
+# pipeline being broken.
+
+_MARKET_FILE = Path(__file__).parent.parent.parent / "public" / "data" / "market.json"
+_freshness_cache: dict = {"mtime": 0.0, "ts": 0.0}
+_FRESHNESS_CACHE_TTL = 30.0  # stat() syscall throttle
+
+
+def _get_data_age_seconds() -> int | None:
+    now = time.time()
+    if (now - _freshness_cache["ts"]) < _FRESHNESS_CACHE_TTL and _freshness_cache["mtime"] > 0:
+        return max(0, int(now - _freshness_cache["mtime"]))
+    try:
+        mtime = _MARKET_FILE.stat().st_mtime
+    except OSError:
+        return None
+    _freshness_cache["mtime"] = mtime
+    _freshness_cache["ts"] = now
+    return max(0, int(now - mtime))
+
+
+@app.middleware("http")
+async def data_freshness_header_middleware(request: Request, call_next):
+    """Attach X-Data-Age-Seconds to every response (Moat-3)."""
+    response = await call_next(request)
+    age = _get_data_age_seconds()
+    if age is not None:
+        response.headers["X-Data-Age-Seconds"] = str(age)
+    return response
+
+
 # --- Cache ---
 
 def cache_key(req: SimulationRequest) -> str:


### PR DESCRIPTION
Moat-3 of wondrous-weaving-galaxy plan — every response now declares how stale the canonical data is. Enables a staleness indicator on the UI, external Prometheus alerts, and third-party audit of our freshness SLO.

## Design
- Source = \`public/data/market.json\` mtime (\`refresh_static\` rewrites on success)
- Middleware (not per-endpoint) — can't forget a route
- 30s \`stat()\` cache
- Absent file → header omitted (explicit absence > garbage value)

## Test plan
- [x] Compiles + header set on healthy deploy
- [ ] \`curl -I api.pruviq.com/health\` shows \`x-data-age-seconds: <N>\`
- [ ] File rotation (refresh_static run) drops the value

🤖 Generated with [Claude Code](https://claude.com/claude-code)