### PR TITLE
feat(workers): CF Worker binance-proxy — Mac-independence for data fetch

### DIFF
--- a/workers/binance-proxy/README.md
+++ b/workers/binance-proxy/README.md
@@ -1,0 +1,60 @@
+# PRUVIQ binance-proxy (Cloudflare Worker)
+
+Forwards a tight allowlist of Binance public endpoints from CF edge, so our KR residential Mac and our SG DigitalOcean droplet can both fetch without hitting Binance's geo 451.
+
+## Why a Worker, not an in-process proxy
+
+- `/opt/binance-proxy.py` on DO has the same public IP as DO itself → Binance still 451s. It defeats KR-local IP caps, not the upstream geo block.
+- A CF Worker originates from CF's anycast edge, which Binance does not block as of this writing.
+- Zero moving parts (no VM, no containers, no key rotation beyond a single secret).
+
+## Scoped allowlist (not a general pass-through)
+
+```js
+ALLOWED_PATHS = {
+  '/api/v3/ticker/24hr':   api.binance.com,    // Spot tickers
+  '/api/v3/ticker/price':  api.binance.com,    // Spot price
+  '/fapi/v1/ticker/24hr':  fapi.binance.com,   // Futures tickers
+  '/fapi/v1/premiumIndex': fapi.binance.com,   // Funding + mark
+  '/fapi/v1/fundingRate':  fapi.binance.com,   // Funding history
+}
+```
+
+Other paths → 404.  Method other than GET → 405.
+
+## Deploy (one-time)
+
+```bash
+cd workers/binance-proxy
+
+# 1. Install wrangler locally (or use npx — repo's root node_modules already has it)
+# 2. Set the proxy-key secret. Use something long and rotate annually.
+wrangler secret put PROXY_KEY
+# (paste a long random string — same one goes into /opt/pruviq/shared/.env
+#  on DO as BINANCE_PROXY_KEY, and into Mac ~/.secrets.env)
+
+# 3. Deploy. Default URL → https://pruviq-binance-proxy.<your-subdomain>.workers.dev
+wrangler deploy
+```
+
+Optionally bind to `binance-proxy.pruviq.com` (uncomment `routes` in `wrangler.toml` and redeploy).
+
+## Client usage
+
+```bash
+curl -H "X-Proxy-Key: <PROXY_KEY>" \
+  "https://pruviq-binance-proxy.<subdomain>.workers.dev/fapi/v1/ticker/24hr"
+```
+
+## Rollout plan (pairs with BINANCE_PROXY_URL env on DO + Mac)
+
+1. Deploy the Worker (above).
+2. Put its URL + the same PROXY_KEY in `/opt/pruviq/shared/.env` on DO and `~/.secrets.env` on Mac.
+3. Flip `backend/scripts/refresh_static.py` and `backend/scripts/update_ohlcv.py` to prefer the proxy URL (separate PR — we ship the Worker first to avoid a flag-day where code expects a proxy that isn't deployed).
+4. Once everything points at the Worker, retire `/opt/binance-proxy.py` on DO.
+
+## Operational notes
+
+- Free plan covers ~100k requests/day. Current refresh cadence (`*/20 *` = 72/day/host × 2 hosts = 144/day) leaves headroom for a long time.
+- Edge cache TTL is 10s — guards against burst self-DoS if multiple callers fire concurrently.
+- `x-pruviq-proxy: binance` header is passed through so downstream can log proxy-path vs direct-path.

--- a/workers/binance-proxy/package.json
+++ b/workers/binance-proxy/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pruviq-binance-proxy",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Cloudflare Worker that forwards a small allowlist of Binance public endpoints from CF edge.",
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev"
+  }
+}

--- a/workers/binance-proxy/src/index.js
+++ b/workers/binance-proxy/src/index.js
@@ -1,0 +1,88 @@
+/**
+ * PRUVIQ binance-proxy — a Cloudflare Worker that forwards to Binance's
+ * public ticker / funding endpoints from CF IP space.
+ *
+ * Why: Binance returns 451 on any request that originates from our KR
+ * residential IP (Mac dev) and apparently from our SG DigitalOcean
+ * droplet as well. CF's anycast edge is not blocked, so a tiny proxy
+ * parked there lets both clients keep fetching with zero ops complexity.
+ *
+ * Scope pinned to two hosts (Binance spot + futures) and read-only
+ * endpoints we actually use. Anything else → 404 so this never becomes a
+ * general Binance pass-through.
+ *
+ * Auth: X-Proxy-Key must match env.PROXY_KEY. Set with:
+ *   wrangler secret put PROXY_KEY
+ */
+
+const ALLOWED_PATHS = {
+  "/api/v3/ticker/24hr": "https://api.binance.com",
+  "/api/v3/ticker/price": "https://api.binance.com",
+  "/fapi/v1/ticker/24hr": "https://fapi.binance.com",
+  "/fapi/v1/premiumIndex": "https://fapi.binance.com",
+  "/fapi/v1/fundingRate": "https://fapi.binance.com",
+};
+
+export default {
+  async fetch(request, env) {
+    // Auth gate. We're on a CF public IP — anything reachable here is on
+    // the public internet until proven otherwise.
+    const providedKey = request.headers.get("X-Proxy-Key") || "";
+    if (!env.PROXY_KEY || providedKey !== env.PROXY_KEY) {
+      return new Response(JSON.stringify({ error: "unauthorized" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // Method allowlist — GET only. Binance spot ticker endpoints don't
+    // accept POST anyway, but the hardening is cheap.
+    if (request.method !== "GET") {
+      return new Response(JSON.stringify({ error: "method not allowed" }), {
+        status: 405,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const url = new URL(request.url);
+    const upstream = ALLOWED_PATHS[url.pathname];
+    if (!upstream) {
+      return new Response(
+        JSON.stringify({ error: "path not allowed", path: url.pathname }),
+        { status: 404, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    const target = upstream + url.pathname + (url.search || "");
+    let resp;
+    try {
+      resp = await fetch(target, {
+        method: "GET",
+        headers: {
+          "User-Agent": "PRUVIQ-binance-proxy/1.0",
+          Accept: "application/json",
+        },
+        // Short edge cache — spot/futures tickers update fast, but 10s of
+        // cache shaves a huge chunk of Binance request cost if multiple
+        // workers/hosts hit this proxy concurrently.
+        cf: { cacheEverything: true, cacheTtl: 10 },
+      });
+    } catch (err) {
+      return new Response(
+        JSON.stringify({ error: "upstream fetch failed", detail: String(err) }),
+        { status: 502, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    // Stream body through; keep content-type, strip everything else so we
+    // don't accidentally leak any CF or Binance debug headers.
+    const respHeaders = new Headers();
+    const ct = resp.headers.get("content-type");
+    if (ct) respHeaders.set("content-type", ct);
+    respHeaders.set("x-pruviq-proxy", "binance");
+    return new Response(resp.body, {
+      status: resp.status,
+      headers: respHeaders,
+    });
+  },
+};

--- a/workers/binance-proxy/wrangler.toml
+++ b/workers/binance-proxy/wrangler.toml
@@ -1,0 +1,9 @@
+name = "pruviq-binance-proxy"
+main = "src/index.js"
+compatibility_date = "2026-02-14"
+
+# No custom route by default — the .workers.dev URL is used by our backend.
+# Uncomment to bind to a subdomain on pruviq.com:
+# routes = [
+#   { pattern = "binance-proxy.pruviq.com/*", custom_domain = true }
+# ]


### PR DESCRIPTION
Thin Cloudflare Worker that forwards a pinned allowlist of Binance public endpoints (spot/futures ticker + price + funding) from CF edge IPs. Binance 451s our KR Mac and our SG DigitalOcean droplet; CF anycast is not blocked, so this is the cleanest way to stop depending on Mac-being-up for data fetch.

## Files
- \`workers/binance-proxy/src/index.js\` — 80 line Worker. X-Proxy-Key auth. GET-only. 5-path allowlist. 10s CF edge cache.
- \`workers/binance-proxy/wrangler.toml\` — standalone config (does NOT share with pruviq-website)
- \`workers/binance-proxy/README.md\` — one-time deploy playbook + rollout plan

## Deploy (owner, one-time)
\`\`\`
cd workers/binance-proxy
wrangler secret put PROXY_KEY   # paste long random string
wrangler deploy
\`\`\`
(Uses the \`CLOUDFLARE_API_TOKEN\` + \`CLOUDFLARE_ACCOUNT_ID\` secrets you already set up.)

## What this PR does NOT change
- refresh_static.py / update_ohlcv.py still hit Binance directly. Those flip to the proxy in a follow-up PR after the Worker is live — prevents flag-day where code expects a proxy that hasn't been deployed.
- /opt/binance-proxy.py on DO stays (not useful, but removing it is a separate cleanup).

Companion to Moat-1/2/3 (#1092, #1095, #1093) — removes the last architectural reason PRUVIQ needs Mac Mini in the hot path for data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)