### PR TITLE
feat(okx+api): Moat-2 — Merkle audit log for executed orders

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -149,7 +149,16 @@ def _refresh_data():
 
 
 async def _okx_auto_trading_loop():
-    """Check signals and auto-execute for subscribed users every 5 minutes."""
+    """Check signals and auto-execute for subscribed users.
+
+    Interval defaults to 300s (Mac-era default) but can be lengthened on
+    constrained hosts via OKX_AUTO_TRADE_INTERVAL_SEC. On DO 2vCPU the
+    scan itself is CPU-heavy (see signal_scanner.scan); running it every
+    5 minutes starves the API event loop. 900s cuts that cost by 3× with
+    no change to signal quality (candles are hourly).
+    """
+    interval_sec = max(60, int(os.environ.get("OKX_AUTO_TRADE_INTERVAL_SEC", "300")))
+    logger.info("OKX auto-trading loop interval = %ds", interval_sec)
     await asyncio.sleep(30)  # Wait for data load
     while True:
         try:
@@ -162,7 +171,7 @@ async def _okx_auto_trading_loop():
             raise
         except Exception as e:
             logger.warning(f"OKX auto-trading loop error: {e}")
-        await asyncio.sleep(300)  # 5 minutes
+        await asyncio.sleep(interval_sec)
 
 
 async def _okx_token_refresh_loop():

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -523,6 +523,43 @@ async def rate_limit_middleware(request: Request, call_next):
     return await call_next(request)
 
 
+# ── Data Freshness SLO (Moat-3) ──────────────────────────────────────
+# Advertise how old the canonical market snapshot is on every response. A
+# monitoring system can alert on max_over_time(data_age[10m]) > 900, and
+# the UI can show a staleness indicator so users never trust a frozen number.
+#
+# Single source: public/data/market.json mtime. refresh_static refreshes
+# this file every 20 minutes; anything > ~1h is almost certainly the refresh
+# pipeline being broken.
+
+_MARKET_FILE = Path(__file__).parent.parent.parent / "public" / "data" / "market.json"
+_freshness_cache: dict = {"mtime": 0.0, "ts": 0.0}
+_FRESHNESS_CACHE_TTL = 30.0  # stat() syscall throttle
+
+
+def _get_data_age_seconds() -> int | None:
+    now = time.time()
+    if (now - _freshness_cache["ts"]) < _FRESHNESS_CACHE_TTL and _freshness_cache["mtime"] > 0:
+        return max(0, int(now - _freshness_cache["mtime"]))
+    try:
+        mtime = _MARKET_FILE.stat().st_mtime
+    except OSError:
+        return None
+    _freshness_cache["mtime"] = mtime
+    _freshness_cache["ts"] = now
+    return max(0, int(now - mtime))
+
+
+@app.middleware("http")
+async def data_freshness_header_middleware(request: Request, call_next):
+    """Attach X-Data-Age-Seconds to every response (Moat-3)."""
+    response = await call_next(request)
+    age = _get_data_age_seconds()
+    if age is not None:
+        response.headers["X-Data-Age-Seconds"] = str(age)
+    return response
+
+
 # --- Cache ---
 
 def cache_key(req: SimulationRequest) -> str:

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -4372,3 +4372,30 @@ async def trust_metrics() -> dict:
     _trust_cache["data"] = data
     _trust_cache["ts"] = now
     return data
+
+
+# ── Moat-2: Merkle audit root ──────────────────────────────────────────
+# Publish the sha256 Merkle root of every recorded order leaf for a given
+# UTC day. A user who keeps their own (session_id, ts, inst_id, side, sz,
+# fill_price, broker_code) tuple can recompute their leaf and verify
+# inclusion — evidence that PRUVIQ didn't quietly drop their order from
+# the ledger.
+#
+# Algorithm is pinned in backend/okx/merkle.py so users can reproduce it.
+
+@app.get("/trust/merkle/{date}")
+async def trust_merkle_root(date: str) -> dict:
+    """Return {date, leaf_count, root, algorithm} for YYYYMMDD UTC day.
+
+    Empty day returns root=null with leaf_count=0 — silence is not
+    omission here, it's evidence the day had no trades."""
+    if not date.isdigit() or len(date) != 8:
+        raise HTTPException(400, "date must be YYYYMMDD")
+    try:
+        from okx.merkle import compute_daily_root
+        return await asyncio.to_thread(compute_daily_root, date)
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+    except Exception as e:
+        logger.error("merkle root compute failed for %s: %s", date, e)
+        raise HTTPException(500, "failed to compute merkle root")

--- a/backend/api/signal_scanner.py
+++ b/backend/api/signal_scanner.py
@@ -6,6 +6,7 @@ Used by /signals/live API endpoint.
 """
 
 import logging
+import os
 import threading
 import time
 from datetime import datetime, timezone
@@ -17,6 +18,17 @@ from api.data_manager import DataManager
 from src.strategies.registry import STRATEGY_REGISTRY, get_strategy
 
 logger = logging.getLogger("pruviq")
+
+
+def _allowed_statuses() -> set[str]:
+    """SIGNAL_SCANNER_STATUSES env = comma-separated list.
+
+    Defaults to {'verified','research'} for backcompat. On DO set to
+    'verified' only — halves the scan cost without affecting live users who
+    care about proven strategies."""
+    raw = os.environ.get("SIGNAL_SCANNER_STATUSES", "verified,research")
+    statuses = {s.strip().lower() for s in raw.split(",") if s.strip()}
+    return statuses or {"verified", "research"}
 
 
 class SignalScanner:
@@ -64,10 +76,11 @@ class SignalScanner:
         scan_started = time.time()
         signals = []
         top_coins = self._get_top_coins()
+        allowed = _allowed_statuses()
 
         for strategy_id, entry in STRATEGY_REGISTRY.items():
             status = entry.get("status", "research")
-            if status not in ("verified", "research"):
+            if status not in allowed:
                 continue
 
             try:

--- a/backend/okx/auto_executor.py
+++ b/backend/okx/auto_executor.py
@@ -641,6 +641,25 @@ async def _try_execute(
     # before place_order; here we only update its status.
     update_signal_status(session_id, strategy_id, coin, dedup_time, "filled")
 
+    # Moat-2: Merkle audit leaf. Canonical pre-image is stable forever so
+    # users can reproduce the hash off-line and verify inclusion in the
+    # daily root at /trust/merkle/{YYYYMMDD}. Fire-and-forget — an audit
+    # failure must never block the trading path.
+    try:
+        from .merkle import record_order as _merkle_record
+        from .config import OKX_BROKER_CODE as _BROKER
+        _merkle_record(
+            session_id=session_id,
+            ts_iso=datetime.fromtimestamp(trade_created_at, tz=timezone.utc).isoformat(timespec="seconds"),
+            inst_id=inst_id,
+            side=close_side,  # executed direction in OKX terminology
+            sz=sz,
+            fill_price=fill_price,
+            broker_code=_BROKER or "",
+        )
+    except Exception as audit_err:
+        logger.warning("merkle audit record failed (non-fatal): %s", audit_err)
+
     logger.warning(
         "Auto-executed: %s %s %s sz=%s fillPx=%.6f SL=%s TP=%s clOrdId=%s session=%s",
         side, inst_id, strategy_id, sz, fill_price, sl_price, tp_price,

--- a/backend/okx/merkle.py
+++ b/backend/okx/merkle.py
@@ -1,0 +1,158 @@
+"""
+PRUVIQ OKX — Merkle audit log (Moat-2).
+
+Every successful OKX order contributes a leaf hash. The daily Merkle root
+is published at /trust/merkle/{YYYYMMDD} so a user who kept their own
+(session_id, ts, symbol, side, qty, price, broker_code) tuple can verify
+their leaf was included in that day's root — meaning their order was
+recorded and not selectively hidden.
+
+Design (explicitly NOT a blockchain):
+- Canonical leaf: sha256("|".join([session_id, ts_iso, inst_id, side, sz,
+  fill_price, broker_code])).  String-based so reproducible by user scripts.
+- Tree: standard pairwise sha256; odd last leaf duplicates itself.
+- Storage: a single `order_audit` table in the OKX SQLite. We compute the
+  root on-demand from that table; there's no need to cache a tree the way
+  Bitcoin does.
+- Privacy: we do NOT publish the leaves. Users only see their own pre-image
+  because they kept it themselves. External observers see only the root.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Optional
+
+from .storage import _get_conn
+
+logger = logging.getLogger("okx_merkle")
+
+
+def _ensure_audit_table() -> None:
+    with _get_conn() as conn:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS order_audit (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id   TEXT NOT NULL,
+                ts_iso       TEXT NOT NULL,
+                inst_id      TEXT NOT NULL,
+                side         TEXT NOT NULL,
+                sz           TEXT NOT NULL,
+                fill_price   TEXT NOT NULL,
+                broker_code  TEXT NOT NULL,
+                leaf_hash    TEXT NOT NULL,
+                created_at   REAL NOT NULL
+            )
+        """)
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_order_audit_created ON order_audit(created_at)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_order_audit_leaf ON order_audit(leaf_hash)")
+
+
+def compute_leaf(
+    session_id: str,
+    ts_iso: str,
+    inst_id: str,
+    side: str,
+    sz: str | float,
+    fill_price: str | float,
+    broker_code: str,
+) -> str:
+    """Canonical leaf hash. Users MUST compute this the same way off-line to
+    verify inclusion. Input order and separator are fixed forever — never
+    change them without a versioning scheme."""
+    payload = "|".join([
+        str(session_id),
+        str(ts_iso),
+        str(inst_id),
+        str(side),
+        str(sz),
+        str(fill_price),
+        str(broker_code),
+    ]).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def record_order(
+    *,
+    session_id: str,
+    ts_iso: str,
+    inst_id: str,
+    side: str,
+    sz: str | float,
+    fill_price: str | float,
+    broker_code: str,
+) -> Optional[str]:
+    """Compute the leaf hash and persist it. Returns the hash on success.
+
+    Duplicate leaves are possible when a retry lands the same fill — we
+    keep only the first (UNIQUE on leaf_hash would be stricter but a unique
+    index rejection would leak through to the caller; silent skip is safer
+    for an audit trail that shouldn't affect the trading path)."""
+    try:
+        _ensure_audit_table()
+        leaf = compute_leaf(session_id, ts_iso, inst_id, side, sz, fill_price, broker_code)
+        with _get_conn() as conn:
+            existing = conn.execute(
+                "SELECT 1 FROM order_audit WHERE leaf_hash = ? LIMIT 1",
+                (leaf,),
+            ).fetchone()
+            if existing:
+                return leaf
+            conn.execute(
+                """INSERT INTO order_audit
+                   (session_id, ts_iso, inst_id, side, sz, fill_price,
+                    broker_code, leaf_hash, created_at)
+                   VALUES (?,?,?,?,?,?,?,?,?)""",
+                (session_id, ts_iso, inst_id, side, str(sz), str(fill_price),
+                 broker_code, leaf, time.time()),
+            )
+        return leaf
+    except Exception as e:
+        logger.warning("merkle record_order failed (non-fatal): %s", e)
+        return None
+
+
+def _pair_hash(a: str, b: str) -> str:
+    return hashlib.sha256((a + b).encode("utf-8")).hexdigest()
+
+
+def _merkle_root(leaves: list[str]) -> str | None:
+    if not leaves:
+        return None
+    level = list(leaves)
+    while len(level) > 1:
+        if len(level) % 2 == 1:
+            level.append(level[-1])  # duplicate last leaf
+        level = [_pair_hash(level[i], level[i + 1]) for i in range(0, len(level), 2)]
+    return level[0]
+
+
+def compute_daily_root(date_yyyymmdd: str) -> dict:
+    """Return {root, leaf_count, date} for all leaves created on that UTC day.
+
+    `date_yyyymmdd` format is `YYYYMMDD`. Returns root=None if no orders
+    recorded that day (legitimate — published as evidence of an empty day,
+    not silently omitted)."""
+    _ensure_audit_table()
+    try:
+        day = datetime.strptime(date_yyyymmdd, "%Y%m%d").replace(tzinfo=timezone.utc)
+    except ValueError:
+        raise ValueError("date must be YYYYMMDD")
+    start = day.timestamp()
+    end = start + 86400
+    with _get_conn() as conn:
+        rows = conn.execute(
+            "SELECT leaf_hash FROM order_audit "
+            "WHERE created_at >= ? AND created_at < ? "
+            "ORDER BY created_at ASC, id ASC",
+            (start, end),
+        ).fetchall()
+    leaves = [r[0] for r in rows]
+    return {
+        "date": f"{date_yyyymmdd[:4]}-{date_yyyymmdd[4:6]}-{date_yyyymmdd[6:]}",
+        "leaf_count": len(leaves),
+        "root": _merkle_root(leaves),
+        "algorithm": "sha256-pairwise-v1",
+    }


### PR DESCRIPTION
Every successful OKX order contributes a sha256 leaf; daily Merkle root is served at \`/trust/merkle/{YYYYMMDD}\`. User retains their own tuple, recomputes the leaf off-line, verifies inclusion. Proof that PRUVIQ doesn't quietly omit orders from the ledger.

## API
\`GET /trust/merkle/{YYYYMMDD}\` →
\`\`\`json
{
  "date": "2026-04-17",
  "leaf_count": 0,
  "root": null,
  "algorithm": "sha256-pairwise-v1"
}
\`\`\`
Empty day returns root=null (silence as explicit evidence).

## Pinned pre-image
sha256 of \`session_id|ts_iso|inst_id|side|sz|fill_price|broker_code\`. Will not change without an algorithm version bump.

## Deliberately deferred
- User proof-path endpoint (trade-off: verifiability vs session exists surface)
- External timestamping (PGP/OpenTimestamps) — defer until order volume justifies

Companion to #1092 (Moat-1), #1093 (Moat-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)