### PR TITLE
fix(refresh-static): close loop with post-deploy CF verification

### DIFF
--- a/backend/scripts/refresh_static.sh
+++ b/backend/scripts/refresh_static.sh
@@ -206,5 +206,32 @@ else
 fi
 cd "$REPO_DIR"
 
-send_alert "OK" "Static data refreshed + deployed"
+# --- Step 3: Post-deploy verification ---
+# Root cause of 13h staleness (PR #1133): wrangler reported success but
+# uploaded 0 assets when invoked from a worktree missing public/* files.
+# A "deploy succeeded" log line is not proof CF is serving fresh data.
+# Close the loop: re-fetch market.json from pruviq.com and compare its
+# `generated` timestamp with the local file we just built.
+# CF propagation ceiling observed ~60s; 90s gives margin.
+log "Verifying CF propagation (90s)..."
+sleep 90
+
+LOCAL_GEN=$(python3 -c "import json; print(json.load(open('public/data/market.json')).get('generated',''))" 2>/dev/null || echo "")
+CF_GEN=$(curl -sf -m 15 "https://pruviq.com/data/market.json?cachebust=$(date +%s)" 2>/dev/null | \
+    python3 -c "import json,sys; print(json.load(sys.stdin).get('generated',''))" 2>/dev/null || echo "")
+
+if [[ -z "$LOCAL_GEN" || -z "$CF_GEN" ]]; then
+    log "Verify FAILED: could not parse timestamps (local='$LOCAL_GEN' cf='$CF_GEN')"
+    send_alert "ERROR" "Deploy verify: cannot parse market.json timestamps"
+    exit 1
+fi
+
+if [[ "$LOCAL_GEN" != "$CF_GEN" ]]; then
+    log "Verify FAILED: CF stale — local=$LOCAL_GEN cf=$CF_GEN"
+    send_alert "ERROR" "Deploy verify FAILED: CF serves stale data. local=$LOCAL_GEN cf=$CF_GEN — wrangler likely skipped assets"
+    exit 1
+fi
+
+log "Verify OK: CF serving fresh $CF_GEN"
+send_alert "OK" "Static data refreshed + deployed (verified: $CF_GEN)"
 exit 0


### PR DESCRIPTION
## Root cause (extension of PR #1133)

PR #1133 fixed the **cause** of the 13h staleness — worktree builds missing `public/` assets. But nothing verifies the next cron cycle catches a regression. "wrangler deploy succeeded" is **not** proof of CF serving fresh data: the 13h incident proved that exact case (wrangler reported success while uploading 0 bytes of assets).

## Fix — Step 3 after deploy

1. `sleep 90` (CF propagation ~60s observed; 90s margin)
2. `curl` \`pruviq.com/data/market.json\` with cachebust param
3. Parse `.generated` from local `dist/` and from CF-served copy
4. Mismatch OR unparseable → Telegram ERROR + `exit 1`

Closes the deploy-to-serve verification loop. Next wrangler silent-skip triggers alarm in ~2min instead of 13h.

## Why 90s sleep, not poll-with-backoff

- 90s / 20min cron = 7.5% budget, well within limits
- If CF hasn't propagated in 90s, something is genuinely broken and a retry won't fix it
- Fail fast, alert owner

## Pairs with PR #1137 (staleness-watch alert-only)

- Staleness-watch at 10-min granularity stays as safety net
- Primary signal is now the deploy-verify in refresh_static.sh
- Two independent detectors of same failure mode, different time horizons

## Test plan

- [ ] CI passes
- [ ] Next cron run (Mac */20) shows `Verify OK: CF serving fresh <ts>` in /tmp/pruviq-refresh.log
- [ ] Telegram receives `✅ Static data refreshed + deployed (verified: <ts>)` message
- [ ] If wrangler ever fails silently: Telegram ERROR arrives within 2min of cron start

## Note

Existing logic in the script (`git stash -q; git checkout main -q`) can hijack developer feature branches mid-edit. Out of scope for this PR, but worth revisiting — it interfered with this PR's own development. The stash/switch logic was important when refresh_static ran from feature branches, but now the cron runs from main only.