### PR TITLE
feat(watchdog): auto-restart pruviq-api on /health hang (defense-in-depth)

### DIFF
--- a/backend/deploy/systemd/bin/api-watchdog.sh
+++ b/backend/deploy/systemd/bin/api-watchdog.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# PRUVIQ — API Watchdog (DO-native, every 1 min, root-privileged)
+#
+# Called by pruviq-api-watchdog.timer. Complements pruviq-api.service's
+# `Restart=always` for the case where the process is alive but hung
+# (event loop starved, 100% CPU, /health not responding). systemd won't
+# restart a live process, so we have to.
+#
+# Architecture:
+#   pruviq-monitor.service (User=pruviq, every 5 min) — sends Telegram alerts
+#   pruviq-api-watchdog (this, User=root, every 1 min) — force-restarts API
+# Separating the two keeps the high-frequency watchdog minimal (no telegram,
+# no python) while the 5-min monitor retains full observability depth.
+#
+# Action: if /health fails CONSECUTIVE_FAIL_THRESHOLD times in a row,
+# force `systemctl restart pruviq-api.service`. Reset the counter on any
+# success. Cooldown after a restart so we don't loop if the service keeps
+# dying during boot.
+set -uo pipefail
+
+HEALTH_URL="http://127.0.0.1:8080/health"
+CONSECUTIVE_FAIL_THRESHOLD=3
+COOLDOWN_SEC=180
+STATE_DIR="/var/lib/pruviq-watchdog"
+FAIL_COUNT_FILE="$STATE_DIR/api-fail-count"
+LAST_RESTART_FILE="$STATE_DIR/api-last-restart"
+
+mkdir -p "$STATE_DIR" 2>/dev/null || true
+
+# Read current counters (default 0).
+fail_count=0
+[ -f "$FAIL_COUNT_FILE" ] && fail_count=$(cat "$FAIL_COUNT_FILE" 2>/dev/null || echo 0)
+fail_count=${fail_count:-0}
+
+last_restart=0
+[ -f "$LAST_RESTART_FILE" ] && last_restart=$(cat "$LAST_RESTART_FILE" 2>/dev/null || echo 0)
+last_restart=${last_restart:-0}
+
+now=$(date +%s)
+
+# Probe /health. curl exit 0 only when HTTP 2xx and non-empty body.
+if curl -sf -m 5 "$HEALTH_URL" >/dev/null 2>&1; then
+    if [ "$fail_count" -gt 0 ]; then
+        echo "recovery: reset fail_count from $fail_count to 0"
+    fi
+    echo 0 > "$FAIL_COUNT_FILE"
+    echo "ok"
+    exit 0
+fi
+
+# Failed probe.
+fail_count=$((fail_count + 1))
+echo "$fail_count" > "$FAIL_COUNT_FILE"
+echo "fail: count=$fail_count threshold=$CONSECUTIVE_FAIL_THRESHOLD"
+
+if [ "$fail_count" -lt "$CONSECUTIVE_FAIL_THRESHOLD" ]; then
+    exit 0
+fi
+
+# Threshold breached. Respect cooldown to prevent restart-loop on
+# persistently-unhealthy service (e.g. bad config, disk full).
+age_since_restart=$(( now - last_restart ))
+if [ "$last_restart" -gt 0 ] && [ "$age_since_restart" -lt "$COOLDOWN_SEC" ]; then
+    echo "cooldown: last restart ${age_since_restart}s ago (< ${COOLDOWN_SEC}s) — skipping"
+    exit 0
+fi
+
+echo "RESTART: pruviq-api after $fail_count consecutive /health failures"
+systemctl restart pruviq-api.service
+echo "$now" > "$LAST_RESTART_FILE"
+echo 0 > "$FAIL_COUNT_FILE"
+
+# Best-effort Telegram notification. Uses /opt/pruviq/shared/.env if the
+# caller sources it; otherwise silently skips.
+if [ -n "${TELEGRAM_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
+    MSG="🔁 PRUVIQ API auto-restarted (watchdog)
+pruviq-api.service was unresponsive for ${fail_count} consecutive probes.
+Hostname: $(hostname -s). Check: journalctl -u pruviq-api -n 100"
+    curl -sf -m 10 -X POST "https://api.telegram.org/bot${TELEGRAM_TOKEN}/sendMessage" \
+        -d chat_id="${TELEGRAM_CHAT_ID}" \
+        -d text="$MSG" >/dev/null 2>&1 || true
+fi

--- a/backend/deploy/systemd/pruviq-api-watchdog.service
+++ b/backend/deploy/systemd/pruviq-api-watchdog.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=PRUVIQ API Watchdog — force-restart pruviq-api on /health hang
+After=network-online.target pruviq-api.service
+# No OnFailure= here — if the watchdog itself fails, we do NOT want to
+# chain into pruviq-alert since this runs as root every minute.
+
+[Service]
+Type=oneshot
+# Must be root: `systemctl restart pruviq-api.service` without polkit.
+# The script is minimal (curl + counter file + systemctl) to keep this
+# trust surface as small as possible.
+User=root
+Group=root
+EnvironmentFile=-/opt/pruviq/shared/.env
+ExecStart=/opt/pruviq/bin/api-watchdog.sh
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=30
+SyslogIdentifier=pruviq-api-watchdog

--- a/backend/deploy/systemd/pruviq-api-watchdog.timer
+++ b/backend/deploy/systemd/pruviq-api-watchdog.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=PRUVIQ API Watchdog timer (every 1 min)
+
+[Timer]
+# 1-minute cadence: 3 consecutive failures = 3-minute detection ceiling,
+# which is below the 5-min pruviq-monitor tick. Fast recovery matters
+# because OAuth callbacks time out at ~10s on the client side.
+OnBootSec=2min
+OnUnitActiveSec=1min
+AccuracySec=10s
+RandomizedDelaySec=0
+Unit=pruviq-api-watchdog.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
2026-04-19 incident: DO uvicorn 100% CPU, **13분 unresponsive**. systemd \`Restart=always\` 는 alive 프로세스 감지 안 함. PR #1180 이 signal_scanner 를 timeout 으로 감쌌지만 다른 경로에서 같은 증상 재발 가능 → **defense-in-depth** 필요.

## 구조
| Service | User | 역할 | 주기 |
|---|---|---|---|
| \`pruviq-monitor\` | pruviq | Telegram alert only | 5min |
| **\`pruviq-api-watchdog\` (신규)** | **root** | \`systemctl restart\` only | **1min** |

권한 분리 (monitor 는 pruviq 유지, watchdog 만 root). 코드 최소화 — curl + 카운터 파일 + systemctl.

## 동작
- 3회 연속 /health fail → \`systemctl restart pruviq-api.service\` → Telegram notify
- 180s 쿨다운으로 restart-loop 방지 (boot-time 실패 대응)
- 상태: \`/var/lib/pruviq-watchdog/api-fail-count\`

## 복구 시간
- Before: 무한정 (operator SSH 필요) · 오늘 13분
- After: **≤ 3분** 감지 + 즉시 restart

## Deploy 후 Operator 1회 (PR body에 재기술)
\`\`\`
ssh -p 2222 root@167.172.81.145 \"systemctl daemon-reload && \\
  systemctl enable --now pruviq-api-watchdog.timer && \\
  systemctl list-timers pruviq-api-watchdog.timer\"
\`\`\`

## Test plan
- [x] \`bash -n api-watchdog.sh\` → syntax ok
- [ ] (CI) automerge
- [ ] (DO) enable timer 후 \`systemctl list-timers\` 에 1min cadence 확인
- [ ] Test restart: \`systemctl stop pruviq-api\` → 3분 내 자동 복귀 + Telegram \"auto-restarted\" 알림

## Non-goals
- uvicorn --workers 증설
- sd_notify 기반 systemd 네이티브 watchdog
- signal_scanner.scan 자체 최적화

🤖 Generated with [Claude Code](https://claude.com/claude-code)