### PR TITLE
fix(compare): binance-vs-okx 404→/fees + kill 240+ SSoT drift

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -20,6 +20,12 @@
 /rankings /strategies/ranking 301
 /rankings/ /strategies/ranking 301
 
+# /compare/binance-vs-okx → /fees (exchange comparison lives on fees page).
+# Handled by src/pages/compare/binance-vs-okx.astro at build time; this line
+# is a belt-and-suspenders for direct edge hits before the Astro route resolves.
+/compare/binance-vs-okx /fees 301
+/compare/binance-vs-okx/ /fees 301
+
 # KO equivalents
 /ko/builder /ko/simulate/ 301
 /ko/builder/* /ko/simulate/ 301

--- a/src/pages/autotrading/index.astro
+++ b/src/pages/autotrading/index.astro
@@ -4,11 +4,12 @@
 // and the /rankings/daily production bug all shipped. Redirect removed;
 // users can now reach the OKX autotrade setup directly.
 import Layout from '../../layouts/Layout.astro';
+import { COINS_ANALYZED } from '../../config/site-stats';
 ---
 
 <Layout
   title="Autotrading — Verified Strategies Running 24/7 | PRUVIQ"
-  description="PRUVIQ backtests 240+ coins. Only verified strategies deploy. Connect your OKX account and let your bot execute automatically with proven risk limits."
+  description={`PRUVIQ backtests ${COINS_ANALYZED}+ coins. Only verified strategies deploy. Connect your OKX account and let your bot execute automatically with proven risk limits.`}
 >
 
   <!-- HERO -->
@@ -27,7 +28,7 @@ import Layout from '../../layouts/Layout.astro';
       </h1>
 
       <p class="text-xl md:text-2xl text-[--color-text-secondary] leading-relaxed max-w-2xl mx-auto mb-10">
-        PRUVIQ backtests <strong class="text-[--color-text]">240+ coins</strong>. Only verified strategies deploy. Your bot executes automatically on OKX.
+        PRUVIQ backtests <strong class="text-[--color-text]">{COINS_ANALYZED}+ coins</strong>. Only verified strategies deploy. Your bot executes automatically on OKX.
       </p>
 
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
@@ -63,7 +64,7 @@ import Layout from '../../layouts/Layout.astro';
         </div>
         <h3 class="font-bold text-xl mb-3">PRUVIQ Verifies</h3>
         <p class="text-[--color-text-muted] leading-relaxed">
-          We test strategies across 240+ coins and real market conditions. Only strategies with proven edge are deployable.
+          We test strategies across {COINS_ANALYZED}+ coins and real market conditions. Only strategies with proven edge are deployable.
         </p>
       </div>
 

--- a/src/pages/compare/binance-vs-okx.astro
+++ b/src/pages/compare/binance-vs-okx.astro
@@ -1,0 +1,3 @@
+---
+return Astro.redirect('/fees', 301);
+---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -153,7 +153,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
     <div class="relative grid md:grid-cols-3 gap-8">
       <div class="hidden md:block absolute top-[2.75rem] left-[calc(33.33%+1rem)] right-[calc(33.33%+1rem)] h-px bg-gradient-to-r from-[--color-accent]/30 via-[--color-accent]/15 to-[--color-accent]/30 reveal" aria-hidden="true"></div>
       <StepCard step={1} title="Connect OKX" description="OAuth only — no API keys shared, no withdrawal access. Secure by design." />
-      <StepCard step={2} title="Pick a Verified Strategy" description="Only strategies that passed rigorous backtests across 240+ coins are deployable." />
+      <StepCard step={2} title="Pick a Verified Strategy" description={`Only strategies that passed rigorous backtests across ${coinsAnalyzed}+ coins are deployable.`} />
       <StepCard step={3} title="Bot Trades 24/7" description="Scans signals every 5 minutes. Executes automatically with your risk limits." />
     </div>
     <div class="text-center mt-14">


### PR DESCRIPTION
## Summary

라이브 재현으로 확인된 두 건의 **일관/무결 위반**을 단일 PR로 수정.

## 🔴 /compare/binance-vs-okx 404

```bash
$ curl -o /dev/null -w '%{http_code}\n' https://pruviq.com/compare/binance-vs-okx   # 404
$ curl -o /dev/null -w '%{http_code}\n' https://pruviq.com/compare/binance-vs-okx/  # 404
```

Binance→OKX 마이그레이션 관련 백링크 및 SEO 트래픽이 404로 유실 중. /fees 가 이미 거래소 비교를 커버하므로 301 리다이렉트.

**변경**:
- `src/pages/compare/binance-vs-okx.astro` — `Astro.redirect('/fees', 301)` 페이지
- `public/_redirects` — 에지 레벨 301 이중 안전장치 (PRUVIQ _redirects 룰 준수: Astro.redirect() 페이지만 넣음)

**검증**: `bash scripts/qa-redirects.sh` → PASS (dist 충돌 0).

> 전용 비교 페이지(migration 스토리 + 양쪽 레퍼럴 SEO) 는 후속 PR. 이번엔 404만 차단.

## 🟠 "240+ coins" 하드코딩 — SSoT 드리프트

룰 3(SSoT) 위반. `src/config/site-stats.ts`의 `COINS_ANALYZED` 가 라이브 값 읽는데 페이지 곳곳에 240+ 리터럴이 박혀 있어 OKX 커버리지 변화 시 자동 갱신 안 됨.

**수정**:
- `src/pages/index.astro:156` — 이미 `coinsAnalyzed` import 되어 있었음. 템플릿 리터럴로 전환.
- `src/pages/autotrading/index.astro` — 3곳 (meta description, hero, step). `COINS_ANALYZED` import 추가.

**범위 밖**: `src/i18n/en.ts` 의 ~30개 "240+ coins" 문자열. 이건 `{coins}` placeholder + 모든 vs_*.astro 소비자 업데이트 필요 → 별도 PR.

## Test plan
- [x] `npm run build` → 1172 pages, 0 errors
- [x] `bash scripts/qa-redirects.sh` → PASS
- [x] grep 검증: `coinsAnalyzed` / `COINS_ANALYZED` 심볼 적용 확인
- [ ] 머지 후 Cloudflare 배포 완료 시 `/compare/binance-vs-okx` 301 재확인

build: 1172 pages, qa-redirects: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)