### PR TITLE
fix(systemd): sim_audit false-fail + daily-ranking timeout

### DIFF
--- a/backend/deploy/systemd/bin/sim_audit.sh
+++ b/backend/deploy/systemd/bin/sim_audit.sh
@@ -12,9 +12,11 @@ LATEST="/tmp/pruviq-sim-audit-latest.txt"
 cd "$REPO_DIR"
 "$VENV" tests/sim_audit.py quick 2>&1 | tee "$LATEST"
 
-FAILS=$(grep -c FAIL "$LATEST" 2>/dev/null || echo 0)
+# 뿌리 수정: `grep -c FAIL`은 SUMMARY 줄의 "0 FAIL"까지 매칭해서 모든 실행이 FAILS=1로
+# 오판 → exit 1. 테스트 라벨 `[FAIL]` 만 정확히 집계한다.
+FAILS=$(grep -c "\[FAIL\]" "$LATEST" 2>/dev/null || echo 0)
 if [ "$FAILS" -gt 0 ]; then
-    SUMMARY=$(grep -E 'SUMMARY|FAIL' "$LATEST" | head -10)
+    SUMMARY=$(grep -E 'SUMMARY|\[FAIL\]' "$LATEST" | head -10)
     if [ -n "${TELEGRAM_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
         curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_TOKEN}/sendMessage" \
             -d chat_id="${TELEGRAM_CHAT_ID}" \

--- a/backend/deploy/systemd/pruviq-daily-ranking.service
+++ b/backend/deploy/systemd/pruviq-daily-ranking.service
@@ -10,7 +10,11 @@ Group=pruviq
 WorkingDirectory=/opt/pruviq/current
 EnvironmentFile=/opt/pruviq/shared/.env
 ExecStart=/opt/pruviq/bin/daily-strategy-ranking.sh
-TimeoutStartSec=3600
+TimeoutStartSec=7200
+# 2026-04-18: 3600 → 7200. strategy × direction × timeframe × group 조합이 많고
+# 무거운 조합(supertrend/top100)은 개별 60s timeout에 걸려 재시도까지 합치면 1h 초과.
+# 병렬화 전까지 제한 완화. 장기적으로는 daily_strategy_ranking.py의 requests를
+# async/concurrent.futures 로 전환 검토.
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=pruviq-daily-ranking


### PR DESCRIPTION
## Summary

DO systemd `list-units --state=failed` 에 2개 유닛이 떠 있던 문제 근본 수정.

### 1. pruviq-sim-audit: 매 실행마다 FAILED
- `sim_audit.sh:15` 의 `grep -c FAIL "$LATEST"` 가 SUMMARY 라인
  `81 PASS / 0 FAIL / 2 WARN / 0 SKIP` 의 "FAIL" 문자열까지 매치
- 결과: 모든 클린 실행이 `FAILS=1 → exit 1` → systemd FAILURE 오판
- 수정: `grep -c "\[FAIL\]"` — 테스트 라벨만 정확히 집계
- 검증: 실 로그로 모의 실행 시 구버전 `1`, 신버전 `0` (클린) / `1` (진짜 FAIL 있을 때)

### 2. pruviq-daily-ranking: timeout TERM
- `TimeoutStartSec=3600` 하에서 `supertrend/long/1H/top100: Timeout` 등
  무거운 조합이 개별 60s API timeout에 걸리면 총 누적 실행이 1h 초과
- 수정: `TimeoutStartSec=7200` 으로 완화
- 장기: `daily_strategy_ranking.py` 의 `requests.post` 를 concurrent.futures
  또는 async 로 병렬화 검토 (별도 PR)

둘 다 Mac `jepo_healthcheck.sh` 에서 거짓 FAIL 감지되어 Telegram alert
발생했던 흐름의 뿌리.

## Test plan

- [x] sim_audit.sh 패치를 실 sim-audit 로그 포맷으로 mock 실행 → 구/신 grep 카운트 정확성 확인
- [x] `bash -n` 문법 검증 통과
- [ ] 머지 후 DO systemd 에 반영돼 다음 timer trigger 시 failed 2건 사라짐 확인
- [ ] 다음 `pruviq-sim-audit.timer` 주기 (00/06/12/18 UTC) 후 `systemctl status pruviq-sim-audit` = active inactive(exit 0)
- [ ] 다음 `pruviq-daily-ranking.timer` 주기 (00:05 UTC) 후 7200s 안에 완료 or 여전히 timeout이면 병렬화 PR 착수

🤖 Generated with [Claude Code](https://claude.com/claude-code)