### PR TITLE
fix(do-systemd): stop overriding RANKING_DIR — let .env be SSoT (PR #1173 regression)

### DIFF
--- a/backend/deploy/systemd/pruviq-api.service
+++ b/backend/deploy/systemd/pruviq-api.service
@@ -7,13 +7,15 @@ Wants=network-online.target
 User=pruviq
 WorkingDirectory=/opt/pruviq/current/backend
 EnvironmentFile=/opt/pruviq/shared/.env
-# Shared SSoT for Mac/DO split. api/main.py:3800 reads RANKING_DIR;
-# api/main.py:4270 reads SUBSCRIBERS_FILE. Without these injected here, the
-# fallback was /Users/jepo/... (Mac paths) — the /rankings/daily handler and
-# /api/subscribe endpoint silently hit PermissionError on DO and served
-# stale data or rejected writes. Values must stay in lockstep with
-# pruviq-daily-ranking.service (which also needs RANKING_DIR for save_results).
-Environment=RANKING_DIR=/opt/pruviq/shared/rankings
+# Mac/DO split SSoT:
+#   - RANKING_DIR: DO 의 `.env` 가 이미 `/opt/pruviq/data/rankings` 로 지정
+#     (실제 2026-03~04-15 archive 보유 경로). systemd `Environment=` 는
+#     `EnvironmentFile=` 을 override 하므로, 이 유닛에서 RANKING_DIR 을
+#     덮어쓰면 API 가 빈 shared/ 디렉토리를 읽어 /rankings/daily 가 빈
+#     응답을 서빙. PR #1173 에서 shared/ 로 덮어쓴 것이 회귀였음.
+#     `.env` 값을 SSoT 로 두고 여기서는 개입하지 않음.
+#   - SUBSCRIBERS_FILE: `.env` 미선언이므로 여기서 주입. `.env` 에 추가되면
+#     이 라인 제거 가능.
 Environment=SUBSCRIBERS_FILE=/opt/pruviq/shared/subscribers.json
 ExecStart=/opt/pruviq/app/.venv/bin/uvicorn api.main:app --host 127.0.0.1 --port 8080 --workers 1
 Restart=always

--- a/backend/deploy/systemd/pruviq-daily-ranking.service
+++ b/backend/deploy/systemd/pruviq-daily-ranking.service
@@ -9,11 +9,11 @@ User=pruviq
 Group=pruviq
 WorkingDirectory=/opt/pruviq/current
 EnvironmentFile=/opt/pruviq/shared/.env
-# RANKING_DIR — shared SSoT read by both api/main.py:/rankings/daily handler
-# and daily_strategy_ranking.py save_results(). Without this, the ranker
-# defaulted to /Users/jepo/Desktop/autotrader/... (Mac archival path) and
-# failed with PermissionError under User=pruviq on DO every run.
-Environment=RANKING_DIR=/opt/pruviq/shared/rankings
+# RANKING_DIR: `.env` 가 이미 `/opt/pruviq/data/rankings` 로 지정 (archive
+# 2026-03~ 보유). systemd `Environment=` 는 `EnvironmentFile=` 을 override
+# 하므로 PR #1173 의 shared/ 덮어쓰기가 실제 데이터 경로를 누락시켰음.
+# 이제 `.env` 값을 단일 SSoT 로 사용 — 여기서는 주입하지 않음.
+# (pruviq-api.service 와 lockstep — 두 프로세스가 같은 .env 를 읽음.)
 ExecStart=/opt/pruviq/bin/daily-strategy-ranking.sh
 TimeoutStartSec=7200
 # 2026-04-18: 3600 → 7200. strategy × direction × timeframe × group 조합이 많고

--- a/backend/tests/test_do_mac_split_env.py
+++ b/backend/tests/test_do_mac_split_env.py
@@ -38,35 +38,49 @@ DAILY_RANKING = REPO / "scripts" / "daily_strategy_ranking.py"
 STALENESS_WATCH = SYSTEMD_DIR / "bin" / "staleness-watch.sh"
 
 
-def test_pruviq_api_service_injects_ranking_and_subscribers():
-    """pruviq-api.service must set both env vars — api/main.py uses these at
-    module import time, so the uvicorn process inherits them or nothing."""
+def test_pruviq_api_service_loads_env_file():
+    """pruviq-api.service must load shared .env — this is where RANKING_DIR
+    lives (DO .env already has RANKING_DIR=/opt/pruviq/data/rankings where
+    actual archive data sits). SUBSCRIBERS_FILE is not in .env yet, so it
+    must be injected here until the operator adds it.
+
+    2026-04-19 regression: PR #1173 originally set Environment=RANKING_DIR=
+    /opt/pruviq/shared/rankings which overrode .env and pointed the API at
+    an empty dir. Corrected: `.env` is SSoT for RANKING_DIR."""
     unit = (SYSTEMD_DIR / "pruviq-api.service").read_text()
-    assert re.search(r"^Environment=RANKING_DIR=", unit, re.M), (
-        "pruviq-api.service missing RANKING_DIR. /rankings/daily will read "
-        "from /Users/jepo/Desktop/autotrader on DO → PermissionError → 4-day "
-        "stale JSON served."
+    assert re.search(r"^EnvironmentFile=/opt/pruviq/shared/\.env\b", unit, re.M), (
+        "pruviq-api.service must load /opt/pruviq/shared/.env — this is "
+        "the shared SSoT for RANKING_DIR and secrets."
     )
+    # RANKING_DIR MUST NOT be overridden here — let .env be authoritative.
+    assert not re.search(r"^Environment=RANKING_DIR=", unit, re.M), (
+        "pruviq-api.service must not set Environment=RANKING_DIR= — this "
+        "overrides .env and was the root of the 2026-04-19 regression."
+    )
+    # SUBSCRIBERS_FILE injection is still required (not in .env).
     assert re.search(r"^Environment=SUBSCRIBERS_FILE=", unit, re.M), (
         "pruviq-api.service missing SUBSCRIBERS_FILE. /api/subscribe will "
         "try to create /Users/jepo/pruviq-data on DO → PermissionError → "
         "every signup silently drops."
     )
-    # Both must point into /opt/pruviq/shared (pruviq user has write there).
-    for m in re.finditer(r"^Environment=(RANKING_DIR|SUBSCRIBERS_FILE)=(.+)$", unit, re.M):
-        assert m.group(2).startswith("/opt/pruviq/shared"), (
-            f"{m.group(1)} must live under /opt/pruviq/shared (the only dir "
-            f"the pruviq systemd user can write to on DO). Got: {m.group(2)!r}"
-        )
+    # SUBSCRIBERS_FILE must point into /opt/pruviq/shared (writable by pruviq).
+    m = re.search(r"^Environment=SUBSCRIBERS_FILE=(.+)$", unit, re.M)
+    assert m and m.group(1).startswith("/opt/pruviq/shared"), (
+        f"SUBSCRIBERS_FILE must live under /opt/pruviq/shared "
+        f"(pruviq user's only writable dir). Got: {m.group(1) if m else 'missing'!r}"
+    )
 
 
-def test_pruviq_daily_ranking_service_injects_ranking_dir():
-    """pruviq-daily-ranking.service must set RANKING_DIR for save_results()."""
+def test_pruviq_daily_ranking_service_defers_ranking_dir_to_env():
+    """pruviq-daily-ranking.service must load .env and must NOT override
+    RANKING_DIR with Environment= (same reasoning as api.service)."""
     unit = (SYSTEMD_DIR / "pruviq-daily-ranking.service").read_text()
-    assert re.search(r"^Environment=RANKING_DIR=", unit, re.M), (
-        "pruviq-daily-ranking.service missing RANKING_DIR. save_results() "
-        "will fall back to /Users/jepo/Desktop/autotrader — PermissionError "
-        "every 00:05 UTC → rankings-daily.json stale → E2E fail."
+    assert re.search(r"^EnvironmentFile=/opt/pruviq/shared/\.env\b", unit, re.M), (
+        "pruviq-daily-ranking.service must load .env so RANKING_DIR is set."
+    )
+    assert not re.search(r"^Environment=RANKING_DIR=", unit, re.M), (
+        "pruviq-daily-ranking.service must not override RANKING_DIR — let "
+        ".env be the single source of truth (lockstep with pruviq-api.service)."
     )
 
 
@@ -89,11 +103,17 @@ def test_daily_strategy_ranking_reads_env_not_hardcoded_mac_path():
     )
 
 
-def test_api_main_env_names_match_systemd_units():
-    """Env var names in code and systemd unit must be byte-identical; a typo
-    like RANKING_DIR vs RANKINGS_DIR silently reverts to the Mac fallback."""
+def test_api_main_env_names_have_injection_path():
+    """Env var names in code must be injectable on DO. Two valid paths:
+      1. `Environment=` line in the service unit (direct inject)
+      2. `EnvironmentFile=/opt/pruviq/shared/.env` (operator manages .env)
+    A code reference with neither path is a silent-fallback-to-Mac-path bug.
+
+    This test does NOT require the systemd unit to have `Environment=`
+    explicitly — RANKING_DIR currently flows through .env to avoid the
+    2026-04-19 override regression."""
     src = API_MAIN.read_text()
-    code_names = set()
+    code_names: set[str] = set()
     for pattern in (
         r'os\.environ\.get\(\s*["\'](RANKING_DIR|SUBSCRIBERS_FILE)["\']',
         r'os\.environ\[\s*["\'](RANKING_DIR|SUBSCRIBERS_FILE)["\']',
@@ -103,9 +123,15 @@ def test_api_main_env_names_match_systemd_units():
     assert "SUBSCRIBERS_FILE" in code_names, "api/main.py no longer reads SUBSCRIBERS_FILE"
 
     api_unit = (SYSTEMD_DIR / "pruviq-api.service").read_text()
+    has_env_file = bool(
+        re.search(r"^EnvironmentFile=/opt/pruviq/shared/\.env\b", api_unit, re.M)
+    )
     for name in code_names:
-        assert re.search(rf"^Environment={name}=", api_unit, re.M), (
-            f"api/main.py reads {name} but pruviq-api.service does not set it."
+        has_direct = bool(re.search(rf"^Environment={name}=", api_unit, re.M))
+        assert has_direct or has_env_file, (
+            f"api/main.py reads {name} but pruviq-api.service has no "
+            f"injection path — no Environment= line AND no EnvironmentFile=. "
+            f"The code will fall back to its /Users/... default on DO."
         )
 
 


### PR DESCRIPTION
## Summary — regression fix

**debugger + architecture-audit** 두 전문가 agent 가 독립적으로 동일 회귀 확인:

PR #1173 이 \`pruviq-api.service\` + \`pruviq-daily-ranking.service\` 에 \`Environment=RANKING_DIR=/opt/pruviq/shared/rankings\` 주입했는데, DO \`.env\` 는 이미 \`RANKING_DIR=/opt/pruviq/data/rankings\` (실제 archive 2026-03~04-15 보유)로 지정. systemd \`Environment=\` 가 \`EnvironmentFile=\` 을 **override** → 빈 shared/ 디렉토리 참조 → \`/rankings/daily\` stale cache.

## 뿌리 시정

\`.env\` 가 SSoT. systemd 는 미개입. SUBSCRIBERS_FILE 만 주입 유지(.env 미선언).

## EVIDENCE
- DO \`grep RANKING_DIR /opt/pruviq/shared/.env\` → \`/opt/pruviq/data/rankings\`
- DO \`ls /opt/pruviq/data/rankings/\` → archive 존재 (Mar 15 ~ Apr 15)
- DO \`ls /opt/pruviq/shared/rankings/\` → 없음
- \`systemctl show pruviq-api --property=Environment\` → shared/ override 확정
- architecture-audit agent 독립 발견: 추가 CRITICAL — **DO uvicorn 13분 CPU 100% hang** (별개, \`systemctl restart\` 로 해소)

## Test plan
- [x] \`pytest tests/test_do_mac_split_env.py -v\` → **7/7 passed** (신규 회귀 방지 테스트 포함)
  - EnvironmentFile=/.env 필수
  - Environment=RANKING_DIR= 금지 (override 회귀 재발 방지)
  - SUBSCRIBERS_FILE 주입 확인
  - 코드-유닛 이름 일치
- [ ] (CI) automerge
- [ ] (DO 배포 후) \`systemctl show pruviq-api --property=Environment\` → RANKING_DIR 이 \`/opt/pruviq/data/rankings\` 로 반영
- [ ] \`curl /rankings/daily\` → 내일 00:05 UTC cron 후 오늘 date
- [ ] Operator: \`touch /opt/pruviq/shared/subscribers.json && chown pruviq:pruviq\` (첫 /api/subscribe 전에)

## Non-goals
- uvicorn 100% CPU hang 원인(signal_scanner 타임아웃) — 별도 PR
- Litestream off-host replica (S3/B2) — CRITICAL, 별도 PR
- 12 프론트엔드 findings + 5 테스트 gap + 7 SEO findings — 개별 PR 로 분리

🤖 Generated with [Claude Code](https://claude.com/claude-code)