### PR TITLE
fix(do-mac-split): inject RANKING_DIR/SUBSCRIBERS_FILE + dedup lock + archive env

### DIFF
--- a/backend/deploy/systemd/bin/staleness-watch.sh
+++ b/backend/deploy/systemd/bin/staleness-watch.sh
@@ -10,9 +10,18 @@ set -uo pipefail
 
 STALE_HOURS="${STALE_HOURS:-1}"
 # Check CF-served static data (fast, edge-cached).
-# /market/live on local API is too slow (572-coin live fetch, ~30s).
+# /market/live on local API is too slow (238-coin live fetch, ~30s).
 SITE_URL="${STALENESS_URL:-https://pruviq.com/data/market.json}"
-STATE_FILE="/tmp/pruviq-staleness-alerted-$(date -u +%Y%m%d).json"
+# Per-key daily lock dir. Previous JSON state file corrupted on concurrent
+# writes (observed 2026-04-19: `{"market_stale": true}{"market_stale": true}...`
+# — four concatenated objects). json.load() then raised, except-pass returned
+# "not alerted", and notify() fired every 10-min tick. Replacing mutable JSON
+# with immutable per-key lock files: existence = dedup, mtime reset daily.
+LOCK_DIR="/tmp/pruviq-staleness-alerts"
+LOCK_DATE="$(date -u +%Y%m%d)"
+mkdir -p "$LOCK_DIR"
+# GC any lock files older than 2 days (harmless remnants from prior runs).
+find "$LOCK_DIR" -type f -mtime +2 -delete 2>/dev/null || true
 
 notify() {
     [ -z "${TELEGRAM_TOKEN:-}" ] && return 0
@@ -22,26 +31,14 @@ notify() {
         -d text="$1" >/dev/null 2>&1 || true
 }
 
-[ ! -f "$STATE_FILE" ] && echo '{}' > "$STATE_FILE"
-
+# Returns 0 if already alerted today, non-zero otherwise.
 already_alerted() {
-    python3 -c "
-import json,sys
-try:
-    with open('$STATE_FILE') as f:
-        d=json.load(f)
-    sys.exit(0 if '$1' in d else 1)
-except: sys.exit(1)
-"
+    [ -f "$LOCK_DIR/$1-$LOCK_DATE" ]
 }
 
+# Records an alert; idempotent via file-create + touch.
 mark_alerted() {
-    python3 -c "
-import json
-with open('$STATE_FILE') as f: d=json.load(f)
-d['$1']=True
-with open('$STATE_FILE','w') as f: json.dump(d,f)
-" 2>/dev/null || true
+    : > "$LOCK_DIR/$1-$LOCK_DATE"
 }
 
 generated=$(curl -sf -m 15 "$SITE_URL" 2>/dev/null | python3 -c "

--- a/backend/deploy/systemd/pruviq-api.service
+++ b/backend/deploy/systemd/pruviq-api.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=PRUVIQ FastAPI Backend
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=pruviq
+WorkingDirectory=/opt/pruviq/current/backend
+EnvironmentFile=/opt/pruviq/shared/.env
+# Shared SSoT for Mac/DO split. api/main.py:3800 reads RANKING_DIR;
+# api/main.py:4270 reads SUBSCRIBERS_FILE. Without these injected here, the
+# fallback was /Users/jepo/... (Mac paths) — the /rankings/daily handler and
+# /api/subscribe endpoint silently hit PermissionError on DO and served
+# stale data or rejected writes. Values must stay in lockstep with
+# pruviq-daily-ranking.service (which also needs RANKING_DIR for save_results).
+Environment=RANKING_DIR=/opt/pruviq/shared/rankings
+Environment=SUBSCRIBERS_FILE=/opt/pruviq/shared/subscribers.json
+ExecStart=/opt/pruviq/app/.venv/bin/uvicorn api.main:app --host 127.0.0.1 --port 8080 --workers 1
+Restart=always
+RestartSec=5
+MemoryMax=2G
+LimitNOFILE=65536
+TimeoutStopSec=45
+KillMode=mixed
+RuntimeMaxSec=86400
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=pruviq-api
+
+[Install]
+WantedBy=multi-user.target

--- a/backend/deploy/systemd/pruviq-daily-ranking.service
+++ b/backend/deploy/systemd/pruviq-daily-ranking.service
@@ -9,6 +9,11 @@ User=pruviq
 Group=pruviq
 WorkingDirectory=/opt/pruviq/current
 EnvironmentFile=/opt/pruviq/shared/.env
+# RANKING_DIR — shared SSoT read by both api/main.py:/rankings/daily handler
+# and daily_strategy_ranking.py save_results(). Without this, the ranker
+# defaulted to /Users/jepo/Desktop/autotrader/... (Mac archival path) and
+# failed with PermissionError under User=pruviq on DO every run.
+Environment=RANKING_DIR=/opt/pruviq/shared/rankings
 ExecStart=/opt/pruviq/bin/daily-strategy-ranking.sh
 TimeoutStartSec=7200
 # 2026-04-18: 3600 → 7200. strategy × direction × timeframe × group 조합이 많고

--- a/backend/scripts/daily_strategy_ranking.py
+++ b/backend/scripts/daily_strategy_ranking.py
@@ -726,7 +726,16 @@ def save_results(
     else:
         now = datetime.utcnow()
         date_str = now.strftime("%Y%m%d")
-    out_dir = "/Users/jepo/Desktop/autotrader/data/daily_rankings"
+    # RANKING_DIR: shared env var with api/main.py:3800. On DO (systemd)
+    # it is set to /opt/pruviq/shared/rankings via pruviq-daily-ranking.service.
+    # On Mac ops runs it falls back to ~/pruviq-data/rankings (not autotrader-
+    # legacy). Hardcoded /Users path previously caused daily PermissionError
+    # when the service ran as user `pruviq` on DO, which skipped the save and
+    # cascaded into 4-day-stale rankings-daily.json → E2E fail.
+    out_dir = os.environ.get(
+        "RANKING_DIR",
+        os.path.expanduser("~/pruviq-data/rankings"),
+    )
     os.makedirs(out_dir, exist_ok=True)
 
     out_path = os.path.join(out_dir, f"ranking_{date_str}.json")

--- a/backend/tests/test_do_mac_split_env.py
+++ b/backend/tests/test_do_mac_split_env.py
@@ -1,0 +1,175 @@
+"""
+DO/Mac split regression guard (PR 2026-04-19).
+
+Two classes of bug this PR closes:
+
+1. Hardcoded Mac paths in DO-hosted code paths. `api/main.py:3800` and
+   `:4270` already use `os.environ.get` with Mac-path fallbacks, but the
+   systemd units that run them on DO (pruviq-api.service,
+   pruviq-daily-ranking.service) did not inject the env vars. Result: the
+   handlers silently hit `/Users/jepo/...` → PermissionError → `/rankings/daily`
+   served 4-day-old JSON and `/api/subscribe` rejected every write.
+2. `daily_strategy_ranking.py:729` wrote archival JSON to the same Mac path
+   as a hardcoded string. Every DO cron run PermissionError-ed; the failure
+   cascaded into E2E `Rankings_daily_structure` FAIL ("date 4.3 days old")
+   which blocked every backend PR automerge.
+
+Verified:
+- The three systemd unit files in repo declare the two env vars.
+- `daily_strategy_ranking.py` now reads `RANKING_DIR` (same name as
+  api/main.py) with a Mac-only home-relative fallback — never the
+  autotrader-legacy path.
+- Bash syntax for `staleness-watch.sh` passes after the JSON-dedup → file-lock
+  rewrite (previous state file corrupted under concurrent writes → alert
+  every 10 min instead of once per day).
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent
+SYSTEMD_DIR = REPO / "deploy" / "systemd"
+API_MAIN = REPO / "api" / "main.py"
+DAILY_RANKING = REPO / "scripts" / "daily_strategy_ranking.py"
+STALENESS_WATCH = SYSTEMD_DIR / "bin" / "staleness-watch.sh"
+
+
+def test_pruviq_api_service_injects_ranking_and_subscribers():
+    """pruviq-api.service must set both env vars — api/main.py uses these at
+    module import time, so the uvicorn process inherits them or nothing."""
+    unit = (SYSTEMD_DIR / "pruviq-api.service").read_text()
+    assert re.search(r"^Environment=RANKING_DIR=", unit, re.M), (
+        "pruviq-api.service missing RANKING_DIR. /rankings/daily will read "
+        "from /Users/jepo/Desktop/autotrader on DO → PermissionError → 4-day "
+        "stale JSON served."
+    )
+    assert re.search(r"^Environment=SUBSCRIBERS_FILE=", unit, re.M), (
+        "pruviq-api.service missing SUBSCRIBERS_FILE. /api/subscribe will "
+        "try to create /Users/jepo/pruviq-data on DO → PermissionError → "
+        "every signup silently drops."
+    )
+    # Both must point into /opt/pruviq/shared (pruviq user has write there).
+    for m in re.finditer(r"^Environment=(RANKING_DIR|SUBSCRIBERS_FILE)=(.+)$", unit, re.M):
+        assert m.group(2).startswith("/opt/pruviq/shared"), (
+            f"{m.group(1)} must live under /opt/pruviq/shared (the only dir "
+            f"the pruviq systemd user can write to on DO). Got: {m.group(2)!r}"
+        )
+
+
+def test_pruviq_daily_ranking_service_injects_ranking_dir():
+    """pruviq-daily-ranking.service must set RANKING_DIR for save_results()."""
+    unit = (SYSTEMD_DIR / "pruviq-daily-ranking.service").read_text()
+    assert re.search(r"^Environment=RANKING_DIR=", unit, re.M), (
+        "pruviq-daily-ranking.service missing RANKING_DIR. save_results() "
+        "will fall back to /Users/jepo/Desktop/autotrader — PermissionError "
+        "every 00:05 UTC → rankings-daily.json stale → E2E fail."
+    )
+
+
+def test_daily_strategy_ranking_reads_env_not_hardcoded_mac_path():
+    """`save_results` must read RANKING_DIR. Previous hardcoded string broke
+    the entire DO pipeline."""
+    src = DAILY_RANKING.read_text()
+    # Old hardcoded path must be gone (no bare literal in the save_results site).
+    # It can still appear in comments/docstrings mentioning the legacy bug,
+    # but not as the default value of the env lookup.
+    bad_literal_pattern = re.compile(
+        r'out_dir\s*=\s*["\']/Users/jepo/Desktop/autotrader'
+    )
+    assert not bad_literal_pattern.search(src), (
+        "daily_strategy_ranking.py still hardcodes the Mac autotrader path "
+        "as the save target. Use os.environ.get('RANKING_DIR', ...) instead."
+    )
+    assert "os.environ.get(" in src and '"RANKING_DIR"' in src, (
+        "daily_strategy_ranking.py save_results must consult RANKING_DIR env."
+    )
+
+
+def test_api_main_env_names_match_systemd_units():
+    """Env var names in code and systemd unit must be byte-identical; a typo
+    like RANKING_DIR vs RANKINGS_DIR silently reverts to the Mac fallback."""
+    src = API_MAIN.read_text()
+    code_names = set()
+    for pattern in (
+        r'os\.environ\.get\(\s*["\'](RANKING_DIR|SUBSCRIBERS_FILE)["\']',
+        r'os\.environ\[\s*["\'](RANKING_DIR|SUBSCRIBERS_FILE)["\']',
+    ):
+        code_names.update(re.findall(pattern, src))
+    assert "RANKING_DIR" in code_names, "api/main.py no longer reads RANKING_DIR"
+    assert "SUBSCRIBERS_FILE" in code_names, "api/main.py no longer reads SUBSCRIBERS_FILE"
+
+    api_unit = (SYSTEMD_DIR / "pruviq-api.service").read_text()
+    for name in code_names:
+        assert re.search(rf"^Environment={name}=", api_unit, re.M), (
+            f"api/main.py reads {name} but pruviq-api.service does not set it."
+        )
+
+
+def test_staleness_watch_bash_syntax_clean():
+    """The staleness-watch rewrite changes dedup from a shared JSON file to
+    per-key flag files. A syntax slip would silently fail and re-introduce
+    the alert-every-10-min storm — run `bash -n` to catch it."""
+    result = subprocess.run(
+        ["bash", "-n", str(STALENESS_WATCH)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"staleness-watch.sh fails bash syntax check:\n{result.stderr}"
+    )
+
+
+def test_staleness_watch_uses_per_key_lock_not_shared_json():
+    """Regression guard for the JSON-dedup bug. Multiple concurrent runs of
+    the old mark_alerted appended instead of overwriting (observed: four
+    `{"market_stale": true}` objects concatenated). The new scheme uses
+    one flag file per key per day — inherently atomic."""
+    src = STALENESS_WATCH.read_text()
+    # The old design had a shared JSON state file; the new one uses LOCK_DIR.
+    assert "LOCK_DIR=" in src, (
+        "staleness-watch.sh must use per-key lock files, not a shared JSON."
+    )
+    # Extract just the already_alerted + mark_alerted function bodies. The
+    # script still does json.load elsewhere (parsing market.json from CF) —
+    # that is a different concern. The dedup functions must not.
+    dedup_fns = re.search(
+        r"already_alerted\(\)\s*\{(.*?)\}\s*#\s*Records an alert.*?mark_alerted\(\)\s*\{(.*?)\}",
+        src,
+        re.DOTALL,
+    )
+    assert dedup_fns, "Could not locate already_alerted / mark_alerted blocks"
+    dedup_body = dedup_fns.group(1) + dedup_fns.group(2)
+    assert "json.load" not in dedup_body, (
+        "staleness-watch.sh dedup functions still load JSON state. The 2026-04-19 "
+        "bug concatenated four JSON objects under concurrent writes; stick to "
+        "file-existence semantics (`: > $FLAG` / `[ -f $FLAG ]`)."
+    )
+    assert "json.dump" not in dedup_body, (
+        "staleness-watch.sh dedup functions still write JSON state."
+    )
+
+
+def test_env_fallback_is_home_relative_not_autotrader():
+    """The archive-path fallback must not reference the autotrader legacy
+    directory. The legacy path was the source of the original bug; future
+    refactors could silently reintroduce it."""
+    # daily_strategy_ranking.py fallback
+    src = DAILY_RANKING.read_text()
+    fallback = re.search(
+        r'os\.environ\.get\(\s*["\']RANKING_DIR["\'],\s*([^)]+)\)',
+        src,
+    )
+    assert fallback, "Could not find RANKING_DIR env fallback expression"
+    fallback_expr = fallback.group(1)
+    assert "autotrader" not in fallback_expr.lower(), (
+        f"RANKING_DIR fallback references autotrader legacy path: "
+        f"{fallback_expr!r}. Use a home-relative path under ~/pruviq-data "
+        f"or similar — autotrader is frozen per project_pruviq_core_intent."
+    )
+    assert "Desktop" not in fallback_expr, (
+        f"RANKING_DIR fallback references Mac Desktop: {fallback_expr!r}."
+    )


### PR DESCRIPTION
## Summary

사용자 아키텍처 리뷰 ("DO서버랑 맥미니랑 나눴잖아 역할을 이걸 제대로 나눈게 맞아?") 에서 발견한 **역할 분리 위반 3건 뿌리 제거**. 구독/랭킹 기능이 silent broken 되어 있었고 E2E 자동머지를 막고 있었음.

## 역할 분배 **원칙은 타당** — 구현에 3건의 split violation

| 영역 | DO | Mac | 현재 상태 |
|---|---|---|---|
| FastAPI pruviq-api | ✅ primary (uvicorn :8080) | ❌ off | OK |
| OHLCV 갱신 (4h) | ✅ systemd timer | — | OK |
| daily ranking (00:05 UTC) | ✅ systemd timer | ❌ | **🔴 Mac 경로 하드코딩** |
| /rankings/daily 서빙 | ✅ | — | **🔴 env 미주입 → Mac fallback PermissionError** |
| /api/subscribe | ✅ | — | **🔴 env 미주입 → 구독 쓰기 실패** |
| refresh_static (20m) | — | ✅ cron | OK (분리 의도 정확) |
| staleness-watch (10m) | ✅ systemd timer | — | **🔴 JSON dedup corrupt → 10분마다 폭주** |

## 뿌리 3건

### 1. api/main.py 의 Mac 경로 fallback 이 DO 프로덕션에 적용
`api/main.py:3800 RANKING_DIR`, `:4270 SUBSCRIBERS_FILE` 모두 이미 env var 구조 (`os.environ.get(..., "/Users/jepo/...")`). 그러나 DO `pruviq-api.service` 에 `Environment=` 주입 없음 → fallback Mac 경로 → `User=pruviq` 권한으로 PermissionError.

**영향**:
- `/rankings/daily` 4-day stale JSON 서빙 (실측 오늘 `"date":"2026-04-15"` on 2026-04-19)
- E2E `Rankings_daily_structure` FAIL ("4.3 days old > max 2") → **모든 backend PR 자동머지 차단** (#1166, #1168, #1169)
- `/api/subscribe` 구독 POST 마다 `/Users/jepo/pruviq-data` mkdir 시도 → silent drop

### 2. daily_strategy_ranking.py:729 하드코딩
`out_dir = "/Users/jepo/Desktop/autotrader/data/daily_rankings"` 리터럴. `project_pruviq_core_intent.md` 의 "autotrader legacy 재시작 안 함" 원칙 역행.

**영향**: 매 00:05 UTC systemd 실행 → `PermissionError: [Errno 13] '/Users'` → `pruviq-alert@` OnFailure → 텔레그램 systemd FAIL 알림 연쇄.

### 3. staleness-watch.sh JSON dedup corruption
`STATE_FILE` 의 `json.load → mutate → json.dump` 패턴이 동시 실행 또는 예외 시 `{...}{...}{...}` concat JSON 생성. 이후 `json.load` 실패 → `except: sys.exit(1)` → "알림 안 했음" 오판 → 매 10분 폭주 (오늘 2:50~4:52 동안 13건).

**실제 corrupt 파일**: \`{"fetch_failed": true, "market_stale": true}{"market_stale": true}{"market_stale": true}{"market_stale": true}\`

## 변경

**backend/deploy/systemd/pruviq-api.service** (신규 · repo SSoT 복원):
- DO 의 실존 unit 을 repo 에 포함. `backend-deploy.yml:141-162` 가 자동 sync.
- \`Environment=RANKING_DIR=/opt/pruviq/shared/rankings\`
- \`Environment=SUBSCRIBERS_FILE=/opt/pruviq/shared/subscribers.json\`

**backend/deploy/systemd/pruviq-daily-ranking.service**:
- \`Environment=RANKING_DIR=/opt/pruviq/shared/rankings\` (api 와 lockstep).

**backend/scripts/daily_strategy_ranking.py**:
- \`save_results()\` out_dir 하드코딩 제거 → \`os.environ.get("RANKING_DIR", "~/pruviq-data/rankings")\`.
- fallback 이 autotrader legacy 경로 참조 금지.

**backend/deploy/systemd/bin/staleness-watch.sh**:
- mutable JSON state → 불변 per-key daily lock 파일.
  - \`already_alerted\` = \`[ -f $LOCK_DIR/$key-$date ]\` (atomic)
  - \`mark_alerted\` = \`: > $LOCK_DIR/$key-$date\` (POSIX create)
- GC: 2일+ flag 자동 삭제.

**backend/tests/test_do_mac_split_env.py** (신규 · 7 테스트):
- systemd unit의 env 주입 · 경로가 `/opt/pruviq/shared` 내
- daily_strategy_ranking.py 에 autotrader 리터럴 0건
- api/main.py 와 unit 의 env var 이름 byte-identical
- staleness-watch `bash -n` 통과 · dedup 함수에 `json.load/dump` 0건
- RANKING_DIR fallback 이 autotrader/Desktop 참조 없음

## EVIDENCE

- DO \`curl /rankings/daily\` → \`"date":"2026-04-15"\` (4일 stale on 2026-04-19)
- DO \`journalctl -u pruviq-daily-ranking\` → \`PermissionError: [Errno 13] '/Users'\`
- DO \`/tmp/pruviq-staleness-alerted-20260419.json\` → corrupt concat JSON 4×
- Mac \`launchctl list\` → \`com.pruviq.daily-strategy-ranking\` 부재 (2026-04-18 unload 완료)
- backend-deploy.yml:141-162 → \`install -m 0644 pruviq-*.service /etc/systemd/system/\` + \`daemon-reload\` 자동 수행

## Test plan

- [x] `pytest tests/test_do_mac_split_env.py -v` → 7/7 passed
- [ ] (CI) automerge
- [ ] (DO 배포 후) \`systemctl show pruviq-api --property=Environment\` → RANKING_DIR·SUBSCRIBERS_FILE 포함
- [ ] (DO 배포 후) \`systemctl start pruviq-daily-ranking.service && journalctl -u pruviq-daily-ranking -f\` → PermissionError 없이 완료 + \`/opt/pruviq/shared/rankings/ranking_*.json\` 생성
- [ ] (DO) 다음 \`pruviq-staleness-watch.timer\` 주기 → 경고 텔레그램 **하루 1회만** (이전은 10분마다)
- [ ] (프론트) \`curl https://api.pruviq.com/rankings/daily\` → \`date\` 가 오늘

## Non-goals (scope discipline · 별도 PR)

- \`send_weekly_email.py:25\` SUBSCRIBERS_FILE 하드코딩 (Mac 전용 스크립트, 당장은 무해)
- DO \`crontab\` 의 autotrader docker health-check 제거 (별도 폐기 PR)
- \`@reboot binance-proxy\` 제거 (Binance→OKX 마이그레이션 완료 후속)
- \`/execute/order\` idempotency · SQLite busy_timeout · Blog 404
- 비즈니스 전문가 10명 호출

## Mac local ops (PR 외, 머지 후 수동)

- \`rm /Users/jepo/scripts/daily_strategy_ranking.py\` (dead code, 2026-04-18 LA unload로 무호출 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)