### PR TITLE
fix(okx): OAuth endpoint /api/v5/oauth/* → /account/oauth/*

### DIFF
--- a/backend/okx/config.py
+++ b/backend/okx/config.py
@@ -22,8 +22,10 @@ OKX_ENCRYPTION_KEY = os.environ.get("OKX_ENCRYPTION_KEY", "")
 
 # ── OKX API v5 URLs ──
 OKX_BASE_URL = "https://www.okx.com"
-OKX_OAUTH_AUTHORIZE = f"{OKX_BASE_URL}/api/v5/oauth/authorize"
-OKX_OAUTH_TOKEN = f"{OKX_BASE_URL}/api/v5/oauth/token"
+# OAuth endpoints moved from /api/v5/oauth/* to /account/oauth/* in OKX 2026.
+# Verified 2026-04-17: /account/oauth/authorize → 302, /api/v5/oauth/authorize → 404.
+OKX_OAUTH_AUTHORIZE = f"{OKX_BASE_URL}/account/oauth/authorize"
+OKX_OAUTH_TOKEN = f"{OKX_BASE_URL}/account/oauth/token"
 
 # ── Demo mode (testnet headers) ──
 OKX_DEMO_MODE = os.environ.get("OKX_DEMO_MODE", "false").lower() == "true"

--- a/src/components/OKXConnectButton.tsx
+++ b/src/components/OKXConnectButton.tsx
@@ -12,7 +12,9 @@ interface Props {
   showCard?: boolean;
 }
 
-const OKX_OAUTH_BASE = "https://www.okx.com/api/v5/oauth/authorize";
+// OKX moved OAuth endpoint from /api/v5/oauth/* to /account/oauth/* in 2026.
+// Old path now returns 404.
+const OKX_OAUTH_BASE = "https://www.okx.com/account/oauth/authorize";
 
 const labels = {
   en: {

--- a/src/components/TradingSettings.tsx
+++ b/src/components/TradingSettings.tsx
@@ -14,8 +14,9 @@ import { API_BASE_URL as API_BASE } from "../config/api";
 interface Props {
   lang?: "en" | "ko";
 }
-// Must match backend okx/config.py OKX_OAUTH_AUTHORIZE
-const OKX_OAUTH_BASE = "https://www.okx.com/api/v5/oauth/authorize";
+// Must match backend okx/config.py OKX_OAUTH_AUTHORIZE.
+// OKX moved OAuth endpoint from /api/v5/oauth/* to /account/oauth/* in 2026.
+const OKX_OAUTH_BASE = "https://www.okx.com/account/oauth/authorize";
 
 function OKXDirectConnectButton({
   lang,


### PR DESCRIPTION
## Summary
OKX moved OAuth endpoints in 2026. The old path returns 404, which is what the owner hit clicking "Connect OKX" on /dashboard.

```
curl -I https://www.okx.com/api/v5/oauth/authorize   → 404
curl -I https://www.okx.com/account/oauth/authorize  → 302 ✓
```

Updates three places (1 backend + 2 frontend) to use `/account/oauth/*`. No logic change.

## Test plan
- [x] Verified `/account/oauth/authorize` returns 302 with our params
- [ ] Post-merge + data-deploy: owner clicks Connect → reaches OKX login page