### PR TITLE
fix(okx): OAuth channelId + correct token URL

### DIFF
--- a/backend/okx/config.py
+++ b/backend/okx/config.py
@@ -22,10 +22,14 @@ OKX_ENCRYPTION_KEY = os.environ.get("OKX_ENCRYPTION_KEY", "")
 
 # ── OKX API v5 URLs ──
 OKX_BASE_URL = "https://www.okx.com"
-# OAuth endpoints moved from /api/v5/oauth/* to /account/oauth/* in OKX 2026.
-# Verified 2026-04-17: /account/oauth/authorize → 302, /api/v5/oauth/authorize → 404.
+# OAuth endpoint split (2026-04-17):
+#  - authorize is a browser-visible login/consent page on okx.com: /account/oauth/authorize
+#  - token is the server-to-server OAuth2 endpoint under /v5/users/oauth/ (NO /api/ segment).
+# Both verified live by HTTP probe. Anything under /api/v5/oauth/* is 404.
+# Token endpoint returns OAuth code 53010 ("client_id error") for invalid probes — that's
+# what confirms it's the right endpoint; it's listed in project_jepo_system memory.
 OKX_OAUTH_AUTHORIZE = f"{OKX_BASE_URL}/account/oauth/authorize"
-OKX_OAUTH_TOKEN = f"{OKX_BASE_URL}/account/oauth/token"
+OKX_OAUTH_TOKEN = f"{OKX_BASE_URL}/v5/users/oauth/token"
 
 # ── Demo mode (testnet headers) ──
 OKX_DEMO_MODE = os.environ.get("OKX_DEMO_MODE", "false").lower() == "true"

--- a/backend/okx/oauth.py
+++ b/backend/okx/oauth.py
@@ -21,6 +21,7 @@ import httpx
 _refresh_locks: dict[str, asyncio.Lock] = {}
 
 from .config import (
+    OKX_BROKER_CODE,
     OKX_CLIENT_ID,
     OKX_CLIENT_SECRET,
     OKX_OAUTH_AUTHORIZE,
@@ -50,10 +51,16 @@ def generate_auth_url(redirect_after: str = "", lang: str = "en") -> str:
     params = {
         "client_id": OKX_CLIENT_ID,
         "response_type": "code",
+        "access_type": "offline",
         "redirect_uri": OKX_REDIRECT_URI,
         "scope": "read_only,trade",
         "state": state,
     }
+    if OKX_BROKER_CODE:
+        # OKX silently sends users to /account/users (not the consent page)
+        # when channelId is missing on broker-program OAuth. See the
+        # 2026-04-17 investigation note in LESSONS_FROM_AUTOTRADER.md.
+        params["channelId"] = OKX_BROKER_CODE
     return f"{OKX_OAUTH_AUTHORIZE}?{urlencode(params)}"
 
 
@@ -65,7 +72,7 @@ def generate_oauth_params(redirect_after: str = "", lang: str = "en") -> dict:
     """
     state = secrets.token_urlsafe(32)
     save_csrf_state(state, redirect_after or "", lang)
-    return {
+    params = {
         "state": state,
         "client_id": OKX_CLIENT_ID,
         "response_type": "code",
@@ -73,6 +80,11 @@ def generate_oauth_params(redirect_after: str = "", lang: str = "en") -> dict:
         "scope": "read_only,trade",
         "redirect_uri": OKX_REDIRECT_URI,
     }
+    if OKX_BROKER_CODE:
+        # Broker channelId — required for OAuth broker flow, otherwise OKX
+        # drops the authorize request and lands on /account/users after login.
+        params["channelId"] = OKX_BROKER_CODE
+    return params
 
 
 async def exchange_code(code: str, state: str, domain: str = "") -> tuple[str, str, str]:  # domain param kept for router compat

--- a/src/components/OKXConnectButton.tsx
+++ b/src/components/OKXConnectButton.tsx
@@ -104,15 +104,20 @@ export default function OKXConnectButton({
       if (!resp.ok) throw new Error(`init failed: ${resp.status}`);
       const p = await resp.json();
 
-      // Build OKX authorize URL (same as OKEXOAuthSDK.authorize() internally)
-      const qs = new URLSearchParams({
+      // Build OKX authorize URL (same as OKEXOAuthSDK.authorize() internally).
+      // channelId is the broker program identifier — without it, OKX silently
+      // drops the authorize request after login and sends the user to
+      // /account/users instead of the consent page (seen 2026-04-17).
+      const authParams: Record<string, string> = {
         client_id: p.client_id,
         response_type: p.response_type,
         access_type: p.access_type,
         scope: p.scope,
         redirect_uri: p.redirect_uri,
         state: p.state,
-      }).toString();
+      };
+      if (p.channelId) authParams.channelId = p.channelId;
+      const qs = new URLSearchParams(authParams).toString();
 
       window.location.assign(`${OKX_OAUTH_BASE}?${qs}`);
     } catch (e) {

--- a/src/components/TradingSettings.tsx
+++ b/src/components/TradingSettings.tsx
@@ -33,14 +33,18 @@ function OKXDirectConnectButton({
       const resp = await fetch(`${API_BASE}/auth/okx/init?lang=${lang}`);
       if (!resp.ok) throw new Error(`init failed: ${resp.status}`);
       const p = await resp.json();
-      const qs = new URLSearchParams({
+      // channelId (broker code) is required on OKX broker-program OAuth;
+      // without it, /account/oauth/authorize silently lands on /account/users.
+      const authParams: Record<string, string> = {
         client_id: p.client_id,
         response_type: p.response_type,
         access_type: p.access_type,
         scope: p.scope,
         redirect_uri: p.redirect_uri,
         state: p.state,
-      }).toString();
+      };
+      if (p.channelId) authParams.channelId = p.channelId;
+      const qs = new URLSearchParams(authParams).toString();
       window.location.assign(`${OKX_OAUTH_BASE}?${qs}`);
     } catch (e) {
       console.error("OKX OAuth init failed:", e);


### PR DESCRIPTION
## Summary
Two fixes from tonight's investigation after owner hit `/account/users` instead of the consent page.

### 1. Wrong token URL
```
/account/oauth/token              → 405 / HTML wall
/api/v5/users/oauth/token         → 404
/v5/users/oauth/token             → {"code":"53010","msg":"client_id error"}  ← real endpoint
```
Moved `OKX_OAUTH_TOKEN` to `/v5/users/oauth/token`. Matches the 53010 incident memory from 2026-04-11.

### 2. Missing `channelId` broker code on authorize URL
OKX silently drops broker-program authorize requests that don't carry `channelId`, and sends the user to `/account/users` after login. This is why last hop failed even though the app is "Active" in the broker portal. Backend now appends `channelId=<OKX_BROKER_CODE>` when set; both frontend builders pass it through.

Also added `access_type=offline` to the redirect-flow URL (was already present in the JS-SDK-style params).

## Test plan
- [x] Token endpoint probed: only `/v5/users/oauth/token` returns 53010 (= real OAuth error, not 404/405)
- [ ] After deploy + owner retry: OKX shows PRUVIQ consent page; callback sets `okx_sessions` row

## Source
General-purpose agent investigation 2026-04-17, verified via live HTTP probes + OKX's own SDK reference.