### PR TITLE
fix: daily-ranking rate-limit bypass + staleness-watch service name

### DIFF
--- a/backend/deploy/systemd/bin/staleness-watch.sh
+++ b/backend/deploy/systemd/bin/staleness-watch.sh
@@ -76,7 +76,7 @@ if [ "$state" = "STALE" ]; then
         notify "🚨 PRUVIQ: Data STALE ${generated}h old (limit ${STALE_HOURS}h). Triggering refresh via systemd..."
         mark_alerted "market_stale"
         # Trigger refresh (systemd unit will exist once Phase 5-B deploys)
-        systemctl start pruviq-refresh-static.service 2>&1 || \
-            notify "⚠️ PRUVIQ: auto-refresh unit not yet installed (Phase 5-B pending)"
+        systemctl start pruviq-refresh-data.service 2>&1 || \
+            notify "⚠️ PRUVIQ: auto-refresh failed — check pruviq-refresh-data.service"
     fi
 fi

--- a/backend/scripts/daily_strategy_ranking.py
+++ b/backend/scripts/daily_strategy_ranking.py
@@ -23,6 +23,7 @@ from typing import Optional
 
 # === Configuration ===
 API_BASE = os.getenv("PRUVIQ_API_BASE", "http://localhost:8080")
+INTERNAL_API_KEY = os.getenv("INTERNAL_API_KEY", "")
 TELEGRAM_BOT_TOKEN = os.getenv("PRUVIQ_SNS_BOT_TOKEN", "")  # 8058630215 SNS 봇
 TELEGRAM_CHAT_ID = os.getenv("PRUVIQ_SNS_CHAT_ID", "")
 
@@ -221,9 +222,11 @@ def run_simulation(
 
     for attempt in range(3):
         try:
+            hdrs = {"X-Internal-Key": INTERNAL_API_KEY} if INTERNAL_API_KEY else {}
             resp = requests.post(
                 f"{API_BASE}/simulate",
                 json=payload,
+                headers=hdrs,
                 timeout=timeout,
             )
             if resp.status_code == 200:


### PR DESCRIPTION
## Summary

- **daily-ranking 429 → validation fail (root cause fix)**: `run_simulation()` in `daily_strategy_ranking.py` now sends `X-Internal-Key: $INTERNAL_API_KEY` header. Without it, 252 parallel `/simulate` calls (21 strategies × 4 groups × 3 periods) hit the 30 req/min rate limiter → strategies silently dropped after 3 retries → `len(entries) < 10` → `periods_data validation failed (7 errors)`.
- **staleness-watch.sh**: Changed `pruviq-refresh-static.service` → `pruviq-refresh-data.service`. The old name doesn't exist on DO; the watch was alerting "not yet installed" every time it tried to trigger a refresh.

## Note

`jepo_healthcheck.sh` fix (allow 401 for /strategies) is a local Mac script — not in this repo. Fixed in-place.

## Test plan

- [ ] After merge+deploy: next `pruviq-daily-ranking.timer` run (00:05 UTC) should complete without FAIL
- [ ] staleness-watch: `systemctl start pruviq-refresh-data.service` now runs without "not installed" error