### PR TITLE
fix: refresh_static.sh worktree → local build (data staleness 13h root cause)

### DIFF
--- a/backend/deploy/systemd/bin/staleness-watch.sh
+++ b/backend/deploy/systemd/bin/staleness-watch.sh
@@ -76,7 +76,7 @@ if [ "$state" = "STALE" ]; then
         notify "🚨 PRUVIQ: Data STALE ${generated}h old (limit ${STALE_HOURS}h). Triggering refresh via systemd..."
         mark_alerted "market_stale"
         # Trigger refresh (systemd unit will exist once Phase 5-B deploys)
-        systemctl start pruviq-refresh-static.service 2>&1 || \
-            notify "⚠️ PRUVIQ: auto-refresh unit not yet installed (Phase 5-B pending)"
+        systemctl start pruviq-refresh-data.service 2>&1 || \
+            notify "⚠️ PRUVIQ: auto-refresh failed — check pruviq-refresh-data.service"
     fi
 fi

--- a/backend/scripts/daily_strategy_ranking.py
+++ b/backend/scripts/daily_strategy_ranking.py
@@ -23,6 +23,7 @@ from typing import Optional
 
 # === Configuration ===
 API_BASE = os.getenv("PRUVIQ_API_BASE", "http://localhost:8080")
+INTERNAL_API_KEY = os.getenv("INTERNAL_API_KEY", "")
 TELEGRAM_BOT_TOKEN = os.getenv("PRUVIQ_SNS_BOT_TOKEN", "")  # 8058630215 SNS 봇
 TELEGRAM_CHAT_ID = os.getenv("PRUVIQ_SNS_CHAT_ID", "")
 
@@ -221,9 +222,11 @@ def run_simulation(
 
     for attempt in range(3):
         try:
+            hdrs = {"X-Internal-Key": INTERNAL_API_KEY} if INTERNAL_API_KEY else {}
             resp = requests.post(
                 f"{API_BASE}/simulate",
                 json=payload,
+                headers=hdrs,
                 timeout=timeout,
             )
             if resp.status_code == 200:

--- a/backend/scripts/refresh_static.sh
+++ b/backend/scripts/refresh_static.sh
@@ -183,49 +183,25 @@ if [[ "$HAS_CHANGES" == "false" && "$HAS_CODE_CHANGES" == "false" ]]; then
     exit 0
 fi
 
-# --- Step 2: Build + deploy in isolated worktree (prevent stale code deploy) ---
-# 2026-03-22 fix: ~/pruviq/ has local-only commits that caused repeated rollbacks.
-# Build from origin/main in a clean worktree to ensure deployed code matches GitHub.
-DEPLOY_WORKTREE="/tmp/pruviq-refresh-deploy-$$"
-cleanup_worktree() {
-    cd "$HOME" 2>/dev/null
-    if [[ -d "$DEPLOY_WORKTREE" ]]; then
-        git -C "$REPO_DIR" worktree remove "$DEPLOY_WORKTREE" --force 2>/dev/null || rm -rf "$DEPLOY_WORKTREE"
-    fi
-}
-trap 'cleanup_worktree' EXIT
-
-git fetch origin main -q 2>/dev/null
-git worktree add "$DEPLOY_WORKTREE" origin/main --detach -q 2>/dev/null || {
-    log "Failed to create deploy worktree, falling back to local build"
-    # Fallback: build locally if worktree fails
-    npm run build 2>&1 | tail -3
-    npx wrangler deploy 2>&1 | tail -5
-    exit $?
-}
-
-# Copy refreshed data files to worktree
-cp -f "$REPO_DIR/public/data/"*.json "$DEPLOY_WORKTREE/public/data/" 2>/dev/null
-
-cd "$DEPLOY_WORKTREE"
-npm ci --prefer-offline 2>/dev/null || npm ci 2>/dev/null || ln -s "$REPO_DIR/node_modules" "$DEPLOY_WORKTREE/node_modules"
-
-log "Building site (worktree)..."
+# --- Step 2: Build + deploy from local repo ---
+# Data refresh only needs fresh public/data/*.json in dist/ — no code changes.
+# Local repo includes all public/ assets (fonts, images, icons) that a worktree
+# created from git-tracked files alone would miss, causing wrangler to skip 800+
+# assets. Build directly here: code on this branch tracks origin/main.
+log "Building site (local)..."
 if npm run build 2>&1 | tail -3; then
     log "Deploying to Cloudflare..."
     if npx wrangler deploy 2>&1 | tail -5; then
-        log "Deployed to Cloudflare Workers (from origin/main worktree)"
+        log "Deployed to Cloudflare Workers (from local build)"
         echo "$ORIGIN_SHA" > "$DEPLOY_MARKER"
     else
         log "Wrangler deploy failed"
         send_alert "ERROR" "CF Workers deploy failed"
-        cd "$REPO_DIR"
         exit 1
     fi
 else
     log "Build failed"
     send_alert "ERROR" "npm build failed"
-    cd "$REPO_DIR"
     exit 1
 fi
 cd "$REPO_DIR"


### PR DESCRIPTION
## Root Cause

`refresh_static.sh` built in a git worktree created from `origin/main`. A worktree only contains git-tracked files — ~880 `public/` assets (fonts, images, icon variants) were NOT tracked in git. When `wrangler deploy` ran from the worktree, it compared the 213 git-tracked files against Cloudflare's asset store, found them all matching (same hashes), uploaded 0 bytes of assets, and left the other 880 files untouched.

`market.json` *is* git-tracked but its content in the worktree matched the committed April 17 17:21 version — either the `cp` to worktree failed silently, or the hash matched after build. Result: Cloudflare served 13h-stale data despite cron running every 20 min.

## Fix

Build directly from the local repo (not worktree). The local `public/` has all assets. `refresh_static.py` runs before the build and updates `public/data/market.json`, so `dist/` gets the fresh version. Verified: manual `npx wrangler deploy` uploaded 879 new files and data staleness resolved immediately (CF now serving 0.14h-old data).

## Note

The original worktree was added 2026-03-22 to prevent local-only commits from being deployed. This issue no longer exists (data cron runs on main branch, no feature branches in local repo during cron).

## Test plan

- [ ] Next 20min cron run: `pruviq-refresh.log` shows "Deployed to Cloudflare Workers (from local build)"
- [ ] `https://pruviq.com/data/market.json` stays fresh (< 30min old)
- [ ] Staleness-watch does not alert again