### PR TITLE
ci: one-click workflow to deploy binance-proxy Worker

### DIFF
--- a/.github/workflows/deploy-binance-proxy.yml
+++ b/.github/workflows/deploy-binance-proxy.yml
@@ -1,0 +1,122 @@
+name: "Deploy binance-proxy Worker"
+
+# Manually dispatched — this is a one-time / occasional workflow, not
+# triggered on every push. Run it from the Actions tab:
+#   https://github.com/pruviq/pruviq/actions/workflows/deploy-binance-proxy.yml
+#
+# Required repo secrets:
+#   CLOUDFLARE_API_TOKEN   (already set)
+#   CLOUDFLARE_ACCOUNT_ID  (already set)
+#   PROXY_KEY              (owner action: create + add this before first run)
+#
+# After a successful run, the Mac runner will also push the same PROXY_KEY
+# to DO /opt/pruviq/shared/.env as BINANCE_PROXY_KEY so the backend can
+# authenticate to the Worker.
+
+on:
+  workflow_dispatch: {}
+
+concurrency:
+  group: deploy-binance-proxy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    # Mac runner is used so we can also ssh to DO with the existing
+    # id_ed25519 key and keep PROXY_KEY aligned across CF Worker and DO .env.
+    runs-on: [self-hosted, mac-mini-m4-ops]
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sanity-check required secrets are non-empty
+        env:
+          CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROXY_KEY: ${{ secrets.PROXY_KEY }}
+        run: |
+          missing=()
+          [ -z "$CF_TOKEN" ] && missing+=("CLOUDFLARE_API_TOKEN")
+          [ -z "$CF_ACCOUNT" ] && missing+=("CLOUDFLARE_ACCOUNT_ID")
+          [ -z "$PROXY_KEY" ] && missing+=("PROXY_KEY")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing repo secrets: ${missing[*]}"
+            exit 1
+          fi
+          echo "secrets OK"
+
+      - name: Install wrangler (via existing repo node_modules)
+        run: |
+          cd workers/binance-proxy
+          # Use the repo-root wrangler already pinned by package-lock
+          ln -sf ../../node_modules ./node_modules || true
+          ../../node_modules/.bin/wrangler --version || {
+            echo "repo-root wrangler missing — installing locally"
+            npm install wrangler --no-save
+          }
+
+      - name: Push PROXY_KEY to the Worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROXY_KEY: ${{ secrets.PROXY_KEY }}
+        run: |
+          cd workers/binance-proxy
+          # `wrangler secret put` reads from stdin non-interactively when
+          # a value is piped in.
+          printf '%s' "$PROXY_KEY" | ../../node_modules/.bin/wrangler secret put PROXY_KEY
+
+      - name: Deploy Worker
+        id: deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          cd workers/binance-proxy
+          ../../node_modules/.bin/wrangler deploy 2>&1 | tee /tmp/wrangler-out.txt
+          # Pull out the deployed URL so subsequent steps/log readers have it
+          url=$(grep -Eo 'https://[A-Za-z0-9.-]+\.workers\.dev' /tmp/wrangler-out.txt | head -1)
+          echo "worker_url=$url" >> "$GITHUB_OUTPUT"
+          echo "worker URL: $url"
+
+      - name: Update DO .env with matching BINANCE_PROXY_KEY + _URL
+        env:
+          PROXY_KEY: ${{ secrets.PROXY_KEY }}
+          WORKER_URL: ${{ steps.deploy.outputs.worker_url }}
+        run: |
+          [ -z "$WORKER_URL" ] && { echo "::error::wrangler output did not include a workers.dev URL"; exit 1; }
+          ssh -p 2222 -o ConnectTimeout=10 -o IdentitiesOnly=yes \
+              -i "$HOME/.ssh/id_ed25519" root@167.172.81.145 "
+            set -e
+            ENV=/opt/pruviq/shared/.env
+            cp \$ENV \$ENV.bak.\$(date +%s)
+            # Replace or append BINANCE_PROXY_KEY
+            if grep -q '^BINANCE_PROXY_KEY=' \$ENV; then
+              sed -i 's|^BINANCE_PROXY_KEY=.*|BINANCE_PROXY_KEY=$PROXY_KEY|' \$ENV
+            else
+              echo 'BINANCE_PROXY_KEY=$PROXY_KEY' >> \$ENV
+            fi
+            # Replace or append BINANCE_PROXY_URL
+            if grep -q '^BINANCE_PROXY_URL=' \$ENV; then
+              sed -i 's|^BINANCE_PROXY_URL=.*|BINANCE_PROXY_URL=$WORKER_URL|' \$ENV
+            else
+              echo 'BINANCE_PROXY_URL=$WORKER_URL' >> \$ENV
+            fi
+            # Do NOT systemctl restart here — let the next backend/** push do
+            # it atomically so users don't see two restarts in a row.
+            echo '=== updated .env keys ==='
+            grep -E '^BINANCE_PROXY_(URL|KEY)=' \$ENV | sed 's|\(KEY=\).*|\1***|'
+          "
+
+      - name: Smoke test Worker
+        env:
+          PROXY_KEY: ${{ secrets.PROXY_KEY }}
+          WORKER_URL: ${{ steps.deploy.outputs.worker_url }}
+        run: |
+          status=$(curl -s -o /tmp/proxy-smoke.json -w '%{http_code}' -m 10 \
+                   -H "X-Proxy-Key: $PROXY_KEY" \
+                   "$WORKER_URL/fapi/v1/premiumIndex?symbol=BTCUSDT")
+          echo "smoke status: $status"
+          head -c 300 /tmp/proxy-smoke.json; echo
+          [ "$status" = "200" ] || exit 1


### PR DESCRIPTION
Adds a \`workflow_dispatch\` job that runs \`wrangler deploy\` for \`workers/binance-proxy\` on the Mac self-hosted runner (reuses existing CLOUDFLARE_API_TOKEN/ACCOUNT_ID secrets) and syncs the same PROXY_KEY into DO's \`/opt/pruviq/shared/.env\` over SSH.

## Owner flow (one-time)
1. Generate a random key: \`openssl rand -hex 32\`
2. Add it as repo secret \`PROXY_KEY\` at /settings/secrets/actions/new
3. Actions tab → "Deploy binance-proxy Worker" → "Run workflow" button

After that, this PR + #1096 together get the Worker live and keep DO's backend able to authenticate to it.

## Why not run wrangler from my local shell

Claude Code can't take the \`wrangler login\` browser handshake for the owner — it would need the API token value typed in, which we'd rather keep in GitHub secrets than in chat history.

## Next PRs (after Worker is live)
- Point \`refresh_static.py\` / \`update_ohlcv.py\` at \`BINANCE_PROXY_URL\` instead of direct binance hosts
- Retire \`/opt/binance-proxy.py\` on DO

🤖 Generated with [Claude Code](https://claude.com/claude-code)