### PR TITLE
chore: commit session artifacts — OKX specs, QA tests, screenshot util

### DIFF
--- a/backend/okx/OKX_API_SPECS.md
+++ b/backend/okx/OKX_API_SPECS.md
@@ -1,0 +1,658 @@
+# OKX API Specs — PRUVIQ Complete Reference
+
+> Source: OKX official docs (broker_en, trick_en, en/#overview). Compiled 2026-04-18.
+> Scope: Perpetual SWAP autotrading (FD Broker OAuth + HMAC API key flow).
+
+---
+
+## 1. OAuth / Fast API Flow
+
+### Key URLs
+
+| Purpose | Method | URL |
+|---------|--------|-----|
+| Authorize (browser) | GET redirect | `https://www.okx.com/account/oauth/authorize` |
+| Token exchange | POST | `https://www.okx.com/v5/users/oauth/token` ← **NO `/api/` prefix** |
+| Create API key | POST | `https://www.okx.com/api/v5/users/oauth/apikey` |
+
+> ⚠️ `/api/v5/oauth/*` → 404. Token endpoint is `/v5/users/oauth/token` (no `/api/`).
+
+### Authorize URL Query Params
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `client_id` | Yes | |
+| `response_type` | Yes | `"code"` |
+| `redirect_uri` | Yes | must exactly match portal-registered URL |
+| `scope` | Yes | **`"fast_api"`** — REQUIRED. `"read_only,trade"` silently routes to `/account/users`. |
+| `state` | Yes | CSRF token |
+| `access_type` | No | `"offline"` for refresh_token |
+| `channelId` | No | broker code for affiliate tracking |
+
+### Token Exchange (`POST /v5/users/oauth/token`)
+
+Content-Type: `application/x-www-form-urlencoded`
+
+| Param | Required | Value |
+|-------|----------|-------|
+| `client_id` | Yes | |
+| `client_secret` | Yes | |
+| `grant_type` | Yes | `"authorization_code"` |
+| `code` | Yes | from callback |
+| `redirect_uri` | Yes | must match registered |
+
+Response: `access_token` (1h TTL), `refresh_token` (3d TTL), `uid`
+
+### Refresh Token (same endpoint)
+
+| Param | Required | Value |
+|-------|----------|-------|
+| `client_id` | Yes | |
+| `client_secret` | Yes | |
+| `grant_type` | Yes | `"refresh_token"` |
+| `refresh_token` | Yes | current token |
+
+> Old access_token immediately invalidated on refresh. New refresh_token also returned.
+
+### Create API Key (`POST /api/v5/users/oauth/apikey`)
+
+Auth: `Authorization: Bearer {access_token}` (one-time)
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `label` | Yes | max 50 chars |
+| `passphrase` | Yes | 8–32 chars, ≥1 upper + lower + digit + special |
+| `perm` | No | `"read_only"`, `"trade"`, `"read_only,trade"` |
+| `ip` | No | up to 20 comma-separated IPs — **strongly recommended** |
+
+Response: `apiKey`, `secretKey`, `perm`
+
+> Keys with trade perm + no IP binding expire after **14 days of inactivity**.
+
+### OAuth Error Codes
+
+| Code | Meaning |
+|------|---------|
+| 53000 | Invalid token |
+| 53001 | Authorization canceled |
+| 53002 | Token expired |
+| 53003 | Token revoked |
+| 53004 | Account frozen |
+| 53005 | Wrong refresh token |
+| 53009 | Authorization failed |
+| 53010 | Parameter error (e.g. wrong client_id) |
+| 53012 | Authorization code expired |
+| 53013 | No permission to access API |
+| 53014 | Invalid IP |
+| 53016 | Invalid redirect_uri |
+| **53017** | **Fast API permissions not enabled — BD must activate** |
+
+---
+
+## 2. HMAC Authentication (API Key)
+
+### Required Headers
+
+| Header | Value |
+|--------|-------|
+| `OK-ACCESS-KEY` | API key |
+| `OK-ACCESS-SIGN` | `Base64(HMAC-SHA256(timestamp + METHOD + requestPath + body, secretKey))` |
+| `OK-ACCESS-TIMESTAMP` | ISO 8601 UTC ms, e.g. `2020-12-08T09:08:57.715Z` |
+| `OK-ACCESS-PASSPHRASE` | passphrase set at key creation |
+| `x-simulated-trading` | `"1"` for demo mode |
+
+### Signature Rules
+
+```python
+pre_hash = timestamp + METHOD.upper() + requestPath + body
+sign = base64.b64encode(hmac.new(secret.encode(), pre_hash.encode(), sha256).digest()).decode()
+```
+
+- GET: `requestPath` = path + `?querystring`; `body` = `""`
+- POST: `requestPath` = path only; `body` = JSON string
+- Timestamp deviation > 30s → error `50102`
+- Content-Type: `application/json` for POST
+
+### Demo Trading
+
+- REST: same `https://www.okx.com` + header `x-simulated-trading: 1`
+- WS Public: `wss://wspap.okx.com:8443/ws/v5/public`
+- WS Private: `wss://wspap.okx.com:8443/ws/v5/private`
+- Demo API keys do **NOT** expire from inactivity (unlike production keys)
+
+---
+
+## 3. Rate Limits
+
+| Rule | Value |
+|------|-------|
+| General rate limit error | `50011` |
+| Sub-account rate limit error | `50061` |
+| Max orders/account | 4,000 |
+| Max orders/instrument | 500 |
+| Sub-account order cap | 1,000 req/2s |
+| WebSocket subscriptions | 480 ops/hr/connection; 30 connections/channel/sub-account |
+| Place order rate limit | 60 req/2s per instId (SPOT/SWAP/FUTURES) |
+| Cancel order rate limit | 60 req/2s per instId |
+| Batch orders | 300 orders/2s per instId, max 20/request |
+| Algo orders | 20 req/2s |
+| Close position | 20 req/2s |
+
+### Pending Algo Limits
+
+| Type | Limit |
+|------|-------|
+| TP/SL per instrument | 100 |
+| Trigger orders total | 500 |
+| Trailing stop total | 50 |
+| Iceberg total | 100 |
+| TWAP total | 20 |
+
+---
+
+## 4. Account Endpoints
+
+### GET /api/v5/account/balance
+
+Rate: 10 req/2s | Permission: Read
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `ccy` | No | comma-separated, max 20 |
+
+Key response fields (account level): `totalEq`, `adjEq`, `availEq`, `imr`, `mmr`, `mgnRatio`, `upl`, `notionalUsd`, `uTime`, `details[]`
+
+Key response fields (details[] per currency): `ccy`, `eq`, `cashBal`, `availBal`, `frozenBal`, `ordFrozen`, `liab`, `interest`, `upl`, `isoEq`, `crossLiab`, `isoLiab`, `imr`, `mmr`, `eqUsd`
+
+### GET /api/v5/account/positions
+
+Rate: 20 req/2s | Permission: Read
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `instType` | No | `MARGIN`, `SWAP`, `FUTURES`, `OPTION` |
+| `instId` | No | |
+| `posId` | No | comma-separated, max 20 |
+
+Key response fields: `posId`, `instId`, `instType`, `mgnMode`, `posSide`, `pos`, `availPos`, `avgPx`, `upl`, `uplRatio`, `lever`, `liqPx`, `imr`, `mmr`, `mgnRatio`, `notionalUsd`, `cTime`, `uTime`
+
+### GET /api/v5/account/positions-history
+
+Rate: 20 req/2s | Permission: Read
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `instType` | Yes | `SWAP`, `FUTURES`, etc. |
+| `instId` | No | |
+| `mgnMode` | No | `isolated`, `cross` |
+| `posId` | No | |
+| `after` | No | pagination |
+| `before` | No | pagination |
+| `limit` | No | max 100 |
+
+Key response fields: `instId`, `openAvgPx`, `closeAvgPx`, `pnl`, `pnlRatio`, `realizedPnl`, `fee`, `fundingFee`, `liqPenalty`, `openTime`, `closeTime`, `lever`, `posId`
+
+### GET /api/v5/account/config
+
+Rate: 10 req/2s | Permission: Read | No params
+
+Key response fields: `uid`, `acctLv`, `posMode` (`net_mode`/`long_short_mode`), `autoLoan`, `greeksType`, `level`, `perm`
+
+### POST /api/v5/account/set-position-mode
+
+Rate: 5 req/2s | Permission: Trade
+
+| Param | Required | Values |
+|-------|----------|--------|
+| `posMode` | Yes | `long_short_mode`, `net_mode` |
+
+> Must close all positions and cancel all orders first.
+
+### POST /api/v5/account/set-leverage
+
+Rate: 20 req/2s | Permission: Trade
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `instId` | Cond. | for per-instrument |
+| `ccy` | Cond. | for cross-margin per-currency |
+| `lever` | Yes | string, e.g. `"10"` |
+| `mgnMode` | Yes | `isolated`, `cross` |
+| `posSide` | Cond. | `long`, `short`, `net` — required for isolated long/short mode |
+
+### GET /api/v5/account/leverage-info
+
+Rate: 20 req/2s | Permission: Read
+
+| Param | Required |
+|-------|----------|
+| `instId` | Yes |
+| `mgnMode` | Yes |
+
+Response: `instId`, `mgnMode`, `posSide`, `lever`
+
+### GET /api/v5/account/trade-fee
+
+Rate: 5 req/2s | Permission: Read
+
+Response: `level`, `maker`, `taker`, `makerU`, `takerU`, `makerUSDC`, `takerUSDC`, `deliveryFeeRate`
+
+### GET /api/v5/account/max-size
+
+Rate: 20 req/2s | Permission: Read
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `instId` | Yes | |
+| `tdMode` | Yes | `cash`, `isolated`, `cross` |
+| `px` | No | price for limit orders |
+| `leverage` | No | |
+
+Response: `instId`, `availBuy`, `availSell`
+
+### GET /api/v5/account/bills
+
+Rate: 10 req/2s | Permission: Read
+
+Params: `instType`, `ccy`, `mgnMode`, `type`, `subType`, `after`, `before`, `begin`, `end`, `limit` (max 100)
+
+Response fields: `billId`, `ccy`, `instId`, `ordId`, `tradeId`, `balChg`, `pnl`, `fee`, `execType`, `ts`
+
+---
+
+## 5. Trading Endpoints
+
+### POST /api/v5/trade/order — Place Order
+
+Rate: 60 req/2s per instId | Permission: Trade
+
+| Param | Type | Required | Values |
+|-------|------|----------|--------|
+| `instId` | String | Yes | e.g. `BTC-USDT-SWAP` |
+| `tdMode` | String | Yes | `cash`, `cross`, `isolated`, `spot_isolated` |
+| `side` | String | Yes | `buy`, `sell` |
+| `ordType` | String | Yes | `market`, `limit`, `post_only`, `fok`, `ioc`, `optimal_limit_ioc` |
+| `sz` | String | Yes | contracts for SWAP/FUTURES; base ccy for SPOT |
+| `px` | String | Cond. | required for `limit`, `post_only`, `fok`, `ioc` |
+| `posSide` | String | Cond. | `long`, `short`, `net` — required in long/short mode |
+| `clOrdId` | String | No | max 32 alphanumeric |
+| `tag` | String | No | **broker code — required for commission** |
+| `reduceOnly` | Boolean | No | close-only |
+| `tgtCcy` | String | No | `base_ccy`, `quote_ccy` — SPOT market orders only |
+| `stpMode` | String | No | `cancel_maker` (default), `cancel_taker`, `cancel_both` |
+| `tpTriggerPx` | String | No | attached TP trigger |
+| `tpOrdPx` | String | No | `-1` = market |
+| `slTriggerPx` | String | No | attached SL trigger |
+| `slOrdPx` | String | No | `-1` = market |
+| `quickMgnType` | String | No | `manual`, `auto_borrow`, `auto_repay` |
+
+Response: `ordId`, `clOrdId`, `tag`, `sCode` (`"0"` = success), `sMsg`, `ts`
+
+### POST /api/v5/trade/batch-orders
+
+Rate: 300 orders/2s | Max 20/request | Same params as place order (array)
+
+### POST /api/v5/trade/cancel-order
+
+Rate: 60 req/2s per instId | Permission: Trade
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `instId` | Yes | |
+| `ordId` | Cond. | either `ordId` or `clOrdId` required |
+| `clOrdId` | Cond. | |
+
+Response: `ordId`, `clOrdId`, `sCode`, `sMsg`
+
+### POST /api/v5/trade/cancel-batch-orders
+
+Rate: 300 orders/2s | Max 20/request | Array of cancel-order objects
+
+### POST /api/v5/trade/amend-order
+
+Rate: 60 req/2s per instId | Permission: Trade
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `instId` | Yes | |
+| `ordId` | Cond. | |
+| `clOrdId` | Cond. | |
+| `newSz` | Cond. | either `newSz` or `newPx` required |
+| `newPx` | Cond. | |
+| `cxlOnFail` | No | cancel if amendment fails |
+| `reqId` | No | client request ID, max 32 chars |
+
+### POST /api/v5/trade/close-position
+
+Rate: 20 req/2s | Permission: Trade
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `instId` | Yes | |
+| `mgnMode` | Yes | `cross`, `isolated` |
+| `posSide` | Cond. | required in long/short mode |
+| `ordType` | No | `market` (default), `limit` |
+| `px` | Cond. | required if `ordType=limit` |
+| `sz` | No | omit to close entire position |
+| `tag` | No | broker code |
+| `autoCxl` | No | auto-cancel pending orders on close |
+| `clOrdId` | No | max 32 chars |
+
+Response: `instId`, `posSide`
+
+### POST /api/v5/trade/cancel-all-after
+
+Rate: 1 req/s | Permission: Trade
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `timeOut` | Yes | seconds, 0–300. `0` cancels countdown |
+
+Response: `triggerTime` (ms), `ts`
+
+### GET /api/v5/trade/order — Get Order Details
+
+Rate: 20 req/2s | Permission: Read
+
+| Param | Required |
+|-------|----------|
+| `instId` | Yes |
+| `ordId` or `clOrdId` | one required |
+
+Key response fields: `ordId`, `clOrdId`, `state` (`live`/`partially_filled`/`filled`/`canceled`), `avgPx`, `accFillSz`, `fillPx`, `fee`, `feeCcy`, `pnl`, `lever`, `cTime`, `uTime`
+
+### GET /api/v5/trade/orders-pending — Pending Orders
+
+Rate: 20 req/2s | Permission: Read
+
+Params: `instType`, `instId`, `ordType`, `state` (`live`/`partially_filled`), `after`, `before`, `limit` (max 100)
+
+### GET /api/v5/trade/orders-history — Order History (7 days)
+
+Rate: 20 req/2s | Permission: Read
+
+Required: `instType`. Optional: `instId`, `state` (`canceled`/`filled`), `after`, `before`, `begin`, `end`, `limit`
+
+### GET /api/v5/trade/fills — Transaction Details (3 days)
+
+Rate: 20 req/2s | Permission: Read
+
+Params: `instType`, `instId`, `ordId`, `after`, `before`, `begin`, `end`, `limit`
+
+Response: `tradeId`, `ordId`, `fillPx`, `fillSz`, `side`, `execType` (`T`/`M`), `fee`, `feeCcy`, `ts`
+
+---
+
+## 6. Algo Trading Endpoints
+
+### POST /api/v5/trade/order-algo — Place Algo Order
+
+Rate: 20 req/2s | Permission: Trade
+
+| Param | Required | Values |
+|-------|----------|--------|
+| `instId` | Yes | |
+| `tdMode` | Yes | `cross`, `isolated`, `cash` |
+| `side` | Yes | `buy`, `sell` |
+| `ordType` | Yes | `conditional`, `oco`, `trigger`, `move_order_stop`, `iceberg`, `twap` |
+| `sz` | Yes | |
+| `posSide` | Cond. | required in long/short mode |
+| `algoClOrdId` | No | max 32 chars |
+| `tag` | No | broker code |
+| `reduceOnly` | No | |
+| `closeFraction` | No | 0–1, for futures/perp only |
+| `cxlOnClosePos` | No | cancel algo when position closes |
+
+**TP/SL (conditional/oco):**
+- `tpTriggerPx`, `tpOrdPx` (`-1`=market), `tpTriggerPxType` (`last`/`index`/`mark`)
+- `slTriggerPx`, `slOrdPx` (`-1`=market), `slTriggerPxType`
+
+**Trigger order:**
+- `triggerPx`, `orderPx` (`-1`=market), `triggerPxType`
+
+**Trailing stop (move_order_stop):**
+- `callbackRatio` (0.01=1%) or `callbackSpread`
+- `activePx` (activation price)
+
+**Iceberg/TWAP:**
+- `pxVar` or `pxSpread`, `szLimit`, `pxLimit`
+- `timeInterval` (seconds, TWAP only)
+
+Response: `algoId`, `algoClOrdId`, `sCode`, `sMsg`
+
+### POST /api/v5/trade/cancel-algos
+
+Rate: 20 req/2s | Array of `{instId, algoId}` objects
+
+### GET /api/v5/trade/order-algo — Get Algo Details
+
+Rate: 20 req/2s | Params: `algoId` or `algoClOrdId`
+
+Key response fields: `algoId`, `ordType`, `state` (`live`/`effective`/`canceled`/`order_failed`), `triggerTime`, `actualSz`, `actualPx`, `failCode`
+
+### GET /api/v5/trade/orders-algo-pending — Pending Algos
+
+Rate: 20 req/2s | Required: `ordType`
+
+---
+
+## 7. Public Data Endpoints
+
+### GET /api/v5/public/instruments
+
+Rate: 20 req/2s | No auth required
+
+| Param | Required | Values |
+|-------|----------|--------|
+| `instType` | Yes | `SPOT`, `MARGIN`, `SWAP`, `FUTURES`, `OPTION` |
+| `instFamily` | Cond. | required for `OPTION` |
+| `instId` | No | |
+
+Key response fields for SWAP:
+
+| Field | Description |
+|-------|-------------|
+| `instId` | e.g. `BTC-USDT-SWAP` |
+| `ctVal` | Notional value per contract |
+| `ctMult` | Contract multiplier |
+| `ctType` | `linear` (USDT-margined) / `inverse` (coin-margined) |
+| `settleCcy` | Margin/settlement currency |
+| `minSz` | Minimum order size (contracts) |
+| `lotSz` | Order size increment (must be multiple) |
+| `tickSz` | Minimum price increment |
+| `lever` | Maximum leverage |
+| `state` | `live`, `suspend`, `preopen` |
+| `maxLmtSz` | Max single limit order qty |
+| `maxMktSz` | Max single market order qty |
+| `maxLmtAmt` | Max USD per limit order |
+| `maxMktAmt` | Max USD per market order |
+
+### GET /api/v5/public/mark-price
+
+| Param | Required | Values |
+|-------|----------|--------|
+| `instType` | Yes | `SWAP`, `FUTURES`, etc. |
+| `instId` | No | |
+
+Response: `instId`, `instType`, `markPx`, `ts`
+
+### GET /api/v5/public/funding-rate
+
+| Param | Required |
+|-------|----------|
+| `instId` | Yes |
+
+Response: `instId`, `fundingRate`, `nextFundingRate`, `fundingTime` (next settlement ms)
+
+### GET /api/v5/public/funding-rate-history
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `instId` | Yes | |
+| `before` | No | pagination |
+| `after` | No | |
+| `limit` | No | max 100 |
+
+Response array: `fundingRate`, `realizedRate`, `fundingTime`
+
+### GET /api/v5/public/open-interest
+
+| Param | Required | Values |
+|-------|----------|--------|
+| `instType` | Yes | `SWAP`, `FUTURES`, `OPTION` |
+| `instId` | No | |
+
+Response: `instId`, `oi` (contracts), `oiCcy`, `ts`
+
+### GET /api/v5/market/candles — Candlesticks
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `instId` | Yes | |
+| `bar` | No | `1m`, `3m`, `5m`, `15m`, `30m`, `1H`, `2H`, `4H`, `6H`, `12H`, `1D`, `1W` |
+| `after` | No | pagination (Unix ms) |
+| `before` | No | |
+| `limit` | No | max 300, default 100 |
+
+Response array fields (index order): `[ts, open, high, low, close, vol, volCcy, volCcyQuote, confirm]`
+- `confirm`: `0`=unclosed, `1`=closed
+
+### GET /api/v5/market/tickers
+
+| Param | Required | Values |
+|-------|----------|--------|
+| `instType` | Yes | `SPOT`, `SWAP`, `FUTURES`, `OPTION` |
+| `instFamily` | No | |
+
+Response: `instId`, `last`, `lastSz`, `askPx`, `askSz`, `bidPx`, `bidSz`, `open24h`, `high24h`, `low24h`, `vol24h`, `volCcy24h`, `ts`
+
+### GET /api/v5/market/ticker
+
+| Param | Required |
+|-------|----------|
+| `instId` | Yes |
+
+Same response as tickers but single instrument.
+
+### GET /api/v5/system/status
+
+No auth | Response: maintenance schedule, `state` (`scheduled`/`ongoing`/`completed`)
+
+---
+
+## 8. Instrument / Order Rules
+
+### sz (Order Size) Rules
+
+- **SWAP/FUTURES**: `sz` = number of **contracts** (integer multiples of `lotSz`)
+- **SPOT/MARGIN**: `sz` = **base currency** quantity
+- Must be ≥ `minSz`, multiple of `lotSz`
+- Notional USD = `sz × ctVal × price`
+
+### Trade Mode (`tdMode`)
+
+| Account Mode | Instrument | Margin | tdMode |
+|---|---|---|---|
+| Any | Spot/Option | None | `cash` |
+| Futures/Multi-ccy | Margin/Derivatives | Cross | `cross` |
+| Futures/Multi-ccy | Margin/Derivatives | Isolated | `isolated` |
+
+### Position Mode
+
+- `net_mode`: one side only, OKX auto open/close based on positive/negative `sz`
+- `long_short_mode`: hold long + short simultaneously, requires `posSide` on all orders
+
+### Order States
+
+`live` → `partially_filled` → `filled` (terminal)
+`live` → `canceled` (terminal)
+
+### Identifier Rules
+
+| ID | Uniqueness |
+|---|---|
+| `ordId` | Globally unique |
+| `clOrdId` | Unique among **pending** orders only, max 32 alphanumeric |
+| `algoId` | Globally unique |
+| `billId` | Globally unique |
+| `tradeId` | Unique per instrument (negative = liquidation/ADL) |
+| `posId` | Unique per `mgnMode` + `posSide` + `instId` + `ccy` |
+
+---
+
+## 9. FD Broker Commission Endpoints
+
+| Endpoint | Method | Notes |
+|----------|--------|-------|
+| `/api/v5/broker/fd/rebate-per-orders` | GET | Download link (valid 2h). Required: `type` (`"true"`=all/`"false"`=range) |
+| `/api/v5/broker/fd/rebate-per-orders` | POST | Generate report (max 180d). Available ~2h |
+| `/api/v5/broker/fd/if-rebate` | GET | Check user rebate by `apiKey` |
+
+Rebate eligibility `type` codes: `0`=eligible, `1`=ID expired, `2`=VIP5-6 cap, `3`=VIP7+
+
+---
+
+## 10. WebSocket
+
+### Endpoints
+
+| Mode | URL |
+|------|-----|
+| Production Public | `wss://ws.okx.com:8443/ws/v5/public` |
+| Production Private | `wss://ws.okx.com:8443/ws/v5/private` |
+| Demo Public | `wss://wspap.okx.com:8443/ws/v5/public` |
+| Demo Private | `wss://wspap.okx.com:8443/ws/v5/private` |
+
+### Private WS Auth
+
+```json
+{
+  "op": "login",
+  "args": [{"apiKey": "...", "passphrase": "...", "timestamp": "1538054050", "sign": "..."}]
+}
+```
+
+Sign: `Base64(HMAC-SHA256(timestamp + 'GET' + '/users/self/verify', secretKey))`
+- `timestamp` = Unix **seconds** (not ms)
+
+### Key Private Channels
+
+| Channel | Snapshot | Update |
+|---------|----------|--------|
+| `account` | Non-zero balances | Event-driven + 5s fixed |
+| `positions` | Non-zero positions | Event-driven + 5s fixed |
+| `orders` | **None** | State changes only |
+| `balance_and_position` | None | Event-driven, lowest latency |
+| `algo-orders` | None | State changes |
+
+### Key Public Channels
+
+| Channel | Frequency | Notes |
+|---------|-----------|-------|
+| `bbo-tbt` | 10ms | Best bid/offer |
+| `books5` | 100ms | 5-level snapshot |
+| `books` | 100ms | Incremental |
+| `tickers` | On change | |
+| `funding-rate` | On change | |
+| `mark-price` | On change | |
+| `instruments` | On change | |
+
+---
+
+## 11. Critical Notes
+
+1. **`scope=fast_api`** required — `read_only,trade` silently fails (routes to /account/users)
+2. **Token endpoint**: `/v5/users/oauth/token` — NO `/api/` prefix
+3. **53017 error**: BD must activate Fast API permissions in OKX portal
+4. **IP binding recommended**: keys without IP + trade perm expire after 14d inactivity
+5. **Broker tag**: `tag` param required on ALL order calls for commission tracking
+6. **Timestamp**: ISO 8601 UTC ms format; server rejects if >30s drift
+7. **sz for SWAP**: number of contracts (integer), NOT USD/coin amount
+8. **ctVal**: contracts × ctVal × price = notional USD value
+9. **Position mode**: `net_mode` default; `long_short_mode` requires `posSide` on orders
+10. **Account mode**: can ONLY be changed via web/mobile UI, not API
+11. **Auto-borrow**: only in multi-currency/portfolio margin; only via web UI
+12. **Demo API keys**: never expire from inactivity; same REST URL + `x-simulated-trading: 1`
+13. **Liquidation/ADL**: do NOT generate order updates; `tradeId` is negative
+14. **Cancel-All-After**: heartbeat pattern — send every <300s, `timeOut=0` to disable
+15. **STP scope**: master account level, applies to all sub-accounts automatically

--- a/scripts/capture-screenshots.mjs
+++ b/scripts/capture-screenshots.mjs
@@ -1,0 +1,85 @@
+import { chromium } from 'playwright';
+import { mkdirSync } from 'fs';
+
+const OUT = 'playwright-report/screenshots';
+mkdirSync(OUT, { recursive: true });
+
+const BASE = 'https://pruviq.com';
+
+const pages = [
+  // EN Desktop
+  { url: '/', name: 'home-en-desktop', w: 1280, h: 900 },
+  { url: '/simulate', name: 'simulate-en-desktop', w: 1280, h: 900 },
+  { url: '/strategies', name: 'strategies-en-desktop', w: 1280, h: 900 },
+  { url: '/strategies/ranking', name: 'strategies-ranking-en-desktop', w: 1280, h: 900 },
+  { url: '/market', name: 'market-en-desktop', w: 1280, h: 900 },
+  { url: '/coins', name: 'coins-en-desktop', w: 1280, h: 900 },
+  { url: '/learn', name: 'learn-en-desktop', w: 1280, h: 900 },
+  { url: '/fees', name: 'fees-en-desktop', w: 1280, h: 900 },
+  { url: '/compare', name: 'compare-en-desktop', w: 1280, h: 900 },
+  { url: '/compare/tradingview', name: 'compare-tradingview-en-desktop', w: 1280, h: 900 },
+  { url: '/signals', name: 'signals-en-desktop', w: 1280, h: 900 },
+  { url: '/about', name: 'about-en-desktop', w: 1280, h: 900 },
+  // EN Mobile
+  { url: '/', name: 'home-en-mobile', w: 375, h: 812 },
+  { url: '/simulate', name: 'simulate-en-mobile', w: 375, h: 812 },
+  { url: '/strategies', name: 'strategies-en-mobile', w: 375, h: 812 },
+  { url: '/strategies/ranking', name: 'strategies-ranking-en-mobile', w: 375, h: 812 },
+  { url: '/market', name: 'market-en-mobile', w: 375, h: 812 },
+  { url: '/learn', name: 'learn-en-mobile', w: 375, h: 812 },
+  { url: '/fees', name: 'fees-en-mobile', w: 375, h: 812 },
+  { url: '/compare', name: 'compare-en-mobile', w: 375, h: 812 },
+  // KO Desktop
+  { url: '/ko/', name: 'ko-home-ko-desktop', w: 1280, h: 900 },
+  { url: '/ko/simulate', name: 'ko-simulate-ko-desktop', w: 1280, h: 900 },
+  { url: '/ko/strategies/ranking', name: 'ko-strategies-ranking-ko-desktop', w: 1280, h: 900 },
+  { url: '/ko/market', name: 'ko-market-ko-desktop', w: 1280, h: 900 },
+  { url: '/ko/learn', name: 'ko-learn-ko-desktop', w: 1280, h: 900 },
+  { url: '/ko/fees', name: 'ko-fees-ko-desktop', w: 1280, h: 900 },
+  { url: '/ko/compare', name: 'ko-compare-ko-desktop', w: 1280, h: 900 },
+  // KO Mobile
+  { url: '/ko/', name: 'ko-home-ko-mobile', w: 375, h: 812 },
+  { url: '/ko/simulate', name: 'ko-simulate-ko-mobile', w: 375, h: 812 },
+  { url: '/ko/strategies/ranking', name: 'ko-strategies-ranking-ko-mobile', w: 375, h: 812 },
+  { url: '/ko/fees', name: 'ko-fees-ko-mobile', w: 375, h: 812 },
+  // Special
+  { url: '/', name: 'home-menu-open-en-mobile', w: 375, h: 812, openMenu: true },
+  { url: '/ko/', name: 'home-menu-open-ko-mobile', w: 375, h: 812, openMenu: true },
+  { url: '/strategies', name: 'nav-strategies-dropdown-en-desktop', w: 1280, h: 900, hoverDropdown: true },
+];
+
+async function run() {
+  const browser = await chromium.launch({ headless: true });
+
+  for (const p of pages) {
+    const ctx = await browser.newContext({ viewport: { width: p.w, height: p.h } });
+    const page = await ctx.newPage();
+    try {
+      await page.goto(`${BASE}${p.url}`, { waitUntil: 'networkidle', timeout: 30000 });
+      await page.waitForTimeout(1500);
+
+      if (p.openMenu) {
+        const btn = page.locator('#mobile-menu-btn');
+        if (await btn.isVisible()) await btn.click();
+        await page.waitForTimeout(500);
+      }
+
+      if (p.hoverDropdown) {
+        const trigger = page.locator('.nav-dropdown-trigger').first();
+        if (await trigger.isVisible()) await trigger.hover();
+        await page.waitForTimeout(500);
+      }
+
+      await page.screenshot({ path: `${OUT}/${p.name}.png`, fullPage: true });
+      console.log(`✓ ${p.name}`);
+    } catch (e) {
+      console.error(`✗ ${p.name}: ${e.message}`);
+    }
+    await ctx.close();
+  }
+
+  await browser.close();
+  console.log('Done.');
+}
+
+run();

--- a/tests/e2e/interactive-qa-extra.spec.ts
+++ b/tests/e2e/interactive-qa-extra.spec.ts
@@ -1,0 +1,244 @@
+/**
+ * Interactive QA Extra — 추가 기능 테스트
+ *
+ * Covers scenarios not in interactive-qa.spec.ts:
+ *   1. URL Share: ?c= param appears for custom strategy, ?strategy= for preset
+ *   2. Optimize tab: Expert mode exposes Optimize tab + heatmap UI renders
+ *   3. KO labels: /ko/simulate/ shows Korean text in results
+ *
+ * prod-smoke 프로젝트 (testMatch에 포함)에서 실행:
+ *   BASE_URL=https://pruviq.com npx playwright test --project=prod-smoke tests/e2e/interactive-qa-extra.spec.ts
+ */
+
+import { test, expect } from "@playwright/test";
+
+const IS_PROD = (process.env.BASE_URL ?? "").includes("pruviq.com");
+
+test.describe("Interactive QA Extra", () => {
+  test.skip(!IS_PROD, "Prod only (BASE_URL=https://pruviq.com)");
+
+  // ── 1. URL Share: preset run → ?strategy= (not ?c=) ───────────────────────
+
+  test("simulate: Breakout run → Share URL contains ?strategy= (preset)", async ({
+    page,
+    context,
+  }) => {
+    // Grant clipboard permissions
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+
+    await page.goto("/simulate/");
+    await page.waitForLoadState("domcontentloaded");
+
+    // Wait for hydration
+    await page.waitForFunction(
+      () => {
+        const tabs = document.querySelectorAll('[role="tab"]');
+        return tabs.length >= 3;
+      },
+      { timeout: 20000 },
+    );
+
+    // Click Breakout quick-test card
+    const breakoutCard = page.locator('[data-testid="quick-cat-breakout"]');
+    await expect(breakoutCard).toBeVisible({ timeout: 15000 });
+    await breakoutCard.click();
+
+    // Wait for result (a % value to appear in body)
+    await expect(page.locator('[data-testid="tab-summary"]')).toBeVisible({
+      timeout: 90000,
+    });
+
+    // Click copy-link button
+    const copyBtn = page.locator('[data-testid="copy-link"]');
+    await expect(copyBtn).toBeVisible({ timeout: 10000 });
+    await copyBtn.click();
+
+    // After click, URL should be updated in browser (window.history.replaceState)
+    await page.waitForFunction(() => window.location.search.length > 0, {
+      timeout: 5000,
+    });
+
+    const currentUrl = page.url();
+    expect(currentUrl).toContain("sl=");
+    expect(currentUrl).toContain("tp=");
+    expect(currentUrl).toContain("dir=");
+
+    // Preset-based: should have strategy= not c=
+    // (c= is only for custom conditions without a preset)
+    expect(currentUrl).not.toContain("c=");
+
+    console.log(`Share URL (preset): ${currentUrl}`);
+  });
+
+  // ── 2. Optimize tab: Expert mode → tab exists → click → heatmap UI ─────────
+
+  test("simulate: Expert mode → Optimize tab visible → click → heatmap renders", async ({
+    page,
+  }) => {
+    await page.goto("/simulate/");
+    await page.waitForLoadState("domcontentloaded");
+
+    // Wait for hydration
+    await page.waitForFunction(
+      () => {
+        const tabs = document.querySelectorAll('[role="tab"]');
+        return tabs.length >= 3;
+      },
+      { timeout: 20000 },
+    );
+
+    // Switch to Expert mode
+    const expertTab = page
+      .locator('[role="tab"]')
+      .filter({ hasText: /Expert|엑스퍼트/i });
+    await expect(expertTab.first()).toBeVisible({ timeout: 10000 });
+    await expertTab.first().click();
+
+    // Wait for STRATEGY BUILDER header
+    await page.waitForSelector("text=/STRATEGY BUILDER|전략 빌더/i", {
+      timeout: 15000,
+    });
+
+    // Run backtest first (Optimize only shows after result exists)
+    const runBtn = page
+      .locator("button")
+      .filter({ hasText: /Simulate on|Coins|Run Backtest|백테스트 실행/i });
+
+    if ((await runBtn.count()) > 0) {
+      await runBtn.first().click();
+
+      // Wait for SUMMARY tab (result ready)
+      await page.waitForSelector(
+        'button:has-text("SUMMARY"), button:has-text("요약"), [data-testid="tab-summary"]',
+        { timeout: 90000 },
+      );
+    }
+
+    // Now Optimize tab should be visible (Expert mode only)
+    const optimizeTab = page.locator('[data-testid="tab-optimize"]');
+    await expect(optimizeTab).toBeVisible({ timeout: 10000 });
+
+    // Click the Optimize tab
+    await optimizeTab.click();
+
+    // Heatmap UI: either a table/grid or a loading/run button should appear
+    // OptimizePanel renders "Optimize by" select + a Run button or heatmap table
+    await page.waitForSelector(
+      "text=/Optimize by|최적화 기준|Run Optimize|Grid/i",
+      { timeout: 10000 },
+    );
+
+    const optimizePanelText = await page.locator("main").first().textContent();
+    // Should contain Optimize UI — either metric selector or results table
+    const hasOptimizeUI =
+      /Optimize by|최적화 기준|SL|TP|Win Rate|Profit Factor/i.test(
+        optimizePanelText ?? "",
+      );
+    expect(hasOptimizeUI).toBe(true);
+
+    // No JS errors
+    const errors: string[] = [];
+    page.on("pageerror", (e) => {
+      if (
+        !e.message.includes("fetch") &&
+        !e.message.includes("net::") &&
+        !e.message.includes("AbortError")
+      ) {
+        errors.push(e.message);
+      }
+    });
+
+    console.log(
+      `Optimize tab visible and clicked. Panel text snippet: ${optimizePanelText?.slice(0, 200)}`,
+    );
+    expect(errors.length).toBe(0);
+  });
+
+  // ── 3. KO landing: /ko/simulate/ shows Korean labels after hydration ────────
+
+  test("ko/simulate: Korean labels visible after hydration", async ({
+    page,
+  }) => {
+    await page.goto("/ko/simulate/");
+    await page.waitForLoadState("domcontentloaded");
+
+    // Wait for hydration
+    await page.waitForFunction(
+      () => {
+        const tabs = document.querySelectorAll('[role="tab"]');
+        return tabs.length >= 3;
+      },
+      { timeout: 20000 },
+    );
+
+    const bodyText = (await page.textContent("body")) ?? "";
+
+    // Korean chars must be present (not just EN)
+    const koreanRegex = /[\uAC00-\uD7AF]/;
+    expect(
+      koreanRegex.test(bodyText),
+      "Korean text must appear after hydration",
+    ).toBe(true);
+
+    // Key Korean UI labels
+    expect(bodyText).toMatch(/전략|시뮬|퀵 테스트|백테스트/i);
+
+    // h1 must be Korean or at least present
+    const h1 = await page.locator("h1").first().textContent();
+    expect(h1?.trim().length ?? 0).toBeGreaterThan(3);
+
+    // Mode tabs should exist in Korean
+    const tabTexts = await page.locator('[role="tab"]').allTextContents();
+    const tabJoined = tabTexts.join(" ");
+    expect(tabJoined.length).toBeGreaterThan(0);
+
+    console.log(
+      `KO /simulate tabs: ${tabTexts.join(", ")} | h1: "${h1?.trim()}"`,
+    );
+  });
+
+  // ── 4. KO simulate: run Breakout → Korean result labels ────────────────────
+
+  test("ko/simulate: Breakout run → Korean result labels (승률, 수익팩터)", async ({
+    page,
+  }) => {
+    await page.goto("/ko/simulate/");
+    await page.waitForLoadState("domcontentloaded");
+
+    // Wait for hydration
+    await page.waitForFunction(
+      () => {
+        const tabs = document.querySelectorAll('[role="tab"]');
+        return tabs.length >= 3;
+      },
+      { timeout: 20000 },
+    );
+
+    // Click Breakout quick-test card
+    const breakoutCard = page.locator('[data-testid="quick-cat-breakout"]');
+    await expect(breakoutCard).toBeVisible({ timeout: 15000 });
+    await breakoutCard.click();
+
+    // Wait for result
+    await expect(page.locator('[data-testid="tab-summary"]')).toBeVisible({
+      timeout: 90000,
+    });
+
+    const bodyText = (await page.textContent("body")) ?? "";
+
+    // Korean metric labels must appear in results
+    const hasKoreanMetric = /승률|수익팩터|최대손실|총수익|거래|결과/i.test(
+      bodyText,
+    );
+    expect(
+      hasKoreanMetric,
+      "Korean result labels (승률, 수익팩터 etc.) must appear",
+    ).toBe(true);
+
+    // No NaN / Infinity
+    expect(bodyText).not.toContain("NaN");
+    expect(bodyText).not.toContain("Infinity");
+
+    console.log("KO Breakout run: Korean labels confirmed");
+  });
+});

--- a/tests/persona-full-test.spec.ts
+++ b/tests/persona-full-test.spec.ts
@@ -1,0 +1,548 @@
+import { test, expect, Page } from "@playwright/test";
+import * as fs from "fs";
+import * as path from "path";
+
+const SS = "/tmp/persona-screenshots";
+fs.mkdirSync(SS, { recursive: true });
+
+async function shot(page: Page, name: string) {
+  await page.screenshot({ path: `${SS}/${name}.png`, fullPage: false });
+}
+
+async function waitForApi(page: Page) {
+  await page.waitForFunction(
+    () => !document.querySelector(".spinner"),
+    { timeout: 15000 }
+  ).catch(() => {});
+  await page.waitForTimeout(500);
+}
+
+// ────────────────────────────────────────────────────────────
+// CASEY: 완전 초보자
+// ────────────────────────────────────────────────────────────
+test("CASEY-01: 첫 방문 — 무엇이 보이는가", async ({ page }) => {
+  await page.goto("http://localhost:4321/simulate");
+  await page.waitForLoadState("networkidle");
+  await shot(page, "casey-01-first-view");
+
+  // Quick Start 배너 존재?
+  const banner = page.locator('[data-testid="quick-start-banner"], .quick-start, [class*="quickStart"]');
+  const bannerText = await page.getByText(/Run Backtest|Click|preset/i).first().isVisible().catch(() => false);
+  console.log("QuickStart banner visible:", bannerText);
+
+  // 탭 모드 확인
+  const standardTab = page.getByRole("button", { name: /Standard|기본/i });
+  const expertTab = page.getByRole("button", { name: /Expert|전문/i });
+  console.log("Standard tab:", await standardTab.isVisible().catch(() => false));
+  console.log("Expert tab:", await expertTab.isVisible().catch(() => false));
+});
+
+test("CASEY-02: Standard 모드 — 슬라이더 + 프리셋 선택 + 실행", async ({ page }) => {
+  await page.goto("http://localhost:4321/simulate");
+  await page.waitForLoadState("networkidle");
+
+  // Standard 탭 클릭 (또는 이미 기본)
+  const stdBtn = page.getByRole("button", { name: /Standard|기본/i }).first();
+  if (await stdBtn.isVisible()) await stdBtn.click();
+  await page.waitForTimeout(300);
+  await shot(page, "casey-02a-standard-mode");
+
+  // 프리셋 버튼 찾기
+  const presets = page.locator("button").filter({ hasText: /BB Squeeze|Squeeze|RSI|EMA/i });
+  const presetCount = await presets.count();
+  console.log("Preset buttons visible:", presetCount);
+  if (presetCount > 0) {
+    await presets.first().click();
+    await page.waitForTimeout(500);
+    await shot(page, "casey-02b-preset-selected");
+  }
+
+  // SL 슬라이더
+  const slSlider = page.locator('input[type="range"]').first();
+  if (await slSlider.isVisible()) {
+    await slSlider.fill("15");
+    await page.waitForTimeout(200);
+  }
+
+  // Run 버튼
+  const runBtn = page.getByTestId("run-simulate").or(page.getByRole("button", { name: /Run Backtest|백테스트 실행|Simulate/i })).first();
+  console.log("Run button visible:", await runBtn.isVisible().catch(() => false));
+  await shot(page, "casey-02c-before-run");
+
+  if (await runBtn.isVisible()) {
+    await runBtn.click();
+    await page.waitForTimeout(1000);
+    await shot(page, "casey-02d-running");
+    await page.waitForFunction(
+      () => {
+        const btn = document.querySelector('[data-testid="run-simulate"]');
+        return btn && !btn.textContent?.includes("Running") && !btn.textContent?.includes("실행 중");
+      },
+      { timeout: 30000 }
+    ).catch(() => {});
+    await page.waitForTimeout(1000);
+    await shot(page, "casey-02e-results");
+    console.log("Results rendered after run");
+  }
+});
+
+test("CASEY-03: 결과 화면 — 초보자가 이해할 수 있나", async ({ page }) => {
+  await page.goto("http://localhost:4321/simulate");
+  await page.waitForLoadState("networkidle");
+
+  // 빠르게 실행
+  const runBtn = page.getByTestId("run-simulate").or(page.getByRole("button", { name: /Run Backtest|백테스트 실행/i })).first();
+  if (await runBtn.isVisible()) {
+    await runBtn.click();
+    await page.waitForFunction(
+      () => !document.querySelector('[data-testid="run-simulate"]')?.textContent?.includes("Running"),
+      { timeout: 30000 }
+    ).catch(() => {});
+    await page.waitForTimeout(1000);
+  }
+
+  // 결과 지표 텍스트 확인
+  const metricTexts = ["Win Rate", "Profit Factor", "Drawdown", "Return", "승률", "수익"];
+  for (const t of metricTexts) {
+    const el = page.getByText(new RegExp(t, "i")).first();
+    const visible = await el.isVisible().catch(() => false);
+    console.log(`Metric "${t}" visible:`, visible);
+  }
+  await shot(page, "casey-03-results-understanding");
+
+  // 등급(Grade) 표시 확인
+  const grades = ["STRONG", "GOOD", "FAIR", "WEAK", "강력", "양호", "보통", "위험"];
+  for (const g of grades) {
+    const el = page.getByText(g).first();
+    if (await el.isVisible().catch(() => false)) {
+      console.log("Grade shown:", g);
+      break;
+    }
+  }
+});
+
+test("CASEY-04: KO 모드 전환 — 미번역 문자열 체크", async ({ page }) => {
+  await page.goto("http://localhost:4321/ko/simulate");
+  await page.waitForLoadState("networkidle");
+  await shot(page, "casey-04a-ko-mode");
+
+  // 영어 하드코딩 확인
+  const bodyText = await page.locator("body").innerText();
+  const hardcodedEN = [
+    "★ Recommended",
+    "Custom",
+    "Hide",
+    "All presets",
+    "Prev",
+    "Curr",
+    "Timeframe",
+    "Run Backtest",
+    "Stop Loss",
+    "Take Profit",
+  ];
+  for (const str of hardcodedEN) {
+    const found = bodyText.includes(str);
+    if (found) console.log(`🔴 EN hardcoded in KO mode: "${str}"`);
+  }
+
+  // KO 번역 확인
+  const koExpected = ["백테스트", "손절", "익절", "레버리지", "전략"];
+  for (const str of koExpected) {
+    const found = bodyText.includes(str);
+    console.log(`KO text "${str}":`, found ? "✅" : "❌ MISSING");
+  }
+  await shot(page, "casey-04b-ko-mode-scrolled");
+});
+
+// ────────────────────────────────────────────────────────────
+// TIM: 중급자 — 파라미터 범위, 비교, History
+// ────────────────────────────────────────────────────────────
+test("TIM-01: Standard 모드 파라미터 범위 한계 테스트", async ({ page }) => {
+  await page.goto("http://localhost:4321/simulate");
+  await page.waitForLoadState("networkidle");
+
+  const stdBtn = page.getByRole("button", { name: /Standard|기본/i }).first();
+  if (await stdBtn.isVisible()) await stdBtn.click();
+  await page.waitForTimeout(300);
+
+  // SL 슬라이더 최대값 확인
+  const slSlider = page.locator('input[type="range"]').first();
+  const slMax = await slSlider.getAttribute("max");
+  const slMin = await slSlider.getAttribute("min");
+  console.log(`SL slider: min=${slMin}, max=${slMax}`);
+
+  // TP 슬라이더
+  const tpSlider = page.locator('input[type="range"]').nth(1);
+  const tpMax = await tpSlider.getAttribute("max");
+  const tpMin = await tpSlider.getAttribute("min");
+  console.log(`TP slider: min=${tpMin}, max=${tpMax}`);
+
+  await shot(page, "tim-01-param-ranges");
+
+  // Direction 버튼들
+  const shortBtn = page.getByTestId("std-dir-short");
+  const longBtn = page.getByTestId("std-dir-long");
+  const bothBtn = page.getByTestId("std-dir-both");
+  console.log("SHORT btn:", await shortBtn.isVisible().catch(() => false));
+  console.log("LONG btn:", await longBtn.isVisible().catch(() => false));
+  console.log("BOTH btn:", await bothBtn.isVisible().catch(() => false));
+
+  // Leverage 1x→5x
+  const lev5 = page.getByRole("button", { name: "5x" });
+  if (await lev5.isVisible()) {
+    await lev5.click();
+    await page.waitForTimeout(200);
+    await shot(page, "tim-01b-leverage-5x");
+  }
+});
+
+test("TIM-02: 코인 필터 + 기간 슬라이더", async ({ page }) => {
+  await page.goto("http://localhost:4321/simulate");
+  await page.waitForLoadState("networkidle");
+
+  // Top 50 코인 선택
+  const top50 = page.getByRole("button", { name: /Top 50/i });
+  if (await top50.isVisible()) {
+    await top50.click();
+    await page.waitForTimeout(200);
+    console.log("Top 50 selected");
+  }
+
+  // 기간 슬라이더 (period)
+  const periodSlider = page.locator('input[type="range"]').nth(2);
+  const pMax = await periodSlider.getAttribute("max").catch(() => null);
+  const pMin = await periodSlider.getAttribute("min").catch(() => null);
+  console.log(`Period slider: min=${pMin}, max=${pMax}`);
+
+  await shot(page, "tim-02-coin-period");
+});
+
+test("TIM-03: History 기능 — 2번 실행 후 비교", async ({ page }) => {
+  await page.goto("http://localhost:4321/simulate");
+  await page.waitForLoadState("networkidle");
+
+  const runBtn = page.getByTestId("run-simulate").or(page.getByRole("button", { name: /Run Backtest|백테스트 실행/i })).first();
+
+  // 1차 실행
+  if (await runBtn.isVisible()) {
+    await runBtn.click();
+    await page.waitForFunction(
+      () => !document.querySelector('[data-testid="run-simulate"]')?.textContent?.includes("Running"),
+      { timeout: 30000 }
+    ).catch(() => {});
+    await page.waitForTimeout(1000);
+    await shot(page, "tim-03a-first-run");
+  }
+
+  // SL 변경 후 2차 실행
+  const slSlider = page.locator('input[type="range"]').first();
+  if (await slSlider.isVisible()) {
+    await slSlider.fill("15");
+    await page.waitForTimeout(200);
+  }
+
+  if (await runBtn.isVisible()) {
+    await runBtn.click();
+    await page.waitForFunction(
+      () => !document.querySelector('[data-testid="run-simulate"]')?.textContent?.includes("Running"),
+      { timeout: 30000 }
+    ).catch(() => {});
+    await page.waitForTimeout(1000);
+    await shot(page, "tim-03b-second-run-history");
+  }
+
+  // History 항목 확인
+  const historyItems = page.locator('[class*="history"], [data-testid*="history"]');
+  console.log("History items:", await historyItems.count());
+});
+
+// ────────────────────────────────────────────────────────────
+// QUINN: 퀀트 — Expert 모드, 조건 빌더, Validate 탭
+// ────────────────────────────────────────────────────────────
+test("QUINN-01: Expert 모드 진입 + 조건 추가", async ({ page }) => {
+  await page.goto("http://localhost:4321/simulate");
+  await page.waitForLoadState("networkidle");
+
+  // Expert 탭 클릭
+  const expertBtn = page.getByRole("button", { name: /Expert|전문|Advanced/i }).first();
+  if (await expertBtn.isVisible()) {
+    await expertBtn.click();
+    await page.waitForTimeout(500);
+    await shot(page, "quinn-01a-expert-mode");
+  }
+
+  // 기존 조건들 확인
+  const conditionRows = page.locator('[class*="ConditionRow"], [data-testid*="condition"]');
+  console.log("Default condition rows:", await conditionRows.count());
+
+  // "조건 추가" 버튼
+  const addBtn = page.getByRole("button", { name: /Add Condition|조건 추가|Add Entry|Add/i }).first();
+  console.log("Add condition button:", await addBtn.isVisible().catch(() => false));
+  if (await addBtn.isVisible()) {
+    await addBtn.click();
+    await page.waitForTimeout(300);
+    await shot(page, "quinn-01b-condition-added");
+  }
+
+  // 지표 선택 드롭다운 (field select)
+  const fieldSelect = page.locator('select[aria-label="Indicator field"]').first();
+  if (await fieldSelect.isVisible()) {
+    const options = await fieldSelect.evaluate((el) =>
+      Array.from((el as HTMLSelectElement).options).map((o) => o.text).slice(0, 5)
+    );
+    console.log("Field options (first 5):", options);
+  }
+  await shot(page, "quinn-01c-full-expert");
+});
+
+test("QUINN-02: Shift 컬럼 — look-ahead bias 경고", async ({ page }) => {
+  await page.goto("http://localhost:4321/simulate");
+  await page.waitForLoadState("networkidle");
+
+  const expertBtn = page.getByRole("button", { name: /Expert|전문/i }).first();
+  if (await expertBtn.isVisible()) await expertBtn.click();
+  await page.waitForTimeout(500);
+
+  // Shift 선택자 (Prev/Curr)
+  const shiftSelect = page.locator('select[aria-label*="Candle"]').first();
+  if (await shiftSelect.isVisible()) {
+    // Curr (shift=0) 선택 → 경고 표시?
+    await shiftSelect.selectOption("0");
+    await page.waitForTimeout(300);
+    await shot(page, "quinn-02a-shift-curr-warning");
+
+    const warning = page.locator('[class*="yellow"], [style*="yellow"]').first();
+    console.log("Look-ahead warning shown:", await warning.isVisible().catch(() => false));
+  }
+});
+
+test("QUINN-03: Validate 탭 (OOS) 접근", async ({ page }) => {
+  await page.goto("http://localhost:4321/simulate");
+  await page.waitForLoadState("networkidle");
+
+  // Expert 모드로
+  const expertBtn = page.getByRole("button", { name: /Expert|전문/i }).first();
+  if (await expertBtn.isVisible()) await expertBtn.click();
+  await page.waitForTimeout(300);
+
+  // 한번 실행
+  const runBtn = page.getByTestId("run-simulate").or(page.getByRole("button", { name: /Run Backtest|백테스트 실행/i })).first();
+  if (await runBtn.isVisible()) {
+    await runBtn.click();
+    await page.waitForFunction(
+      () => !document.querySelector('[data-testid="run-simulate"]')?.textContent?.includes("Running"),
+      { timeout: 30000 }
+    ).catch(() => {});
+    await page.waitForTimeout(1000);
+  }
+
+  // Validate 탭
+  const validateTab = page.getByRole("tab", { name: /Validate|OOS|검증/i });
+  const validateTabAlt = page.getByRole("button", { name: /Validate|OOS|검증/i });
+  const vtab = await validateTab.isVisible().catch(() => false) ? validateTab : validateTabAlt;
+  console.log("Validate tab visible:", await vtab.isVisible().catch(() => false));
+  if (await vtab.isVisible()) {
+    await vtab.click();
+    await page.waitForTimeout(500);
+    await shot(page, "quinn-03-validate-tab");
+  } else {
+    await shot(page, "quinn-03-no-validate-tab");
+    console.log("🔴 Validate tab NOT found after expert mode run");
+  }
+});
+
+test("QUINN-04: 데이터 출처 정보 확인", async ({ page }) => {
+  await page.goto("http://localhost:4321/simulate");
+  await page.waitForLoadState("networkidle");
+
+  // 실행 후 결과
+  const runBtn = page.getByTestId("run-simulate").or(page.getByRole("button", { name: /Run Backtest|백테스트 실행/i })).first();
+  if (await runBtn.isVisible()) {
+    await runBtn.click();
+    await page.waitForFunction(
+      () => !document.querySelector('[data-testid="run-simulate"]')?.textContent?.includes("Running"),
+      { timeout: 30000 }
+    ).catch(() => {});
+    await page.waitForTimeout(1000);
+  }
+
+  const bodyText = await page.locator("body").innerText();
+  const dataSourceKeywords = ["OKX", "Binance", "1H", "candle", "데이터 출처", "data source", "exchange"];
+  for (const kw of dataSourceKeywords) {
+    if (bodyText.toLowerCase().includes(kw.toLowerCase())) {
+      console.log(`✅ Data source info found: "${kw}"`);
+    } else {
+      console.log(`❌ No mention of: "${kw}"`);
+    }
+  }
+  await shot(page, "quinn-04-data-source");
+});
+
+// ────────────────────────────────────────────────────────────
+// SAM: 전략가 — 복잡한 조건, Export, Share, OR 로직
+// ────────────────────────────────────────────────────────────
+test("SAM-01: 복잡한 조건 빌딩 + field2 비교", async ({ page }) => {
+  await page.goto("http://localhost:4321/simulate");
+  await page.waitForLoadState("networkidle");
+
+  const expertBtn = page.getByRole("button", { name: /Expert|전문/i }).first();
+  if (await expertBtn.isVisible()) await expertBtn.click();
+  await page.waitForTimeout(500);
+
+  // field2 (indicator vs indicator) 선택자 확인
+  const field2Select = page.locator('select[aria-label="Comparison field"]').first();
+  console.log("field2 selector visible:", await field2Select.isVisible().catch(() => false));
+
+  // Avoid Hours 버튼 그리드
+  const avoidHoursGrid = page.locator('[class*="avoidHour"], button[class*="hour"]').first();
+  const avoidBtns = page.getByRole("button", { name: /^[0-9]{1,2}$/ });
+  console.log("Avoid hour buttons:", await avoidBtns.count());
+
+  await shot(page, "sam-01-expert-builder");
+  await page.waitForTimeout(300);
+
+  // Compounding 토글
+  const compoundToggle = page.getByRole("button", { name: /Compound|컴파운드|복리/i }).first();
+  const compoundCheck = page.locator('input[type="checkbox"]').filter({ hasText: /compound/i });
+  console.log("Compound toggle:", await compoundToggle.isVisible().catch(() => false));
+  await shot(page, "sam-01b-compound");
+});
+
+test("SAM-02: 실행 후 Export (CSV/Excel) + Share", async ({ page }) => {
+  await page.goto("http://localhost:4321/simulate");
+  await page.waitForLoadState("networkidle");
+
+  const runBtn = page.getByTestId("run-simulate").or(page.getByRole("button", { name: /Run Backtest|백테스트 실행/i })).first();
+  if (await runBtn.isVisible()) {
+    await runBtn.click();
+    await page.waitForFunction(
+      () => !document.querySelector('[data-testid="run-simulate"]')?.textContent?.includes("Running"),
+      { timeout: 30000 }
+    ).catch(() => {});
+    await page.waitForTimeout(1000);
+  }
+
+  await shot(page, "sam-02a-results");
+
+  // Export 버튼
+  const csvBtn = page.getByRole("button", { name: /CSV|Export|내보내기/i }).first();
+  const excelBtn = page.getByRole("button", { name: /Excel|XLSX/i }).first();
+  console.log("CSV export button:", await csvBtn.isVisible().catch(() => false));
+  console.log("Excel export button:", await excelBtn.isVisible().catch(() => false));
+
+  // Share 버튼
+  const shareBtn = page.getByRole("button", { name: /Share|공유/i }).first();
+  console.log("Share button:", await shareBtn.isVisible().catch(() => false));
+  if (await shareBtn.isVisible()) {
+    await shareBtn.click();
+    await page.waitForTimeout(500);
+    await shot(page, "sam-02b-share-modal");
+  }
+
+  await shot(page, "sam-02c-all-results-buttons");
+});
+
+test("SAM-03: OR 조건 — AND 제약 확인", async ({ page }) => {
+  await page.goto("http://localhost:4321/simulate");
+  await page.waitForLoadState("networkidle");
+
+  const expertBtn = page.getByRole("button", { name: /Expert|전문/i }).first();
+  if (await expertBtn.isVisible()) await expertBtn.click();
+  await page.waitForTimeout(500);
+
+  // AND/OR 토글 있는가?
+  const orBtn = page.getByRole("button", { name: /\bOR\b/i }).first();
+  const andBtn = page.getByRole("button", { name: /\bAND\b/i }).first();
+  console.log("OR button visible:", await orBtn.isVisible().catch(() => false));
+  console.log("AND button visible:", await andBtn.isVisible().catch(() => false));
+
+  // "AND conditions only" 같은 안내 텍스트
+  const bodyText = await page.locator("body").innerText();
+  const hasAndNotice = /all conditions|AND only|모든 조건/.test(bodyText);
+  console.log("AND-only notice visible:", hasAndNotice);
+
+  await shot(page, "sam-03-and-or-logic");
+});
+
+// ────────────────────────────────────────────────────────────
+// 모바일 뷰포트 테스트
+// ────────────────────────────────────────────────────────────
+test("MOBILE-01: 375px — Expert 모드 조건 rows 가독성", async ({ browser }) => {
+  const ctx = await browser.newContext({ viewport: { width: 375, height: 812 } });
+  const page = await ctx.newPage();
+  await page.goto("http://localhost:4321/simulate");
+  await page.waitForLoadState("networkidle");
+
+  const expertBtn = page.getByRole("button", { name: /Expert|전문/i }).first();
+  if (await expertBtn.isVisible()) await expertBtn.click();
+  await page.waitForTimeout(500);
+
+  await shot(page, "mobile-01a-expert-375");
+  await page.mouse.wheel(0, 300);
+  await page.waitForTimeout(300);
+  await shot(page, "mobile-01b-expert-scrolled");
+
+  // 조건 row가 몇 줄 차지하는가
+  const condRows = page.locator('[class*="flex-wrap"]');
+  console.log("flex-wrap condition rows:", await condRows.count());
+  await ctx.close();
+});
+
+test("MOBILE-02: 375px — Standard 모드 Run 버튼 가시성", async ({ browser }) => {
+  const ctx = await browser.newContext({ viewport: { width: 375, height: 812 } });
+  const page = await ctx.newPage();
+  await page.goto("http://localhost:4321/simulate");
+  await page.waitForLoadState("networkidle");
+  await shot(page, "mobile-02-standard-375");
+
+  const runBtn = page.getByTestId("run-simulate").or(page.getByRole("button", { name: /Run Backtest|백테스트 실행/i })).first();
+  console.log("Run button visible (375px):", await runBtn.isVisible().catch(() => false));
+  await ctx.close();
+});
+
+// ────────────────────────────────────────────────────────────
+// EDGE CASES
+// ────────────────────────────────────────────────────────────
+test("EDGE-01: 조건 0개로 Expert 실행", async ({ page }) => {
+  await page.goto("http://localhost:4321/simulate");
+  await page.waitForLoadState("networkidle");
+
+  const expertBtn = page.getByRole("button", { name: /Expert|전문/i }).first();
+  if (await expertBtn.isVisible()) await expertBtn.click();
+  await page.waitForTimeout(500);
+
+  // 모든 조건 삭제
+  const removeBtns = page.getByRole("button", { name: /x|Remove|삭제/i });
+  const count = await removeBtns.count();
+  for (let i = 0; i < count; i++) {
+    const btn = removeBtns.first();
+    if (await btn.isVisible()) {
+      await btn.click();
+      await page.waitForTimeout(100);
+    }
+  }
+  await shot(page, "edge-01a-no-conditions");
+
+  // 빈 조건으로 실행 시도
+  const runBtn = page.getByTestId("run-simulate").or(page.getByRole("button", { name: /Run Backtest|백테스트 실행/i })).first();
+  if (await runBtn.isVisible()) {
+    const isDisabled = await runBtn.isDisabled();
+    console.log("Run button disabled with 0 conditions:", isDisabled);
+    if (!isDisabled) {
+      await runBtn.click();
+      await page.waitForTimeout(2000);
+      await shot(page, "edge-01b-run-no-conditions-result");
+    }
+  }
+});
+
+test("EDGE-02: URL 파라미터로 프리셋 로드", async ({ page }) => {
+  await page.goto("http://localhost:4321/simulate?preset=bb-squeeze-short");
+  await page.waitForLoadState("networkidle");
+  await page.waitForTimeout(1000);
+  await shot(page, "edge-02-url-preset");
+
+  const bodyText = await page.locator("body").innerText();
+  console.log("URL preset loaded:", bodyText.includes("BB Squeeze") || bodyText.includes("bb-squeeze"));
+});
+

--- a/tests/sim-audit.spec.ts
+++ b/tests/sim-audit.spec.ts
@@ -1,0 +1,815 @@
+/**
+ * sim-audit.spec.ts
+ * 시뮬레이터 페이지 감사 — EN/KO 양방향, 3개 모드, 결과 탭, UX 체크
+ * BASE_URL=https://pruviq.com npx playwright test tests/sim-audit.spec.ts --project=prod-smoke
+ */
+import { test, expect, Page } from "@playwright/test";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const SS_DIR = path.resolve(__dirname, "sim-audit-screenshots");
+
+async function ss(page: Page, name: string) {
+  await page.screenshot({
+    path: path.join(SS_DIR, `${name}.png`),
+    fullPage: false,
+  });
+}
+
+async function ssFull(page: Page, name: string) {
+  await page.screenshot({
+    path: path.join(SS_DIR, `${name}.png`),
+    fullPage: true,
+  });
+}
+
+// ── 공통 헬퍼: 시뮬레이터 Preact 컴포넌트가 마운트될 때까지 대기 ──
+async function waitForSimulator(page: Page) {
+  // spinner가 사라지고 ModeSwitcher가 나타날 때까지
+  await page
+    .waitForSelector(
+      "#simulator-mount .mode-switcher, #simulator-mount [class*='mode'], #simulator-mount button",
+      {
+        timeout: 20000,
+      },
+    )
+    .catch(() => {});
+  // 추가로 loader가 사라질 때 대기
+  await page
+    .waitForFunction(
+      () => {
+        const spinner = document.querySelector(".spinner");
+        return !spinner || (spinner as HTMLElement).offsetParent === null;
+      },
+      { timeout: 20000 },
+    )
+    .catch(() => {});
+  await page.waitForTimeout(1500);
+}
+
+// ── 결과가 나타날 때까지 대기 ──
+async function waitForResults(page: Page, timeoutMs = 60000) {
+  await page
+    .waitForSelector(
+      '[data-tab="summary"], [class*="result"], table, [class*="ResultsPanel"]',
+      { timeout: timeoutMs },
+    )
+    .catch(() => {});
+  await page.waitForTimeout(1000);
+}
+
+// ─────────────────────────────────────────────────
+// 1. 페이지 로드 + 정적 텍스트 감사
+// ─────────────────────────────────────────────────
+test.describe("1. Page Load & Static Text", () => {
+  test("EN /simulate/ — 페이지 로드, 하드코딩 텍스트 체크", async ({
+    page,
+  }) => {
+    await page.goto("/simulate/", { waitUntil: "domcontentloaded" });
+    await ssFull(page, "01-en-simulate-load");
+
+    // title
+    const title = await page.title();
+    expect(title.length, "EN title should not be empty").toBeGreaterThan(5);
+
+    // 하드코딩된 영문 텍스트들 (EN 페이지는 정상)
+    const bodyText = await page.locator("body").innerText();
+
+    // "simulations run" / "coins analyzed" / "strategies available" counter 텍스트가 존재해야 함
+    expect(bodyText).toContain("simulations run");
+    expect(bodyText).toContain("coins analyzed");
+    expect(bodyText).toContain("strategies available");
+
+    // 알려진 하드코딩 패턴: "How we calculate" 링크
+    const hardcodedLink = page.locator('text="How we calculate →"');
+    const cnt = await hardcodedLink.count();
+    console.log(`[EN] 'How we calculate →' count: ${cnt}`);
+
+    // "First time? Try a preset strategy" Quick Start 배너 (EN 정상)
+    const bannerText = await page.locator("text=First time?").count();
+    console.log(`[EN] 'First time?' banner count: ${bannerText}`);
+
+    // "Run a backtest to see your results" 오버레이
+    const overlayText = await page
+      .locator("text=Run a backtest to see your results")
+      .count();
+    console.log(`[EN] overlay text count: ${overlayText}`);
+  });
+
+  test("KO /ko/simulate/ — 영문 하드코딩 누락 체크", async ({ page }) => {
+    await page.goto("/ko/simulate/", { waitUntil: "domcontentloaded" });
+    await ssFull(page, "02-ko-simulate-load");
+
+    const bodyText = await page.locator("body").innerText();
+
+    // KO 페이지에서 카운터는 한국어여야 함
+    expect(bodyText).toContain("시뮬레이션 실행");
+    expect(bodyText).toContain("코인 분석");
+    expect(bodyText).toContain("전략 이용 가능");
+
+    // [ISSUE CHECK] EN 하드코딩이 KO 페이지에 남아있는지
+    const issues: string[] = [];
+
+    if (bodyText.includes("simulations run")) {
+      issues.push("HARDCODED EN: 'simulations run' found on KO page");
+    }
+    if (bodyText.includes("coins analyzed")) {
+      issues.push("HARDCODED EN: 'coins analyzed' found on KO page");
+    }
+    if (bodyText.includes("strategies available")) {
+      issues.push("HARDCODED EN: 'strategies available' found on KO page");
+    }
+    if (bodyText.includes("How we calculate")) {
+      issues.push("HARDCODED EN: 'How we calculate' link found on KO page");
+    }
+    if (bodyText.includes("First time?")) {
+      issues.push("HARDCODED EN: 'First time?' banner found on KO page");
+    }
+    if (bodyText.includes("Pick a strategy from Hot Strategies")) {
+      issues.push(
+        "HARDCODED EN: Quick Start banner body text found on KO page",
+      );
+    }
+    if (bodyText.includes("Run a backtest to see your results")) {
+      issues.push("HARDCODED EN: overlay CTA text found on KO page");
+    }
+    if (
+      bodyText.includes("Start with BB Squeeze (Verified)") &&
+      !bodyText.includes("BB Squeeze로 시작하기")
+    ) {
+      issues.push(
+        "HARDCODED EN: 'Start with BB Squeeze (Verified)' CTA found on KO page",
+      );
+    }
+    if (bodyText.includes("Choose a preset or build your own strategy")) {
+      issues.push("HARDCODED EN: loading sub-text found on KO page");
+    }
+
+    if (issues.length > 0) {
+      await ss(page, "02-ko-hardcoded-issues");
+      console.warn("=== KO HARDCODED ISSUES ===");
+      issues.forEach((i) => console.warn(" " + i));
+    }
+
+    // 페이지 로드 자체는 성공해야 함
+    expect(bodyText.length, "KO page should have content").toBeGreaterThan(100);
+  });
+});
+
+// ─────────────────────────────────────────────────
+// 2. Simulator 컴포넌트 로드 (EN+KO)
+// ─────────────────────────────────────────────────
+test.describe("2. Simulator Component Mount", () => {
+  test("EN — simulator mounts with preset=bb-squeeze-short", async ({
+    page,
+  }) => {
+    await page.goto("/simulate/?preset=bb-squeeze-short", {
+      waitUntil: "domcontentloaded",
+    });
+    await waitForSimulator(page);
+    await ss(page, "03-en-simulator-mounted");
+
+    // Preact 컴포넌트가 마운트됐는지 확인: animate-pulse skeleton이 사라져야 함
+    const skeletonVisible = await page
+      .locator(".animate-pulse")
+      .isVisible()
+      .catch(() => false);
+    if (skeletonVisible) {
+      await ss(page, "03-en-skeleton-still-visible");
+      console.warn(
+        "[EN] Skeleton still visible — simulator may not have mounted",
+      );
+    }
+
+    // ModeSwitcher 또는 QuickTest 버튼 존재 확인
+    const buttons = await page.locator("#simulator-mount button").count();
+    console.log(`[EN] Simulator buttons count: ${buttons}`);
+    expect(
+      buttons,
+      "EN: Simulator should render buttons after mount",
+    ).toBeGreaterThan(0);
+  });
+
+  test("KO — simulator mounts with preset=bb-squeeze-short", async ({
+    page,
+  }) => {
+    await page.goto("/ko/simulate/?preset=bb-squeeze-short", {
+      waitUntil: "domcontentloaded",
+    });
+    await waitForSimulator(page);
+    await ss(page, "04-ko-simulator-mounted");
+
+    const buttons = await page.locator("#simulator-mount button").count();
+    console.log(`[KO] Simulator buttons count: ${buttons}`);
+    expect(
+      buttons,
+      "KO: Simulator should render buttons after mount",
+    ).toBeGreaterThan(0);
+
+    // KO 모드: 버튼 텍스트가 한국어인지 확인
+    const simulatorText = await page
+      .locator("#simulator-mount")
+      .innerText()
+      .catch(() => "");
+    console.log(
+      `[KO] Simulator text snippet: ${simulatorText.substring(0, 300)}`,
+    );
+
+    const enOnlyPatterns = [
+      "Run Backtest",
+      "Stop Loss",
+      "Take Profit",
+      "Leverage",
+      "Direction",
+    ];
+    for (const pattern of enOnlyPatterns) {
+      if (simulatorText.includes(pattern)) {
+        console.warn(
+          `[KO] Possible EN hardcode in simulator component: '${pattern}'`,
+        );
+      }
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────
+// 3. 3개 모드 전환 테스트 (EN)
+// ─────────────────────────────────────────────────
+test.describe("3. Mode Switching (EN)", () => {
+  test("ModeSwitcher — Quick/Standard/Expert 탭 전환", async ({ page }) => {
+    await page.goto("/simulate/?preset=bb-squeeze-short", {
+      waitUntil: "domcontentloaded",
+    });
+    await waitForSimulator(page);
+
+    // ModeSwitcher 찾기
+    const simMount = page.locator("#simulator-mount");
+    await ss(page, "05-mode-switcher-initial");
+
+    // Quick Test 모드 버튼 찾기
+    const quickBtn = simMount
+      .locator("button")
+      .filter({ hasText: /quick/i })
+      .first();
+    const standardBtn = simMount
+      .locator("button")
+      .filter({ hasText: /standard/i })
+      .first();
+    const expertBtn = simMount
+      .locator("button")
+      .filter({ hasText: /expert/i })
+      .first();
+
+    const quickCount = await quickBtn.count();
+    const standardCount = await standardBtn.count();
+    const expertCount = await expertBtn.count();
+
+    console.log(
+      `[Mode] Quick: ${quickCount}, Standard: ${standardCount}, Expert: ${expertCount}`,
+    );
+
+    if (quickCount > 0) {
+      await quickBtn.click();
+      await page.waitForTimeout(500);
+      await ss(page, "06-mode-quick");
+    } else {
+      await ss(page, "06-mode-quick-NOT-FOUND");
+      console.warn("[Mode] Quick Test button not found");
+    }
+
+    if (standardCount > 0) {
+      await standardBtn.click();
+      await page.waitForTimeout(500);
+      await ss(page, "07-mode-standard");
+    } else {
+      console.warn("[Mode] Standard button not found");
+    }
+
+    if (expertCount > 0) {
+      await expertBtn.click();
+      await page.waitForTimeout(500);
+      await ss(page, "08-mode-expert");
+    } else {
+      console.warn("[Mode] Expert button not found");
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────
+// 4. Run Backtest 실행 + 결과 탭 (EN)
+// ─────────────────────────────────────────────────
+test.describe("4. Run Backtest & Results (EN)", () => {
+  test("Run 버튼 클릭 → 결과 표시 + 탭 체크", async ({ page }) => {
+    // 타임아웃: 90초 (API 응답 포함)
+    test.setTimeout(120000);
+
+    await page.goto("/simulate/?preset=bb-squeeze-short", {
+      waitUntil: "domcontentloaded",
+    });
+    await waitForSimulator(page);
+    await ss(page, "09-before-run");
+
+    // Run 버튼 찾기
+    const simMount = page.locator("#simulator-mount");
+    const runBtn = simMount
+      .locator("button")
+      .filter({ hasText: /run backtest|run|simulate|실행/i })
+      .first();
+    const runCount = await runBtn.count();
+    console.log(`[Run] Run button count: ${runCount}`);
+
+    if (runCount === 0) {
+      await ss(page, "09-run-button-NOT-FOUND");
+      console.warn("[Run] Run button not found — cannot test backtest flow");
+      return;
+    }
+
+    // Run 버튼 텍스트 확인
+    const runText = await runBtn.innerText();
+    console.log(`[Run] Run button text: '${runText}'`);
+
+    await runBtn.click();
+    await ss(page, "10-after-run-click");
+
+    // 실행 중 표시 대기
+    await page.waitForTimeout(1000);
+    await ss(page, "11-running-state");
+
+    // 결과 대기
+    await waitForResults(page, 90000);
+    await ss(page, "12-results-appeared");
+
+    const resultsText = await simMount.innerText().catch(() => "");
+
+    // Summary 탭 체크
+    const summaryVisible =
+      resultsText.includes("Win Rate") ||
+      resultsText.includes("승률") ||
+      resultsText.includes("Summary") ||
+      resultsText.includes("요약");
+    console.log(`[Results] Summary visible: ${summaryVisible}`);
+    if (!summaryVisible) {
+      await ss(page, "12-no-summary");
+      console.warn("[Results] Summary metrics not found after run");
+    }
+
+    // NaN 체크
+    if (resultsText.includes("NaN")) {
+      await ss(page, "12-nan-detected");
+      console.warn("[Results] NaN value detected in results");
+    }
+
+    // 탭 버튼들 찾기
+    const tabs = [
+      "Summary",
+      "Equity Curve",
+      "Trade List",
+      "Per Coin",
+      "Validate",
+    ];
+    for (const tab of tabs) {
+      const tabBtn = simMount
+        .locator(`button, [role="tab"]`)
+        .filter({ hasText: tab })
+        .first();
+      const tabCount = await tabBtn.count();
+      console.log(`[Tab] '${tab}': found=${tabCount}`);
+      if (tabCount > 0) {
+        await tabBtn.click();
+        await page.waitForTimeout(500);
+        await ss(page, `13-tab-${tab.replace(/ /g, "-").toLowerCase()}`);
+      }
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────
+// 5. KO 시뮬레이터 실행 + 영문 하드코딩 체크
+// ─────────────────────────────────────────────────
+test.describe("5. KO Simulator Run & i18n", () => {
+  test("KO Run → 결과에 영문 하드코딩 없는지 확인", async ({ page }) => {
+    test.setTimeout(120000);
+
+    await page.goto("/ko/simulate/?preset=bb-squeeze-short", {
+      waitUntil: "domcontentloaded",
+    });
+    await waitForSimulator(page);
+    await ss(page, "14-ko-before-run");
+
+    const simMount = page.locator("#simulator-mount");
+
+    // KO에서 Run 버튼 텍스트 확인
+    const allBtns = await simMount.locator("button").allInnerTexts();
+    console.log("[KO] All button texts:", allBtns.slice(0, 20));
+
+    const runBtn = simMount
+      .locator("button")
+      .filter({ hasText: /백테스트 실행|실행|run backtest|simulate/i })
+      .first();
+    const runCount = await runBtn.count();
+
+    if (runCount > 0) {
+      const runText = await runBtn.innerText();
+      console.log(`[KO] Run button text: '${runText}'`);
+
+      // Run 버튼이 한국어인지 확인
+      if (runText.toLowerCase().includes("run backtest")) {
+        console.warn(`[KO i18n] Run button still shows EN text: '${runText}'`);
+        await ss(page, "14-ko-run-btn-en-text");
+      }
+
+      await runBtn.click();
+      await waitForResults(page, 90000);
+      await ss(page, "15-ko-results");
+
+      const resultsText = await simMount.innerText().catch(() => "");
+
+      // KO 결과 내 영문 하드코딩 체크
+      const enLabels = [
+        "Win Rate",
+        "Profit Factor",
+        "Max Drawdown",
+        "Total Trades",
+        "Trade List",
+        "Per Coin",
+        "Equity Curve",
+        "Summary",
+        "Validate",
+        "Strategy:",
+        "Grade:",
+        "Walk-Forward",
+        "Monthly Returns",
+        "Yearly Breakdown",
+      ];
+      const found: string[] = [];
+      for (const label of enLabels) {
+        if (resultsText.includes(label)) {
+          found.push(label);
+        }
+      }
+      if (found.length > 0) {
+        await ss(page, "15-ko-en-labels-in-results");
+        console.warn(
+          `[KO i18n] EN labels found in KO results: ${found.join(", ")}`,
+        );
+      }
+    } else {
+      await ss(page, "14-ko-run-NOT-FOUND");
+      console.warn("[KO] Run button not found");
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────
+// 6. Share/Copy Link + Download CSV
+// ─────────────────────────────────────────────────
+test.describe("6. Share & Download", () => {
+  test("Copy Link 버튼 작동 (EN)", async ({ page }) => {
+    test.setTimeout(120000);
+    // 결과가 있는 상태 만들기
+    await page.goto("/simulate/?preset=bb-squeeze-short", {
+      waitUntil: "domcontentloaded",
+    });
+    await waitForSimulator(page);
+
+    const simMount = page.locator("#simulator-mount");
+    const runBtn = simMount
+      .locator("button")
+      .filter({ hasText: /run backtest|실행/i })
+      .first();
+    if ((await runBtn.count()) > 0) {
+      await runBtn.click();
+      await waitForResults(page, 90000);
+    }
+
+    await ss(page, "16-before-copy-link");
+
+    // Copy Link 버튼 찾기
+    const copyBtn = simMount
+      .locator("button")
+      .filter({ hasText: /copy link|링크 복사/i })
+      .first();
+    const copyCount = await copyBtn.count();
+    console.log(`[Share] Copy Link button count: ${copyCount}`);
+
+    if (copyCount > 0) {
+      // clipboard 권한 부여
+      await page
+        .context()
+        .grantPermissions(["clipboard-read", "clipboard-write"]);
+      await copyBtn.click();
+      await page.waitForTimeout(500);
+      await ss(page, "16-after-copy-link");
+      // "Copied!" 피드백 확인
+      const copiedText = simMount.locator("text=Copied!, text=복사됨!");
+      const copiedCount = await copiedText.count();
+      console.log(`[Share] 'Copied!' feedback: ${copiedCount}`);
+      if (copiedCount === 0) {
+        console.warn(
+          "[Share] 'Copied!' feedback not shown after Copy Link click",
+        );
+      }
+    } else {
+      console.warn(
+        "[Share] Copy Link button not found — results may not have loaded",
+      );
+    }
+
+    // CSV Download 버튼
+    const csvBtn = simMount
+      .locator("button, a")
+      .filter({ hasText: /csv|download csv|CSV 다운로드/i })
+      .first();
+    const csvCount = await csvBtn.count();
+    console.log(`[Download] CSV button count: ${csvCount}`);
+    if (csvCount > 0) {
+      await ss(page, "17-csv-button-found");
+    } else {
+      console.warn("[Download] CSV button not found after results loaded");
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────
+// 7. UX 체크 — End Date 기본값, NaN, 빈 값
+// ─────────────────────────────────────────────────
+test.describe("7. UX & Edge Cases", () => {
+  test("End Date 기본값 채워져 있는지 확인 (EN)", async ({ page }) => {
+    await page.goto("/simulate/?preset=bb-squeeze-short", {
+      waitUntil: "domcontentloaded",
+    });
+    await waitForSimulator(page);
+
+    const simMount = page.locator("#simulator-mount");
+    await ss(page, "18-date-inputs");
+
+    // date input 찾기
+    const dateInputs = simMount.locator(
+      "input[type='date'], input[placeholder*='date'], input[placeholder*='날짜']",
+    );
+    const dateCount = await dateInputs.count();
+    console.log(`[Date] Date input count: ${dateCount}`);
+
+    for (let i = 0; i < dateCount; i++) {
+      const val = await dateInputs.nth(i).inputValue();
+      const placeholder = await dateInputs.nth(i).getAttribute("placeholder");
+      console.log(
+        `[Date] input[${i}] placeholder='${placeholder}' value='${val}'`,
+      );
+      if (!val || val === "") {
+        console.warn(
+          `[Date] date input[${i}] has empty value (may be intentional if auto-populated)`,
+        );
+      }
+    }
+
+    // Expert 모드에서 date range 확인
+    const expertBtn = simMount
+      .locator("button")
+      .filter({ hasText: /expert/i })
+      .first();
+    if ((await expertBtn.count()) > 0) {
+      await expertBtn.click();
+      await page.waitForTimeout(500);
+      const dateInputsExpert = simMount.locator("input[type='date']");
+      const expertDateCount = await dateInputsExpert.count();
+      console.log(`[Date Expert] Date input count: ${expertDateCount}`);
+      for (let i = 0; i < expertDateCount; i++) {
+        const val = await dateInputsExpert.nth(i).inputValue();
+        console.log(`[Date Expert] input[${i}] value='${val}'`);
+        if (!val || val === "") {
+          await ss(page, `18-date-empty-expert-input-${i}`);
+          console.warn(`[Date] EXPERT mode date input[${i}] is EMPTY`);
+        }
+      }
+    }
+  });
+
+  test("First-run tooltip (KO) 영문 혼용 체크", async ({ page }) => {
+    // localStorage 비워서 first-run 상태 시뮬레이션
+    await page.goto("/ko/simulate/?preset=bb-squeeze-short", {
+      waitUntil: "domcontentloaded",
+    });
+    // localStorage clear 후 reload
+    await page.evaluate(() => localStorage.removeItem("has-run-backtest"));
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await waitForSimulator(page);
+    await page.waitForTimeout(2000);
+    await ss(page, "19-ko-first-run-tooltip");
+
+    // first-run tooltip 찾기
+    const tooltip = page.locator("#first-run-tooltip");
+    const tooltipCount = await tooltip.count();
+    console.log(`[Tooltip] first-run tooltip count: ${tooltipCount}`);
+
+    if (tooltipCount > 0) {
+      const tooltipText = await tooltip.innerText();
+      console.log(`[Tooltip] text: '${tooltipText}'`);
+      // KO tooltip에 영문 "Click 'Run Backtest'" 혼용 여부
+      if (
+        tooltipText.includes("Click") &&
+        tooltipText.includes("Run Backtest")
+      ) {
+        console.warn(
+          `[Tooltip KO] EN instruction found in KO tooltip: '${tooltipText}'`,
+        );
+        await ss(page, "19-ko-tooltip-en-text");
+      }
+    }
+  });
+
+  test("Trade on OKX CTA 존재 확인 (EN)", async ({ page }) => {
+    test.setTimeout(120000);
+    await page.goto("/simulate/?preset=bb-squeeze-short", {
+      waitUntil: "domcontentloaded",
+    });
+    await waitForSimulator(page);
+
+    const runBtn = page
+      .locator("#simulator-mount button")
+      .filter({ hasText: /run backtest/i })
+      .first();
+    if ((await runBtn.count()) > 0) {
+      await runBtn.click();
+      await waitForResults(page, 90000);
+    }
+
+    await ss(page, "20-okx-cta-check");
+    const okxCta = page
+      .locator("a, button")
+      .filter({ hasText: /trade on okx|okx/i });
+    const okxCount = await okxCta.count();
+    console.log(`[CTA] Trade on OKX count: ${okxCount}`);
+    if (okxCount === 0) {
+      console.warn("[CTA] 'Trade on OKX' CTA not found after results loaded");
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────
+// 8. 반응형 — 모바일 375px
+// ─────────────────────────────────────────────────
+test.describe("8. Mobile 375px", () => {
+  test("KO /ko/simulate/ 모바일 레이아웃", async ({ browser }) => {
+    const ctx = await browser.newContext({
+      viewport: { width: 375, height: 667 },
+      isMobile: true,
+      hasTouch: true,
+    });
+    const page = await ctx.newPage();
+    await page.goto("/ko/simulate/?preset=bb-squeeze-short", {
+      waitUntil: "domcontentloaded",
+    });
+    await waitForSimulator(page);
+    await ss(page, "21-mobile-ko-simulate");
+
+    // 가로 스크롤 없음 확인
+    const scrollWidth = await page.evaluate(() => document.body.scrollWidth);
+    const clientWidth = await page.evaluate(() => document.body.clientWidth);
+    console.log(
+      `[Mobile] scrollWidth=${scrollWidth} clientWidth=${clientWidth}`,
+    );
+    if (scrollWidth > clientWidth + 5) {
+      await ss(page, "21-mobile-horizontal-scroll");
+      console.warn(
+        `[Mobile KO] Horizontal scroll detected: ${scrollWidth} > ${clientWidth}`,
+      );
+    }
+
+    // 모바일에서 simulator mount 버튼들 44px 이상 확인
+    const buttons = page.locator("#simulator-mount button");
+    const btnCount = await buttons.count();
+    let smallBtns = 0;
+    for (let i = 0; i < Math.min(btnCount, 10); i++) {
+      const box = await buttons.nth(i).boundingBox();
+      if (box && (box.height < 44 || box.width < 44)) {
+        smallBtns++;
+        console.warn(
+          `[Mobile] button[${i}] too small: ${box.width}x${box.height}`,
+        );
+      }
+    }
+    if (smallBtns > 0) {
+      await ss(page, "21-mobile-small-touch-targets");
+    }
+
+    await ctx.close();
+  });
+});
+
+// ─────────────────────────────────────────────────
+// 9. i18n 스위치 — /simulate/ → /ko/simulate/ 네비게이션
+// ─────────────────────────────────────────────────
+test.describe("9. Language Switch", () => {
+  test("EN → KO 언어 전환 (네비게이션 링크)", async ({ page }) => {
+    await page.goto("/simulate/", { waitUntil: "domcontentloaded" });
+    await ss(page, "22-en-before-switch");
+
+    // 언어 전환 링크 찾기 (한국어, KO 등)
+    const koLink = page
+      .locator("a")
+      .filter({ hasText: /^KO$|한국어|Korean/i })
+      .first();
+    const koLinkCount = await koLink.count();
+    console.log(`[LangSwitch] KO link count: ${koLinkCount}`);
+
+    if (koLinkCount > 0) {
+      const href = await koLink.getAttribute("href");
+      console.log(`[LangSwitch] KO link href: ${href}`);
+      await koLink.click();
+      await page.waitForLoadState("domcontentloaded");
+      const url = page.url();
+      console.log(`[LangSwitch] After KO click, URL: ${url}`);
+      await ss(page, "22-after-ko-switch");
+
+      if (!url.includes("/ko/")) {
+        console.warn(
+          `[LangSwitch] Expected /ko/ in URL after language switch, got: ${url}`,
+        );
+      }
+    } else {
+      // 언어 스위치 버튼을 nav에서 찾기
+      const navKo = page
+        .locator("nav a, header a")
+        .filter({ hasText: /ko|한국|korean/i })
+        .first();
+      const navKoCount = await navKo.count();
+      console.log(`[LangSwitch] Nav KO link count: ${navKoCount}`);
+      await ss(page, "22-lang-switch-not-found");
+    }
+  });
+
+  test("KO → EN 언어 전환", async ({ page }) => {
+    await page.goto("/ko/simulate/", { waitUntil: "domcontentloaded" });
+    await ss(page, "23-ko-before-switch");
+
+    const enLink = page
+      .locator("a")
+      .filter({ hasText: /^EN$|영어|English/i })
+      .first();
+    const enCount = await enLink.count();
+    console.log(`[LangSwitch] EN link count: ${enCount}`);
+
+    if (enCount > 0) {
+      await enLink.click();
+      await page.waitForLoadState("domcontentloaded");
+      const url = page.url();
+      console.log(`[LangSwitch] After EN click, URL: ${url}`);
+      await ss(page, "23-after-en-switch");
+      if (url.includes("/ko/")) {
+        console.warn(`[LangSwitch] Still on /ko/ URL after EN switch: ${url}`);
+      }
+    } else {
+      await ss(page, "23-en-link-not-found");
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────
+// 10. Validate 탭 (OOS/Monte Carlo)
+// ─────────────────────────────────────────────────
+test.describe("10. Validate Tab", () => {
+  test("Validate 탭 — OOS/Monte Carlo 설정 표시 (EN)", async ({ page }) => {
+    test.setTimeout(120000);
+    await page.goto("/simulate/?preset=bb-squeeze-short", {
+      waitUntil: "domcontentloaded",
+    });
+    await waitForSimulator(page);
+
+    const simMount = page.locator("#simulator-mount");
+    const runBtn = simMount
+      .locator("button")
+      .filter({ hasText: /run backtest/i })
+      .first();
+    if ((await runBtn.count()) > 0) {
+      await runBtn.click();
+      await waitForResults(page, 90000);
+    }
+
+    const validateTab = simMount
+      .locator("button, [role='tab']")
+      .filter({ hasText: /validate|검증/i })
+      .first();
+    const validateCount = await validateTab.count();
+    console.log(`[Validate] tab count: ${validateCount}`);
+
+    if (validateCount > 0) {
+      await validateTab.click();
+      await page.waitForTimeout(1000);
+      await ss(page, "24-validate-tab");
+
+      const validateText = await simMount.innerText().catch(() => "");
+      const hasOos =
+        validateText.toLowerCase().includes("oos") ||
+        validateText.toLowerCase().includes("out-of-sample");
+      const hasMC = validateText.toLowerCase().includes("monte carlo");
+      console.log(`[Validate] Has OOS: ${hasOos}, Has Monte Carlo: ${hasMC}`);
+    } else {
+      await ss(page, "24-validate-tab-not-found");
+      console.warn("[Validate] Validate tab not found");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

5 previously untracked files that are legitimate repo content (not ignore candidates from PR #1136):

- \`backend/okx/OKX_API_SPECS.md\` — OKX FD Broker API reference (OAuth + HMAC, endpoint map, known gotchas)
- \`scripts/capture-screenshots.mjs\` — Playwright screenshot utility
- \`tests/sim-audit.spec.ts\` — Simulator prod-smoke audit
- \`tests/persona-full-test.spec.ts\` — Persona e2e
- \`tests/e2e/interactive-qa-extra.spec.ts\` — Interactive-QA extensions

## Why now

Working-tree audit (2026-04-18) showed these accumulated over multiple sessions without git decision. Each is self-contained legitimate content. Together with PR #1136 (.gitignore expansion), this closes the untracked-file loop: any future file is either tracked or ignored, no third state.

## Test plan

- [ ] CI passes (existing sim-audit.spec uses prod-smoke project — not in default E2E, should not impact CI time)
- [ ] After merge: \`git status\` on a fresh clone is clean (no untracked besides build artifacts)