### PR TITLE
fix(backend): hardening batch — silent-death loops + idempotency + secret leaks (6 fixes)

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -196,25 +196,43 @@ async def _okx_token_refresh_loop():
 
 
 async def _okx_reconcile_loop():
-    """Reconcile OKX live positions vs DB trade_log every 5 minutes (P0-2)."""
-    try:
-        from okx.reconciler import reconcile_loop
-        await reconcile_loop()
-    except asyncio.CancelledError:
-        raise
-    except Exception as e:
-        logger.error(f"OKX reconcile loop terminated: {e}")
+    """Reconcile OKX live positions vs DB trade_log every 5 minutes (P0-2).
+
+    2026-04-19: original version delegated entirely to the inner
+    `reconcile_loop()`; if that raised any non-CancelledError exception,
+    the outer task exited permanently — **silent death**, no alert, no
+    systemd visibility (task lives inside uvicorn). Now wrapped in an
+    outer while-True with per-iteration retry.
+    """
+    from okx.reconciler import reconcile_loop
+    while True:
+        try:
+            await reconcile_loop()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error(
+                "OKX reconcile loop crashed (%s); restarting in 60s", e,
+            )
+            await asyncio.sleep(60)
 
 
 async def _okx_pnl_retry_loop():
-    """Retry pnl_sync for trade_log rows flagged pnl_synced=0 every 30 min (P0-3)."""
-    try:
-        from okx.pnl_sync import retry_failed_pnl_sync_loop
-        await retry_failed_pnl_sync_loop()
-    except asyncio.CancelledError:
-        raise
-    except Exception as e:
-        logger.error(f"OKX pnl retry loop terminated: {e}")
+    """Retry pnl_sync for trade_log rows flagged pnl_synced=0 every 30 min (P0-3).
+
+    Same silent-death fix as _okx_reconcile_loop (2026-04-19).
+    """
+    from okx.pnl_sync import retry_failed_pnl_sync_loop
+    while True:
+        try:
+            await retry_failed_pnl_sync_loop()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error(
+                "OKX pnl retry loop crashed (%s); restarting in 60s", e,
+            )
+            await asyncio.sleep(60)
 
 
 async def _background_refresh():

--- a/backend/okx/oauth.py
+++ b/backend/okx/oauth.py
@@ -73,8 +73,14 @@ def _validate_redirect(url: str) -> str:
     except Exception:
         return ""
     scheme = (parsed.scheme or "").lower()
-    netloc = (parsed.netloc or "").lower()
-    if not scheme and not netloc:
+    # 2026-04-19: use `.hostname` (stripped userinfo, lower-cased) instead
+    # of `.netloc`. Input like `https://pruviq.com@evil.pruviq.com/` has
+    # netloc=`pruviq.com@evil.pruviq.com` which endswith `.pruviq.com`
+    # and would pass the host check, but the effective destination host
+    # is `evil.pruviq.com` (attacker-controlled). .hostname returns only
+    # the host part and drops `user:pass@`.
+    host = (parsed.hostname or "").lower()
+    if not scheme and not host:
         # Relative path. Require leading "/" to avoid ambiguous inputs.
         if url.startswith("/"):
             return url
@@ -83,7 +89,12 @@ def _validate_redirect(url: str) -> str:
     if scheme not in ("http", "https"):
         logger.warning("OAuth redirect blocked (bad scheme=%s): %s", scheme, url[:100])
         return ""
-    if netloc == "pruviq.com" or netloc.endswith(".pruviq.com"):
+    # Reject any userinfo in the URL — it has no legitimate use here and
+    # confuses downstream parsers.
+    if "@" in (parsed.netloc or ""):
+        logger.warning("OAuth redirect blocked (userinfo in URL): %s", url[:100])
+        return ""
+    if host == "pruviq.com" or host.endswith(".pruviq.com"):
         return url
     logger.warning("OAuth redirect blocked (not pruviq.com): %s", url[:100])
     return ""

--- a/backend/okx/router.py
+++ b/backend/okx/router.py
@@ -222,10 +222,30 @@ async def execute_order(
     # request silently succeeded on OKX but failed to return to the client.
     # Format: [A-Za-z0-9_]{1,32}. We hash + truncate to stay in spec and
     # prefix with session_id[:4] to make debug logs traceable.
+    #
+    # 2026-04-19: reject header-present-but-empty rather than silently
+    # skipping. Empty header is a client bug (sent `Idempotency-Key:` with
+    # no value) — silently ignoring gives the caller NO replay protection
+    # when they thought they had it.
     cl_ord_id: Optional[str] = None
-    if idempotency_key:
+    if idempotency_key is not None:
+        stripped = idempotency_key.strip()
+        if not stripped:
+            _order_rate_limit.pop(session_id, None)
+            raise HTTPException(
+                400,
+                "Idempotency-Key header present but empty. Either omit the "
+                "header or supply a non-whitespace value (recommended: a "
+                "stable hash of the source signal).",
+            )
+        if len(stripped) > 256:
+            _order_rate_limit.pop(session_id, None)
+            raise HTTPException(
+                400,
+                f"Idempotency-Key too long ({len(stripped)}); max 256 chars.",
+            )
         import hashlib as _hashlib
-        raw = f"{session_id}:{idempotency_key}".encode()
+        raw = f"{session_id}:{stripped}".encode()
         cl_ord_id = _hashlib.sha1(raw).hexdigest()[:32]
 
     try:

--- a/backend/okx/server.py
+++ b/backend/okx/server.py
@@ -59,10 +59,12 @@ async def _signal_polling_loop() -> None:
             try:
                 resp = await client.get(OKX_SIGNAL_SOURCE_URL, headers=headers)
                 if resp.status_code != 200:
+                    # Do NOT log resp.text. The signal source authenticates
+                    # via X-Internal-Key; some upstream error pages echo
+                    # request headers (nginx default error_page templates),
+                    # which would leak INTERNAL_API_KEY to journalctl.
                     logger.warning(
-                        "Signal poll non-200: status=%s body=%s",
-                        resp.status_code,
-                        resp.text[:300],
+                        "Signal poll non-200: status=%s", resp.status_code,
                     )
                 else:
                     data = resp.json()

--- a/backend/okx/telegram_halt.py
+++ b/backend/okx/telegram_halt.py
@@ -54,9 +54,16 @@ async def _send_telegram(text: str) -> None:
                     "disable_web_page_preview": True,
                 },
             )
+            # Telegram error bodies can echo the bot token in `description`
+            # on some misconfig (401/404). Log status + narrow description only.
+            desc = ""
+            try:
+                desc = str(resp.json().get("description", ""))[:120]
+            except Exception:
+                pass
             logger.warning(
-                "\u2190 Telegram halt notify status=%s body=%s",
-                resp.status_code, resp.text[:300],
+                "\u2190 Telegram halt notify status=%s desc=%s",
+                resp.status_code, desc,
             )
     except Exception as e:
         logger.error("Telegram halt notify failed: %s", e)
@@ -78,9 +85,16 @@ async def _get_updates(offset: int) -> list[dict[str, Any]]:
             )
             if resp.status_code == 200:
                 return resp.json().get("result", []) or []
+            # Drop raw body — Telegram error `description` on auth failures
+            # can echo bot token fragments.
+            desc = ""
+            try:
+                desc = str(resp.json().get("description", ""))[:120]
+            except Exception:
+                pass
             logger.warning(
-                "Telegram getUpdates non-200 status=%s body=%s",
-                resp.status_code, resp.text[:300],
+                "Telegram getUpdates non-200 status=%s desc=%s",
+                resp.status_code, desc,
             )
     except Exception as e:
         logger.warning("Telegram getUpdates failed: %s", e)

--- a/backend/tests/test_backend_hardening_20260419.py
+++ b/backend/tests/test_backend_hardening_20260419.py
@@ -1,0 +1,152 @@
+"""
+Backend hardening regression guards (PR 2026-04-19).
+
+Closes 5 items flagged by the expert sweep after the 8-PR cascade merged:
+
+1. [CRITICAL] `_okx_reconcile_loop` / `_okx_pnl_retry_loop` silent death on
+   any non-CancelledError — outer try/except logged once and let the task
+   exit. No alert. Reconciliation for orphan positions would silently
+   stop forever.
+2. [HIGH] `/execute/order` Idempotency-Key header treated empty same as
+   absent — client sending `Idempotency-Key: ` (header present, empty
+   value) silently got NO replay protection. A client-side retry would
+   place a duplicate order.
+3. [HIGH] `okx/server.py` signal-poll non-200 logged `resp.text[:300]`.
+   The signal source auths via X-Internal-Key; nginx default error_page
+   templates echo request headers → INTERNAL_API_KEY can leak to journalctl.
+4. [HIGH] `okx/telegram_halt.py` notify/getUpdates non-200 logged
+   `resp.text[:300]` — Telegram error `description` on 401/404 can echo
+   the bot token.
+5. [LOW] `okx/oauth.py` `_validate_redirect` used `parsed.netloc` which
+   includes `user:pass@host`. Input `https://pruviq.com@evil.pruviq.com/`
+   passes the endswith check while redirecting to evil.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+REPO = Path(__file__).resolve().parent.parent
+API_MAIN = REPO / "api" / "main.py"
+ROUTER = REPO / "okx" / "router.py"
+SERVER = REPO / "okx" / "server.py"
+TELEGRAM_HALT = REPO / "okx" / "telegram_halt.py"
+OAUTH = REPO / "okx" / "oauth.py"
+
+
+def _extract_function_body(src: str, name: str) -> str:
+    """Grab the text of `async def <name>(...)` up to the next top-level
+    def/async def. Good enough for our linear-style functions."""
+    m = re.search(
+        rf"^async def {re.escape(name)}\b.*?(?=^(?:async )?def |\Z)",
+        src,
+        re.DOTALL | re.MULTILINE,
+    )
+    return m.group(0) if m else ""
+
+
+def test_reconcile_loop_has_outer_while_true():
+    """Regression: inner reconcile_loop crash must NOT kill the outer task."""
+    src = API_MAIN.read_text()
+    body = _extract_function_body(src, "_okx_reconcile_loop")
+    assert body, "_okx_reconcile_loop not found"
+    assert "while True" in body, (
+        "_okx_reconcile_loop must have outer `while True` wrapping the "
+        "inner reconcile_loop() call. Without it, any exception kills "
+        "reconciliation permanently — orphan positions go undetected."
+    )
+    assert "asyncio.sleep" in body, (
+        "_okx_reconcile_loop must sleep between restarts (avoid hot-loop "
+        "on persistent failure)."
+    )
+
+
+def test_pnl_retry_loop_has_outer_while_true():
+    src = API_MAIN.read_text()
+    body = _extract_function_body(src, "_okx_pnl_retry_loop")
+    assert body, "_okx_pnl_retry_loop not found"
+    assert "while True" in body
+    assert "asyncio.sleep" in body
+
+
+def test_idempotency_key_empty_rejected():
+    """Regression: empty Idempotency-Key must be rejected with 400, not
+    silently fall through to cl_ord_id=None (which means NO replay protection)."""
+    src = ROUTER.read_text()
+    # Hunt the idempotency block; it must strip + 400 on empty.
+    assert re.search(
+        r"idempotency_key\s*is\s*not\s*None",
+        src,
+    ), (
+        "router.py must use `is not None` — Python falsy check (`if key:`) "
+        "treats empty string as absent."
+    )
+    assert re.search(r"HTTPException\(\s*400\b", src) and "empty" in src.lower(), (
+        "router.py must return 400 when Idempotency-Key is present but "
+        "empty/whitespace — silently ignoring = silent retry bug."
+    )
+
+
+def test_server_signal_poll_does_not_log_response_body():
+    """Regression: X-Internal-Key must not leak via nginx error_page echo."""
+    src = SERVER.read_text()
+    # Find the Signal poll non-200 logger line and verify no resp.text there.
+    block = re.search(r'"Signal poll non-200.*?\)', src, re.DOTALL)
+    assert block, "Signal poll log block not found (test needs update)"
+    assert "resp.text" not in block.group(0), (
+        "okx/server.py Signal-poll non-200 log must not include resp.text — "
+        "INTERNAL_API_KEY can leak via upstream error_page echo."
+    )
+
+
+def test_telegram_halt_does_not_log_response_body():
+    """Regression: bot token can leak in Telegram error `description`."""
+    src = TELEGRAM_HALT.read_text()
+    # The two historical leak sites were halt-notify and getUpdates 401.
+    # After fix, neither should have resp.text in the warning body.
+    warning_lines = re.findall(
+        r'logger\.warning\([^)]*resp\.text', src, re.DOTALL,
+    )
+    assert not warning_lines, (
+        f"okx/telegram_halt.py still logs resp.text on {len(warning_lines)} "
+        "line(s). Log status + json()['description'][:120] instead."
+    )
+
+
+def test_validate_redirect_uses_hostname_not_netloc():
+    """Regression: `https://pruviq.com@evil.pruviq.com/` must be rejected."""
+    src = OAUTH.read_text()
+    # Source-level check: the host comparison must be against `parsed.hostname`,
+    # not `parsed.netloc`. Also userinfo rejection.
+    assert "parsed.hostname" in src, (
+        "_validate_redirect must use parsed.hostname (strips user:pass@) "
+        "instead of parsed.netloc. netloc fails open on URL with userinfo."
+    )
+    # The file may still have a legacy `netloc.endswith(".pruviq.com")` line
+    # BUT it must not be on the final gate. Verify userinfo rejection exists.
+    assert re.search(r'"@"\s+in\s+\(?\s*parsed\.netloc', src) or re.search(
+        r'if\s+"@"\s+in\s+parsed\.netloc', src
+    ), (
+        "_validate_redirect should explicitly reject URLs with `@` in netloc "
+        "(userinfo) — no legitimate use on this endpoint."
+    )
+    # Runtime check (best effort).
+    try:
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("oauth_under_test", OAUTH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    except Exception:
+        return  # env not configured — source check above is sufficient
+    assert mod._validate_redirect("https://pruviq.com@evil.pruviq.com/") == ""
+    assert mod._validate_redirect("https://user:pw@evil.pruviq.com/") == ""
+    # Happy path still works.
+    assert mod._validate_redirect("https://pruviq.com/dashboard") == (
+        "https://pruviq.com/dashboard"
+    )
+    assert mod._validate_redirect("https://app.pruviq.com/x") == (
+        "https://app.pruviq.com/x"
+    )


### PR DESCRIPTION
## Summary
expert sweep 결과 CRITICAL 1 + HIGH 4 + LOW 1 병행. 각 독립이지만 repo 내 hot path 집중으로 묶음.

| 심각도 | 파일 | 이슈 |
|---|---|---|
| **CRITICAL** | \`api/main.py:198-217\` | \`_okx_reconcile_loop\` / \`_okx_pnl_retry_loop\` 의 outer \`except Exception\` 이 task 영구 종료 → orphan position detection silent 중단 |
| HIGH | \`okx/router.py:226\` | Idempotency-Key empty string 이 falsy check 로 None 같이 처리 → silent 중복 주문 |
| HIGH | \`okx/server.py:65\` | Signal poll non-200 에 \`resp.text\` 로깅 → INTERNAL_API_KEY leak (nginx error_page echo) |
| HIGH | \`okx/telegram_halt.py:59,83\` | Telegram 401/404 non-200 에 \`resp.text\` → bot token leak in \`description\` |
| LOW | \`okx/oauth.py\` | \`parsed.netloc.endswith(".pruviq.com")\` 이 \`https://pruviq.com@evil.pruviq.com\` 통과 → userinfo redirect bypass |

## 원론 수정
- reconcile/pnl loops: \`while True\` + per-iter except + 60s backoff (이미 있는 `_background_refresh` 패턴과 통일)
- Idempotency: \`is not None\` + \`.strip()\` + 빈/너무긴 값 400 반환
- server.py: status 만 로그 (body drop)
- telegram_halt: \`resp.json()["description"][:120]\` 만
- oauth: \`parsed.hostname\` (userinfo 제거) + \`@\` in netloc 거부

## Test plan
- [x] \`pytest tests/test_backend_hardening_20260419.py tests/test_okx_oauth_security.py tests/test_okx_idempotency_and_busy_timeout.py -v\` → **15/15 passed** (회귀 포함)
- [ ] (CI) automerge

## Non-goals (expert sweep 후속)
- DB calls in async (busy_timeout event-loop block) — 큰 refactor
- \`auto_executor.py:181\` session try/except — 별도 PR
- \`pruviq-commit-data.service\` dead unit — 삭제 PR
- \`_order_rate_limit\` 언바운드 성장 — sweep 추가
- \`pruviq-alert@\` OnFailure cascade — 별도
- daily-ranking TimeoutStartSec=7200 masking — parallelization PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)