### PR TITLE
fix(p0): MDD halt + OAuth redirect + security + SSoT drift

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -4300,7 +4300,11 @@ async def unsubscribe_email(email: str, token: str):
     """Unsubscribe via signed link in emails."""
     from fastapi.responses import HTMLResponse
 
-    secret = os.environ.get("UNSUBSCRIBE_SECRET", "pruviq-unsub-2026")
+    # 🔴 2026-04-19: 하드코딩 기본값 제거 (public GitHub repo에 노출돼 있었음).
+    # DO /opt/pruviq/shared/.env 에 32+ 랜덤 설정 필수.
+    secret = os.environ.get("UNSUBSCRIBE_SECRET", "")
+    if not secret:
+        raise HTTPException(503, detail="Unsubscribe service misconfigured")
     expected_full = hmac.new(secret.encode(), email.lower().encode(), hashlib.sha256).hexdigest()
     # Accept legacy 16-char tokens (old emails) and new full 64-char tokens
     expected_legacy = expected_full[:16]

--- a/backend/okx/oauth.py
+++ b/backend/okx/oauth.py
@@ -47,8 +47,29 @@ def _gen_passphrase() -> str:
     return f"Pr1!{rand}"  # guaranteed: upper(P), lower(r), digit(1), special(!)
 
 
+def _validate_redirect(url: str) -> str:
+    """Return url if it points to pruviq.com (or subdomain) or is empty; else "".
+    Defends `/auth/okx/*?redirect=evil.com` open-redirect phishing vector."""
+    if not url:
+        return ""
+    from urllib.parse import urlparse
+    try:
+        netloc = urlparse(url).netloc.lower()
+    except Exception:
+        return ""
+    if not netloc:
+        # Relative path — same origin, safe
+        return url
+    # Allow pruviq.com and *.pruviq.com only
+    if netloc == "pruviq.com" or netloc.endswith(".pruviq.com"):
+        return url
+    logger.warning("OAuth redirect blocked (not pruviq.com): %s", url[:100])
+    return ""
+
+
 def generate_oauth_params(redirect_after: str = "", lang: str = "en") -> dict:
     """Generate OAuth params for frontend authorize URL."""
+    redirect_after = _validate_redirect(redirect_after)
     state = secrets.token_urlsafe(32)
     save_csrf_state(state, redirect_after or "", lang)
     params = {
@@ -67,6 +88,7 @@ def generate_oauth_params(redirect_after: str = "", lang: str = "en") -> dict:
 def generate_auth_url(redirect_after: str = "", lang: str = "en") -> str:
     """Generate full OKX authorize URL (server-side redirect variant)."""
     from urllib.parse import urlencode
+    redirect_after = _validate_redirect(redirect_after)
     state = secrets.token_urlsafe(32)
     save_csrf_state(state, redirect_after or "", lang)
     params = {

--- a/backend/okx/reconciler.py
+++ b/backend/okx/reconciler.py
@@ -182,7 +182,10 @@ async def check_mdd_and_halt(session_id: str) -> bool:
     except Exception as e:
         logger.warning("MDD check: get_trade_log failed for %s: %s", session_id[:8], e)
         return False
-    cum_pnl = sum(float(t.get("pnl") or 0) for t in trades)
+    # 🔴 MDD halt 버그 (2026-04-19): storage.get_trade_log 는 `pnl_usdt` 키로 반환하는데
+    # 이 함수가 `t.get("pnl")`로 읽으면 항상 None → cum_loss=0 → halt 영영 트리거 안 됨.
+    # 레거시 대비 두 키 모두 검사.
+    cum_pnl = sum(float(t.get("pnl_usdt") or t.get("pnl") or 0) for t in trades)
     cum_loss = max(0.0, -cum_pnl)
     if cum_loss <= threshold_usd:
         return False

--- a/backend/okx/router.py
+++ b/backend/okx/router.py
@@ -170,6 +170,19 @@ async def execute_order(
         raise HTTPException(429, f"Rate limit: wait {wait}s before next order")
     _order_rate_limit[session_id] = now
 
+    # 🔴 2026-04-19: 서버측 position cap. auto_executor 에는 있었으나 수동 POST 경로는 우회됨.
+    # settings.max_per_trade_usdt (default 200) 로 강제 캡.
+    from .settings import get_settings
+    _settings = get_settings(session_id)
+    _cap = float(_settings.get("max_per_trade_usdt", 200.0))
+    if req.position_size_usdt > _cap:
+        _order_rate_limit.pop(session_id, None)
+        raise HTTPException(
+            400,
+            f"Position size ${req.position_size_usdt:.2f} exceeds max_per_trade_usdt cap ${_cap:.2f}. "
+            f"Adjust in settings or reduce size.",
+        )
+
     try:
         result = await execute_from_simulation(session_id, req, current_price)
         return {"status": "executed", **result}

--- a/backend/okx/token_refresh.py
+++ b/backend/okx/token_refresh.py
@@ -40,21 +40,17 @@ async def refresh_all_sessions() -> dict:
             stats["expired"] += 1
             continue
 
-        # Check if refresh token is too old
-        if time.time() > tokens["expires_at"] + REFRESH_TOKEN_MAX_AGE:
+        # 🔴 2026-04-19 버그 수정: `tokens["expires_at"]` 은 존재하지 않음 (save_session 은
+        # created_at / updated_at 만 기록). OKX Fast API는 API 키 방식이라 refresh 불필요 →
+        # stale 세션 제거만 수행. 과거 로직은 매 실행 KeyError 발생해 cleanup 정지.
+        created_at = float(tokens.get("created_at") or 0)
+        if created_at and time.time() > created_at + REFRESH_TOKEN_MAX_AGE:
             delete_session(session_id)
             stats["expired"] += 1
-            logger.info("Session %s expired (refresh token too old)", session_id[:8])
+            logger.info("Session %s expired (age > %ds)", session_id[:8], REFRESH_TOKEN_MAX_AGE)
             continue
-
-        # Proactively refresh if access token expires within window
-        if time.time() > tokens["expires_at"] - REFRESH_WINDOW:
-            try:
-                pass  # Fast API: API keys don't need token refresh
-                stats["refreshed"] += 1
-            except Exception as e:
-                logger.error("Failed to refresh session %s: %s", session_id[:8], e)
-                stats["errors"] += 1
+        # OKX Fast API (API keys): no refresh; just keep stats aligned.
+        stats["refreshed"] += 1
 
     logger.info(
         "Token refresh complete: %d refreshed, %d expired, %d errors (of %d total)",

--- a/backend/scripts/refresh_static.sh
+++ b/backend/scripts/refresh_static.sh
@@ -141,14 +141,20 @@ import json, datetime, urllib.request
 path = '$REPO_DIR/$SITE_STATS'
 with open(path) as f:
     d = json.load(f)
+# 2026-04-19: silent `except: pass` 제거. health/strategies 응답 실패 시 명시적 경고
+# (stderr 로 올라가 refresh_static.sh 의 `2>/dev/null` 너머 log 에서 감지 가능).
+# fallback 기본값은 그대로 유지 (refresh 전체가 실패하지 않도록 non-blocking).
+import sys
 try:
     health = json.loads(urllib.request.urlopen('http://127.0.0.1:8080/health', timeout=5).read())
-    d['coins_analyzed'] = health.get('coins_loaded', d.get('coins_analyzed', 572))
-except: pass
+    d['coins_analyzed'] = health.get('coins_loaded', d.get('coins_analyzed', 240))
+except Exception as e:
+    print(f'WARN: /health fetch failed — coins_analyzed unchanged ({e.__class__.__name__})', file=sys.stderr)
 try:
     strats = json.loads(urllib.request.urlopen('http://127.0.0.1:8080/strategies', timeout=5).read())
     d['strategies_tested'] = len(strats) if isinstance(strats, list) else d.get('strategies_tested', 17)
-except: pass
+except Exception as e:
+    print(f'WARN: /strategies fetch failed — strategies_tested unchanged ({e.__class__.__name__})', file=sys.stderr)
 start = datetime.date(2023, 12, 30)
 d['trading_days'] = (datetime.date.today() - start).days
 d['last_updated'] = datetime.date.today().isoformat()

--- a/backend/scripts/send_weekly_email.py
+++ b/backend/scripts/send_weekly_email.py
@@ -25,7 +25,10 @@ import httpx
 SUBSCRIBERS_FILE = Path("/Users/jepo/pruviq-data/subscribers.json")
 API_URL = "http://localhost:8080"
 SENDGRID_API_KEY = os.environ.get("SENDGRID_API_KEY", "")
-UNSUBSCRIBE_SECRET = os.environ.get("UNSUBSCRIBE_SECRET", "pruviq-unsub-2026")
+# 2026-04-19: 하드코딩 기본값 제거. UNSUBSCRIBE_SECRET 이 없으면 이메일 발송 차단.
+UNSUBSCRIBE_SECRET = os.environ.get("UNSUBSCRIBE_SECRET", "")
+if not UNSUBSCRIBE_SECRET:
+    raise RuntimeError("UNSUBSCRIBE_SECRET must be set in environment (see DO /opt/pruviq/shared/.env)")
 FROM_EMAIL = "alerts@pruviq.com"
 
 

--- a/src/config/site-stats.ts
+++ b/src/config/site-stats.ts
@@ -3,14 +3,14 @@ import coinsStats from "../../public/data/coins-stats.json";
 
 /** Total coins currently loaded into the scanner.
  *
- *  Prefers `coins-stats.json.total_coins` (the authoritative, post-Phase-B
- *  coverage filter — 235 after the 2026-04-17 OKX cutover). Falls back to
- *  `site-stats.json.coins_analyzed`, which is a separate daily-pipeline
- *  artifact and can lag the coverage filter by up to a day. */
+ *  Post OKX cutover (2026-04-17 Phase E). Reads coins-stats.json.total_coins
+ *  first (coverage filter), falls back to site-stats.json.coins_analyzed
+ *  (OKX /api/v5/public/instruments?instType=SWAP live count).
+ *  Fallback default 240 matches PR #1147 post-migration target. */
 export const COINS_ANALYZED: number =
   (coinsStats as { total_coins?: number })?.total_coins ??
   stats.coins_analyzed ??
-  235;
+  240;
 
 /** Total strategies tested */
 export const STRATEGIES_COUNT: number = stats.strategies_tested ?? 16;


### PR DESCRIPTION
## Summary

이번 세션 **6 전문가 병렬 감사**(code-reviewer × 2, debugger, automation-engineer, security audit, architecture audit)가 발견한 **모든 기술 이슈를 단일 PR로 묶음** (performance 페이지 제외 — 사용자 지시).

## 🔴 실거래 시작 전 Critical

### 1. MDD halt 영원히 안 됨 — `reconciler.py:185`
- `storage.get_trade_log` 는 **`pnl_usdt`** 키로 반환하는데 reconciler는 `t.get("pnl")` 로 읽음 → 항상 `None` → `cum_loss = 0` → **halt 트리거 불가**
- 실거래 개시 시 일간 손실 한도(MDD) 감지 실패 = 리스크 관리 부재
- Fix: `t.get("pnl_usdt") or t.get("pnl") or 0` (레거시 호환 유지)

### 2. OAuth open redirect — `oauth.py:50-91`
- `/auth/okx/{init,start,callback}?redirect=https://evil.com` 검증 없이 저장
- 피싱 벡터: 진짜 OKX 로그인 후 evil.com 리다이렉트 가능
- Fix: `_validate_redirect()` 헬퍼 추가 — `urlparse().netloc` 이 pruviq.com 또는 *.pruviq.com 일 때만 허용, 외부 도메인은 "" 로 무력화

### 3. UNSUBSCRIBE_SECRET 하드코딩 기본값 — `main.py:4303` + `send_weekly_email.py:28`
- `os.environ.get(..., "pruviq-unsub-2026")` — public GitHub에 노출
- 이메일 주소만 알면 누구든 강제 구독 해지 가능
- Fix: 기본값 제거 → 미설정 시 `HTTPException(503)` / `RuntimeError`
- **머지 후 DO `/opt/pruviq/shared/.env` 에 32+ 랜덤 값 설정 필수**

### 4. `/execute/order` 서버측 position cap 부재 — `router.py:154`
- `SimToExecRequest` 는 `position_size_usdt >= 1` 만 검증, 상한 없음
- `auto_executor.py` 의 `max_per_trade_usdt` 가드가 수동 POST 경로로 우회됨
- Fix: execute 진입부에서 `settings.max_per_trade_usdt` 로 강제 캡 + 친절한 에러

### 5. `token_refresh.py:44` KeyError
- `tokens["expires_at"]` 참조 — `save_session` 은 `created_at`/`updated_at` 만 저장
- 결과: 매 실행 KeyError, **stale 세션 제거 로직 완전 정지** → DB 무제한 누적
- Fix: `created_at` 기반 로직으로 교체. OKX Fast API 는 refresh 없음 → stale cleanup 만 수행.

## 🟡 SSoT / 무결성

### 6. `refresh_static.sh` silent failure
- `except: pass` 2곳 (health/strategies fetch 실패 삼킴)
- Fix: 명시적 `WARN: ... failed` stderr 로그 + fallback 기본값 572 → **240** (OKX post-migration)

### 7. `src/config/site-stats.ts` COINS_ANALYZED fallback 235 → 240
- 앞선 PR #1147 이 숫자를 240으로 통일했으나 `site-stats.ts` 최종 fallback 은 235 잔존 → SSoT 드리프트 잔재

## 🟢 인프라 관측 공백 보완

### 8. `jepo_healthcheck.sh` DO 디스크 + cloudflared 체크 추가
- DO `pruviq-monitor-full.timer` 제거로 발생한 공백 (automation-engineer 지적)
- Section 3 `AUTOTRADER_ACTIVE=false` SKIP 분기에 `ssh df` + `systemctl is-active pruviq-cloudflared` 2줄 추가
- 30min 주기 충분. 별도 timer 불필요.

## Test plan

- [x] `npm run build` 1171 pages · 0 errors · 6.24s
- [x] `py_compile` 6 파일 전부 OK
- [x] `jepo_healthcheck.sh --alert` dry run: **PASS 19 / FAIL 0 / WARN 1(git) / SKIP 2**
  - 신규 DO 체크 2건 PASS 확인: `DO disk (28%)`, `DO cloudflared tunnel`
- [ ] 머지 후 DO `/opt/pruviq/shared/.env` 에 `UNSUBSCRIBE_SECRET` 32+ 랜덤 설정 (없으면 weekly email 발송 실패)
- [ ] OKX OAuth broker 승인 완료 후 `/execute/order` 실거래 테스트 (position cap + MDD halt 확인)

## 감사 출처

- code-reviewer (백엔드 OKX 모듈): MDD halt 버그 최초 발견
- Security audit (general-purpose): OAuth redirect + UNSUBSCRIBE_SECRET + position cap + token_refresh
- Architecture audit (general-purpose): SSoT 5-way 드리프트 + refresh_static silent
- automation-engineer: monitor-full 공백

## 참고 (이 PR 제외 — 별도 PR/결정)

- **SEO 5개 개선** (meta desc, OG, JSON-LD, FAQPage, /coins/[symbol] og:image) — 별도 PR
- **performance 페이지 재설계** — 사용자 방향 결정 대기 (옵션 A/B/C)
- **OKX broker channelId 승인** — Jun Kim 외부 프로세스
- **Bybit/Bitget 레퍼럴 추가** — 마케팅/레퍼럴 결정 영역
- **WebSocket 구현** — 실사용자 5+ 등 트리거 대기
- **code-reviewer 백엔드/프론트, test-writer** 미완 보고서 — 별도 세션 재실행 권장

🤖 Generated with [Claude Code](https://claude.com/claude-code)