### PR TITLE
feat(backend): OKX-native OHLCV updater — Phase C (Binance→OKX)

### DIFF
--- a/backend/deploy/systemd/bin/update-ohlcv.sh
+++ b/backend/deploy/systemd/bin/update-ohlcv.sh
@@ -1,11 +1,20 @@
 #!/bin/bash
 # PRUVIQ — OHLCV Update (DO-native, every 4h at :15)
-# Fetches latest OHLCV from Binance (via DO proxy) into /opt/pruviq/data/futures/
+# Fetches latest OHLCV from OKX USDT-SWAP directly. The older Binance path
+# is retained (backend/scripts/update_ohlcv.py) for audit / rollback, but
+# Binance blocks DO's Singapore IP + CF edge, so only OKX runs in production.
+#
+# Env:
+#   PRUVIQ_DATA_DIR  — target futures/ dir (default /opt/pruviq/data/futures)
+#   PRUVIQ_OKX_NEW_SYMBOLS — space-separated OKX-only symbols to seed if missing
+#                            (default: 5 meme coins chosen 2026-04-17)
 set -uo pipefail
 
 DATA_DIR="${PRUVIQ_DATA_DIR:-/opt/pruviq/data/futures}"
+NEW_SYMBOLS="${PRUVIQ_OKX_NEW_SYMBOLS:-SHIBUSDT PEPEUSDT BONKUSDT FLOKIUSDT SATSUSDT}"
 
 mkdir -p "$DATA_DIR"
 exec /opt/pruviq/app/.venv/bin/python \
-    /opt/pruviq/current/backend/scripts/update_ohlcv.py \
-    --data-dir "$DATA_DIR"
+    /opt/pruviq/current/backend/scripts/update_ohlcv_okx.py \
+    --data-dir "$DATA_DIR" \
+    --new-symbols $NEW_SYMBOLS

--- a/backend/deploy/systemd/pruviq-update-ohlcv.service
+++ b/backend/deploy/systemd/pruviq-update-ohlcv.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=PRUVIQ OHLCV Data Update (4h interval, 572 coins from Binance)
+Description=PRUVIQ OHLCV Data Update (4h interval, 240 coins from OKX USDT-SWAP)
 After=network-online.target pruviq-api.service
 Wants=network-online.target
 OnFailure=pruviq-alert@%n.service
@@ -13,7 +13,7 @@ EnvironmentFile=/opt/pruviq/shared/.env
 ExecStart=/opt/pruviq/bin/update-ohlcv.sh
 StandardOutput=journal
 StandardError=journal
-TimeoutStartSec=1800
+TimeoutStartSec=1200
 Nice=10
 IOSchedulingClass=best-effort
 IOSchedulingPriority=5

--- a/backend/okx/market_fetcher.py
+++ b/backend/okx/market_fetcher.py
@@ -23,10 +23,17 @@ OKX_PUBLIC_BASE = "https://www.okx.com"
 CANDLES_PATH = "/api/v5/market/candles"
 HISTORY_CANDLES_PATH = "/api/v5/market/history-candles"
 
-# OKX published limit on /market/candles is 20 req/2s. We target 18 to leave
-# headroom for any infra retry that sneaks a duplicate call inside the window.
-_DEFAULT_RATE_LIMIT = 18
+# OKX publishes 20 req/2s on both /market/candles AND /market/history-candles,
+# but empirically (2026-04-17 burn-in) the IP-level budget behaves as though
+# it is shared across these endpoints — running near 20/2s on one still
+# triggers 429 on the other. Cap at 12/2s so combined traffic stays inside.
+_DEFAULT_RATE_LIMIT = 12
 _DEFAULT_WINDOW_SEC = 2.0
+
+# When a 429 does slip through, back off exponentially. OKX rarely sends a
+# Retry-After header on these endpoints, so seed at one rate-window.
+_RETRY_BACKOFF_BASE_SEC = 2.0
+_RETRY_MAX_ATTEMPTS = 4
 
 logger = logging.getLogger("pruviq")
 
@@ -138,6 +145,29 @@ class OkxMarketFetcher:
             raise ValueError(f"unsupported interval: {interval}")
         return m[iv]
 
+    async def _get_with_backoff(self, path: str, params: dict) -> dict:
+        """GET with 429 exponential backoff. Raises the last exception on exhaustion."""
+        last_exc: Exception | None = None
+        for attempt in range(_RETRY_MAX_ATTEMPTS):
+            await self._throttle()
+            try:
+                resp = await self._client.get(path, params=params)
+            except httpx.RequestError as e:
+                last_exc = e
+                await asyncio.sleep(_RETRY_BACKOFF_BASE_SEC * (2 ** attempt))
+                continue
+            if resp.status_code == 429:
+                last_exc = httpx.HTTPStatusError("429 Too Many Requests", request=resp.request, response=resp)
+                wait = _RETRY_BACKOFF_BASE_SEC * (2 ** attempt)
+                logger.warning("OKX 429 on %s — backing off %.1fs (attempt %d/%d)",
+                               path, wait, attempt + 1, _RETRY_MAX_ATTEMPTS)
+                await asyncio.sleep(wait)
+                continue
+            resp.raise_for_status()
+            return resp.json()
+        assert last_exc is not None
+        raise last_exc
+
     # ── fetch ─────────────────────────────────────────────────────────
     async def fetch_candles(
         self,
@@ -152,13 +182,10 @@ class OkxMarketFetcher:
         """
         inst_id = self.to_okx_inst_id(symbol)
         bar = self.to_okx_bar(interval)
-        await self._throttle()
-        resp = await self._client.get(
+        data = await self._get_with_backoff(
             CANDLES_PATH,
-            params={"instId": inst_id, "bar": bar, "limit": str(limit)},
+            {"instId": inst_id, "bar": bar, "limit": str(limit)},
         )
-        resp.raise_for_status()
-        data = resp.json()
         if data.get("code") != "0":
             raise RuntimeError(
                 f"OKX market error {data.get('code')}: {data.get('msg')} (instId={inst_id})"
@@ -191,6 +218,32 @@ class OkxMarketFetcher:
                 "volume": [c.volume for c in candles],
             }
         )
+
+    async def fetch_history_page(
+        self,
+        symbol: str,
+        interval: str = "1h",
+        after_ms: str | None = None,
+        limit: int = 100,
+    ) -> list[OkxCandle]:
+        """Fetch one page from /history-candles (older data, paged by `after` cursor).
+
+        Returns the page old→new. An empty list means no more history.
+        """
+        inst_id = self.to_okx_inst_id(symbol)
+        bar = self.to_okx_bar(interval)
+        params: dict[str, str] = {"instId": inst_id, "bar": bar, "limit": str(limit)}
+        if after_ms:
+            params["after"] = after_ms
+        data = await self._get_with_backoff(HISTORY_CANDLES_PATH, params)
+        if data.get("code") != "0":
+            raise RuntimeError(
+                f"OKX history error {data.get('code')}: {data.get('msg')} (instId={inst_id})"
+            )
+        rows = data.get("data") or []
+        candles = [OkxCandle.from_row(r) for r in rows]
+        candles.reverse()
+        return candles
 
     async def fetch_many(
         self,

--- a/backend/scripts/update_ohlcv_okx.py
+++ b/backend/scripts/update_ohlcv_okx.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""
+PRUVIQ — OHLCV update from OKX public API (USDT-SWAP).
+
+Replaces the Binance fetcher (`update_ohlcv.py`) for the Full-OKX data-source
+migration. Writes the same CSV schema into the same directory, so the
+downstream DataManager / signal_scanner see no code change.
+
+Behaviour:
+  * For every existing `*_1h.csv` in --data-dir:
+      - if the symbol IS live on OKX USDT-SWAP → append new bars since the
+        last CSV timestamp (bounded at 100 bars per call — enough for any
+        4h-timer catch-up).
+      - if the symbol is NOT on OKX → log and skip (will be removed from the
+        repo in Phase B).
+  * For each `--new-symbol` passed: if its CSV is missing, seed up to
+    `--seed-days * 24` hours of history from OKX `/history-candles`
+    (OKX typically has ~2.3y of 1h depth).
+
+Outputs one line per updated symbol plus a final summary.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+import time
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from okx.market_fetcher import OkxMarketFetcher, OKX_PUBLIC_BASE  # noqa: E402
+
+logger = logging.getLogger("pruviq.update_ohlcv_okx")
+
+CSV_HEADER = "timestamp,open,high,low,close,volume"
+OKX_INSTRUMENTS_URL = f"{OKX_PUBLIC_BASE}/api/v5/public/instruments?instType=SWAP"
+
+
+def fetch_okx_usdt_swap_symbols(timeout: float = 15.0) -> set[str]:
+    """Return the set of Binance-style symbols that have a live OKX USDT-SWAP."""
+    req = urllib.request.Request(OKX_INSTRUMENTS_URL, headers={"User-Agent": "pruviq-update/1"})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        data = __import__("json").loads(r.read())
+    if data.get("code") != "0":
+        raise RuntimeError(f"OKX instruments error: {data}")
+    syms: set[str] = set()
+    for x in data["data"]:
+        if x.get("state") != "live" or x.get("settleCcy") != "USDT":
+            continue
+        parts = x["instId"].split("-")
+        if len(parts) == 3 and parts[1] == "USDT" and parts[2] == "SWAP":
+            syms.add((parts[0] + "USDT").upper())
+    return syms
+
+
+def get_last_timestamp(csv_path: Path) -> datetime | None:
+    """Read the last row's timestamp without loading the whole file.
+    Returns None if the CSV is header-only or unreadable."""
+    try:
+        with open(csv_path, "rb") as f:
+            f.seek(0, 2)
+            size = f.tell()
+            f.seek(max(0, size - 4096))
+            tail = f.read().decode("utf-8", errors="ignore").strip().split("\n")
+        if len(tail) < 2:
+            return None
+        last = tail[-1]
+        ts_str = last.split(",", 1)[0]
+        return pd.Timestamp(ts_str).to_pydatetime().replace(tzinfo=timezone.utc)
+    except Exception:
+        return None
+
+
+def df_to_csv_rows(df: pd.DataFrame) -> list[str]:
+    """Serialise a fetched DataFrame back into CSV lines matching the existing schema.
+    We intentionally keep only the 6 canonical columns (timestamp, OHLCV) — extras
+    from the Binance ingest pipeline (quote_volume, trades) are left absent; DataManager
+    only reads the 6 we write."""
+    rows = []
+    for _, r in df.iterrows():
+        ts = r["timestamp"]
+        if hasattr(ts, "strftime"):
+            ts_str = ts.strftime("%Y-%m-%d %H:%M:%S")
+        else:
+            ts_str = str(ts)
+        rows.append(
+            f"{ts_str},{r['open']},{r['high']},{r['low']},{r['close']},{r['volume']}"
+        )
+    return rows
+
+
+async def update_existing_csv(
+    fetcher: OkxMarketFetcher,
+    csv_path: Path,
+    symbol: str,
+    dry_run: bool = False,
+) -> int:
+    """Append new OKX 1h bars to an existing CSV. Returns #rows added."""
+    last_ts = get_last_timestamp(csv_path)
+    now = datetime.now(timezone.utc)
+
+    # If the CSV is recent (< 2h old) — nothing to do
+    if last_ts is not None and (now - last_ts) < timedelta(hours=2):
+        return 0
+
+    # OKX /market/candles returns newest-first, limit up to 300
+    df = await fetcher.fetch_df(symbol, interval="1h", limit=100)
+    if df.empty:
+        return 0
+
+    # Drop any bar whose close-time hasn't happened yet (incomplete candle)
+    # OKX returns bars with open-time; 1h-bar at 14:00 is incomplete until 15:00.
+    # `now` is already tz-aware UTC, so pd.Timestamp() without tz=.
+    complete_cutoff = pd.Timestamp(now - timedelta(hours=1))
+    df = df[df["timestamp"] <= complete_cutoff]
+
+    # Keep only bars strictly newer than last_ts
+    if last_ts is not None:
+        df = df[df["timestamp"] > pd.Timestamp(last_ts)]
+
+    if df.empty:
+        return 0
+
+    if dry_run:
+        return len(df)
+
+    rows = df_to_csv_rows(df)
+    with open(csv_path, "a") as f:
+        for row in rows:
+            f.write(row + "\n")
+    return len(rows)
+
+
+async def fetch_history_paged(
+    symbol: str,
+    fetcher: OkxMarketFetcher,
+    max_pages: int = 200,
+) -> pd.DataFrame:
+    """Walk /history-candles backward to assemble a long history.
+    Uses the `after` cursor (older-than), 100 bars per page. Cap at max_pages.
+    Shared-rate-limit + 429 backoff are handled inside `fetch_history_page`.
+    """
+    all_candles = []
+    oldest_ts: str | None = None
+    for _ in range(max_pages):
+        page = await fetcher.fetch_history_page(
+            symbol, interval="1h", after_ms=oldest_ts, limit=100,
+        )
+        if not page:
+            break
+        page_oldest = str(page[0].ts_ms)  # page is sorted old→new
+        if page_oldest == oldest_ts:
+            break
+        all_candles.extend(page)
+        oldest_ts = page_oldest
+    if not all_candles:
+        return pd.DataFrame(columns=["timestamp", "open", "high", "low", "close", "volume"])
+    all_candles.sort(key=lambda c: c.ts_ms)
+    return pd.DataFrame({
+        "timestamp": pd.to_datetime([c.ts_ms for c in all_candles], unit="ms", utc=True),
+        "open":   [c.open for c in all_candles],
+        "high":   [c.high for c in all_candles],
+        "low":    [c.low for c in all_candles],
+        "close":  [c.close for c in all_candles],
+        "volume": [c.volume for c in all_candles],
+    })
+
+
+async def seed_new_symbol(
+    fetcher: OkxMarketFetcher,
+    data_dir: Path,
+    symbol: str,
+    max_pages: int,
+    dry_run: bool,
+) -> int:
+    """Create a CSV for a symbol that doesn't exist yet, seeding with OKX history."""
+    csv_path = data_dir / f"{symbol.lower()}_1h.csv"
+    if csv_path.exists():
+        return 0  # caller's job to invoke update_existing_csv instead
+
+    df = await fetch_history_paged(symbol, fetcher, max_pages=max_pages)
+    if df.empty:
+        logger.warning("no history for %s — skipping seed", symbol)
+        return 0
+
+    if dry_run:
+        return len(df)
+
+    rows = df_to_csv_rows(df)
+    with open(csv_path, "w") as f:
+        f.write(CSV_HEADER + "\n")
+        for r in rows:
+            f.write(r + "\n")
+    return len(rows)
+
+
+async def run(args: argparse.Namespace) -> int:
+    data_dir = Path(args.data_dir)
+    if not data_dir.exists():
+        print(f"ERROR: data directory not found: {data_dir}", file=sys.stderr)
+        return 1
+
+    okx_syms = fetch_okx_usdt_swap_symbols()
+    print(f"OKX USDT-SWAP live symbols: {len(okx_syms)}")
+
+    existing_csvs = sorted(data_dir.glob("*_1h.csv"))
+    existing_syms = {p.stem.replace("_1h", "").upper() for p in existing_csvs}
+
+    targets_update = [
+        (p, p.stem.replace("_1h", "").upper())
+        for p in existing_csvs
+        if p.stem.replace("_1h", "").upper() in okx_syms
+    ]
+    off_coverage = sorted(s for s in existing_syms if s not in okx_syms)
+
+    new_syms = [s.upper() for s in (args.new_symbols or [])]
+    seed_targets = [s for s in new_syms if s in okx_syms and s not in existing_syms]
+    skipped_new = [s for s in new_syms if s not in okx_syms]
+
+    print(
+        f"update-plan: {len(targets_update)} existing, "
+        f"{len(seed_targets)} new seeds, "
+        f"{len(off_coverage)} off-coverage (skip), "
+        f"{len(skipped_new)} requested-but-not-on-OKX"
+    )
+    if off_coverage:
+        print(f"  off-coverage sample: {off_coverage[:10]}{'...' if len(off_coverage) > 10 else ''}")
+    if skipped_new:
+        print(f"  skipped_new: {skipped_new}")
+
+    total_updated = 0
+    total_new_bars = 0
+    total_seeded = 0
+    errors = 0
+
+    async with OkxMarketFetcher() as fetcher:
+        for csv_path, symbol in targets_update:
+            try:
+                n = await update_existing_csv(fetcher, csv_path, symbol, dry_run=args.dry_run)
+                if n > 0:
+                    total_updated += 1
+                    total_new_bars += n
+                    print(f"  update {symbol}: +{n} bars")
+            except Exception as e:
+                errors += 1
+                print(f"  update {symbol}: ERROR {type(e).__name__}: {e}")
+
+        for symbol in seed_targets:
+            try:
+                n = await seed_new_symbol(
+                    fetcher, data_dir, symbol,
+                    max_pages=args.seed_pages, dry_run=args.dry_run,
+                )
+                if n > 0:
+                    total_seeded += 1
+                    print(f"  seed {symbol}: +{n} bars (new file)")
+                else:
+                    print(f"  seed {symbol}: (no data returned)")
+            except Exception as e:
+                errors += 1
+                print(f"  seed {symbol}: ERROR {type(e).__name__}: {e}")
+
+    print(
+        f"\nDone: updated={total_updated}, seeded={total_seeded}, "
+        f"new_bars={total_new_bars}, errors={errors}"
+    )
+    if args.dry_run:
+        print("(dry run — no files modified)")
+    return 0 if errors == 0 else 2
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Update OHLCV from OKX USDT-SWAP")
+    parser.add_argument(
+        "--data-dir",
+        type=str,
+        default=os.getenv(
+            "PRUVIQ_DATA_DIR",
+            str(Path(__file__).parent.parent / "data" / "futures"),
+        ),
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--new-symbols", nargs="*", default=[],
+        help="OKX-only symbols to seed with full history (e.g. SHIBUSDT PEPEUSDT).",
+    )
+    parser.add_argument(
+        "--seed-pages", type=int, default=200,
+        help="Max /history-candles pages per new-seed symbol (100 bars each).",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+    started = time.time()
+    try:
+        rc = asyncio.run(run(args))
+    except KeyboardInterrupt:
+        print("interrupted", file=sys.stderr)
+        rc = 130
+    print(f"elapsed: {time.time() - started:.1f}s")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Replaces the Binance path for the 4h OHLCV systemd timer with an OKX USDT-SWAP updater that runs entirely on DO (no Mac dependency). Signal scanner / DataManager unchanged — CSV schema is identical.

## What changes
- **`backend/scripts/update_ohlcv_okx.py`** — new fetcher using `OkxMarketFetcher`
  - Updates existing `*_1h.csv` only for OKX-live symbols (the 235 intersect from Phase A)
  - Skips the 339 off-coverage coins (purge PR for those is Phase B, follow-up)
  - `--new-symbols` seeds ~2.3 y of `/history-candles` for symbols without a CSV — systemd wrapper ships it with the 5 meme coins confirmed on 2026-04-17: SHIB, PEPE, BONK, FLOKI, SATS
- **`backend/okx/market_fetcher.py`**
  - Rate limit 18 → **12 req/2s**. Burn-in showed OKX's IP budget behaves as if `/market/candles` and `/market/history-candles` share one bucket, and 18+ triggered 429 under mixed traffic.
  - `fetch_history_page()` + `_get_with_backoff()` (4 attempts, 2s × 2ⁿ) — 429 handling is now fetcher-internal.
- **systemd wrapper + service** — points at the OKX script, timeout 1800→1200s (dry-run hit 205s)

## Dry-run against live OKX (2026-04-17)
```
update-plan: 235 existing, 5 new seeds, 339 off-coverage (skip)
Done: updated=235, seeded=5, new_bars=2205, errors=0
elapsed: 205.1s
```

## Migration progress
| | |
|--|--|
| Phase A | ✅ coverage diff (574→240 = 235 intersect + 5 OKX meme) |
| Phase B' | ✅ `OkxMarketFetcher` module (#1103) |
| **Phase C (this PR)** | OKX-native OHLCV updater |
| Phase B | pending — purge 339 off-coverage CSVs |
| Phase D | pending — UI coverage/source labels |
| Phase E | pending — Mac update-ohlcv retirement |

## Test plan
- [x] Unit tests (market_fetcher) — 16/16 pass (14 offline + 2 live OKX smoke)
- [x] Dry-run against live OKX — 235 updates + 5 seeds (≈100k history bars), 0 errors
- [ ] Post-merge on DO: `systemctl daemon-reload && systemctl start pruviq-update-ohlcv.service` to watch one full fire
- [ ] After first successful fire, verify `/signals/live` still returns expected shape on DO (DataManager reads the same CSVs — no code change)