### PR TITLE
fix(backend): strip INTERNAL/ADMIN_API_KEY env vars (prevent silent auth failure)

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -28,9 +28,9 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import JSONResponse, Response
 
-_admin_key_raw = os.environ.get("ADMIN_API_KEY", "")
+_admin_key_raw = os.environ.get("ADMIN_API_KEY", "").strip()
 ADMIN_API_KEY: Optional[str] = _admin_key_raw if len(_admin_key_raw) >= 32 else None
-_internal_key_raw = os.environ.get("INTERNAL_API_KEY", "")
+_internal_key_raw = os.environ.get("INTERNAL_API_KEY", "").strip()
 INTERNAL_API_KEY: Optional[str] = _internal_key_raw if len(_internal_key_raw) >= 32 else None
 OKX_AUTO_TRADE_LOCAL = os.environ.get("OKX_AUTO_TRADE_LOCAL", "true").lower() == "true"
 COINGECKO_API_KEY = os.environ.get("COINGECKO_API_KEY", "")

--- a/backend/scripts/daily_strategy_ranking.py
+++ b/backend/scripts/daily_strategy_ranking.py
@@ -22,10 +22,10 @@ from datetime import datetime, timedelta
 from typing import Optional
 
 # === Configuration ===
-API_BASE = os.getenv("PRUVIQ_API_BASE", "http://localhost:8080")
-INTERNAL_API_KEY = os.getenv("INTERNAL_API_KEY", "")
-TELEGRAM_BOT_TOKEN = os.getenv("PRUVIQ_SNS_BOT_TOKEN", "")  # 8058630215 SNS 봇
-TELEGRAM_CHAT_ID = os.getenv("PRUVIQ_SNS_CHAT_ID", "")
+API_BASE = os.getenv("PRUVIQ_API_BASE", "http://localhost:8080").strip()
+INTERNAL_API_KEY = os.getenv("INTERNAL_API_KEY", "").strip()
+TELEGRAM_BOT_TOKEN = os.getenv("PRUVIQ_SNS_BOT_TOKEN", "").strip()  # 8058630215 SNS 봇
+TELEGRAM_CHAT_ID = os.getenv("PRUVIQ_SNS_CHAT_ID", "").strip()
 
 AVOID_HOURS_1H = [2, 3, 10, 20, 21, 22, 23]  # 1H 전략용 시간 필터
 


### PR DESCRIPTION
## Root Cause (Ultrareview Finding #1)

If ` /opt/pruviq/shared/.env` ever acquires trailing whitespace or CRLF on `INTERNAL_API_KEY` / `ADMIN_API_KEY`, **HTTP transport normalizes the outgoing header (RFC 7230) while the server-side Python constant keeps the whitespace**. `hmac.compare_digest` then silently mismatches and falls through to the 429 rate-limit path.

Symptom would be identical to the daily-ranking `periods_data validation failed (7 errors)` failure (all 252 parallel `/simulate` calls rate-limited → strategies silently dropped).

## Fix

`.strip()` both env reads, aligning with the existing pattern at `backend/okx/server.py:28` which already does this.

- `backend/api/main.py:31,33` — ADMIN + INTERNAL keys
- `backend/scripts/daily_strategy_ranking.py:25-28` — client-side INTERNAL_API_KEY + other env vars

## Current state verified clean

`ssh root@DO "sudo -u pruviq bash -c 'source .env && echo len=\${#INTERNAL_API_KEY} tail=\$(...)' "` → `len=64 tail_byte=L` (no whitespace).

So this is **preventative hygiene**, not a live fix. Removes a latent foot-gun if .env is ever edited by an editor that appends `\n` or via `echo KEY=... >> .env`.

## Test plan

- [ ] CI passes
- [ ] After merge + backend-deploy: DO has updated file, no regression
- [ ] Next daily-ranking run (00:05 UTC) completes without periods_data errors (this already ran at 06:27 and failed due to unrelated "not yet deployed" — so tomorrow's run is the real test, combined with PR #1132 now being deployed)