### PR TITLE
fix(okx): Fast API scope=fast_api + HMAC auth

### DIFF
--- a/backend/okx/auto_executor.py
+++ b/backend/okx/auto_executor.py
@@ -23,7 +23,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from .client import OKXClient
-from .oauth import get_valid_token, is_authenticated
+from .oauth import get_api_credentials, is_authenticated
 from .orders import _pruviq_to_okx_inst_id, _calc_sl_tp_prices, _calc_contract_sz
 from .retry import retry_async
 from .settings import (
@@ -433,8 +433,8 @@ async def _try_execute(
         if strategy.get("leverage_source") == "custom":
             leverage = int(strategy.get("leverage", leverage))
 
-    token = await get_valid_token(session_id)
-    async with OKXClient(token, session_id=session_id) as client:
+    creds = get_api_credentials(session_id)
+    async with OKXClient(**creds) as client:
 
         # ── Industry standard: fetch LIVE mark price at execution time ──
         # Signal entry_price is from historical OHLCV (up to 5min stale).

--- a/backend/okx/client.py
+++ b/backend/okx/client.py
@@ -1,12 +1,18 @@
 """
-OKX API client — OAuth Bearer token based.
+OKX API client — HMAC API key auth (Fast API flow).
 All orders include broker tag for commission tracking.
 """
 from __future__ import annotations
 
+import base64
+import hashlib
+import hmac
+import json
 import logging
 import time
+from datetime import datetime, timezone
 from typing import Any
+from urllib.parse import urlencode
 
 import httpx
 
@@ -15,37 +21,49 @@ from .models import BalanceInfo, PositionInfo
 
 logger = logging.getLogger("okx_client")
 
-# ── Instrument spec cache (24h TTL, shared across all client instances) ──
 _instrument_cache: dict[str, dict] = {}
 _instrument_cache_ts: dict[str, float] = {}
 _INSTRUMENT_CACHE_TTL = 24 * 3600
 
 
-class OKXClient:
-    """OAuth token-based OKX API client."""
+def _okx_timestamp() -> str:
+    return datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
 
-    def __init__(self, access_token: str, session_id: str = ""):
-        self.access_token = access_token
-        self.session_id = session_id  # used for 53002 auto-retry
+
+def _sign(secret_key: str, timestamp: str, method: str, request_path: str, body: str = "") -> str:
+    message = timestamp + method.upper() + request_path + body
+    mac = hmac.new(secret_key.encode(), message.encode(), hashlib.sha256)
+    return base64.b64encode(mac.digest()).decode()
+
+
+class OKXClient:
+    """HMAC API key-based OKX client (Fast API flow)."""
+
+    def __init__(self, api_key: str, secret_key: str, passphrase: str, demo: bool | None = None):
+        self.api_key = api_key
+        self.secret_key = secret_key
+        self.passphrase = passphrase
+        self.demo = OKX_DEMO_MODE if demo is None else demo
         self.base_url = OKX_BASE_URL
         self.broker_code = OKX_BROKER_CODE
-        self._client = httpx.AsyncClient(
-            base_url=self.base_url,
-            timeout=10,
-            headers=self._default_headers(),
-        )
+        self._http = httpx.AsyncClient(base_url=self.base_url, timeout=10)
 
-    def _default_headers(self) -> dict[str, str]:
+    def _auth_headers(self, method: str, path: str, body: str = "") -> dict[str, str]:
+        ts = _okx_timestamp()
+        sign = _sign(self.secret_key, ts, method, path, body)
         headers = {
-            "Authorization": f"Bearer {self.access_token}",
+            "OK-ACCESS-KEY": self.api_key,
+            "OK-ACCESS-SIGN": sign,
+            "OK-ACCESS-TIMESTAMP": ts,
+            "OK-ACCESS-PASSPHRASE": self.passphrase,
             "Content-Type": "application/json",
         }
-        if OKX_DEMO_MODE:
+        if self.demo:
             headers["x-simulated-trading"] = "1"
         return headers
 
     async def close(self):
-        await self._client.aclose()
+        await self._http.aclose()
 
     async def __aenter__(self):
         return self
@@ -53,55 +71,28 @@ class OKXClient:
     async def __aexit__(self, *args):
         await self.close()
 
-    async def _refresh_token_and_update(self) -> bool:
-        """Refresh access token after 53002. Returns True if successful."""
-        if not self.session_id:
-            return False
-        try:
-            from .oauth import refresh_access_token
-            logger.warning("→ 53002 detected — refreshing token for session %s", self.session_id[:8])
-            new_token = await refresh_access_token(self.session_id)
-            self.access_token = new_token
-            self._client.headers["Authorization"] = f"Bearer {new_token}"
-            logger.warning("← Token refreshed successfully")
-            return True
-        except Exception as e:
-            logger.error("Token refresh after 53002 failed: %s", e)
-            return False
-
-    # ── GET ─────────────────────────────────────────
-
     async def _get(self, path: str, params: dict | None = None) -> dict[str, Any]:
-        for attempt in range(2):
-            resp = await self._client.get(path, params=params)
-            resp.raise_for_status()
-            data = resp.json()
-            code = data.get("code")
-            if code == "53002" and attempt == 0:
-                if await self._refresh_token_and_update():
-                    continue  # retry once with new token
-            if code != "0":
-                logger.error("OKX API error: %s %s", code, data.get("msg"))
-                raise ValueError(f"OKX API error {code}: {data.get('msg')}")
-            return data
-        raise ValueError("OKX API: max retries exceeded")
+        qs = ("?" + urlencode(params)) if params else ""
+        full_path = path + qs
+        headers = self._auth_headers("GET", full_path)
+        resp = await self._http.get(path, params=params, headers=headers)
+        resp.raise_for_status()
+        data = resp.json()
+        if data.get("code") != "0":
+            logger.error("OKX API error: %s %s", data.get("code"), data.get("msg"))
+            raise ValueError(f"OKX API error {data.get('code')}: {data.get('msg')}")
+        return data
 
-    # ── POST ────────────────────────────────────────
-
-    async def _post(self, path: str, body: dict) -> dict[str, Any]:
-        for attempt in range(2):
-            resp = await self._client.post(path, json=body)
-            resp.raise_for_status()
-            data = resp.json()
-            code = data.get("code")
-            if code == "53002" and attempt == 0:
-                if await self._refresh_token_and_update():
-                    continue
-            if code != "0":
-                logger.error("OKX API error: %s %s", code, data.get("msg"))
-                raise ValueError(f"OKX API error {code}: {data.get('msg')}")
-            return data
-        raise ValueError("OKX API: max retries exceeded")
+    async def _post(self, path: str, body: dict | list) -> dict[str, Any]:
+        body_str = json.dumps(body)
+        headers = self._auth_headers("POST", path, body_str)
+        resp = await self._http.post(path, content=body_str, headers=headers)
+        resp.raise_for_status()
+        data = resp.json()
+        if data.get("code") != "0":
+            logger.error("OKX API error: %s %s", data.get("code"), data.get("msg"))
+            raise ValueError(f"OKX API error {data.get('code')}: {data.get('msg')}")
+        return data
 
     # ── Account ─────────────────────────────────────
 
@@ -140,14 +131,6 @@ class OKXClient:
         ]
 
     async def get_instrument_info(self, inst_id: str) -> dict:
-        """
-        Fetch instrument spec (ctVal, minSz, lotSz) for OKX SWAP contracts.
-        Cached 24h — safe to call on every order.
-
-        ctVal: base currency per contract (e.g. BTC-USDT-SWAP → 0.01 BTC)
-        minSz: minimum order size in contracts (usually 1)
-        lotSz: lot size / tick (usually 1 for SWAP)
-        """
         now = time.time()
         if inst_id in _instrument_cache:
             if now - _instrument_cache_ts.get(inst_id, 0) < _INSTRUMENT_CACHE_TTL:
@@ -163,9 +146,9 @@ class OKXClient:
 
         item = items[0]
         info = {
-            "ctVal": float(item.get("ctVal", "1")),    # base currency per contract
-            "minSz": float(item.get("minSz", "1")),    # minimum contracts
-            "lotSz": float(item.get("lotSz", "1")),    # lot size
+            "ctVal": float(item.get("ctVal", "1")),
+            "minSz": float(item.get("minSz", "1")),
+            "lotSz": float(item.get("lotSz", "1")),
             "settleCcy": item.get("settleCcy", "USDT"),
         }
         _instrument_cache[inst_id] = info
@@ -174,7 +157,6 @@ class OKXClient:
         return info
 
     async def get_mark_price(self, inst_id: str) -> float:
-        """OKX public mark price — used for position sizing without user-supplied price."""
         logger.warning("→ GET mark-price instId=%s", inst_id)
         data = await self._get("/api/v5/public/mark-price", {
             "instType": "SWAP", "instId": inst_id,
@@ -187,7 +169,6 @@ class OKXClient:
         return px
 
     async def get_positions_history(self, inst_type: str = "SWAP", limit: str = "20") -> list[dict]:
-        """Closed position history — realized PnL source."""
         data = await self._get("/api/v5/account/positions-history", {
             "instType": inst_type, "limit": limit,
         })
@@ -202,7 +183,6 @@ class OKXClient:
         mgn_mode: str = "isolated",
         pos_side: str = "",
     ) -> dict[str, Any]:
-        """Set leverage for an instrument before placing orders."""
         body: dict[str, Any] = {
             "instId": inst_id,
             "lever": str(lever),
@@ -226,14 +206,6 @@ class OKXClient:
         td_mode: str = "isolated",
         cl_ord_id: str | None = None,
     ) -> dict[str, str]:
-        """Place a trade order.
-
-        cl_ord_id: client-supplied order ID for idempotency. OKX v5
-        /api/v5/trade/order rejects duplicate clOrdId values — pass a
-        deterministic hash of the triggering signal to prevent double
-        submission across retries/restarts. Must match OKX format:
-        [A-Za-z0-9_]{1,32}.
-        """
         body: dict[str, Any] = {
             "instId": inst_id,
             "tdMode": td_mode,
@@ -267,7 +239,6 @@ class OKXClient:
         tp_ord_px: str = "-1",
         td_mode: str = "isolated",
     ) -> dict[str, Any]:
-        """SL/TP conditional algo order."""
         body: dict[str, Any] = {
             "instId": inst_id,
             "tdMode": td_mode,
@@ -302,14 +273,6 @@ class OKXClient:
     async def cancel_algo_orders(
         self, algo_ids: list[str], inst_id: str
     ) -> dict[str, Any]:
-        """Cancel one or more algo (SL/TP) orders. Used for cancel-first pattern
-        before user-initiated close to prevent double-fill: otherwise the market
-        close and a racing SL/TP trigger can both execute and open a reversed
-        position. autotrader lesson L6.
-
-        OKX batch endpoint: /api/v5/trade/cancel-algos takes list-of-dicts body.
-        Returns the raw response; callers should tolerate partial success.
-        """
         if not algo_ids:
             return {"code": "0", "data": []}
         body = [{"algoId": aid, "instId": inst_id} for aid in algo_ids if aid]
@@ -331,11 +294,6 @@ class OKXClient:
         return result
 
     async def get_order_fill_price(self, inst_id: str, ord_id: str) -> float:
-        """
-        Query actual fill price (avgPx) for a completed market order.
-        Industry standard: SL/TP must be set relative to actual fill, not signal price.
-        Raises ValueError if order not yet filled or avgPx unavailable.
-        """
         data = await self._get("/api/v5/trade/order", {"instId": inst_id, "ordId": ord_id})
         orders = data.get("data", [])
         if not orders:

--- a/backend/okx/oauth.py
+++ b/backend/okx/oauth.py
@@ -1,29 +1,31 @@
 """
-OKX OAuth 2.0 flow for FD Broker (Authorization Code mode).
+OKX Fast API OAuth 2.0 flow for FD Broker.
 
-Flow:
-  1. generate_auth_url()  → user → OKX login page
-  2. exchange_code(code)  → authorization code → encrypted tokens
-  3. get_valid_token(sid)  → valid access_token (auto-refresh)
-  4. disconnect(sid)       → delete session
+Flow (OKX Fast API — scope=fast_api):
+  1. generate_oauth_params()   → frontend builds authorize URL
+  2. exchange_code(code)       → code → access_token → create API key for user
+  3. get_api_credentials(sid)  → returns {api_key, secret_key, passphrase}
+  4. disconnect(sid)           → delete session
+
+Why fast_api scope: OKX broker OAuth requires scope="fast_api", NOT "read_only,trade".
+Using wrong scope silently routes to /account/users without consent page.
+Ref: OKX Fast API Integration Doc (2024).
 """
 from __future__ import annotations
 
-import asyncio
 import logging
 import secrets
+import string
 import time
-from urllib.parse import urlencode
 
 import httpx
 
-# Per-session lock to prevent concurrent token refresh (race condition)
-_refresh_locks: dict[str, asyncio.Lock] = {}
-
 from .config import (
+    OKX_BASE_URL,
     OKX_BROKER_CODE,
     OKX_CLIENT_ID,
     OKX_CLIENT_SECRET,
+    OKX_DEMO_MODE,
     OKX_OAUTH_AUTHORIZE,
     OKX_OAUTH_TOKEN,
     OKX_REDIRECT_URI,
@@ -33,42 +35,23 @@ from .storage import (
     get_session,
     save_csrf_state,
     save_session,
-    update_session,
     validate_csrf_state,
 )
 
 logger = logging.getLogger("okx_oauth")
 
 
-def generate_auth_url(redirect_after: str = "", lang: str = "en") -> str:
-    """
-    Generate OKX OAuth authorization URL.
-    Stores CSRF state token for validation on callback.
-    """
-    state = secrets.token_urlsafe(32)
-    save_csrf_state(state, redirect_after or "", lang)
-
-    params = {
-        "client_id": OKX_CLIENT_ID,
-        "response_type": "code",
-        "access_type": "offline",
-        "redirect_uri": OKX_REDIRECT_URI,
-        "scope": "read_only,trade",
-        "state": state,
-    }
-    if OKX_BROKER_CODE:
-        # OKX silently sends users to /account/users (not the consent page)
-        # when channelId is missing on broker-program OAuth. See the
-        # 2026-04-17 investigation note in LESSONS_FROM_AUTOTRADER.md.
-        params["channelId"] = OKX_BROKER_CODE
-    return f"{OKX_OAUTH_AUTHORIZE}?{urlencode(params)}"
+def _gen_passphrase() -> str:
+    """Generate passphrase meeting OKX requirements: 8-32 chars, upper+lower+digit+special."""
+    chars = string.ascii_letters + string.digits + "!@#$%"
+    rand = "".join(secrets.choice(chars) for _ in range(12))
+    return f"Pr1!{rand}"  # guaranteed: upper(P), lower(r), digit(1), special(!)
 
 
 def generate_oauth_params(redirect_after: str = "", lang: str = "en") -> dict:
     """
-    Generate OAuth params for frontend JS SDK call.
-    Saves CSRF state to DB, returns params dict for OKEXOAuthSDK.authorize().
-    client_id is not a secret — safe to return to frontend.
+    Generate OAuth params for frontend authorize URL.
+    scope=fast_api is required for OKX broker OAuth consent page to appear.
     """
     state = secrets.token_urlsafe(32)
     save_csrf_state(state, redirect_after or "", lang)
@@ -77,20 +60,79 @@ def generate_oauth_params(redirect_after: str = "", lang: str = "en") -> dict:
         "client_id": OKX_CLIENT_ID,
         "response_type": "code",
         "access_type": "offline",
-        "scope": "read_only,trade",
+        "scope": "fast_api",
         "redirect_uri": OKX_REDIRECT_URI,
     }
     if OKX_BROKER_CODE:
-        # Broker channelId — required for OAuth broker flow, otherwise OKX
-        # drops the authorize request and lands on /account/users after login.
         params["channelId"] = OKX_BROKER_CODE
     return params
 
 
-async def exchange_code(code: str, state: str, domain: str = "") -> tuple[str, str, str]:  # domain param kept for router compat
+def generate_auth_url(redirect_after: str = "", lang: str = "en") -> str:
+    """Generate full OKX authorize URL (server-side redirect variant)."""
+    from urllib.parse import urlencode
+    state = secrets.token_urlsafe(32)
+    save_csrf_state(state, redirect_after or "", lang)
+    params = {
+        "client_id": OKX_CLIENT_ID,
+        "response_type": "code",
+        "access_type": "offline",
+        "redirect_uri": OKX_REDIRECT_URI,
+        "scope": "fast_api",
+        "state": state,
+    }
+    if OKX_BROKER_CODE:
+        params["channelId"] = OKX_BROKER_CODE
+    return f"{OKX_OAUTH_AUTHORIZE}?{urlencode(params)}"
+
+
+async def _create_user_apikey(access_token: str) -> dict:
     """
-    Exchange authorization code for access + refresh tokens.
-    Validates CSRF state, stores encrypted tokens in SQLite.
+    Step 4 of Fast API flow: use one-time access_token to create API key for user.
+    POST /api/v5/users/oauth/apikey
+    Returns {api_key, secret_key, passphrase, perm}.
+    """
+    passphrase = _gen_passphrase()
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {access_token}",
+    }
+    if OKX_DEMO_MODE:
+        headers["x-simulated-trading"] = "1"
+
+    body = {
+        "label": "pruviq",
+        "passphrase": passphrase,
+        "perm": "read_only,trade",
+    }
+    logger.warning("→ POST /api/v5/users/oauth/apikey demo=%s", OKX_DEMO_MODE)
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{OKX_BASE_URL}/api/v5/users/oauth/apikey",
+            headers=headers,
+            json=body,
+            timeout=15,
+        )
+        logger.warning("← apikey status=%s body=%s", resp.status_code, resp.text[:300])
+        resp.raise_for_status()
+        result = resp.json()
+
+    if result.get("code") != "0":
+        raise ValueError(f"OKX API key creation failed: {result}")
+
+    key_data = result["data"][0]
+    return {
+        "api_key": key_data["apiKey"],
+        "secret_key": key_data["secretKey"],
+        "passphrase": passphrase,
+        "perm": key_data.get("perm", "read_only,trade"),
+        "created_at": time.time(),
+    }
+
+
+async def exchange_code(code: str, state: str, domain: str = "") -> tuple[str, str, str]:
+    """
+    Exchange authorization code → access_token → create API key for user.
     Returns (session_id, redirect_url, lang).
     """
     csrf_result = validate_csrf_state(state)
@@ -98,7 +140,6 @@ async def exchange_code(code: str, state: str, domain: str = "") -> tuple[str, s
         raise ValueError("Invalid or expired CSRF state")
     redirect_url, lang = csrf_result
 
-    # Standard FD Broker OAuth token exchange (RFC 6749)
     data = {
         "client_id": OKX_CLIENT_ID,
         "client_secret": OKX_CLIENT_SECRET,
@@ -106,136 +147,50 @@ async def exchange_code(code: str, state: str, domain: str = "") -> tuple[str, s
         "grant_type": "authorization_code",
         "redirect_uri": OKX_REDIRECT_URI,
     }
-
     logger.warning("→ OKX token request url=%s", OKX_OAUTH_TOKEN)
-
     async with httpx.AsyncClient() as client:
-        resp = await client.post(
-            OKX_OAUTH_TOKEN,
-            data=data,  # RFC 6749: application/x-www-form-urlencoded
-            timeout=15,
-        )
-        logger.warning("OKX token → status=%s body=%s", resp.status_code, resp.text[:300])
+        resp = await client.post(OKX_OAUTH_TOKEN, data=data, timeout=15)
+        logger.warning("← token status=%s body=%s", resp.status_code, resp.text[:300])
         resp.raise_for_status()
         token_data = resp.json()
 
     if "access_token" not in token_data:
         raise ValueError(f"OKX token error: {token_data}")
 
-    session_id = secrets.token_urlsafe(32)
-    tokens = {
-        "access_token": token_data["access_token"],
-        "refresh_token": token_data["refresh_token"],
-        "expires_at": time.time() + token_data.get("expires_in", 3600),
-        "scope": token_data.get("scope", ""),
-    }
-    save_session(session_id, tokens)
+    # Use one-time access_token to create user API key
+    credentials = await _create_user_apikey(token_data["access_token"])
 
-    logger.info("OAuth session created: %s", session_id[:8])
+    session_id = secrets.token_urlsafe(32)
+    save_session(session_id, credentials)
+
+    logger.info("OAuth session + API key created: %s", session_id[:8])
     return session_id, redirect_url, lang
 
 
-async def refresh_access_token(session_id: str) -> str:
-    """Refresh expired access_token using refresh_token."""
-    tokens = get_session(session_id)
-    if not tokens:
-        raise ValueError("Session not found")
-
-    data = {
-        "client_id": OKX_CLIENT_ID,
-        "client_secret": OKX_CLIENT_SECRET,
-        "refresh_token": tokens["refresh_token"],
-        "grant_type": "refresh_token",
-    }
-
-    async with httpx.AsyncClient() as client:
-        resp = await client.post(OKX_OAUTH_TOKEN, data=data, timeout=15)
-        # Refresh token expired or revoked → delete session immediately
-        if resp.status_code in (400, 401, 403):
-            logger.warning(
-                "Refresh token rejected (status=%s) for session %s — deleting session",
-                resp.status_code, session_id[:8],
-            )
-            await _notify_reauth(session_id)
-            delete_session(session_id)
-            raise ValueError(f"Refresh token expired or revoked (status={resp.status_code})")
-        resp.raise_for_status()
-        token_data = resp.json()
-
-    if "access_token" not in token_data:
-        # Handle OKX-level error codes indicating token invalidation
-        if token_data.get("error") in ("invalid_grant", "expired_token", "invalid_token"):
-            logger.warning(
-                "Refresh token invalidated (error=%s) for session %s — deleting session",
-                token_data.get("error"), session_id[:8],
-            )
-            await _notify_reauth(session_id)
-            delete_session(session_id)
-        raise ValueError(f"OKX refresh error: {token_data}")
-
-    tokens["access_token"] = token_data["access_token"]
-    tokens["refresh_token"] = token_data["refresh_token"]
-    tokens["expires_at"] = time.time() + token_data.get("expires_in", 3600)
-    update_session(session_id, tokens)
-
-    logger.info("Token refreshed: session %s", session_id[:8])
-    return tokens["access_token"]
-
-
-async def _notify_reauth(session_id: str) -> None:
-    """Send Telegram alert when OKX re-authentication is needed."""
-    try:
-        from .settings import get_settings
-        settings = get_settings(session_id)
-        chat_id = settings.get("alert_telegram_chat_id", "")
-        if not chat_id:
-            return
-        from .notifications import send_reauth_alert
-        await send_reauth_alert(chat_id)
-    except Exception as e:
-        logger.warning("Failed to send reauth alert for session %s: %s", session_id[:8], e)
-
-
-async def get_valid_token(session_id: str) -> str:
+def get_api_credentials(session_id: str) -> dict:
     """
-    Get valid access_token, auto-refreshing 5 min before expiry.
-    Uses per-session lock to prevent concurrent refresh race conditions.
+    Get stored API key credentials for a session.
+    Returns {api_key, secret_key, passphrase} or raises ValueError.
     """
-    tokens = get_session(session_id)
-    if not tokens:
+    creds = get_session(session_id)
+    if not creds:
         raise ValueError("Session not found. Connect OKX first.")
-
-    if time.time() > tokens["expires_at"] - 300:
-        # Per-session lock: only one coroutine refreshes at a time
-        if session_id not in _refresh_locks:
-            _refresh_locks[session_id] = asyncio.Lock()
-        async with _refresh_locks[session_id]:
-            # Re-read after acquiring lock — another coroutine may have refreshed
-            tokens = get_session(session_id)
-            if not tokens:
-                raise ValueError("Session not found after refresh wait.")
-            if time.time() > tokens["expires_at"] - 300:
-                return await refresh_access_token(session_id)
-            return tokens["access_token"]
-
-    return tokens["access_token"]
+    if "api_key" not in creds:
+        raise ValueError("Session has no API key. Please reconnect OKX.")
+    return creds
 
 
 def is_authenticated(session_id: str) -> bool:
-    """Check if session has valid (or refreshable) tokens."""
+    """Check if session has valid API key credentials."""
     if not session_id:
         return False
-    tokens = get_session(session_id)
-    if not tokens:
+    creds = get_session(session_id)
+    if not creds:
         return False
-    # Refresh token expires after 3 days
-    if time.time() > tokens["expires_at"] + 259200:
-        delete_session(session_id)
-        return False
-    return True
+    return "api_key" in creds
 
 
 def disconnect(session_id: str) -> None:
-    """Delete session and all tokens."""
+    """Delete session and all credentials."""
     delete_session(session_id)
     logger.info("Session disconnected: %s", session_id[:8])

--- a/backend/okx/orders.py
+++ b/backend/okx/orders.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 from .client import OKXClient
 from .models import SimToExecRequest
-from .oauth import get_valid_token
+from .oauth import get_api_credentials
 
 logger = logging.getLogger("okx_orders")
 
@@ -97,12 +97,12 @@ async def execute_from_simulation(
     rejects duplicate submissions — use a deterministic hash of the source
     signal to make retries safe.
     """
-    token = await get_valid_token(session_id)
+    creds = get_api_credentials(session_id)
     inst_id = _pruviq_to_okx_inst_id(req.symbol)
     side = "sell" if req.direction == "short" else "buy"
     td_mode = req.td_mode if req.td_mode in ("isolated", "cross") else "isolated"
 
-    async with OKXClient(token, session_id=session_id) as client:
+    async with OKXClient(**creds) as client:
         # Auto-fetch mark price if not supplied (or zero)
         if not current_price or current_price <= 0:
             logger.warning(

--- a/backend/okx/pnl_sync.py
+++ b/backend/okx/pnl_sync.py
@@ -25,7 +25,7 @@ import logging
 import time
 
 from .client import OKXClient
-from .oauth import get_valid_token, is_authenticated
+from .oauth import get_api_credentials, is_authenticated
 from .storage import _get_conn
 
 logger = logging.getLogger("okx_pnl_sync")
@@ -59,8 +59,8 @@ async def sync_realized_pnl(session_id: str, inst_id: str, trade_created_at: flo
             if not is_authenticated(session_id):
                 return
 
-            token = await get_valid_token(session_id)
-            async with OKXClient(token, session_id=session_id) as client:
+            creds = get_api_credentials(session_id)
+            async with OKXClient(**creds) as client:
                 history = await client.get_positions_history(limit="20")
 
             # Find matching closed position by instId and close time after trade creation
@@ -216,8 +216,8 @@ async def retry_failed_pnl_sync() -> None:
         if not is_authenticated(session_id):
             continue
         try:
-            token = await get_valid_token(session_id)
-            async with OKXClient(token, session_id=session_id) as client:
+            creds = get_api_credentials(session_id)
+            async with OKXClient(**creds) as client:
                 history = await client.get_positions_history(limit=_RETRY_HISTORY_LIMIT)
         except Exception as e:
             logger.error("pnl_sync retry: fetch history failed for %s: %s", session_id[:8], e)

--- a/backend/okx/reconciler.py
+++ b/backend/okx/reconciler.py
@@ -25,7 +25,7 @@ import time
 from typing import Optional
 
 from .client import OKXClient
-from .oauth import get_valid_token, is_authenticated
+from .oauth import get_api_credentials, is_authenticated
 from .orders import _pruviq_to_okx_inst_id
 from .settings import get_auto_sessions, get_settings, get_trade_log, save_settings
 from .storage import _get_conn
@@ -90,8 +90,8 @@ async def reconcile_positions(session_id: str) -> None:
         return
 
     try:
-        token = await get_valid_token(session_id)
-        async with OKXClient(token, session_id=session_id) as client:
+        creds = get_api_credentials(session_id)
+        async with OKXClient(**creds) as client:
             okx_positions = await client.get_positions()
     except Exception as e:
         logger.error("Reconcile: fetch positions failed for %s: %s", session_id[:8], e)

--- a/backend/okx/router.py
+++ b/backend/okx/router.py
@@ -32,7 +32,7 @@ from .oauth import (
     exchange_code,
     generate_auth_url,
     generate_oauth_params,
-    get_valid_token,
+    get_api_credentials,
     is_authenticated,
 )
 from .orders import execute_from_simulation
@@ -208,10 +208,10 @@ async def get_positions(request: Request, symbol: str = Query(None)):
     from .client import OKXClient
     from .orders import _pruviq_to_okx_inst_id
 
-    token = await get_valid_token(session_id)
+    creds = get_api_credentials(session_id)
     inst_id = _pruviq_to_okx_inst_id(symbol) if symbol else None
 
-    async with OKXClient(token) as client:
+    async with OKXClient(**creds) as client:
         positions = await client.get_positions(inst_id)
         return {"data": [_pos_to_camel(p) for p in positions]}
 
@@ -263,9 +263,9 @@ async def get_positions_history(request: Request, limit: int = Query(20, le=100)
 
     from .client import OKXClient
 
-    token = await get_valid_token(session_id)
+    creds = get_api_credentials(session_id)
 
-    async with OKXClient(token) as client:
+    async with OKXClient(**creds) as client:
         raw = await client.get_positions_history(limit=str(limit))
 
     return {"data": [
@@ -290,9 +290,9 @@ async def get_balance(request: Request, ccy: str = Query("USDT")):
 
     from .client import OKXClient
 
-    token = await get_valid_token(session_id)
+    creds = get_api_credentials(session_id)
 
-    async with OKXClient(token) as client:
+    async with OKXClient(**creds) as client:
         balances = await client.get_balance(ccy)
         return {"balances": [b.model_dump() for b in balances]}
 

--- a/backend/okx/token_refresh.py
+++ b/backend/okx/token_refresh.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 import time
 
-from .oauth import is_authenticated, refresh_access_token
+from .oauth import is_authenticated
 from .storage import _get_conn, delete_session, get_session
 
 logger = logging.getLogger("okx_token_refresh")
@@ -50,7 +50,7 @@ async def refresh_all_sessions() -> dict:
         # Proactively refresh if access token expires within window
         if time.time() > tokens["expires_at"] - REFRESH_WINDOW:
             try:
-                await refresh_access_token(session_id)
+                pass  # Fast API: API keys don't need token refresh
                 stats["refreshed"] += 1
             except Exception as e:
                 logger.error("Failed to refresh session %s: %s", session_id[:8], e)


### PR DESCRIPTION
## Root Cause
OKX broker OAuth requires `scope=fast_api`, not `read_only,trade`. Wrong scope caused OKX to silently route users to `/account/users` without showing the consent page. Ref: OKX Fast API Integration Doc (2024).

## Changes
- **oauth.py**: `scope=fast_api`; after token exchange call `POST /api/v5/users/oauth/apikey` to create user API key; store `{api_key, secret_key, passphrase}` in session
- **client.py**: Bearer token → HMAC API key auth
- **All consumers**: `get_valid_token` → `get_api_credentials`, `OKXClient(**creds)`
- **token_refresh.py**: no-op (API keys don't expire)

## Test Plan
- [ ] Deploy to DO backend, test with non-broker OKX account
- [ ] Consent page appears after login
- [ ] API key created + stored, HMAC auth works