### PR TITLE
feat(ui): OKX coverage labels — Phase D

### DIFF
--- a/src/components/SignalsDashboard.tsx
+++ b/src/components/SignalsDashboard.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "preact/hooks";
 import { API_BASE_URL } from "../config/api";
+import { COINS_ANALYZED } from "../config/site-stats";
 
 interface Signal {
   strategy: string;
@@ -153,13 +154,17 @@ export default function SignalsDashboard({ lang = "en" }: Props) {
               {lang === "ko" ? (
                 <>
                   전략 조건을{" "}
-                  <span class="font-mono text-[--color-accent]">572</span>개
-                  코인에서 분석 중...
+                  <span class="font-mono text-[--color-accent]">
+                    {COINS_ANALYZED}
+                  </span>
+                  개 코인에서 분석 중...
                 </>
               ) : (
                 <>
                   Analyzing strategy conditions across{" "}
-                  <span class="font-mono text-[--color-accent]">572</span>{" "}
+                  <span class="font-mono text-[--color-accent]">
+                    {COINS_ANALYZED}
+                  </span>{" "}
                   coins...
                 </>
               )}

--- a/src/config/site-stats.ts
+++ b/src/config/site-stats.ts
@@ -1,10 +1,25 @@
 import stats from "../../public/data/site-stats.json";
+import coinsStats from "../../public/data/coins-stats.json";
 
-/** Total coins analyzed (from site-stats.json, auto-updated by pipeline) */
-export const COINS_ANALYZED: number = stats.coins_analyzed ?? 572;
+/** Total coins currently loaded into the scanner.
+ *
+ *  Prefers `coins-stats.json.total_coins` (the authoritative, post-Phase-B
+ *  coverage filter — 235 after the 2026-04-17 OKX cutover). Falls back to
+ *  `site-stats.json.coins_analyzed`, which is a separate daily-pipeline
+ *  artifact and can lag the coverage filter by up to a day. */
+export const COINS_ANALYZED: number =
+  (coinsStats as { total_coins?: number })?.total_coins ??
+  stats.coins_analyzed ??
+  235;
 
 /** Total strategies tested */
 export const STRATEGIES_COUNT: number = stats.strategies_tested ?? 16;
 
 /** Indicator count (not in site-stats.json, manually maintained) */
 export const INDICATORS_COUNT: number = 14;
+
+/** Data-source disclosure. Shown in trust/transparency copy so the coverage
+ *  cut and the mid-period source change are visible to users without
+ *  scattering the same sentence across a dozen pages. */
+export const DATA_SOURCE_NOTE =
+  "Binance historical ≤ 2026-04-17, OKX USDT-SWAP live from 2026-04-18";

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1605,7 +1605,7 @@ export const en = {
   "compare.row2_pruviq": "No code needed",
   "compare.row3_label": "Coins",
   "compare.row3_other": "1 coin at a time",
-  "compare.row3_pruviq": "572 coins at once",
+  "compare.row3_pruviq": "235 coins at once",
   "compare.row4_label": "Signup",
   "compare.row4_other": "Email + credit card",
   "compare.row4_pruviq": "No account needed",
@@ -2090,7 +2090,7 @@ export const en = {
   "trust.updated": "updated",
   "trust.why_title": "Why we publish this.",
   "trust.why_body":
-    "Every crypto autotrade platform claims \"precise execution.\" We let you check. Slippage over 0.5% triggers an immediate position close by design. If that number walks up over time, you'll see it here first.",
+    'Every crypto autotrade platform claims "precise execution." We let you check. Slippage over 0.5% triggers an immediate position close by design. If that number walks up over time, you\'ll see it here first.',
   "trust.what_not_title": "What this isn't.",
   "trust.what_not_body":
     "Not a leaderboard. Not individual user returns. No clickbait.",

--- a/src/pages/api.astro
+++ b/src/pages/api.astro
@@ -94,7 +94,7 @@ const API_BASE = 'https://api.pruviq.com';
           response={`{
   "status": "ok",
   "version": "0.3.0",
-  "coins_loaded": 572,
+  "coins_loaded": 235,
   "uptime_seconds": 415785.5
 }`}
         />
@@ -205,7 +205,7 @@ const API_BASE = 'https://api.pruviq.com';
     "date_from": "2023-12-30",
     "date_to": "2026-04-03"
   },
-  ... // 572 coins total
+  ... // 235 coins total (OKX USDT-SWAP live)
 ]`}
         />
 

--- a/src/pages/ko/api.astro
+++ b/src/pages/ko/api.astro
@@ -81,7 +81,7 @@ const API_BASE = 'https://api.pruviq.com';
           response={`{
   "status": "ok",
   "version": "0.3.0",
-  "coins_loaded": 572,
+  "coins_loaded": 235,
   "uptime_seconds": 415785.5
 }`}
         />
@@ -192,7 +192,7 @@ const API_BASE = 'https://api.pruviq.com';
     "date_from": "2023-12-30",
     "date_to": "2026-04-03"
   },
-  ... // 572개 코인
+  ... // 235개 코인 (OKX USDT-SWAP 라이브)
 ]`}
         />
 


### PR DESCRIPTION
## Summary
Updates the handful of places still citing 572 to track the current coverage number after Phase B (#1105). Adds a single-source data-source string for transparency copy.

## Changes
- **`src/config/site-stats.ts`** — `COINS_ANALYZED` now reads `coins-stats.json.total_coins` first (updated atomically by Phase B), falls back to `site-stats.json.coins_analyzed` (daily pipeline, can lag up to a day). Avoids stale 572 appearing during pipeline lag. Exports new `DATA_SOURCE_NOTE` constant.
- **`src/components/SignalsDashboard.tsx`** — imports `COINS_ANALYZED` instead of hard-coded 572 in loading copy.
- **`src/i18n/en.ts`** — `compare.row3_pruviq` "572 coins at once" → "235". `ko.ts` already used `{coins}` interpolation.
- **`src/pages/api.astro` + `src/pages/ko/api.astro`** — `/health` response example `coins_loaded: 572 → 235`, comment updated to cite OKX USDT-SWAP source.

## Not changed
- Blog posts (`src/content/blog*/`) stay at 572 — they're dated historical writings.
- The 5 OKX-only meme coins (SHIB/PEPE/BONK/FLOKI/SATS) aren't in metadata yet, so UI shows 235 (not 240) until next daily CoinGecko refresh.

## Migration progress
| | |
|--|--|
| Phase A | ✅ coverage diff |
| Phase B' | ✅ OkxMarketFetcher (#1103) |
| Phase C | ✅ OKX OHLCV updater (#1104) |
| Phase B | ✅ coverage purge (#1105) |
| **Phase D (this PR)** | UI coverage labels |
| Phase E | Mac update-ohlcv retirement |

## Test plan
- [x] `npm run build` — clean (2527 pages on current pre-#1105 main; will drop to 1171 after #1105 merges into shared base)
- [ ] After #1105 + this PR deploy: homepage + /signals live + /api docs show 235 consistently