### PR TITLE
fix: sim-audit 429 bypass + commit-data env quote + coin threshold

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -505,6 +505,10 @@ async def security_headers_middleware(request: Request, call_next):
 @app.middleware("http")
 async def rate_limit_middleware(request: Request, call_next):
     if request.url.path in ("/simulate", "/simulate/coin", "/simulate/compare", "/simulate/validate", "/simulate/optimize", "/backtest", "/export/csv"):
+        # Bypass rate limit for internal callers (sim-audit, signal-telegram, etc.)
+        req_key = request.headers.get("X-Internal-Key", "")
+        if INTERNAL_API_KEY and req_key and hmac.compare_digest(req_key, INTERNAL_API_KEY):
+            return await call_next(request)
         client_ip = get_client_ip(request)
         if not check_rate_limit(client_ip):
             oldest = rate_limits.get(client_ip, [0])[0]

--- a/backend/deploy/systemd/pruviq-commit-data.service
+++ b/backend/deploy/systemd/pruviq-commit-data.service
@@ -11,7 +11,7 @@ Group=pruviq
 WorkingDirectory=/opt/pruviq/current
 EnvironmentFile=/opt/pruviq/shared/.env
 # Make the deploy key visible
-Environment=GIT_SSH_COMMAND=ssh -i /opt/pruviq/.ssh/id_ed25519 -o IdentitiesOnly=yes
+Environment="GIT_SSH_COMMAND=ssh -i /opt/pruviq/.ssh/id_ed25519 -o IdentitiesOnly=yes"
 ExecStart=/opt/pruviq/bin/commit-data.sh
 StandardOutput=journal
 StandardError=journal

--- a/tests/sim_audit.py
+++ b/tests/sim_audit.py
@@ -33,12 +33,17 @@ INFO = "\033[94m[INFO]\033[0m"
 results = {"pass": 0, "fail": 0, "warn": 0, "skip": 0}
 
 
+_INTERNAL_KEY = os.getenv("INTERNAL_API_KEY", "")
+
+
 def api_call(endpoint, method="GET", data=None, base=None, _retries=3):
     """Call PRUVIQ API endpoint with rate-limit retry."""
     if base is None:
         base = API_BASE
     url = f"{base}{endpoint}"
     headers = {"Content-Type": "application/json", "User-Agent": "PRUVIQ-SimAudit/1.0"}
+    if _INTERNAL_KEY:
+        headers["X-Internal-Key"] = _INTERNAL_KEY
     body = json.dumps(data).encode() if data else None
     req = Request(url, data=body, headers=headers, method=method)
     try:
@@ -127,7 +132,7 @@ def run_layer0():
         check(0, "API reachable", False, detail=health["error"])
         return
     check(0, "API reachable", True)
-    check(0, f"Coins loaded: {health.get('coins_loaded', 0)}", health.get("coins_loaded", 0) >= 500)
+    check(0, f"Coins loaded: {health.get('coins_loaded', 0)}", health.get("coins_loaded", 0) >= 200)
 
     # Check endpoints exist
     endpoints = ["/simulate", "/backtest", "/simulate/validate", "/simulate/compare",


### PR DESCRIPTION
## Summary

- **sim-audit 429 (root cause fix)**: Rate limiter middleware now checks for valid `X-Internal-Key` header before applying per-IP throttle. `sim_audit.py` sends this header from `INTERNAL_API_KEY` env var — already in `/opt/pruviq/shared/.env`.
- **coin threshold**: Layer 0 check lowered 500→200 (OKX phase: 238 live coins, matches `MIN_COINS` in deploy workflow).
- **pruviq-commit-data.service**: Added quotes around `GIT_SSH_COMMAND=...` value so systemd doesn't parse `-i` as a separate invalid environment token (fixes `Invalid environment assignment, ignoring: -i`).

## Test plan

- [ ] After merge: `backend-deploy.yml` drift detector deploys to DO (backend/ changed)
- [ ] Next `pruviq-sim-audit.timer` fire (every 6h) should complete without 429 FAIL
- [ ] `systemctl restart pruviq-commit-data` logs no more `Invalid environment assignment`