### PR TITLE
fix: auto-fix #1098 (+1 related)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -35,8 +35,6 @@ const currentYear = new Date().getFullYear();
 const { title, description = t('meta.home_desc'), type = 'website', date, updatedDate, category, keywords: customKeywords, canonicalOverride, noAlternate = false, skipArticleLD = false } = Astro.props;
 const lastModified = updatedDate || date || buildTime;
 const ogImage = new URL(Astro.props.ogImage || '/og-image.jpg', Astro.site || 'https://pruviq.com').href;
-// derive AVIF/WebP variants safely for jpg/png sources
-const ogImageAvif = ogImage.replace(/\.(png|jpe?g)(\?.*)?$/i, '.avif$2');
 const ogImageWebp = ogImage.replace(/\.(png|jpe?g)(\?.*)?$/i, '.webp$2');
 const canonicalPath = canonicalOverride || Astro.url.pathname;
 const canonicalURL = new URL(canonicalPath, Astro.site || 'https://pruviq.com');
@@ -172,7 +170,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <meta name="last-modified" content={lastModified} />
     {basePath.startsWith('/404') && <meta name="robots" content="noindex" />}
     <link rel="preconnect" href="https://api.pruviq.com" crossorigin />
-    <link rel="preconnect" href="https://coin-images.coingecko.com" />
+    <link rel="preconnect" href="https://coin-images.coingecko.com" crossorigin />
     <link rel="preconnect" href="https://static.cloudflareinsights.com" crossorigin />
     <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin />
     <!-- Open Graph -->
@@ -184,9 +182,16 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <meta property="og:locale" content={lang === 'ko' ? 'ko_KR' : 'en_US'} />
     {!noAlternate && <meta property="og:locale:alternate" content={lang === 'ko' ? 'en_US' : 'ko_KR'} />}
     <meta property="og:image" content={ogImage} />
+    <meta property="og:image:type" content="image/jpeg" />
     <meta property="og:image:alt" content={Astro.props.ogImage ? title : "PRUVIQ — Free Crypto Strategy Backtester"} />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
+    {ogImageWebp !== ogImage && (
+      <meta property="og:image" content={ogImageWebp} />
+      <meta property="og:image:type" content="image/webp" />
+      <meta property="og:image:width" content="1200" />
+      <meta property="og:image:height" content="630" />
+    )}
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={title} />


### PR DESCRIPTION
## Auto-fix for 2 issue(s)

#1098: [claude-auto][P2] `src/layouts/Layout.astro:39-40` — AVIF/WebP OG image variants computed but ne
#1099: [claude-auto][P2] `src/layouts/Layout.astro:175` — CoinGecko preconnect missing `crossorigin` at

### Changes
```
 src/layouts/Layout.astro | 11 ++++++++---
 1 file changed, 8 insertions(+), 3 deletions(-)
```

### Safety Checks
- Files changed: **1** (limit: 20)
- Lines changed: **11** (limit: 1500)

---
*Auto-generated by JEPO auto-fix agent. Requires auto-test pass before merge.*