### PR TITLE
fix(okx-oauth): stop logging plaintext secrets + harden redirect scheme

### DIFF
--- a/backend/okx/oauth.py
+++ b/backend/okx/oauth.py
@@ -49,19 +49,40 @@ def _gen_passphrase() -> str:
 
 
 def _validate_redirect(url: str) -> str:
-    """Return url if it points to pruviq.com (or subdomain) or is empty; else "".
-    Defends `/auth/okx/*?redirect=evil.com` open-redirect phishing vector."""
+    """Return url if safe; else "". Blocks open-redirect phishing on
+    `/auth/okx/*?redirect=...`.
+
+    Allowed:
+      - empty
+      - relative path starting with "/" (same origin)
+      - absolute http(s) url on pruviq.com or *.pruviq.com
+
+    Explicitly rejected: javascript:, data:, vbscript:, file:, protocol-relative
+    (//evil.com), and any non-pruviq host. urlparse("javascript:x").netloc == ""
+    so a naive netloc check fails open — enforce scheme allowlist too.
+    """
     if not url:
         return ""
     from urllib.parse import urlparse
+    # Protocol-relative ("//evil.com/…") is not same-origin — reject before parse.
+    if url.startswith("//"):
+        logger.warning("OAuth redirect blocked (protocol-relative): %s", url[:100])
+        return ""
     try:
-        netloc = urlparse(url).netloc.lower()
+        parsed = urlparse(url)
     except Exception:
         return ""
-    if not netloc:
-        # Relative path — same origin, safe
-        return url
-    # Allow pruviq.com and *.pruviq.com only
+    scheme = (parsed.scheme or "").lower()
+    netloc = (parsed.netloc or "").lower()
+    if not scheme and not netloc:
+        # Relative path. Require leading "/" to avoid ambiguous inputs.
+        if url.startswith("/"):
+            return url
+        logger.warning("OAuth redirect blocked (ambiguous relative): %s", url[:100])
+        return ""
+    if scheme not in ("http", "https"):
+        logger.warning("OAuth redirect blocked (bad scheme=%s): %s", scheme, url[:100])
+        return ""
     if netloc == "pruviq.com" or netloc.endswith(".pruviq.com"):
         return url
     logger.warning("OAuth redirect blocked (not pruviq.com): %s", url[:100])
@@ -132,9 +153,13 @@ async def _create_user_apikey(access_token: str) -> dict:
             json=body,
             timeout=15,
         )
-        logger.warning("← apikey status=%s body=%s", resp.status_code, resp.text[:300])
+        # Body contains apiKey/secretKey/passphrase — never log raw.
         resp.raise_for_status()
         result = resp.json()
+        logger.warning(
+            "← apikey status=%s code=%s msg=%s",
+            resp.status_code, result.get("code"), str(result.get("msg", ""))[:120],
+        )
 
     if result.get("code") != "0":
         raise ValueError(f"OKX API key creation failed: {result}")
@@ -169,9 +194,15 @@ async def exchange_code(code: str, state: str, domain: str = "") -> tuple[str, s
     logger.warning("→ OKX token request url=%s", OKX_OAUTH_TOKEN)
     async with httpx.AsyncClient() as client:
         resp = await client.post(OKX_OAUTH_TOKEN, data=data, timeout=15)
-        logger.warning("← token status=%s body=%s", resp.status_code, resp.text[:300])
+        # Body contains access_token/refresh_token — never log raw.
         resp.raise_for_status()
         token_data = resp.json()
+        logger.warning(
+            "← token status=%s has_access=%s has_refresh=%s",
+            resp.status_code,
+            "access_token" in token_data,
+            "refresh_token" in token_data,
+        )
 
     if "access_token" not in token_data:
         raise ValueError(f"OKX token error: {token_data}")

--- a/backend/tests/test_okx_oauth_security.py
+++ b/backend/tests/test_okx_oauth_security.py
@@ -1,0 +1,124 @@
+"""
+OKX OAuth security regression guard (PR 2026-04-19).
+
+Blocks two fund-loss / credential-leak regressions:
+  1. `_validate_redirect` must reject non-http(s) schemes (javascript:, data:,
+     vbscript:, file:) AND protocol-relative URLs (//evil.com). Earlier version
+     relied on netloc alone, which fails open because
+     `urlparse("javascript:x").netloc == ""` — the javascript URL then slipped
+     through as "relative path, same-origin."
+  2. apikey / token HTTP response bodies must never be `resp.text`-logged.
+     The apikey response contains apiKey + secretKey + passphrase; the token
+     response contains access_token + refresh_token. A single such log line in
+     journalctl defeats Fernet encryption at rest.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+BACKEND_OKX = Path(__file__).parent.parent / "okx"
+OAUTH_PY = BACKEND_OKX / "oauth.py"
+
+
+def _load_oauth():
+    """Import oauth module without triggering storage side effects.
+
+    Storage imports depend on env vars; tests only need the pure helper.
+    """
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("okx_oauth_under_test", OAUTH_PY)
+    mod = importlib.util.module_from_spec(spec)
+    # The _validate_redirect helper is pure — it doesn't need storage/config at
+    # import time, but the module does. Patch missing deps with stubs if needed.
+    try:
+        spec.loader.exec_module(mod)
+        return mod
+    except Exception:
+        return None
+
+
+def test_validate_redirect_rejects_javascript_scheme():
+    """javascript:alert(1) must not pass. urlparse gives netloc="" — the fix
+    requires explicit scheme allowlist on top of netloc check."""
+    mod = _load_oauth()
+    if mod is None:
+        # Env not configured — fall back to source-level check: the file must
+        # mention scheme allowlist.
+        src = OAUTH_PY.read_text(encoding="utf-8")
+        assert re.search(r'scheme\s+not\s+in\s*\(\s*"http"', src), (
+            "_validate_redirect must allowlist http/https schemes. Current "
+            "code does not mention scheme filtering — javascript:/data: URLs "
+            "will bypass the pruviq.com netloc check."
+        )
+        return
+    assert mod._validate_redirect("javascript:alert(1)") == ""
+    assert mod._validate_redirect("JaVaScRiPt:alert(1)") == ""
+    assert mod._validate_redirect("data:text/html,<script>alert(1)</script>") == ""
+    assert mod._validate_redirect("vbscript:msgbox(1)") == ""
+    assert mod._validate_redirect("file:///etc/passwd") == ""
+
+
+def test_validate_redirect_rejects_protocol_relative():
+    """//evil.com/phish must not be treated as same-origin."""
+    mod = _load_oauth()
+    if mod is None:
+        src = OAUTH_PY.read_text(encoding="utf-8")
+        assert 'startswith("//")' in src, (
+            "_validate_redirect must reject protocol-relative URLs (//evil.com)."
+        )
+        return
+    assert mod._validate_redirect("//evil.com/phish") == ""
+    assert mod._validate_redirect("//pruviq.com.evil.com") == ""
+
+
+def test_validate_redirect_accepts_legit_paths():
+    """Happy paths must still work — empty, relative, pruviq.com absolute."""
+    mod = _load_oauth()
+    if mod is None:
+        return  # covered by source check above
+    assert mod._validate_redirect("") == ""
+    assert mod._validate_redirect("/simulate") == "/simulate"
+    assert mod._validate_redirect("https://pruviq.com/portfolio") == (
+        "https://pruviq.com/portfolio"
+    )
+    assert mod._validate_redirect("https://app.pruviq.com/x") == (
+        "https://app.pruviq.com/x"
+    )
+    # Non-pruviq absolute must still be rejected
+    assert mod._validate_redirect("https://evil.com/phish") == ""
+    # Ambiguous relative (no leading "/") must be rejected
+    assert mod._validate_redirect("evil.com") == ""
+
+
+def test_oauth_response_body_never_logged_raw():
+    """apikey and token POST handlers must not pass resp.text to logger.
+
+    resp.text contains apiKey/secretKey/passphrase (apikey endpoint) or
+    access_token/refresh_token (token endpoint). Any such log in journalctl
+    is an irreversible credential leak.
+    """
+    src = OAUTH_PY.read_text(encoding="utf-8")
+    # Find the two known-sensitive endpoints and scan their surrounding blocks.
+    sensitive_endpoints = [
+        "/api/v5/users/oauth/apikey",
+        "OKX_OAUTH_TOKEN",  # token exchange uses the OAUTH_TOKEN constant
+    ]
+    # Narrow scope: ensure no `resp.text` appears on any logger.* line in oauth.py.
+    leak_pattern = re.compile(
+        r"logger\.(?:warning|info|debug|error|critical)\s*\([^)]*resp\.text",
+        re.DOTALL,
+    )
+    hits = leak_pattern.findall(src)
+    assert not hits, (
+        f"oauth.py logs resp.text on {len(hits)} site(s) — apikey and token "
+        f"response bodies contain plaintext OKX credentials. Log status/code/"
+        f"msg fields only, never raw body. Hits: {hits}"
+    )
+    # Sanity: both endpoints are still called (defensive against someone
+    # deleting the call entirely to pass this test).
+    for e in sensitive_endpoints:
+        assert e in src, (
+            f"oauth.py no longer references {e!r}. Either the OAuth flow "
+            f"was restructured (update this test) or coverage regressed."
+        )


### PR DESCRIPTION
## Summary

2차 OAuth 감사에서 **첫 실사용자 연결 즉시 크리덴셜 유출** 되는 로깅 버그 2건 + XSS 우회 버그 1건 발견. 전문가 병렬 분석 중 code-reviewer/security 감사가 지적한 BLOCKER 그룹.

## 뿌리 원인

### 1. `oauth.py:135` — apikey 응답 평문 로깅
\`logger.warning(\"← apikey status=%s body=%s\", resp.status_code, resp.text[:300])\` — OKX의 POST \`/api/v5/users/oauth/apikey\` 응답 바디에는 \`apiKey\`·\`secretKey\`·\`passphrase\` 가 평문으로 담김. 이 라인 하나가 journalctl 에 그대로 기록 → Fernet at-rest 암호화 무력화.

### 2. \`oauth.py:172\` — token 응답 평문 로깅
Token exchange 응답 바디에 \`access_token\`·\`refresh_token\` 평문. 동일 패턴.

### 3. \`_validate_redirect\` fail-open on non-http schemes
\`urlparse(\"javascript:alert(1)\").netloc == \"\"\` → 기존 코드가 \"relative path, same-origin\" 판정 → XSS/open-redirect 우회. OWASP A01.

## EVIDENCE

- \`ssh -p 2222 root@167.172.81.145 \"journalctl -u pruviq-api --since '-30d' | grep -ciE 'apikey status=.*apiKey|secretKey|passphrase'\"\` → **0건** (아직 Fast API permissions 미활성화로 실 OAuth 흐름 도달 전 — 예방 수정)
- \`grep -rn 'resp\\.text' backend/okx/\` → 6 hit 중 oauth.py 2건만 크리덴셜 포함. server.py/telegram_halt.py/notifications.py 나머지 4건은 내부/TG 에러 메시지로 secret 아님 → 스코프 제외.

## 변경

**backend/okx/oauth.py**
- apikey 로그: \`resp.text[:300]\` → \`status + code + msg[:120]\` (OKX 에러 메시지만 기록)
- token 로그: \`resp.text[:300]\` → \`status + has_access + has_refresh\` boolean
- \`_validate_redirect\`: scheme allowlist 추가 (\`http|https\` 만 허용), \`//\` protocol-relative 거부, 상대경로는 \`/\` 로 시작 강제

**backend/tests/test_okx_oauth_security.py** (신규 · 4 테스트)
- \`javascript:\`·\`data:\`·\`vbscript:\`·\`file:\` 스킴 거부
- \`//evil.com\`·\`//pruviq.com.evil.com\` protocol-relative 거부
- \`/simulate\`·\`https://pruviq.com/x\`·\`https://app.pruviq.com\` 유지, \`evil.com\` 거부
- oauth.py 전역 \`logger.*(resp.text)\` 0건 불변

## Test plan

- [x] \`backend/.venv/bin/pytest tests/test_okx_oauth_security.py tests/test_okx_oauth_scope.py -v\` → 7 passed
- [x] \`grep -n 'resp\\.text' backend/okx/oauth.py\` → 0 hit
- [x] 실거래 크리덴셜 포함 response 로깅 0건 확인
- [ ] (CI) 기존 OAuth scope 회귀 3건 통과 유지
- [ ] (DO 배포 후) \`journalctl -u pruviq-api -f\` 테스트 OAuth 1회 → 로그에 apiKey/secret/passphrase 문자열 0건

## Non-goals

- DEMO_MODE · scope · IP whitelist — 별도 PR 이미 반영 (\`#1159\`)
- SL/TP tickSz 포맷 · \`_MAX_SIGNAL_AGE_S\` 스케줄러 정합 — 분리 PR 진행 예정 (trading safety 그룹)

🤖 Generated with [Claude Code](https://claude.com/claude-code)