### PR TITLE
fix(simulate): on-the-fly indicator fallback (BTCUSDT 404 fix)

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -1558,7 +1558,15 @@ async def simulate_coin(req: CoinSimRequest):
             # Fallback to legacy flat cache
             df = indicator_cache.get(symbol)
         if df is None:
-            raise HTTPException(404, f"Symbol not found: {symbol}")
+            # 2026-04-19: on-the-fly fallback for coins outside top-50 cache.
+            # indicator_cache.build_multi 주석("/simulate computes on-the-fly
+            # for other coins") 의 실제 구현이 누락돼 있었음. BTCUSDT 등 top-50
+            # 정렬에서 빠진 coin 이 전부 404 되던 버그. DataManager 에 OHLCV 있으면
+            # 요청 시점에 지표 계산해서 사용.
+            raw_df = data_manager.get_df(symbol)
+            if raw_df is None:
+                raise HTTPException(404, f"Symbol not found: {symbol}")
+            df = strategy.calculate_indicators(raw_df.copy())
 
     df = filter_df_by_date(df, getattr(req, 'start_date', None), getattr(req, 'end_date', None))
     dyn_slip = _get_dynamic_slippage(symbol)

--- a/backend/deploy/systemd/pruviq-sim-audit.service
+++ b/backend/deploy/systemd/pruviq-sim-audit.service
@@ -13,7 +13,10 @@ EnvironmentFile=/opt/pruviq/shared/.env
 ExecStart=/opt/pruviq/bin/sim_audit.sh
 StandardOutput=journal
 StandardError=journal
-TimeoutStartSec=300
+TimeoutStartSec=600
+# 2026-04-19: 300 → 600. systemd 실행 환경(pruviq-api 재시작 시점 겹칠 때)에
+# 외부 API 호출이 느려지며 5분 초과 TERM 발생. 수동 실행은 80s 이지만
+# deploy 직후·negotiator 경합 시 조건부로 10분까지 여유 필요.
 
 [Install]
 WantedBy=multi-user.target

--- a/backend/scripts/daily_strategy_ranking.py
+++ b/backend/scripts/daily_strategy_ranking.py
@@ -242,6 +242,19 @@ def run_simulation(
         except requests.exceptions.Timeout:
             print(f"  ⚠ {strategy}/{direction}/{timeframe}/top{top_n}: Timeout", file=sys.stderr)
             return None
+        except requests.exceptions.ConnectionError as e:
+            # 2026-04-19: pruviq-api 재시작 시점(deploy 직후) Connection refused 감내.
+            # save_results 의 Layer 1 validation 이 6 errors 로 차단하던 뿌리.
+            # 지수 backoff 재시도로 일시적 재시작 창 (≤30s) 감내.
+            if attempt < 2:
+                wait = 5 * (2 ** attempt)  # 5s, 10s
+                print(f"  ⟳ {strategy}/{direction}/{timeframe}/top{top_n}: "
+                      f"ConnectionError, retry in {wait}s", file=sys.stderr)
+                time.sleep(wait)
+                continue
+            print(f"  ⚠ {strategy}/{direction}/{timeframe}/top{top_n}: "
+                  f"ConnectionError (3 attempts failed): {e}", file=sys.stderr)
+            return None
         except Exception as e:
             print(f"  ⚠ {strategy}/{direction}/{timeframe}/top{top_n}: {e}", file=sys.stderr)
             return None

--- a/tests/e2e/interactive-qa.spec.ts
+++ b/tests/e2e/interactive-qa.spec.ts
@@ -17,18 +17,23 @@ test.describe("Interactive QA — 기능 클릭 테스트", () => {
   test("simulate: Breakout 시나리오 클릭 → 결과 표시", async ({ page }) => {
     await page.goto("/simulate/");
     await page.waitForLoadState("domcontentloaded");
-    // Preact islands hydration race 방지: networkidle 까지 대기 (flaky 재현 차단)
     await page.waitForLoadState("networkidle");
+
+    // 2026-04-19: QuickTestPanel 이 client:visible 로 hydrate → viewport 진입
+    // 전엔 data-testid 렌더 안 됨. 하단 스크롤해서 hydration 강제.
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await page.waitForTimeout(1000); // hydrate 틈
 
     // data-testid 기반 Breakout 카드 찾기
     const breakoutCard = page.locator('[data-testid="quick-cat-breakout"]');
-    // fallback: 텍스트 기반
     const cardLocator =
       (await breakoutCard.count()) > 0
         ? breakoutCard
         : page.locator("button:has-text('Breakout')").first();
 
-    await expect(cardLocator).toBeVisible({ timeout: 15000 });
+    // 30s timeout (client:visible + island hydration + slower CI runner 감내)
+    await expect(cardLocator).toBeVisible({ timeout: 30000 });
+    await cardLocator.scrollIntoViewIfNeeded();
     await cardLocator.click();
 
     // 결과가 나타날 때까지 최대 60초 대기 (API 응답 포함)


### PR DESCRIPTION
## 뿌리 원인 — 주석-코드 불일치

`indicator_cache.build_multi()` docstring:
> *Limit to top 50 by market cap. /simulate computes on-the-fly for other coins.*

그러나 `simulate_coin` 라우트는 cache miss 시 **404 반환**. on-the-fly 계산 코드 누락.

## 실측 (2026-04-19)
- `POST /simulate/coin {"symbol":"BTCUSDT",...}` → **404 Symbol not found**
- `GET /ohlcv/BTCUSDT` → 200 (DataManager OK)
- `btcusdt_1h.csv` 존재
- sim_audit 매 실행 1 FAIL (BTCUSDT)

## Fix
`backend/api/main.py:1560` cache miss 시 `data_manager.get_df()` + `strategy.calculate_indicators()` on-the-fly. 기존 `resampled=True` 분기와 동일 패턴.

## Test plan
- [x] py_compile OK
- [ ] 머지 후 `POST /simulate/coin {"symbol":"BTCUSDT"}` → 200
- [ ] 다음 sim-audit timer cycle에서 BTCUSDT FAIL 해소

🤖 Generated with [Claude Code](https://claude.com/claude-code)