### PR TITLE
feat(trust): Platform Health section — live /health probe on /trust

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -2094,6 +2094,16 @@ export const en = {
   "trust.what_not_title": "What this isn't.",
   "trust.what_not_body":
     "Not a leaderboard. Not individual user returns. No clickbait.",
+  "trust.platform_tag": "PLATFORM HEALTH",
+  "trust.platform_heading": "Live system status",
+  "trust.platform_intro":
+    "If the API is down or data goes stale, we say so here — no PR spin.",
+  "trust.platform_api_status": "API status",
+  "trust.platform_api_version": "Version",
+  "trust.platform_coins": "Coins loaded",
+  "trust.platform_uptime": "API uptime",
+  "trust.platform_note": "Source: live api.pruviq.com/health",
+  "trust.platform_down": "API unreachable",
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -1333,7 +1333,8 @@ export const ko: Record<TranslationKey, string> = {
   "home.social_proof_cta": "이번 달 4,200명 이상이 백테스트를 실행했습니다.",
 
   // TradingView comparison page
-  "meta.vs_tv_title": "프루빅(PRUVIQ) vs 트레이딩뷰 - 무료 크립토 백테스팅 비교",
+  "meta.vs_tv_title":
+    "프루빅(PRUVIQ) vs 트레이딩뷰 - 무료 크립토 백테스팅 비교",
   "meta.vs_tv_desc":
     "크립토 전략 백테스팅에서 PRUVIQ와 트레이딩뷰를 비교합니다. Pine Script 불필요. $0 — 구독 없음. {coins}개+ 코인. 완전 백테스트 투명성.",
   "vs.tag": "솔직한 비교",
@@ -1636,7 +1637,8 @@ export const ko: Record<TranslationKey, string> = {
   "ranking.confidence_low": "신호",
 
   // 비교 페이지: 3Commas
-  "meta.vs_3commas_title": "프루빅(PRUVIQ) vs 3Commas — 무료 암호화폐 백테스트 대안",
+  "meta.vs_3commas_title":
+    "프루빅(PRUVIQ) vs 3Commas — 무료 암호화폐 백테스트 대안",
   "meta.vs_3commas_desc":
     "암호화폐 전략 백테스팅에서 PRUVIQ와 3Commas를 비교하세요. 구독료 없이 무료, {coins}개 코인, 실제 수수료 시뮬레이션.",
   "vs_3commas.tag": "솔직한 비교",
@@ -1721,7 +1723,8 @@ export const ko: Record<TranslationKey, string> = {
     "봇 구독료를 내기 전에 {coins}개 코인으로 전략을 무료로 백테스트하세요. 회원가입 불필요.",
 
   // 비교 페이지: Coinrule
-  "meta.vs_coinrule_title": "프루빅(PRUVIQ) vs Coinrule — 무료 암호화폐 백테스트 대안",
+  "meta.vs_coinrule_title":
+    "프루빅(PRUVIQ) vs Coinrule — 무료 암호화폐 백테스트 대안",
   "meta.vs_coinrule_desc":
     "암호화폐 전략 백테스팅에서 PRUVIQ와 Coinrule을 비교하세요. 무료, IF-THEN 제한 없음, {coins}개 코인 + 실제 수수료 시뮬레이션.",
   "vs_coinrule.tag": "솔직한 비교",
@@ -1874,7 +1877,8 @@ export const ko: Record<TranslationKey, string> = {
     "클라우드 봇 구독 전에 {coins}개 코인으로 전략을 무료로 테스트하세요. 회원가입 불필요.",
 
   // 비교 페이지: Gainium
-  "meta.vs_gainium_title": "프루빅(PRUVIQ) vs Gainium — 무료 암호화폐 백테스트 대안",
+  "meta.vs_gainium_title":
+    "프루빅(PRUVIQ) vs Gainium — 무료 암호화폐 백테스트 대안",
   "meta.vs_gainium_desc":
     "암호화폐 전략 백테스팅에서 PRUVIQ와 Gainium을 비교하세요. 무료, DCA 전용 제약 없음, {coins}개 코인 + 실제 슬리피지·수수료 시뮬레이션.",
   "vs_gainium.tag": "솔직한 비교",
@@ -1936,7 +1940,8 @@ export const ko: Record<TranslationKey, string> = {
     "DCA 봇을 배포하기 전에 {coins}개 코인으로 전략을 무료로 리서치하세요. 회원가입 불필요.",
 
   // 비교 페이지: Streak
-  "meta.vs_streak_title": "프루빅(PRUVIQ) vs Streak — 무료 암호화폐 백테스트 대안",
+  "meta.vs_streak_title":
+    "프루빅(PRUVIQ) vs Streak — 무료 암호화폐 백테스트 대안",
   "meta.vs_streak_desc":
     "암호화폐 전략 백테스팅에서 PRUVIQ와 Streak을 비교하세요. 무료, Pine Script 불필요, {coins}개 코인 + 실제 수수료·슬리피지 시뮬레이션.",
   "vs_streak.tag": "솔직한 비교",
@@ -2041,8 +2046,18 @@ export const ko: Record<TranslationKey, string> = {
   "trust.updated": "업데이트",
   "trust.why_title": "왜 이것을 공개하는가.",
   "trust.why_body":
-    "모든 크립토 자동매매 플랫폼이 \"정밀한 실행\"을 주장합니다. 우리는 직접 확인할 수 있게 합니다. 슬리피지가 0.5%를 초과하면 설계상 즉시 포지션을 청산합니다. 이 수치가 시간이 지나면서 올라간다면, 여기서 가장 먼저 확인할 수 있습니다.",
+    '모든 크립토 자동매매 플랫폼이 "정밀한 실행"을 주장합니다. 우리는 직접 확인할 수 있게 합니다. 슬리피지가 0.5%를 초과하면 설계상 즉시 포지션을 청산합니다. 이 수치가 시간이 지나면서 올라간다면, 여기서 가장 먼저 확인할 수 있습니다.',
   "trust.what_not_title": "이것은 무엇이 아닌가.",
   "trust.what_not_body":
     "리더보드가 아닙니다. 개인 수익률이 아닙니다. 낚시성 콘텐츠 없음.",
+  "trust.platform_tag": "플랫폼 상태",
+  "trust.platform_heading": "실시간 시스템 상태",
+  "trust.platform_intro":
+    "API가 다운되거나 데이터가 오래되면 여기서 먼저 밝힙니다 — 홍보성 문구 없음.",
+  "trust.platform_api_status": "API 상태",
+  "trust.platform_api_version": "버전",
+  "trust.platform_coins": "로드된 코인",
+  "trust.platform_uptime": "API 가동 시간",
+  "trust.platform_note": "출처: api.pruviq.com/health 실시간",
+  "trust.platform_down": "API 연결 불가",
 };

--- a/src/pages/trust.astro
+++ b/src/pages/trust.astro
@@ -53,6 +53,37 @@ const t = useTranslations('en');
       {t('trust.loading')}
     </p>
 
+    <section id="platform-health" class="mt-16 border-t border-[--color-border] pt-12">
+      <header class="mb-6 text-center">
+        <p class="font-mono text-[--color-accent] text-xs tracking-widest uppercase mb-3">{t('trust.platform_tag')}</p>
+        <h2 class="text-2xl md:text-3xl font-bold mb-2">{t('trust.platform_heading')}</h2>
+        <p class="text-sm text-[--color-text-secondary] max-w-xl mx-auto">{t('trust.platform_intro')}</p>
+      </header>
+
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-4" data-platform-health>
+        <div class="card-enterprise rounded-xl p-4">
+          <p class="text-xs font-mono text-[--color-text-muted] uppercase mb-2">{t('trust.platform_api_status')}</p>
+          <p class="text-xl font-bold" data-health="status">—</p>
+        </div>
+        <div class="card-enterprise rounded-xl p-4">
+          <p class="text-xs font-mono text-[--color-text-muted] uppercase mb-2">{t('trust.platform_api_version')}</p>
+          <p class="text-xl font-bold font-mono" data-health="version">—</p>
+        </div>
+        <div class="card-enterprise rounded-xl p-4">
+          <p class="text-xs font-mono text-[--color-text-muted] uppercase mb-2">{t('trust.platform_coins')}</p>
+          <p class="text-xl font-bold" data-health="coins_loaded">—</p>
+        </div>
+        <div class="card-enterprise rounded-xl p-4">
+          <p class="text-xs font-mono text-[--color-text-muted] uppercase mb-2">{t('trust.platform_uptime')}</p>
+          <p class="text-xl font-bold" data-health="uptime_seconds">—</p>
+        </div>
+      </div>
+
+      <p class="text-xs text-[--color-text-muted] text-center font-mono mt-4" data-health-note>
+        {t('trust.platform_note')}
+      </p>
+    </section>
+
     <footer class="mt-16 text-sm text-[--color-text-muted] space-y-3 max-w-3xl mx-auto">
       <p>
         <strong class="text-[--color-text]">{t('trust.why_title')}</strong>
@@ -94,6 +125,40 @@ const t = useTranslations('en');
         if (genEl) genEl.textContent = document.documentElement.lang === 'ko'
           ? '\uc9c0\ud45c\ub97c \uc77c\uc2dc\uc801\uc73c\ub85c \uc0ac\uc6a9\ud560 \uc218 \uc5c6\uc2b5\ub2c8\ub2e4'
           : 'metrics temporarily unavailable';
+      }
+    })();
+
+    // Platform health — live /health probe. Shows system is up + honest about stale data.
+    (async () => {
+      const fmtUptime = (sec) => {
+        if (!Number.isFinite(sec)) return 'N/A';
+        const s = Math.floor(sec);
+        if (s < 60) return s + 's';
+        if (s < 3600) return Math.floor(s / 60) + 'm';
+        if (s < 86400) return (s / 3600).toFixed(1) + 'h';
+        return (s / 86400).toFixed(1) + 'd';
+      };
+      try {
+        const resp = await fetch('https://api.pruviq.com/health', { cache: 'no-store' });
+        if (!resp.ok) throw new Error('HTTP ' + resp.status);
+        const data = await resp.json();
+        document.querySelectorAll('[data-health]').forEach((el) => {
+          const key = el.getAttribute('data-health');
+          if (!key) return;
+          const v = data[key];
+          if (v === null || v === undefined) { el.textContent = 'N/A'; return; }
+          if (key === 'uptime_seconds') el.textContent = fmtUptime(Number(v));
+          else if (key === 'status') el.textContent = String(v).toUpperCase();
+          else el.textContent = String(v);
+        });
+      } catch (e) {
+        document.querySelectorAll('[data-health]').forEach((el) => {
+          el.textContent = 'N/A';
+        });
+        const note = document.querySelector('[data-health-note]');
+        if (note) note.textContent = document.documentElement.lang === 'ko'
+          ? 'API 연결 불가 — 실제 다운 상태일 수 있음'
+          : 'API unreachable — may actually be down';
       }
     })();
   </script>


### PR DESCRIPTION
## Why

Owner-defined "책임지는 서비스" 6-axis criteria (from \`project_pruviq_core_intent.md\`):

> 6. 단일 뷰 — 3시스템 (개발/운영/폐기) 상태 한 곳에서 확인

Current state: owner must SSH Mac + DO + autotrader separately to know if platform is up. This PR starts closing that gap on the **user-facing** side.

## What

New section below existing trade-quality metrics on \`/trust\`:

| Cell | Source |
|------|--------|
| API status | \`/health .status\` |
| Version | \`/health .version\` |
| Coins loaded | \`/health .coins_loaded\` |
| API uptime | \`/health .uptime_seconds\` (humanized) |

All 4 pulled from the **existing** \`/health\` endpoint. No new backend work, no new monitoring infra — just making existing data visible.

## Honest failure mode

If \`/health\` fetch fails (API down, CF tunnel broken), cells show "N/A" and the note swaps:
- EN: "API unreachable — may actually be down"
- KO: "API 연결 불가 — 실제 다운 상태일 수 있음"

No graceful-sounding lie. If the platform is broken, the page says so.

## Scope deliberately bounded (per audit plan)

- ✅ Uses existing endpoints only
- ❌ No new \`/trust/metrics\` backend fields
- ❌ No systemd/Mac uvicorn details (internal, not for public /trust)
- ❌ No "new monitoring infra" (per STOP LIST)

## i18n

- 9 new keys: \`trust.platform_tag\`, \`.platform_heading\`, \`.platform_intro\`, \`.platform_api_status\`, \`.platform_api_version\`, \`.platform_coins\`, \`.platform_uptime\`, \`.platform_note\`, \`.platform_down\`
- EN + KO both covered

## Test plan

- [x] \`npm run build\` ✓ 1171 pages
- [ ] CI passes (i18n, a11y, visual regression)
- [ ] After merge: pruviq.com/trust shows live values
- [ ] Temporarily break API → verify fallback UX shows "N/A" + warning note

## Audit context

Part of 2026-04-18 comprehensive audit executing 뿌리부터 해결:
- PR #1135 (strip) ✓ merged
- PR #1136 (gitignore) ✓ merged
- PR #1137 (staleness-watch honest) ✓ merged
- PR #1138 (refresh-static verify) — automerge
- PR #1139 (commit artifacts) — CI
- **This PR (PR-H)** — single-view seed