### PR TITLE
fix(weekly-email): env-ify SUBSCRIBERS_FILE + PRUVIQ_API_URL defaults

### DIFF
--- a/backend/scripts/send_weekly_email.py
+++ b/backend/scripts/send_weekly_email.py
@@ -22,8 +22,19 @@ from urllib.parse import quote
 
 import httpx
 
-SUBSCRIBERS_FILE = Path("/Users/jepo/pruviq-data/subscribers.json")
-API_URL = "http://localhost:8080"
+# SSoT with api/main.py:4270 SUBSCRIBERS_FILE. On DO systemd this is
+# /opt/pruviq/shared/subscribers.json (set in pruviq-api.service env).
+# Mac ops runs fall back to ~/pruviq-data/subscribers.json.
+SUBSCRIBERS_FILE = Path(
+    os.environ.get(
+        "SUBSCRIBERS_FILE",
+        os.path.expanduser("~/pruviq-data/subscribers.json"),
+    )
+)
+# Default to the public CF-tunneled API so this script runs correctly from
+# either Mac (no local uvicorn after Phase 8) or DO (where localhost:8080
+# also works but CF tunnel is still reachable).
+API_URL = os.environ.get("PRUVIQ_API_URL", "https://api.pruviq.com").rstrip("/")
 SENDGRID_API_KEY = os.environ.get("SENDGRID_API_KEY", "")
 # 2026-04-19: 하드코딩 기본값 제거. UNSUBSCRIBE_SECRET 이 없으면 이메일 발송 차단.
 UNSUBSCRIBE_SECRET = os.environ.get("UNSUBSCRIBE_SECRET", "")

--- a/backend/tests/test_send_weekly_email_env.py
+++ b/backend/tests/test_send_weekly_email_env.py
@@ -1,0 +1,79 @@
+"""
+send_weekly_email.py env guard (PR 2026-04-19).
+
+Part of the DO/Mac split cleanup sweep. The earlier `SUBSCRIBERS_FILE =
+Path("/Users/jepo/pruviq-data/subscribers.json")` hardcode paired with
+`API_URL = "http://localhost:8080"` meant:
+  - Run on Mac (via `com.pruviq.weekly-email` LaunchAgent): API_URL hits
+    nothing (Phase 8 killed Mac uvicorn), SUBSCRIBERS_FILE happens to exist
+    but is drift-prone.
+  - Run on DO (if ever wired to systemd): SUBSCRIBERS_FILE unreadable
+    (/Users not mounted, User=pruviq), API_URL works.
+Both paths are broken in one direction. Env-driven is the only correct fix.
+"""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "send_weekly_email.py"
+
+
+def test_subscribers_file_reads_from_env():
+    src = SCRIPT.read_text()
+    # Hard-coded Mac path must be gone as the default.
+    assert not re.search(
+        r'SUBSCRIBERS_FILE\s*=\s*Path\(\s*["\']/Users/jepo/',
+        src,
+    ), (
+        "send_weekly_email.py still hardcodes a /Users/jepo path. The same "
+        "file is shared with api/main.py:4270 and must be env-configured so "
+        "DO (systemd) and Mac (LA) can both resolve it correctly."
+    )
+    assert "os.environ.get" in src and '"SUBSCRIBERS_FILE"' in src, (
+        "send_weekly_email.py must read SUBSCRIBERS_FILE from env."
+    )
+
+
+def test_api_url_reads_from_env_and_defaults_public():
+    src = SCRIPT.read_text()
+    # Bare localhost:8080 default is broken on Mac post-Phase-8.
+    assert not re.search(
+        r'API_URL\s*=\s*["\']http://localhost:8080["\']',
+        src,
+    ), (
+        "send_weekly_email.py still defaults API_URL to localhost:8080. "
+        "After Phase 8, Mac has no uvicorn, so weekly-email silently fails "
+        "on the LA run."
+    )
+    assert re.search(
+        r'API_URL\s*=\s*os\.environ\.get\(\s*["\']PRUVIQ_API_URL["\']',
+        src,
+    ), "send_weekly_email.py must read PRUVIQ_API_URL from env."
+    # Default must be the public CF-tunneled host (reachable from anywhere).
+    m = re.search(
+        r'API_URL\s*=\s*os\.environ\.get\(\s*["\']PRUVIQ_API_URL["\']\s*,\s*["\']([^"\']+)["\']',
+        src,
+    )
+    assert m, "API_URL env lookup must have a default"
+    default = m.group(1)
+    assert "api.pruviq.com" in default, (
+        f"API_URL default {default!r} must use api.pruviq.com (CF tunnel), "
+        "not localhost — this script runs on Mac where there is no uvicorn."
+    )
+
+
+def test_fallback_paths_are_home_relative_not_autotrader():
+    """Same rule as daily_strategy_ranking.py: no autotrader legacy refs in
+    fallback paths."""
+    src = SCRIPT.read_text()
+    fallback = re.search(
+        r'os\.environ\.get\(\s*["\']SUBSCRIBERS_FILE["\']\s*,\s*([^)]+)\)',
+        src,
+    )
+    assert fallback, "Could not find SUBSCRIBERS_FILE env fallback"
+    assert "autotrader" not in fallback.group(1).lower()
+    assert "Desktop" not in fallback.group(1)


### PR DESCRIPTION
## Summary
DO/Mac split 잔재 정리. \`send_weekly_email.py\` 가 양쪽 실행 환경 모두에서 silent broken:
- **Mac LA** \`com.pruviq.weekly-email\`: Phase 8 이후 Mac uvicorn OFF 인데 \`API_URL=\"http://localhost:8080\"\` → 매 월요일 09:00 KST connection refused → 구독자 이메일 0건 발송.
- **DO systemd 이식 시나리오**: \`SUBSCRIBERS_FILE=\"/Users/jepo/...\"\` 하드코딩 → User=pruviq PermissionError.

## 원론 수정
- \`SUBSCRIBERS_FILE = os.environ.get(\"SUBSCRIBERS_FILE\", \"~/pruviq-data/subscribers.json\")\` — api/main.py:4270 과 byte-identical SSoT.
- \`PRUVIQ_API_URL\` default = \`https://api.pruviq.com\` (CF 터널 · Mac/DO 양쪽 reachable).

## Test plan
- [x] \`pytest tests/test_send_weekly_email_env.py\` → 3/3 passed
- [ ] (CI) automerge
- [ ] (DO 배포 + #1173 머지 후) Mac \`SUBSCRIBERS_FILE=/opt/pruviq/shared/subscribers.json\` env 설정하든지, DO systemd unit 으로 이관하든지 operator 선택

## Non-goals
- \`generate_autopsy.py\` 유사 하드코딩 4건 (blog 생성 경로, 별도 검증 PR)
- Mac LA → DO systemd 이관 (이 PR 은 둘 다 동작 가능 상태까지만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)