### PR TITLE
feat(okx): public market data fetcher — Phase B' of Binance→OKX migration

### DIFF
--- a/backend/okx/market_fetcher.py
+++ b/backend/okx/market_fetcher.py
@@ -1,0 +1,212 @@
+"""
+OKX public market data fetcher — PRUVIQ signal scanner data source.
+
+Unauthenticated calls to /api/v5/market/candles. Async, with a shared
+token-bucket so concurrent scanners collectively respect OKX's 20 req/2s
+rate budget on this endpoint.
+
+Designed to replace the Binance-via-Mac fetch path (Phase B'). Not yet
+wired into signal_scanner — that's Phase C. Tested in isolation first.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from typing import Iterable
+
+import httpx
+import pandas as pd
+
+OKX_PUBLIC_BASE = "https://www.okx.com"
+CANDLES_PATH = "/api/v5/market/candles"
+HISTORY_CANDLES_PATH = "/api/v5/market/history-candles"
+
+# OKX published limit on /market/candles is 20 req/2s. We target 18 to leave
+# headroom for any infra retry that sneaks a duplicate call inside the window.
+_DEFAULT_RATE_LIMIT = 18
+_DEFAULT_WINDOW_SEC = 2.0
+
+logger = logging.getLogger("pruviq")
+
+
+@dataclass(frozen=True)
+class OkxCandle:
+    ts_ms: int
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+    volume_ccy: float  # quote-currency volume (USDT for USDT-SWAP)
+
+    @classmethod
+    def from_row(cls, row: list) -> "OkxCandle":
+        # OKX row: [ts, o, h, l, c, vol, volCcy, volCcyQuote, confirm]
+        # vol     = base currency volume (BTC for BTC-USDT-SWAP)
+        # volCcy  = contract count
+        # volCcyQuote = quote currency volume (USDT)
+        return cls(
+            ts_ms=int(row[0]),
+            open=float(row[1]),
+            high=float(row[2]),
+            low=float(row[3]),
+            close=float(row[4]),
+            volume=float(row[5]),
+            volume_ccy=float(row[7]) if len(row) > 7 else float(row[6]),
+        )
+
+
+class OkxMarketFetcher:
+    """Public OKX candle fetcher with shared rate-limit.
+
+    A single instance is meant to be shared across all concurrent callers so
+    the rate-limit accounting is correct. Safe to use from asyncio.gather.
+    """
+
+    def __init__(
+        self,
+        rate_limit: int = _DEFAULT_RATE_LIMIT,
+        window_sec: float = _DEFAULT_WINDOW_SEC,
+        timeout: float = 15.0,
+    ):
+        self._rate_limit = rate_limit
+        self._window_sec = window_sec
+        self._window_start = 0.0
+        self._window_count = 0
+        self._lock = asyncio.Lock()
+        self._client = httpx.AsyncClient(
+            base_url=OKX_PUBLIC_BASE,
+            timeout=timeout,
+            headers={"User-Agent": "pruviq-market/1"},
+        )
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def __aenter__(self) -> "OkxMarketFetcher":
+        return self
+
+    async def __aexit__(self, *args) -> None:
+        await self.close()
+
+    async def _throttle(self) -> None:
+        """Fixed-window rate limiter. Blocks until this call fits within budget."""
+        async with self._lock:
+            now = time.monotonic()
+            elapsed = now - self._window_start
+            if elapsed > self._window_sec:
+                self._window_start = now
+                self._window_count = 0
+            if self._window_count >= self._rate_limit:
+                sleep_for = self._window_sec - (now - self._window_start)
+                if sleep_for > 0:
+                    await asyncio.sleep(sleep_for)
+                self._window_start = time.monotonic()
+                self._window_count = 0
+            self._window_count += 1
+
+    # ── symbol / interval mapping ─────────────────────────────────────
+    @staticmethod
+    def to_okx_inst_id(binance_symbol: str) -> str:
+        """Binance-style BTCUSDT → OKX BTC-USDT-SWAP.
+
+        Raises ValueError for symbols not settled in USDT.
+        """
+        sym = binance_symbol.upper().strip()
+        if not sym.endswith("USDT"):
+            raise ValueError(f"unsupported symbol (not USDT-quoted): {binance_symbol}")
+        base = sym[:-4]
+        if not base:
+            raise ValueError(f"empty base for symbol: {binance_symbol}")
+        return f"{base}-USDT-SWAP"
+
+    @staticmethod
+    def to_okx_bar(interval: str) -> str:
+        """Binance interval → OKX bar.
+
+        OKX uses uppercase suffix for >= 1h intervals: 1H, 4H, 1D.
+        """
+        m = {
+            "1m": "1m", "3m": "3m", "5m": "5m", "15m": "15m", "30m": "30m",
+            "1h": "1H", "2h": "2H", "4h": "4H", "6h": "6H", "12h": "12H",
+            "1d": "1D", "1w": "1W",
+        }
+        iv = interval.lower().strip()
+        if iv not in m:
+            raise ValueError(f"unsupported interval: {interval}")
+        return m[iv]
+
+    # ── fetch ─────────────────────────────────────────────────────────
+    async def fetch_candles(
+        self,
+        symbol: str,
+        interval: str = "1h",
+        limit: int = 300,
+    ) -> list[OkxCandle]:
+        """Fetch recent candles. Returned old→new (sorted).
+
+        OKX /market/candles gives newest-first; we reverse before returning so
+        strategy code can iterate chronologically.
+        """
+        inst_id = self.to_okx_inst_id(symbol)
+        bar = self.to_okx_bar(interval)
+        await self._throttle()
+        resp = await self._client.get(
+            CANDLES_PATH,
+            params={"instId": inst_id, "bar": bar, "limit": str(limit)},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        if data.get("code") != "0":
+            raise RuntimeError(
+                f"OKX market error {data.get('code')}: {data.get('msg')} (instId={inst_id})"
+            )
+        rows = data.get("data") or []
+        candles = [OkxCandle.from_row(r) for r in rows]
+        candles.reverse()
+        return candles
+
+    async def fetch_df(
+        self,
+        symbol: str,
+        interval: str = "1h",
+        limit: int = 300,
+    ) -> pd.DataFrame:
+        """Return a DataFrame matching the Binance CSV schema used by
+        DataManager/signal_scanner:
+          columns: timestamp (UTC tz-aware), open, high, low, close, volume
+        """
+        candles = await self.fetch_candles(symbol, interval, limit)
+        if not candles:
+            return pd.DataFrame(columns=["timestamp", "open", "high", "low", "close", "volume"])
+        return pd.DataFrame(
+            {
+                "timestamp": pd.to_datetime([c.ts_ms for c in candles], unit="ms", utc=True),
+                "open": [c.open for c in candles],
+                "high": [c.high for c in candles],
+                "low": [c.low for c in candles],
+                "close": [c.close for c in candles],
+                "volume": [c.volume for c in candles],
+            }
+        )
+
+    async def fetch_many(
+        self,
+        symbols: Iterable[str],
+        interval: str = "1h",
+        limit: int = 300,
+    ) -> dict[str, pd.DataFrame]:
+        """Concurrent fetch across symbols. Failed symbols are logged and
+        dropped from the result (caller sees only successes)."""
+        async def _one(s: str) -> tuple[str, pd.DataFrame | None]:
+            try:
+                return s, await self.fetch_df(s, interval, limit)
+            except Exception as e:
+                logger.warning("OKX fetch failed for %s: %s: %s", s, type(e).__name__, e)
+                return s, None
+
+        tasks = [_one(s) for s in symbols]
+        results = await asyncio.gather(*tasks)
+        return {s: df for s, df in results if df is not None}

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    okx_live: hits OKX public API for live data verification — skipped in CI

--- a/backend/tests/test_okx_market_fetcher.py
+++ b/backend/tests/test_okx_market_fetcher.py
@@ -1,0 +1,129 @@
+"""Unit tests for OKX public market data fetcher.
+
+Network tests are marked and skipped by default; run with
+`pytest -m okx_live backend/tests/test_okx_market_fetcher.py`
+to hit OKX directly (useful locally + in DO burn-in).
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import asyncio
+import time
+
+import pandas as pd
+import pytest
+
+from okx.market_fetcher import OkxCandle, OkxMarketFetcher
+
+
+class TestSymbolMapping:
+    def test_btc(self):
+        assert OkxMarketFetcher.to_okx_inst_id("BTCUSDT") == "BTC-USDT-SWAP"
+
+    def test_lowercase(self):
+        assert OkxMarketFetcher.to_okx_inst_id("ethusdt") == "ETH-USDT-SWAP"
+
+    def test_whitespace(self):
+        assert OkxMarketFetcher.to_okx_inst_id("  BTCUSDT  ") == "BTC-USDT-SWAP"
+
+    def test_rejects_non_usdt(self):
+        with pytest.raises(ValueError, match="USDT-quoted"):
+            OkxMarketFetcher.to_okx_inst_id("BTCBUSD")
+
+    def test_rejects_empty_base(self):
+        with pytest.raises(ValueError):
+            OkxMarketFetcher.to_okx_inst_id("USDT")
+
+
+class TestIntervalMapping:
+    def test_1h(self):
+        assert OkxMarketFetcher.to_okx_bar("1h") == "1H"
+
+    def test_4h(self):
+        assert OkxMarketFetcher.to_okx_bar("4H") == "4H"
+
+    def test_1d(self):
+        assert OkxMarketFetcher.to_okx_bar("1d") == "1D"
+
+    def test_1m(self):
+        assert OkxMarketFetcher.to_okx_bar("1m") == "1m"
+
+    def test_rejects_2h_upper(self):
+        # Confirm our table is authoritative: 2h exists, 2h-upper exists — both map
+        assert OkxMarketFetcher.to_okx_bar("2h") == "2H"
+
+    def test_rejects_unknown(self):
+        with pytest.raises(ValueError):
+            OkxMarketFetcher.to_okx_bar("10m")
+
+
+class TestOkxCandleParse:
+    def test_9col_row(self):
+        # Newer OKX rows are 9 columns — confirm volume_ccy reads col-7 (volCcyQuote)
+        row = ["1700000000000", "100.0", "105.0", "95.0", "102.0",
+               "10.5", "11.0", "1071.0", "1"]
+        c = OkxCandle.from_row(row)
+        assert c.ts_ms == 1700000000000
+        assert c.open == 100.0
+        assert c.close == 102.0
+        assert c.volume == 10.5
+        assert c.volume_ccy == 1071.0  # from col-7 (volCcyQuote)
+
+    def test_7col_fallback(self):
+        # Legacy 7-column response — fall back to col-6
+        row = ["1700000000000", "100.0", "105.0", "95.0", "102.0",
+               "10.5", "11.0"]
+        c = OkxCandle.from_row(row)
+        assert c.volume_ccy == 11.0
+
+
+class TestThrottle:
+    def test_blocks_when_budget_exhausted(self):
+        # 3 req/1.0s window → 4th call must sleep ~1s
+        async def _run():
+            async with OkxMarketFetcher(rate_limit=3, window_sec=1.0) as f:
+                start = time.monotonic()
+                await f._throttle()
+                await f._throttle()
+                await f._throttle()
+                mid = time.monotonic()
+                await f._throttle()  # this one sleeps
+                end = time.monotonic()
+            return start, mid, end
+
+        start, mid, end = asyncio.run(_run())
+        assert (mid - start) < 0.1, "first 3 should be immediate"
+        assert (end - mid) >= 0.7, f"4th should have slept; actual={end - mid:.3f}s"
+
+
+@pytest.mark.okx_live
+class TestLiveOkx:
+    """Hit OKX for real. Run with `pytest -m okx_live`."""
+
+    def test_fetch_btc_shape(self):
+        async def _run():
+            async with OkxMarketFetcher() as f:
+                return await f.fetch_df("BTCUSDT", interval="1h", limit=100)
+
+        df = asyncio.run(_run())
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) > 0
+        for col in ["timestamp", "open", "high", "low", "close", "volume"]:
+            assert col in df.columns, f"missing column {col}"
+        # sorted old→new
+        assert df["timestamp"].is_monotonic_increasing
+        # sane BTC price range
+        assert df["close"].min() > 10_000
+        assert df["close"].max() < 1_000_000
+
+    def test_fetch_many_three(self):
+        async def _run():
+            async with OkxMarketFetcher() as f:
+                return await f.fetch_many(["BTCUSDT", "ETHUSDT", "SOLUSDT"], limit=50)
+
+        out = asyncio.run(_run())
+        assert set(out.keys()) == {"BTCUSDT", "ETHUSDT", "SOLUSDT"}
+        for sym, df in out.items():
+            assert len(df) > 0, f"empty df for {sym}"

--- a/scripts/okx_coverage_diff.py
+++ b/scripts/okx_coverage_diff.py
@@ -1,0 +1,160 @@
+"""Phase A: OKX vs Binance coverage diff + history depth probe.
+
+Usage: python3 scripts/okx_coverage_diff.py [--probe-history]
+Outputs:
+  /tmp/pruviq_keep.json    — symbols in both exchanges
+  /tmp/pruviq_remove.json  — Binance-only (to be dropped)
+  /tmp/pruviq_okx_only.json — OKX-only (potential future coverage)
+  /tmp/pruviq_1000x.json   — 1000X meme-coin pairs (need product decision)
+
+With --probe-history, also probes earliest history-candles for 3 majors.
+"""
+
+import argparse
+import json
+import sys
+import time
+import urllib.request
+
+
+OKX_INST_URL = "https://www.okx.com/api/v5/public/instruments?instType=SWAP"
+OKX_HIST_URL = "https://www.okx.com/api/v5/market/history-candles"
+
+
+def fetch_okx_swaps():
+    req = urllib.request.Request(OKX_INST_URL, headers={"User-Agent": "pruviq-diff/1"})
+    with urllib.request.urlopen(req, timeout=15) as r:
+        data = json.loads(r.read())
+    if data.get("code") != "0":
+        raise RuntimeError(f"OKX error: {data}")
+    linear = [x for x in data["data"] if x["settleCcy"] == "USDT" and x["state"] == "live"]
+    syms = set()
+    detail = {}
+    for x in linear:
+        parts = x["instId"].split("-")
+        if len(parts) == 3 and parts[1] == "USDT" and parts[2] == "SWAP":
+            sym = (parts[0] + "USDT").upper()
+            syms.add(sym)
+            detail[sym] = x["instId"]
+    return syms, detail
+
+
+def probe_history_depth(inst_id: str, bar: str = "1H") -> dict:
+    """Return earliest timestamp available via OKX history-candles for instId.
+
+    We page backward with `after` param. One page = 100 candles.
+    Stop when a page returns empty or repeats the same oldest ts.
+    """
+    oldest_ts = None
+    pages = 0
+    after = ""
+    while True:
+        url = f"{OKX_HIST_URL}?instId={inst_id}&bar={bar}&limit=100"
+        if after:
+            url += f"&after={after}"
+        req = urllib.request.Request(url, headers={"User-Agent": "pruviq-diff/1"})
+        try:
+            with urllib.request.urlopen(req, timeout=15) as r:
+                resp = json.loads(r.read())
+        except Exception as e:
+            return {"instId": inst_id, "error": str(e), "pages": pages, "oldest_ts": oldest_ts}
+        if resp.get("code") != "0":
+            return {"instId": inst_id, "err_api": resp, "pages": pages, "oldest_ts": oldest_ts}
+        rows = resp.get("data") or []
+        if not rows:
+            break
+        new_oldest = rows[-1][0]
+        if new_oldest == oldest_ts:
+            break
+        oldest_ts = new_oldest
+        after = new_oldest
+        pages += 1
+        time.sleep(0.15)  # gentle — OKX limit is 20 req/2s on this endpoint
+        if pages > 200:  # 20k candles = ~2.3y on 1h, ~55y on 1d — enough
+            break
+    return {
+        "instId": inst_id,
+        "bar": bar,
+        "pages": pages,
+        "approx_candles": pages * 100,
+        "oldest_ts_ms": oldest_ts,
+        "oldest_utc": _ms_to_utc(oldest_ts) if oldest_ts else None,
+    }
+
+
+def _ms_to_utc(ms: str) -> str:
+    import datetime
+    return datetime.datetime.fromtimestamp(int(ms) / 1000, tz=datetime.timezone.utc).isoformat()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--probe-history", action="store_true")
+    args = ap.parse_args()
+
+    # 1. Our Binance coverage
+    with open("public/data/coins-stats.json") as f:
+        binance = {c["symbol"].upper() for c in json.load(f)["coins"]}
+
+    # 2. OKX USDT-SWAPs
+    okx, okx_detail = fetch_okx_swaps()
+
+    # 3. Diff
+    keep = sorted(binance & okx)
+    remove = sorted(binance - okx)
+    okx_only = sorted(okx - binance)
+
+    # 4. 1000X mapping — Binance's 1000FOO vs OKX's FOO-USDT-SWAP
+    thousand_x = []
+    for rm in remove:
+        if rm.startswith("1000") and not rm.startswith("10000"):
+            base = rm[4:-4]  # 1000PEPEUSDT → PEPE
+            okx_equiv = f"{base}USDT"
+            if okx_equiv in okx:
+                thousand_x.append({
+                    "binance": rm,
+                    "okx_equivalent": okx_equiv,
+                    "okx_inst_id": okx_detail.get(okx_equiv),
+                    "note": "1000x contract-size difference; historical data not comparable",
+                })
+        elif rm.startswith("1000000"):
+            base = rm[7:-4]
+            okx_equiv = f"{base}USDT"
+            if okx_equiv in okx:
+                thousand_x.append({
+                    "binance": rm,
+                    "okx_equivalent": okx_equiv,
+                    "okx_inst_id": okx_detail.get(okx_equiv),
+                    "note": "1Mx contract-size difference",
+                })
+
+    json.dump(keep, open("/tmp/pruviq_keep.json", "w"), indent=2)
+    json.dump(remove, open("/tmp/pruviq_remove.json", "w"), indent=2)
+    json.dump(okx_only, open("/tmp/pruviq_okx_only.json", "w"), indent=2)
+    json.dump(thousand_x, open("/tmp/pruviq_1000x.json", "w"), indent=2)
+
+    print(f"=== Coverage diff ===")
+    print(f"  Binance current:   {len(binance)}")
+    print(f"  OKX USDT-SWAPs:    {len(okx)}")
+    print(f"  Keep (intersect):  {len(keep)}")
+    print(f"  Remove (B-only):   {len(remove)}")
+    print(f"  OKX-only:          {len(okx_only)}")
+    print()
+    print(f"=== 1000X contract-size collisions ({len(thousand_x)}) ===")
+    print("These are SAME asset with different contract multiplier.")
+    print("Strict match drops them. Normalization = re-derive historical price (non-trivial).")
+    for t in thousand_x[:15]:
+        print(f"  {t['binance']:20s} ↔ {t['okx_equivalent']:12s} ({t['okx_inst_id']})")
+    if len(thousand_x) > 15:
+        print(f"  ... and {len(thousand_x) - 15} more")
+
+    if args.probe_history:
+        print()
+        print(f"=== OKX history-candles depth probe (1H) ===")
+        for inst in ["BTC-USDT-SWAP", "ETH-USDT-SWAP", "LINK-USDT-SWAP"]:
+            r = probe_history_depth(inst, bar="1H")
+            print(f"  {inst}: ~{r.get('approx_candles'):>6} candles, oldest={r.get('oldest_utc')}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `backend/okx/market_fetcher.py` — async fetcher against OKX's public `/api/v5/market/candles`, shared 18 req/2s token-bucket (OKX limit is 20/2s; headroom for retries)
- Output schema matches the existing Binance CSV consumer path in `DataManager`, so Phase C (signal_scanner rewire) becomes a drop-in source swap without touching strategy code
- Not wired to live scanner yet — module + tests only, isolates risk before the source switch
- Also ships `scripts/okx_coverage_diff.py` (Phase A artifact: 235 keep / 339 remove / 55 OKX-only / 5 1000X-collision) and `backend/pytest.ini` (registers `okx_live` marker so network tests stay out of CI but can run locally/burn-in)

## Migration context
Part of the Full-OKX data-source migration decided 2026-04-17:
- **Phase A** ✅ coverage diff computed (574 Binance → 240 final = 235 intersect + 5 OKX meme-coins fresh)
- **Phase B' (this PR)** — OKX fetcher module
- Phase C — signal_scanner OKX rewire (env-flagged, burn-in)
- Phase B — historical purge of 339 Binance-only coins
- Phase D — UI relabeling
- Phase E — Mac `update-ohlcv` retirement

## Test plan
- [x] Unit tests — 14/14 (symbol + interval mapping, candle parse, token-bucket timing)
- [x] Live OKX smoke — 2/2 (`BTCUSDT`/`ETHUSDT`/`SOLUSDT` shape + sanity price range)
- [x] No regression — 3 pre-existing failures (`test_strategies` 401, `test_cost_model*` fee_pct) are unchanged by this PR
- [ ] Post-merge burn-in: run `pytest -m okx_live` on DO to confirm `api.okx.com` reachability from Singapore IP (already proven via OKX autotrade on DO, but explicit check for candles endpoint)