### PR TITLE
fix(api): wrap signal_scanner.scan in wait_for — prevent uvicorn 100% CPU hang

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -164,13 +164,35 @@ async def _okx_auto_trading_loop():
     no change to signal quality (candles are hourly).
     """
     interval_sec = max(60, int(os.environ.get("OKX_AUTO_TRADE_INTERVAL_SEC", "300")))
-    logger.info("OKX auto-trading loop interval = %ds", interval_sec)
+    # Bound a single scan at < 1 interval so a hung thread cannot starve the
+    # next tick. 2026-04-19 incident: an unbounded scan pegged DO uvicorn
+    # --workers 1 at 100% CPU for 13 min and /health stopped responding.
+    # Pass OKX_SCAN_TIMEOUT_SEC to tune (default 90s < 300s interval default).
+    scan_timeout_sec = max(30, int(os.environ.get("OKX_SCAN_TIMEOUT_SEC", "90")))
+    logger.info(
+        "OKX auto-trading loop interval=%ds scan_timeout=%ds",
+        interval_sec, scan_timeout_sec,
+    )
     await asyncio.sleep(30)  # Wait for data load
     while True:
         try:
             from okx.auto_executor import process_signals
             if _signal_scanner is not None:
-                signals = await asyncio.to_thread(_signal_scanner.scan)
+                try:
+                    signals = await asyncio.wait_for(
+                        asyncio.to_thread(_signal_scanner.scan),
+                        timeout=scan_timeout_sec,
+                    )
+                except asyncio.TimeoutError:
+                    # The thread is still running in the background (Python
+                    # cannot cancel a sync function cleanly); we drop the
+                    # result and wait for the next tick. A chronic timeout
+                    # means scan.py needs optimization, not a longer budget.
+                    logger.error(
+                        "signal_scanner.scan exceeded %ds — skipping this tick",
+                        scan_timeout_sec,
+                    )
+                    signals = []
                 if signals:
                     await process_signals(signals)
         except asyncio.CancelledError:
@@ -349,9 +371,16 @@ async def lifespan(app: FastAPI):
                 print(f"WARNING: indicator build failed before pre-warm: {e}")
                 return
             try:
-                await asyncio.to_thread(_signal_scanner.scan)
+                # Cap pre-warm at 120s. If cold-cache scan is slow we'd rather
+                # let the first runtime scan populate signals than block startup.
+                await asyncio.wait_for(
+                    asyncio.to_thread(_signal_scanner.scan),
+                    timeout=120,
+                )
                 n = len(_signal_scanner._cache)
                 print(f"Signal cache pre-warmed: {n} active signals")
+            except asyncio.TimeoutError:
+                print("WARNING: Signal cache pre-warm timed out (>120s) — first runtime scan will fill cache")
             except Exception as e:
                 print(f"WARNING: Signal cache pre-warm failed: {e}")
 
@@ -800,7 +829,13 @@ async def signals_live(top_n: int = 30):
     def _scan():
         return _signal_scanner.scan()
 
-    signals = await asyncio.to_thread(_scan)
+    # 30s hard cap — this is a user-facing endpoint; better to return empty
+    # than to hold a request while the scanner thread is stuck.
+    try:
+        signals = await asyncio.wait_for(asyncio.to_thread(_scan), timeout=30)
+    except asyncio.TimeoutError:
+        logger.error("/signals/live scan exceeded 30s — returning empty")
+        return []
     return signals
 
 
@@ -834,7 +869,16 @@ async def internal_signals(
         return {"signals": [], "ts": ts}
 
     try:
-        signals = await asyncio.to_thread(_signal_scanner.scan)
+        # 60s cap for the internal poll path (called every 5 min by the
+        # DO auto-trading worker). Timeout → 500 so the worker skips this
+        # tick and retries — better than silently serving stale data.
+        signals = await asyncio.wait_for(
+            asyncio.to_thread(_signal_scanner.scan),
+            timeout=60,
+        )
+    except asyncio.TimeoutError:
+        logger.error("/internal/signals scan exceeded 60s")
+        raise HTTPException(status_code=504, detail="scan timeout")
     except Exception as e:
         logger.warning(f"/internal/signals scan failed: {e}")
         raise HTTPException(status_code=500, detail=f"scan failed: {e}")

--- a/backend/tests/test_signal_scanner_timeout.py
+++ b/backend/tests/test_signal_scanner_timeout.py
@@ -1,0 +1,105 @@
+"""
+signal_scanner.scan timeout regression guard.
+
+2026-04-19 CRITICAL: DO uvicorn pegged at 100% CPU for 13 minutes — the
+`asyncio.to_thread(_signal_scanner.scan)` call sites in api/main.py had
+no timeout, so a hung/slow scan pinned the single worker indefinitely.
+/health stopped responding (Cloudflare Tunnel "context canceled"); the
+architecture-audit agent confirmed the symptom live.
+
+This guard ensures every scan call site is wrapped in `asyncio.wait_for`
+with a finite timeout.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+REPO = Path(__file__).resolve().parent.parent
+API_MAIN = REPO / "api" / "main.py"
+
+
+def test_every_scan_to_thread_has_wait_for():
+    """Every `asyncio.to_thread(*scan)` or `asyncio.to_thread(_scan)` call
+    must be wrapped in `asyncio.wait_for(...)` on the same or immediately
+    preceding line. Raw `await asyncio.to_thread(scan)` = potential hang."""
+    src = API_MAIN.read_text()
+    lines = src.splitlines()
+
+    scan_patterns = [
+        # _signal_scanner.scan direct
+        re.compile(r"asyncio\.to_thread\(\s*_signal_scanner\.scan\s*[,)]"),
+        # local _scan wrapper (e.g. in /signals/live)
+        re.compile(r"asyncio\.to_thread\(\s*_scan\s*[,)]"),
+    ]
+
+    findings: list[tuple[int, str]] = []
+    for i, line in enumerate(lines, start=1):
+        for p in scan_patterns:
+            if p.search(line):
+                # Look at a 3-line window (this line + 2 preceding) for
+                # an `asyncio.wait_for(` enclosing the to_thread call.
+                window = "\n".join(lines[max(0, i - 3):i])
+                if "asyncio.wait_for(" not in window:
+                    findings.append((i, line.strip()[:120]))
+
+    assert not findings, (
+        "Unwrapped signal scan call(s) found — each must be inside "
+        "asyncio.wait_for(..., timeout=N). A hung scan will peg uvicorn at "
+        "100% CPU and break /health. Locations:\n"
+        + "\n".join(f"  api/main.py:{n}: {code}" for n, code in findings)
+    )
+
+
+def test_timeout_values_are_bounded():
+    """Timeouts must be finite (not None, not huge). Sanity check the
+    numeric values we chose fit the 300s scheduler tick."""
+    src = API_MAIN.read_text()
+    # Extract every timeout= literal on a wait_for line that mentions scan.
+    timeouts: list[int] = []
+    for match in re.finditer(
+        r"asyncio\.wait_for\(\s*asyncio\.to_thread\([^)]*scan[^)]*\)[^)]*timeout\s*=\s*(\w+)",
+        src,
+        re.DOTALL,
+    ):
+        val = match.group(1)
+        if val.isdigit():
+            timeouts.append(int(val))
+        # Env-derived timeouts (scan_timeout_sec) are accepted; we can't
+        # know the runtime value here but the variable name check is below.
+    # At least one numeric timeout present
+    assert timeouts or "scan_timeout_sec" in src, (
+        "Expected at least one numeric timeout on wait_for(to_thread(scan)). "
+        "Either hardcode one (30-120) or read from env (scan_timeout_sec)."
+    )
+    for t in timeouts:
+        assert 10 <= t <= 300, (
+            f"Scan timeout {t}s is out of reasonable range. "
+            "Too short → false timeouts under load; too long → 5-min "
+            "scheduler tick can overlap itself."
+        )
+
+
+def test_timeout_handlers_are_explicit():
+    """Each wait_for site must handle asyncio.TimeoutError explicitly, not
+    let it bubble up to the generic `except Exception` — that loses the
+    signal about hung scans vs real errors."""
+    src = API_MAIN.read_text()
+    # Count `asyncio.wait_for` with `scan` near it
+    wait_for_sites = len(
+        re.findall(
+            r"asyncio\.wait_for\(\s*asyncio\.to_thread\([^)]*scan",
+            src,
+            re.DOTALL,
+        )
+    )
+    # Count TimeoutError catches inside /signals|/internal|_okx_auto_trading|_prewarm
+    timeout_catches = src.count("asyncio.TimeoutError")
+    assert timeout_catches >= wait_for_sites, (
+        f"Have {wait_for_sites} wait_for(scan) sites but only "
+        f"{timeout_catches} asyncio.TimeoutError handlers — "
+        "some paths swallow timeouts as generic errors."
+    )


### PR DESCRIPTION
## Summary — live-incident postmortem fix

**architecture-audit agent** 가 독립 감사 중 실시간 장애 포착:
> DO uvicorn --workers 1 이 현재 100% CPU **13분** unresponsive.
> /health curl 5s timeout, cloudflared \"context canceled\".

원인: \`api/main.py\` 의 \`asyncio.to_thread(_signal_scanner.scan)\` **4개 call site 전부 timeout 없음**. scan 이 느리면 thread 영구 점유 → event loop starvation → Restart=always 도 alive 상태라 trigger 안 됨 → operator 수동 SSH 만 복구 가능.

## 수정 (4 call site)

| Line | 함수 | 타임아웃 | 실패 시 |
|---|---|---|---|
| 173 | `_okx_auto_trading_loop` | `OKX_SCAN_TIMEOUT_SEC` env (기본 90s) | `signals=[]`, 다음 tick 대기 |
| 352 | `_prewarm_signals` (startup) | 120s | 경고 로그, 첫 runtime scan 이 cache 채움 |
| 832 | `/signals/live` | 30s | `return []` (stale 보다 empty) |
| 866 | `/internal/signals` | 60s | HTTP 504 (worker 가 skip+retry) |

## Test plan
- [x] `pytest tests/test_signal_scanner_timeout.py -v` → **3/3 passed**
  - 모든 `asyncio.to_thread(*scan)` 이 wait_for 안에
  - timeout 10-300s 범위
  - `asyncio.TimeoutError` catch 수 ≥ wait_for 수
- [ ] (CI) automerge + deploy
- [ ] (DO 배포 후) `ssh DO "journalctl -u pruviq-api -f | grep -E 'exceeded|timeout'"` — 실패 경로가 log 로 surfacing 되는지

## EVIDENCE
- 장애 관측: systemctl restart 로 즉시 해소, 새 uvicorn uptime 12.2s, coins_loaded=238
- 이전 hang 은 `asyncio.to_thread` 가 sync 함수를 cancel 못 하는 점 + 타임아웃 부재 조합

## Non-goals (별도 PR)
- `signal_scanner.scan` 자체 CPU 최적화 (238 coins × 지표, GIL contention)
- `pruviq-monitor` watchdog — `/health` 3회 실패 시 `systemctl restart` (operator-free recovery)
- Litestream off-host replica (S3/B2)
- Idempotency-Key required 승격

🤖 Generated with [Claude Code](https://claude.com/claude-code)