### PR TITLE
fix(okx-trading): SL/TP tickSz grid + signal age derived from poll interval

### DIFF
--- a/backend/okx/auto_executor.py
+++ b/backend/okx/auto_executor.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+import os
 import time
 from datetime import datetime, timezone
 from typing import Optional
@@ -57,10 +58,18 @@ logger = logging.getLogger("okx_auto_executor")
 _FILL_WAIT_S = 1.5
 
 # Reject signals older than this many seconds. OKX mark price drifts ~0.1–0.5%
-# per minute on volatile pairs — executing a 5-minute-old signal means trading
-# against stale entry conditions. 60s is permissive enough for one scheduler
-# tick (5min) to be late without dropping everything.
-_MAX_SIGNAL_AGE_S = 60
+# per minute on volatile pairs, so we cap at one poll cycle + slack: any
+# signal older than that was already in-flight when the next poll would pick
+# it up, meaning entry conditions are stale.
+#
+# Must be ≥ SIGNAL_POLL_INTERVAL (OKX_SIGNAL_POLL_INTERVAL, default 300s in
+# server.py). Hardcoded 60s previously silently skipped every signal because
+# DO poll runs at 5-min cadence → age_s ≈ 250s > 60s on every pickup.
+# Override via OKX_MAX_SIGNAL_AGE_S. Default = poll_interval + 60s slack.
+_SIGNAL_POLL_INTERVAL_S = int(os.environ.get("OKX_SIGNAL_POLL_INTERVAL", "300"))
+_MAX_SIGNAL_AGE_S = int(
+    os.environ.get("OKX_MAX_SIGNAL_AGE_S", str(_SIGNAL_POLL_INTERVAL_S + 60))
+)
 
 # Reject the trade (close immediately after fill) if actual fill price deviates
 # from signal-time mark price by more than this fraction. 0.5% covers routine
@@ -500,7 +509,7 @@ async def _try_execute(
             )
             return None
 
-        # ── Contract size using live mark price ──
+        # ── Contract size using live mark price + tickSz for SL/TP grid ──
         try:
             sz = await _calc_contract_sz(client, inst_id, position_size, leverage, mark_price)
         except ValueError as e:
@@ -508,6 +517,9 @@ async def _try_execute(
             if chat_id:
                 asyncio.create_task(send_execution_failed(chat_id, signal, f"position too small: {e}"))
             return None
+        # Same instrument-info call is cached inside OKXClient — O(0) after _calc_contract_sz.
+        _inst_info = await client.get_instrument_info(inst_id)
+        tick_sz = _inst_info.get("tickSz", 0.01)
 
         # ── Set leverage ──
         await client.set_leverage(inst_id=inst_id, lever=leverage, mgn_mode=td_mode)
@@ -591,7 +603,9 @@ async def _try_execute(
                 return None
 
         # ── SL/TP calculated from ACTUAL FILL PRICE (industry standard) ──
-        sl_price, tp_price = _calc_sl_tp_prices(fill_price, signal["direction"], sl_pct, tp_pct)
+        sl_price, tp_price = _calc_sl_tp_prices(
+            fill_price, signal["direction"], sl_pct, tp_pct, tick_sz=tick_sz,
+        )
         close_side = "buy" if signal["direction"] == "short" else "sell"
 
         try:

--- a/backend/okx/client.py
+++ b/backend/okx/client.py
@@ -149,11 +149,19 @@ class OKXClient:
             "ctVal": float(item.get("ctVal", "1")),
             "minSz": float(item.get("minSz", "1")),
             "lotSz": float(item.get("lotSz", "1")),
+            # tickSz = minimum price increment (grid). OKX rejects algo-order
+            # trigger prices that are not a multiple of tickSz. DOGE=0.00001,
+            # SHIB=1e-9 — naive `.2f` formatting yields "0.00" and the trade
+            # fills but SL/TP never registers → emergency-close loop.
+            "tickSz": float(item.get("tickSz", "0.01")),
             "settleCcy": item.get("settleCcy", "USDT"),
         }
         _instrument_cache[inst_id] = info
         _instrument_cache_ts[inst_id] = now
-        logger.warning("← instrument %s: ctVal=%s minSz=%s", inst_id, info["ctVal"], info["minSz"])
+        logger.warning(
+            "← instrument %s: ctVal=%s minSz=%s tickSz=%s",
+            inst_id, info["ctVal"], info["minSz"], info["tickSz"],
+        )
         return info
 
     async def get_mark_price(self, inst_id: str) -> float:

--- a/backend/okx/orders.py
+++ b/backend/okx/orders.py
@@ -62,20 +62,62 @@ async def _calc_contract_sz(
     return str(int(contracts))
 
 
+def _round_to_tick(price: float, tick_sz: float, *, round_down: bool) -> str:
+    """Snap `price` to the tickSz grid and format without scientific notation.
+
+    OKX rejects algo-order trigger prices that are off-grid. tickSz varies
+    per instrument: BTC-USDT-SWAP=0.1, DOGE-USDT-SWAP=0.00001, SHIB-1e-9.
+    For SL we round conservatively (towards-stop — below entry on longs, above
+    on shorts); for TP, towards-goal. The caller chooses via round_down.
+
+    Format: %.Nf where N = decimal places implied by tickSz (no 'e-notation').
+    Python's `repr(1e-9)` gives '1e-09' which OKX rejects.
+    """
+    if tick_sz <= 0:
+        tick_sz = 0.01
+    ticks = price / tick_sz
+    snapped = (math.floor(ticks) if round_down else math.ceil(ticks)) * tick_sz
+    # Derive decimals from tickSz (e.g. 0.00001 → 5). Guard log10 of int/float.
+    try:
+        decimals = max(0, -int(math.floor(math.log10(tick_sz))))
+    except (ValueError, OverflowError):
+        decimals = 8
+    # Cap at 10 — OKX price precision ceiling.
+    decimals = min(decimals, 10)
+    return f"{snapped:.{decimals}f}"
+
+
 def _calc_sl_tp_prices(
     entry_price: float,
     direction: str,
     sl_pct: float,
     tp_pct: float,
+    tick_sz: float = 0.01,
 ) -> tuple[str, str]:
-    """Convert simulation SL/TP percentages to absolute prices."""
+    """Convert simulation SL/TP percentages to absolute prices, snapped to
+    OKX tickSz grid.
+
+    tick_sz MUST come from client.get_instrument_info(inst_id)["tickSz"] for
+    low-price coins (DOGE/SHIB/PEPE). Default 0.01 is BTC-ish and rounds
+    sub-cent coins to "0.00" — guaranteed OKX reject → naked position.
+    """
     if direction == "short":
         sl_price = entry_price * (1 + sl_pct / 100)
         tp_price = entry_price * (1 - tp_pct / 100)
-    else:
-        sl_price = entry_price * (1 - sl_pct / 100)
-        tp_price = entry_price * (1 + tp_pct / 100)
-    return f"{sl_price:.2f}", f"{tp_price:.2f}"
+        # short: SL above entry (round up = conservative toward-stop),
+        # TP below entry (round up = less aggressive goal).
+        return (
+            _round_to_tick(sl_price, tick_sz, round_down=False),
+            _round_to_tick(tp_price, tick_sz, round_down=False),
+        )
+    sl_price = entry_price * (1 - sl_pct / 100)
+    tp_price = entry_price * (1 + tp_pct / 100)
+    # long: SL below entry (round down = conservative toward-stop),
+    # TP above entry (round down = less aggressive goal).
+    return (
+        _round_to_tick(sl_price, tick_sz, round_down=True),
+        _round_to_tick(tp_price, tick_sz, round_down=True),
+    )
 
 
 async def execute_from_simulation(
@@ -110,7 +152,10 @@ async def execute_from_simulation(
             )
             current_price = await client.get_mark_price(inst_id)
 
-        # Correct OKX SWAP contract size (integer, uses ctVal)
+        # Correct OKX SWAP contract size (integer, uses ctVal). Fetch tickSz
+        # in the same call (cached) so SL/TP can snap to grid below.
+        info = await client.get_instrument_info(inst_id)
+        tick_sz = info.get("tickSz", 0.01)
         sz = await _calc_contract_sz(client, inst_id, req.position_size_usdt, req.leverage, current_price)
 
         logger.warning(
@@ -138,7 +183,7 @@ async def execute_from_simulation(
 
         # SL/TP algo order — if this fails, immediately close the naked position
         sl_price, tp_price = _calc_sl_tp_prices(
-            current_price, req.direction, req.sl_pct, req.tp_pct,
+            current_price, req.direction, req.sl_pct, req.tp_pct, tick_sz=tick_sz,
         )
         close_side = "buy" if req.direction == "short" else "sell"
 

--- a/backend/tests/test_okx_tick_and_age.py
+++ b/backend/tests/test_okx_tick_and_age.py
@@ -1,0 +1,145 @@
+"""
+OKX trading-safety regression guard (PR 2026-04-19).
+
+Blocks two fund-loss regressions:
+  1. `_calc_sl_tp_prices` must snap to per-instrument tickSz. Naive `.2f`
+     formatting returns "0.00" for DOGE ($0.09, tickSz 0.00001) and SHIB
+     ($0.000009, tickSz 1e-9). OKX rejects off-grid prices → market order
+     fills but SL/TP fails → emergency-close loop → guaranteed loss per trade.
+  2. `_MAX_SIGNAL_AGE_S` must be at least `SIGNAL_POLL_INTERVAL`. Previous
+     hardcoded 60s with 300s poll cadence silently dropped every signal
+     (age ≈ 250s > 60s every cycle) → autotrading never fired.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import pytest
+
+from okx.orders import _calc_sl_tp_prices, _round_to_tick
+
+
+def test_tick_snap_btc_two_decimals():
+    """BTC-USDT-SWAP tickSz ≈ 0.1 — the default 0.01 path is not wrong for
+    BTC pricing (cents-precision is within grid), but we verify snapping."""
+    sl, tp = _calc_sl_tp_prices(85000.0, "long", 2.0, 4.0, tick_sz=0.1)
+    # SL = 85000 * 0.98 = 83300.0; TP = 85000 * 1.04 = 88400.0
+    # Both already on 0.1 grid.
+    assert sl == "83300.0"
+    assert tp == "88400.0"
+
+
+def test_tick_snap_doge_five_decimals():
+    """DOGE-USDT-SWAP tickSz = 0.00001. Entry $0.09, SL -5%, TP +10%.
+
+    Without the fix: f"{0.0855:.2f}" → "0.09" and f"{0.099:.2f}" → "0.10" —
+    both lose all precision and collide with entry price. OKX rejects the
+    algo order and the position stays naked.
+    """
+    sl, tp = _calc_sl_tp_prices(0.09, "long", 5.0, 10.0, tick_sz=0.00001)
+    # SL ≈ 0.0855, TP ≈ 0.099. Float arithmetic means 0.09*0.95 is actually
+    # 0.08549999... so floor-to-tick may yield 0.08549 (off by one tick = 0.012%
+    # of price, below OKX rounding tolerance and on the *conservative* side
+    # for a long SL). What matters: precision is preserved and values do not
+    # collapse to two decimals.
+    sl_val = float(sl)
+    tp_val = float(tp)
+    assert 0.0854 <= sl_val <= 0.0856, f"DOGE SL off: {sl!r}"
+    assert 0.0988 <= tp_val <= 0.0990, f"DOGE TP off: {tp!r}"
+    # Must show 5 decimals, not 2 (the broken default)
+    assert len(sl.split(".")[1]) == 5, f"DOGE SL lost precision: {sl!r}"
+    assert len(tp.split(".")[1]) == 5, f"DOGE TP lost precision: {tp!r}"
+    # Explicitly refuse the broken default
+    assert sl != "0.09"
+    assert tp != "0.10"
+
+
+def test_tick_snap_shib_scientific_precision():
+    """SHIB tickSz ≈ 1e-9. Price ~$0.00001. Ensure no scientific notation
+    (OKX rejects '1e-9' style strings) and full precision preserved."""
+    sl, tp = _calc_sl_tp_prices(0.00001, "long", 5.0, 10.0, tick_sz=0.00000001)
+    # 1e-5 * 0.95 = 9.5e-6 → snap → 0.00000950
+    assert "e" not in sl.lower(), f"No scientific notation: got {sl!r}"
+    assert "e" not in tp.lower(), f"No scientific notation: got {tp!r}"
+    assert sl.startswith("0.0000"), f"SHIB precision lost: {sl!r}"
+    assert tp.startswith("0.0000"), f"SHIB precision lost: {tp!r}"
+
+
+def test_round_to_tick_direction():
+    """SL should round toward the stop direction (more protective); TP
+    rounds toward the goal (less aggressive)."""
+    # long SL: round down (below entry) — 100.07 with tick 0.1 → 100.0
+    assert _round_to_tick(100.07, 0.1, round_down=True) == "100.0"
+    # short SL: round up (above entry) — 100.03 with tick 0.1 → 100.1
+    assert _round_to_tick(100.03, 0.1, round_down=False) == "100.1"
+
+
+def test_tick_snap_short_direction():
+    """Short: SL above entry (rounds up), TP below entry (rounds up)."""
+    sl, tp = _calc_sl_tp_prices(100.0, "short", 2.0, 4.0, tick_sz=0.1)
+    # SL = 100 * 1.02 = 102.0, TP = 100 * 0.96 = 96.0
+    assert sl == "102.0"
+    assert tp == "96.0"
+
+
+def test_default_tick_sz_does_not_zero_out_cheap_coin():
+    """Regression: prior code used f'{price:.2f}' with no tick_sz param. New
+    signature keeps tick_sz=0.01 default for back-compat, but callers must
+    pass instrument tickSz. If the default is somehow used with a cheap coin,
+    we still want the output to be non-zero."""
+    # Entry 0.09, default tick 0.01 → SL 0.0855 → "0.09" (unchanged from bug)
+    # This test documents the fallback: default 0.01 IS still broken for DOGE.
+    # Callers must pass real tickSz. The test is here so a future refactor
+    # making the default smaller (e.g. 0.0001) does not silently "fix" this
+    # without updating all callers.
+    sl, _ = _calc_sl_tp_prices(0.09, "long", 5.0, 10.0)  # default tick_sz=0.01
+    # "0.09" — this is the known-broken default. Documentation, not happy path.
+    # Assertion intentionally soft: we just want no crash + string output.
+    assert isinstance(sl, str)
+    assert not sl.startswith("-")
+
+
+def test_signal_age_default_covers_poll_interval():
+    """_MAX_SIGNAL_AGE_S default must be ≥ SIGNAL_POLL_INTERVAL. Otherwise
+    every polled signal is already stale and auto-execute never fires."""
+    # Clear any override so we test the derived default.
+    orig_poll = os.environ.pop("OKX_SIGNAL_POLL_INTERVAL", None)
+    orig_age = os.environ.pop("OKX_MAX_SIGNAL_AGE_S", None)
+    try:
+        # Reload module to pick up cleared env.
+        import importlib
+        import okx.auto_executor as ae
+        importlib.reload(ae)
+        poll = ae._SIGNAL_POLL_INTERVAL_S
+        age = ae._MAX_SIGNAL_AGE_S
+        assert age >= poll, (
+            f"_MAX_SIGNAL_AGE_S ({age}s) < SIGNAL_POLL_INTERVAL ({poll}s) — "
+            f"every signal will be older than max on pickup. autotrading "
+            f"will never fire. Default must include at least one full poll "
+            f"cycle + slack."
+        )
+    finally:
+        if orig_poll is not None:
+            os.environ["OKX_SIGNAL_POLL_INTERVAL"] = orig_poll
+        if orig_age is not None:
+            os.environ["OKX_MAX_SIGNAL_AGE_S"] = orig_age
+
+
+def test_signal_age_env_override():
+    """Operators can override via OKX_MAX_SIGNAL_AGE_S for tighter or looser
+    staleness. Round-trip a deliberate value."""
+    os.environ["OKX_MAX_SIGNAL_AGE_S"] = "900"
+    try:
+        import importlib
+        import okx.auto_executor as ae
+        importlib.reload(ae)
+        assert ae._MAX_SIGNAL_AGE_S == 900
+    finally:
+        os.environ.pop("OKX_MAX_SIGNAL_AGE_S", None)
+        import importlib
+        import okx.auto_executor as ae
+        importlib.reload(ae)


### PR DESCRIPTION
## Summary

2차 OAuth 감사에서 나온 trading-safety BLOCKER 2건. 실거래 시작 시 자금 손실 직결.

## 뿌리 1 — SL/TP `.2f` → 저가 코인 전량 청산 루프

\`orders.py:78\` 이 트리거 가격을 \`f"{price:.2f}"\` 로 포맷. OKX 는 instrument 별 tickSz 배수만 허용.
- BTC-USDT-SWAP tickSz 0.1: 괜찮음
- **DOGE-USDT-SWAP tickSz 0.00001**: 0.0855 → \`"0.09"\` 로 뭉개짐 → OKX reject
- **SHIB tickSz 1e-9**: 0.00001 → \`"0.00"\` 완전 소실 → OKX reject
- market order 체결 → SL/TP algo 실패 → \`orders.py:155-165\` emergency close → 매매마다 즉시 청산.

## 뿌리 2 — \`_MAX_SIGNAL_AGE_S=60\` vs \`SIGNAL_POLL_INTERVAL=300\`

\`auto_executor.py:63\` 하드코딩 60s. 그런데 \`server.py:29\` 폴링은 300s (5분) 기본. 모든 신호의 \`age_s\` 가 평균 250s → **매 사이클 전부 skip → autotrading 침묵**. 주석 \"60s is permissive enough for one scheduler tick (5min)\" 자체가 산수 모순.

## EVIDENCE
- \`ssh DO: systemctl list-timers | grep signal\` → \`pruviq-signal-telegram\` 외 signal scheduler 없음. \`server.py\` 내부 poll loop 가 유일 소스.
- \`grep -n "SIGNAL_POLL_INTERVAL" backend/okx/\` → default \`300\`.
- \`.venv/bin/pytest tests/test_okx_tick_and_age.py -v\` → **8/8 passed**.
- 전체 backend 테스트 → 28 passed / 3 failed (cost_model 0.08%→0.05%·auth 401 — 이번 변경과 무관한 사전 회귀).

## 변경

**backend/okx/client.py**
- \`get_instrument_info\` 반환에 \`tickSz\` 추가. 기존 호출지는 \`.get\` 으로 안전 접근 → 하위호환.

**backend/okx/orders.py**
- \`_round_to_tick(price, tick_sz, round_down)\`: tickSz 배수 snap, 소수자릿수 \`log10(tickSz)\` 로 자동 유도, scientific notation 방지.
- \`_calc_sl_tp_prices(..., tick_sz=0.01)\`: tickSz 기반 grid snap. Long SL/TP 는 보수적(floor), Short 는 반대(ceil).
- \`execute_from_simulation\`: \`get_instrument_info\` 호출(캐시 히트), tick_sz 전달.

**backend/okx/auto_executor.py**
- \`_MAX_SIGNAL_AGE_S\` = \`OKX_SIGNAL_POLL_INTERVAL + 60s\` slack 파생. \`OKX_MAX_SIGNAL_AGE_S\` env override 지원.
- \`process_signals\`: tick_sz 변수 추가, \`_calc_sl_tp_prices(tick_sz=…)\` 전달.

**backend/tests/test_okx_tick_and_age.py** (신규·8 테스트)
- BTC(0.1)·DOGE(0.00001)·SHIB(1e-9) tickSz snap, scientific notation 0건.
- \`round_to_tick\` 방향성 (long floor / short ceil).
- \`_MAX_SIGNAL_AGE_S ≥ SIGNAL_POLL_INTERVAL\` 기본값 불변.
- \`OKX_MAX_SIGNAL_AGE_S\` env override 작동.

## Test plan
- [x] 8/8 tick/age regression
- [x] 회귀 없음 확인 (기존 3건 사전 실패와 무관)
- [ ] (CI) automerge
- [ ] (DO 배포 후) \`journalctl -u pruviq-api -f\` → DOGE/SHIB 포지션 open 시 SL/TP set 로그 \`SL=0.08549 TP=0.09900\` 같이 5자리 값 확인
- [ ] (DO) Mac 신호 한 건 → DO poll 1사이클 내 \`process_signals\` 호출 → \`signal age 60s > X\` warning 0건

## Non-goals
- PR #1168 의 oauth 로깅·redirect 스킴 은 분리 PR.
- 향후: tickSz 외에 \`maxOrdPrc\`/\`minOrdPrc\` grid 도 강제 필요 시 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)