### PR TITLE
fix(refresh-static): point to api.pruviq.com (restore coin SSoT single writer)

### DIFF
--- a/backend/scripts/refresh_static.sh
+++ b/backend/scripts/refresh_static.sh
@@ -146,12 +146,12 @@ with open(path) as f:
 # fallback 기본값은 그대로 유지 (refresh 전체가 실패하지 않도록 non-blocking).
 import sys
 try:
-    health = json.loads(urllib.request.urlopen('http://127.0.0.1:8080/health', timeout=5).read())
+    health = json.loads(urllib.request.urlopen('https://api.pruviq.com/health', timeout=5).read())
     d['coins_analyzed'] = health.get('coins_loaded', d.get('coins_analyzed', 240))
 except Exception as e:
     print(f'WARN: /health fetch failed — coins_analyzed unchanged ({e.__class__.__name__})', file=sys.stderr)
 try:
-    strats = json.loads(urllib.request.urlopen('http://127.0.0.1:8080/strategies', timeout=5).read())
+    strats = json.loads(urllib.request.urlopen('https://api.pruviq.com/strategies', timeout=5).read())
     d['strategies_tested'] = len(strats) if isinstance(strats, list) else d.get('strategies_tested', 17)
 except Exception as e:
     print(f'WARN: /strategies fetch failed — strategies_tested unchanged ({e.__class__.__name__})', file=sys.stderr)


### PR DESCRIPTION
## 뿌리
Phase 8 (2026-04-18) 이후 Mac uvicorn OFF. refresh_static.sh Python block 은 여전히 `http://127.0.0.1:8080/health` 호출 → 연결 실패 → except → fallback 240 고정.

결과: `site-stats.json.coins_analyzed` 가 실제 `/health.coins_loaded` (238) 과 무관하게 240 에 멈춰있음. coin count 4-way drift 지속 (235/238/240/240).

## Fix
refresh_static.sh 의 3 URL 을 `api.pruviq.com` 으로 교체:
- rankings/daily
- /health (coins_analyzed 동기화)
- /strategies (strategies_tested 동기화)

## 기대
다음 refresh_static cron cycle (20min) 에서 `site-stats.json.coins_analyzed = 238` 자동 갱신. 이후 매번 `/health` 변화 추종.

## SSoT 복구
- **Source of truth**: `/health.coins_loaded` (DO runtime)
- **Writer**: refresh_static.sh (Mac 20min cron, 유일)
- **Storage**: `public/data/site-stats.json` (frontend 참조)

프루빅 5원칙 #3 (일관) 준수.

## Test plan
- [x] bash -n OK
- [ ] 머지 후 다음 refresh cron → `site-stats.json.coins_analyzed` = 238 확인
- [ ] 그 이후 `/health` 값 변경 시 자동 추종 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)