### PR TITLE
fix(staleness-watch): remove fake self-heal — alert-only, honest about arch gap

### DIFF
--- a/backend/deploy/systemd/bin/staleness-watch.sh
+++ b/backend/deploy/systemd/bin/staleness-watch.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # PRUVIQ — Data Staleness Watchdog (DO-native, every 10 min)
-# Checks live API data freshness, auto-triggers refresh if stale.
+# Checks live API data freshness via CF-served market.json. On STALE,
+# alerts the owner via Telegram (once per UTC day, deduped via state file).
+# Does NOT attempt auto-remediation — the refresh owner is Mac cron, which
+# cannot be triggered from DO. Separating detection from remediation is
+# intentional: false self-healing claims (previous behavior) hid the real
+# architectural gap between Mac cron and DO systemd.
 set -uo pipefail
 
 STALE_HOURS="${STALE_HOURS:-1}"
@@ -73,10 +78,14 @@ print('STALE' if a>=t else ('WARN' if a>=t*0.75 else 'OK'))
 
 if [ "$state" = "STALE" ]; then
     if ! already_alerted "market_stale"; then
-        notify "🚨 PRUVIQ: Data STALE ${generated}h old (limit ${STALE_HOURS}h). Triggering refresh via systemd..."
+        # Architecture: refresh_static.sh runs on Mac cron (external-data fetch needs
+        # non-DO IP for Binance 451 workaround). Staleness-watch on DO cannot
+        # trigger Mac cron — alert the owner to investigate manually.
+        # Do NOT call `systemctl start` here: even though pruviq-refresh-data.service
+        # exists, it runs as user `pruviq` which cannot invoke systemctl without
+        # polkit auth, and the unit was designed for a Phase-5 full-DO migration
+        # that is intentionally on hold (Mac-cron stays authoritative for now).
+        notify "🚨 PRUVIQ: Data STALE ${generated}h old (limit ${STALE_HOURS}h). Mac refresh_static.sh cron may be stuck — check /tmp/pruviq-refresh.log on Mac Mini."
         mark_alerted "market_stale"
-        # Trigger refresh (systemd unit will exist once Phase 5-B deploys)
-        systemctl start pruviq-refresh-data.service 2>&1 || \
-            notify "⚠️ PRUVIQ: auto-refresh failed — check pruviq-refresh-data.service"
     fi
 fi


### PR DESCRIPTION
## Root cause

Previous code at \`backend/deploy/systemd/bin/staleness-watch.sh:79\` called:

\`\`\`bash
systemctl start pruviq-refresh-data.service
\`\`\`

Three problems stacked:

1. **Auth failure in practice**: The service exists and is \`User=pruviq\`, but \`systemctl start\` from the \`pruviq\` user requires polkit authentication. Every call for days has failed with \`Interactive authentication required\` in the journal.
2. **Comment drift (Ultrareview Finding #2)**: Line 78 said \`# Trigger refresh (systemd unit will exist once Phase 5-B deploys)\` — but Phase 5-B shipped, the unit exists, and the rename was the entire point of PR #1132. Comment lied about the deploy state.
3. **Architectural fiction**: The *real* refresh owner is \`refresh_static.sh\` on Mac cron (Binance 451 requires non-DO IP for external fetch). Staleness-watch running on DO cannot invoke Mac cron. The self-heal call was never going to work.

## Fix

- Remove the \`systemctl start\` call entirely.
- Keep detection (Telegram alert, once-per-UTC-day dedupe) — that part works.
- Update the alert text to point the owner at Mac Mini's \`/tmp/pruviq-refresh.log\`, which is where the failure actually is 99% of the time.
- Rewrite the header comment to state the detection/remediation split explicitly.

## Why no replacement auto-heal

Adding polkit rules or sudo allowlist for \`pruviq-refresh-data.service\` was considered and rejected:

- It would make staleness-watch "work" for the DO-side unit, but Mac cron would still be the authoritative refresh. Two refresh paths = drift risk.
- Phase 5 full-DO migration is intentionally deferred (\`backend/deploy/systemd/PHASE5B_PLAN.md\`) because external-data fetch from DO hits Binance 451.
- So adding polkit would paper over the split and create a second lie.

Honest alerting > fake self-healing. Owner decides remediation.

## Test plan

- [ ] After merge + backend-deploy: next \`pruviq-staleness-watch.service\` journal entry shows no more \`Interactive authentication required\`.
- [ ] If data ever goes STALE (>1h old), a single Telegram alert arrives pointing at Mac log.
- [ ] No regression in the \`already_alerted\` dedup (still 1/day cap).