### PR TITLE
fix(csp): restore style-src 'unsafe-inline' — active nav highlight broken for 4 weeks

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -4,7 +4,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self'; font-src 'self'; img-src 'self' data: https:; connect-src 'self' https://*.pruviq.com https://cloudflareinsights.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com; frame-src https://s.tradingview.com https://www.tradingview-widget.com; frame-ancestors 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https:; connect-src 'self' https://*.pruviq.com https://cloudflareinsights.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com; frame-src https://s.tradingview.com https://www.tradingview-widget.com; frame-ancestors 'none'
 
 /fonts/*
   Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
## Summary
PR #600 (2026-03-21, "security hardening" auto-fix) dropped 'unsafe-inline' from style-src, but the site has 50+ inline style="..." attributes relied on for active nav highlight, chart colors, and dynamic tints. For 4 weeks every visitor has seen a broken active-nav state (no accent color, no font-weight:500). The Playwright regression is already in the suite (tests/e2e/nav-highlight.spec.ts:174,184) and has been failing against production since PR #600.

## Runtime evidence (pruviq.com, Playwright headless, 2026-04-18)

| Page | CSP style-src violations |
|---|---|
| / | 44 (53 inline-styled elements affected) |
| /simulate/ | 57 |
| /strategies/ | 40 |
| /coins/ | 27 |
| /performance/ | 28 |
| /market/ | 27 |
| /dashboard/ | 29 |

Active nav link on /market/ (inline style="color:var(--color-accent);font-weight:500"):
- getComputedStyle().fontWeight = 400 (expected 500)
- getComputedStyle().color = rgb(228, 228, 231) (expected accent purple)
- el.style.fontWeight = "" — browser stripped the inline style per CSP

Console: "Applying inline style violates the following Content Security Policy directive 'style-src 'self''"

## Fix
Add 'unsafe-inline' back to style-src. Restores exact state that shipped before PR #600.

## Alternatives considered
- Migrate 50+ inline styles to utility classes — large refactor, valid follow-up, not a hotfix
- CSP hashes — charts use dynamic colors, hashes would churn per deploy

Net change: 0 security regression vs. pre-PR-#600 baseline; resolves user-visible P0.

## Test plan
- [ ] Merge + Cloudflare deploy
- [ ] /market/ active nav link is accent-colored + font-weight:500
- [ ] DevTools console on / and /simulate/ shows no style-src CSP violations
- [ ] tests/e2e/nav-highlight.spec.ts passes in prod-smoke after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)