### PR TITLE
fix(security): hide Swagger + drop localhost CORS in prod

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -83,3 +83,11 @@ COINGECKO_API_KEY=
 
 # Data directory override (default: ~/pruviq-data/futures)
 # PRUVIQ_DATA_DIR=/Users/jepo/pruviq-data/futures
+
+# ── Runtime environment ─────────────────────────────────────────────────────
+# Set to "production" on the Mac Mini live server (api.pruviq.com).
+# Effect:
+#   1. Hide /docs, /redoc, /openapi.json (Swagger UI + schema dump)
+#   2. Drop localhost:4321 / localhost:3000 from CORS allow_origins
+# Leave unset (or "development") for local dev — keeps Swagger + localhost CORS.
+PRUVIQ_ENV=development

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -81,6 +81,12 @@ from src.strategies.registry import STRATEGY_REGISTRY, get_strategy, get_all_str
 
 # Config
 VERSION = "0.3.0"
+
+# Production hardening toggle.
+# Set PRUVIQ_ENV=production on the Mac Mini .env to disable Swagger/redoc/openapi
+# and strip localhost origins from CORS. Defaults to development for safe local use.
+IS_PRODUCTION = os.getenv("PRUVIQ_ENV", "development").strip().lower() == "production"
+
 DATA_DIR = Path(os.getenv(
     "PRUVIQ_DATA_DIR",
     str(Path(__file__).resolve().parent.parent / "data" / "futures")
@@ -409,6 +415,9 @@ app = FastAPI(
     version=VERSION,
     description="Run crypto strategy simulations with realistic costs.",
     lifespan=lifespan,
+    docs_url=None if IS_PRODUCTION else "/docs",
+    redoc_url=None if IS_PRODUCTION else "/redoc",
+    openapi_url=None if IS_PRODUCTION else "/openapi.json",
 )
 
 # OKX Broker router
@@ -417,14 +426,22 @@ app.include_router(okx_router)
 
 app.add_middleware(GZipMiddleware, minimum_size=1000)
 
+_cors_prod_origins = [
+    "https://pruviq.com",
+    "https://www.pruviq.com",
+]
+_cors_dev_origins = [
+    "http://localhost:4321",
+    "http://localhost:3000",
+]
+# In production, allow_credentials=True + localhost origin enables DNS rebinding
+# and cookie-theft from any process that resolves localhost:4321. Only keep
+# localhost when explicitly running outside production.
+_cors_origins = _cors_prod_origins if IS_PRODUCTION else _cors_prod_origins + _cors_dev_origins
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "https://pruviq.com",
-        "https://www.pruviq.com",
-        "http://localhost:4321",
-        "http://localhost:3000",
-    ],
+    allow_origins=_cors_origins,
     allow_credentials=True,
     allow_methods=["GET", "POST"],
     allow_headers=["Content-Type", "Accept", "Origin"],

--- a/backend/okx/server.py
+++ b/backend/okx/server.py
@@ -29,6 +29,9 @@ INTERNAL_API_KEY = os.environ.get("INTERNAL_API_KEY", "").strip()
 SIGNAL_POLL_INTERVAL = int(os.environ.get("OKX_SIGNAL_POLL_INTERVAL", "300"))  # 5 min default
 SIGNAL_POLL_TIMEOUT = float(os.environ.get("OKX_SIGNAL_POLL_TIMEOUT", "15"))
 
+# Hide Swagger/redoc/openapi when PRUVIQ_ENV=production.
+IS_PRODUCTION = os.environ.get("PRUVIQ_ENV", "development").strip().lower() == "production"
+
 
 async def _signal_polling_loop() -> None:
     """Poll Mac Mini `/internal/signals` every `SIGNAL_POLL_INTERVAL` seconds.
@@ -108,6 +111,9 @@ app = FastAPI(
     version="0.1.0",
     description="PRUVIQ → OKX trade execution via OAuth Broker",
     lifespan=lifespan,
+    docs_url=None if IS_PRODUCTION else "/docs",
+    redoc_url=None if IS_PRODUCTION else "/redoc",
+    openapi_url=None if IS_PRODUCTION else "/openapi.json",
 )
 
 app.add_middleware(


### PR DESCRIPTION
## Summary

17명 전문가 병렬 감사 + 라이브 재현으로 확인된 **두 건의 프로덕션 노출**을 환경변수 게이트로 차단.

## 🔴 재현된 노출 (검증 시점: 2026-04-19 02:20 KST)

### 1. Swagger / OpenAPI 공개
```bash
$ curl -o /dev/null -w '%{http_code}\n' https://api.pruviq.com/docs        # 200
$ curl -o /dev/null -w '%{http_code}\n' https://api.pruviq.com/openapi.json # 200
$ curl -s https://api.pruviq.com/openapi.json | jq '.paths | keys | length' # 51
```
51개 내부 엔드포인트 전체 스키마 노출 — `/auth/okx/init`, `/execute/order`, `/execute/positions`, `/admin/halt`, `/internal/signals`, `/strategies/{id}/activate` 등.

### 2. CORS localhost + credentials in prod
```bash
$ curl -sI -H "Origin: http://localhost:4321" https://api.pruviq.com/health
access-control-allow-credentials: true
access-control-allow-origin: http://localhost:4321
```
`allow_credentials=True` + 로컬 오리진 허용 = DNS rebinding / 쿠키 탈취 벡터.

## Fix

`PRUVIQ_ENV=production` 환경변수로 게이트:
- `FastAPI(docs_url=None, redoc_url=None, openapi_url=None)` when production
- CORS `_cors_origins`에서 `localhost:4321`, `localhost:3000` 제외 when production
- `backend/okx/server.py` (별도 broker FastAPI)에도 동일 적용

개발 기본값 `development` 유지 → 로컬 개발 경험 무변경.

## Files
- `backend/api/main.py` — IS_PRODUCTION 플래그 + FastAPI/CORS 분기
- `backend/okx/server.py` — Swagger 게이트 동일 적용
- `backend/.env.example` — `PRUVIQ_ENV` 문서화

## 📋 머지 후 Mac Mini 배포 (수동 필수)

```bash
# 1. 환경변수 추가
echo "PRUVIQ_ENV=production" >> ~/pruviq/backend/.env

# 2. uvicorn 재시작
~/Desktop/start-backend.command

# 3. 검증 — 둘 다 404여야 함
curl -o /dev/null -w '%{http_code}\n' https://api.pruviq.com/docs
curl -o /dev/null -w '%{http_code}\n' https://api.pruviq.com/openapi.json

# 4. CORS 검증 — localhost 오리진은 응답 헤더에 찍히지 않아야 함
curl -sI -H "Origin: http://localhost:4321" https://api.pruviq.com/health | grep -i access-control
```

## Non-goals
- /health 의 `version` / `uptime_seconds` 노출은 **의도된 신호** (Moat-3 Platform Health, #1141). 건드리지 않음.
- CSP `script-src 'unsafe-inline'` 제거는 인라인 스크립트 hash/nonce 전환 필요 — 별도 PR.

## Test plan
- [x] `python3 -c "import ast; ast.parse(...)"` 양쪽 파일 syntax OK
- [x] `grep` 검증: IS_PRODUCTION, docs_url=None, _cors_origins 모두 적용
- [ ] Mac Mini 재배포 후 라이브 재검 (오너 수동)

🤖 Generated with [Claude Code](https://claude.com/claude-code)