### PR TITLE
ci(unit): wire vitest harness to every PR

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,40 @@
+name: Unit Tests
+
+# Vitest harness wasn't wired to CI — 6 tests in tests/unit/ ran locally but
+# every PR shipped without them. This job catches regressions that are too
+# small for e2e (i18n keys, site-stats SSoT, exchange list invariants, etc.)
+# on a cheap ubuntu runner so it stays off the Mac Mini self-hosted queue.
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: unit-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  vitest:
+    name: Vitest
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run vitest
+        run: npm run test:unit


### PR DESCRIPTION
## Summary

17명 전문가 감사에서 발견된 조용한 CI 공백 — `tests/unit/` 에 Vitest 6 파일 · 22 테스트가 있고 `test:unit` npm script 도 이미 있는데 **어떤 workflow 도 실행하지 않음**.

- grep 결과: `.github/workflows/` 28 개 파일 중 `vitest` 실행 job **0 개**
- CSP `script-src 'unsafe-inline'` 4주 회귀 (#1146), stale coin-count 549 가 계속 반복 통과한 이유 중 하나

## Fix

`.github/workflows/unit-tests.yml` 신규 — ubuntu-latest, 5min timeout, PR→main 트리거.

```yaml
on:
  pull_request:
    branches: [main]
```

Mac Mini self-hosted 큐(현재 load avg 26.34)를 건드리지 않도록 별도 ubuntu-latest 러너. automerge gate 의 `MIN_CHECK_RUNS=2` 와 `'success'|'skipped'` 정책에 자동으로 합류.

## Local verification

```
$ npm run test:unit
 RUN  v4.1.2
 Test Files  6 passed (6)
      Tests  22 passed (22)
   Duration  891ms
```

## Test plan
- [x] 로컬 `npm run test:unit` 통과 (6/6 files, 22/22 tests)
- [x] 워크플로 YAML syntax 유효 (GitHub Actions 파서 validate)
- [ ] 이 PR 에서 Unit Tests workflow 자체가 green 으로 완주
- [ ] automerge 가 Unit Tests 체크도 카운트하는지 체크 리스트에 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)