### PR TITLE
fix(okx): per-session isolation in process_signals + sanitize halt DB errors

### DIFF
--- a/backend/okx/auto_executor.py
+++ b/backend/okx/auto_executor.py
@@ -179,15 +179,29 @@ async def process_signals(signals: list[dict]) -> list[dict]:
     executed = []
 
     for session_id in auto_sessions:
-        if not is_authenticated(session_id):
-            continue
+        # Per-session isolation (2026-04-19 code-reviewer finding): a
+        # malformed settings row (schema drift, truncated JSON, storage hiccup)
+        # used to raise here and kill the entire loop — dropping ALL other
+        # sessions' signals for this tick. Wrap pre-signal setup too, not
+        # just the per-signal `try:` below.
+        try:
+            if not is_authenticated(session_id):
+                continue
 
-        settings = get_settings(session_id)
-        if not settings.get("enabled"):
-            continue
+            settings = get_settings(session_id)
+            if not settings.get("enabled"):
+                continue
 
-        # Active strategy overrides (if any) take precedence over raw settings.
-        active_strategy = get_active_strategy(session_id)
+            # Active strategy overrides (if any) take precedence over raw settings.
+            active_strategy = get_active_strategy(session_id)
+        except Exception as session_setup_err:
+            logger.error(
+                "process_signals: session %s setup failed (%s) — skipping this "
+                "session, continuing with remaining %d sessions",
+                str(session_id)[:8], session_setup_err,
+                len(auto_sessions) - 1,
+            )
+            continue
 
         for signal in signals:
             try:

--- a/backend/okx/telegram_halt.py
+++ b/backend/okx/telegram_halt.py
@@ -135,10 +135,14 @@ async def execute_halt() -> str:
                     str(session_id)[:8], parse_err,
                 )
     except Exception as db_err:
+        # Log full error server-side, but don't leak DB internals (file paths,
+        # SQL fragments, column names) to Telegram. Also f-string + HTML
+        # parse_mode would break if the exception text contains `<` or `&`.
         logger.error("HALT: DB enumeration failed: %s", db_err)
         return (
             "\u26a0\ufe0f <b>HALT FAILED</b>\n"
-            f"Could not enumerate sessions: <code>{db_err}</code>"
+            "Could not enumerate sessions — check server logs "
+            "(<code>journalctl -u pruviq-api</code>)."
         )
 
     halted: list[str] = []

--- a/backend/tests/test_session_isolation_and_sanitize.py
+++ b/backend/tests/test_session_isolation_and_sanitize.py
@@ -1,0 +1,111 @@
+"""
+Expert-sweep follow-ups (PR 2026-04-19, medium tier).
+
+1. `auto_executor.process_signals` — one bad session crashes the entire
+   loop and drops signals for all other sessions. Wrap pre-signal setup
+   (is_authenticated + get_settings + get_active_strategy) in try/except
+   so a malformed settings row only affects that session.
+
+2. `telegram_halt.execute_halt` — DB error was f-string'd into the
+   Telegram response, leaking SQL fragments/paths/column names + breaking
+   HTML parse_mode on `<`/`&`. Replace with a generic message; full error
+   stays in server logs.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+AUTO_EXECUTOR = REPO / "okx" / "auto_executor.py"
+TELEGRAM_HALT = REPO / "okx" / "telegram_halt.py"
+
+
+def test_process_signals_wraps_session_setup_in_try():
+    """Regression: the pre-signal setup lines (is_authenticated, get_settings,
+    get_active_strategy) must sit inside a try/except so one malformed
+    session does not break every subsequent session on that tick."""
+    src = AUTO_EXECUTOR.read_text()
+    # Locate the `process_signals` body and assert the outer loop has a
+    # try wrapping the session setup calls.
+    body_match = re.search(
+        r"async def process_signals\(.*?(?=^(?:async )?def |\Z)",
+        src,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert body_match, "process_signals not found"
+    body = body_match.group(0)
+    # Find the outer for-loop and check that its body starts with `try:`
+    # before calling is_authenticated.
+    outer_loop = re.search(
+        r"for session_id in auto_sessions:\s*\n(.+?)(?=\n\s*for |\Z)",
+        body,
+        re.DOTALL,
+    )
+    assert outer_loop, "outer session loop not found"
+    loop_body = outer_loop.group(1)
+    # try: must precede the is_authenticated call.
+    try_pos = loop_body.find("try:")
+    is_auth_pos = loop_body.find("is_authenticated(")
+    assert try_pos != -1 and 0 < try_pos < is_auth_pos, (
+        "process_signals outer loop must have `try:` wrapping is_authenticated "
+        "+ get_settings + get_active_strategy. Without it, one malformed "
+        "session row kills the whole tick — every other subscriber's signals "
+        "are silently dropped."
+    )
+
+
+def test_process_signals_logs_and_continues_on_session_setup_error():
+    src = AUTO_EXECUTOR.read_text()
+    # Somewhere near the session-setup try/except, there should be a
+    # logger.error + continue.
+    assert re.search(
+        r"session.*?setup\s+failed.*?continue",
+        src,
+        re.IGNORECASE | re.DOTALL,
+    ), (
+        "Session-setup exception handler must log clearly and `continue` "
+        "to the next session — not swallow silently."
+    )
+
+
+def test_halt_db_error_does_not_leak_to_telegram():
+    """Regression: `f\"...{db_err}\"` would put raw exception text (SQL,
+    paths, column names) + unescaped < > & into the Telegram HTML body."""
+    src = TELEGRAM_HALT.read_text()
+    # Narrow to the halt-FAILED message construction that used to interpolate
+    # db_err. After the fix, db_err must NOT appear inside the return string.
+    bad_pattern = re.compile(
+        r'"[^"]*HALT FAILED[^"]*"\s*\n\s*f"[^"]*\{db_err\}',
+        re.DOTALL,
+    )
+    assert not bad_pattern.search(src), (
+        "telegram_halt.py HALT FAILED still interpolates db_err into the "
+        "Telegram response. Log full error server-side; send generic "
+        "\"check server logs\" to Telegram."
+    )
+    # And positive: the generic phrase must appear.
+    assert re.search(
+        r"check server logs|journalctl",
+        src,
+    ), (
+        "telegram_halt.py HALT FAILED response should point the operator "
+        "to server logs instead of dumping the exception."
+    )
+
+
+def test_halt_db_error_still_logged_server_side():
+    """Regression guard: we sanitize the Telegram output but must keep
+    the full error in server logs for actual debugging."""
+    src = TELEGRAM_HALT.read_text()
+    # Expect `logger.error("HALT: DB enumeration failed: %s", db_err)`
+    # somewhere in the file.
+    assert re.search(
+        r'logger\.error\([^)]*HALT.*?db_err',
+        src,
+        re.DOTALL,
+    ), (
+        "telegram_halt.py must still log the full db_err server-side. "
+        "Sanitizing the Telegram output without server-side logging would "
+        "destroy debuggability."
+    )


### PR DESCRIPTION
## Summary
expert sweep MEDIUM 2건.

### [MEDIUM] \`auto_executor.process_signals\` session 고립
\`auto_executor.py:181\` outer loop 에서 \`is_authenticated\` + \`get_settings\` + \`get_active_strategy\` 가 try 밖에 있어, 한 session 의 malformed settings 가 **전체 tick** 을 중단 → 다른 모든 auto-subscriber signal drop.

수정: session 당 try/except 로 감싸 skip + log + \`continue\`.

### [MEDIUM] \`telegram_halt.execute_halt\` DB 예외 Telegram 에코
\`telegram_halt.py:140\` f-string 이 DB 예외를 HTML 본문에 interpolate → SQL/path/column 이름 노출 + \`<\`/\`&\` 포함 시 parse_mode=HTML 깨짐.

수정: Telegram 메시지는 \"check server logs\" generic, 전체 에러는 이미 있는 \`logger.error\` 로 journalctl 저장.

## Test plan
- [x] \`pytest tests/test_session_isolation_and_sanitize.py -v\` → **4/4 passed**
- [ ] (CI) automerge

## Non-goals
- Frontend 3 HIGH (partner fee · raw error msg · AbortSignal.timeout) — 별도 PR
- SEO 3 HIGH (Article schema · hreflang · /market canonical) — 별도 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)