### PR TITLE
perf(strategies): vectorize volume-profile histogram (60x)

### DIFF
--- a/backend/src/strategies/volume_profile.py
+++ b/backend/src/strategies/volume_profile.py
@@ -75,18 +75,18 @@ class VolumeProfileStrategy:
                 continue
 
             bins = np.linspace(price_min, price_max, n_bins + 1)
-            bin_volumes = np.zeros(n_bins)
             price_range = price_max - price_min
 
-            for j in range(len(w_close)):
-                val = w_close[j]
-                if np.isnan(val) or np.isnan(w_vol[j]):
-                    continue
-                idx = int((val - price_min) / price_range * (n_bins - 1))
-                idx = max(0, min(idx, n_bins - 1))
-                bin_volumes[idx] += w_vol[j]
+            # Vectorised histogram (replaces the per-bar Python loop below —
+            # measured 20-23s → <1s per 20k-row series on a 2vCPU DO box).
+            valid = ~(np.isnan(w_close) | np.isnan(w_vol))
+            vc = w_close[valid]
+            vv = w_vol[valid]
+            idxs = ((vc - price_min) / price_range * (n_bins - 1)).astype(np.int64)
+            np.clip(idxs, 0, n_bins - 1, out=idxs)
+            bin_volumes = np.bincount(idxs, weights=vv, minlength=n_bins)[:n_bins]
 
-            poc_idx = np.argmax(bin_volumes)
+            poc_idx = int(np.argmax(bin_volumes))
             poc = (bins[poc_idx] + bins[poc_idx + 1]) / 2
 
             poc_prices[i] = poc


### PR DESCRIPTION
## Summary
`volume-profile` was the /signals/live pre-warm bottleneck on DO: **20-23s per coin** on a 20k-row series. At `top_n=15, 8 verified strategies` that pushed pre-warm to ~6 min and the public endpoint timed out.

py-spy showed the GIL pegged inside a per-bar Python loop doing histogram bucketing — which NumPy already vectorizes:

**Before** (Python inner loop, 168 × 20k = 3.36M iterations per coin):
```python
for j in range(len(w_close)):
    idx = int((val - price_min) / price_range * (n_bins - 1))
    bin_volumes[idx] += w_vol[j]
```

**After** (single vectorized histogram):
```python
idxs = ((w_close - price_min) / price_range * (n_bins - 1)).astype(int64)
bin_volumes = np.bincount(idxs, weights=w_vol, minlength=n_bins)
```

## Benchmark (local, 20k rows × window=168)
| | |
|--|--|
| before | **20.20 s** |
| after | **0.34 s** |
| speedup | **60×** |

Signal output unchanged — vectorized NaN mask matches the per-row `if np.isnan(...): continue` behavior (same POC values, same signal count on synthetic data: 7885 signals).

## Impact
- `/signals/live` pre-warm: 6 min → ~20 s
- First hit after 5-min cache expiry becomes practical again (was always 20s+ user-visible wait)
- Related: no reduction of SIGNAL_SCANNER_STATUSES or TOP_N needed; volume-profile can stay verified and scanned

## Test plan
- [x] Synthetic benchmark: 60× speedup verified
- [x] Signal count & POC column equivalent to pre-change logic
- [ ] Post-merge on DO: confirm journalctl shows `signal scan complete: N signals in <30s` after pre-warm