### PR TITLE
fix(frontend): fetch timeouts + user-friendly ranking errors (2 HIGH)

### DIFF
--- a/src/components/StrategyRanking.tsx
+++ b/src/components/StrategyRanking.tsx
@@ -148,6 +148,10 @@ export function StrategyRanking({ lang = "en" }: { lang?: Lang }) {
       setLoading(true);
       setError(null);
       const controller = new AbortController();
+      // 10s hard timeout so a hung API doesn't leave the UI spinning
+      // forever (LivePositions/OptimizePanel use the same 15s; ranking
+      // endpoint is fast-served from static JSON → 10s is enough).
+      const timeoutId = setTimeout(() => controller.abort(), 10_000);
 
       fetch(
         `${API_BASE_URL}/rankings/daily?period=${encodeURIComponent(p)}&group=${encodeURIComponent(g)}`,
@@ -156,7 +160,13 @@ export function StrategyRanking({ lang = "en" }: { lang?: Lang }) {
         },
       )
         .then((res) => {
-          if (!res.ok) throw new Error(`API ${res.status}: ${res.statusText}`);
+          if (!res.ok) {
+            // Tag the error with the status code but never expose raw
+            // statusText / upstream error bodies to the user.
+            const err = new Error("fetch_not_ok");
+            (err as Error & { status?: number }).status = res.status;
+            throw err;
+          }
           return res.json() as Promise<RankingData>;
         })
         .then((json) => {
@@ -164,12 +174,25 @@ export function StrategyRanking({ lang = "en" }: { lang?: Lang }) {
           setLoading(false);
         })
         .catch((err) => {
-          if (err.name === "AbortError") return;
-          setError(err.message ?? lbl.loadFail);
+          if (err.name === "AbortError") {
+            // Either the caller switched period/group (normal) or the
+            // 10s timeout fired. In both cases reset loading to avoid
+            // a stuck skeleton.
+            setLoading(false);
+            return;
+          }
+          // Map HTTP status → user-facing i18n, never expose raw message.
+          setError(lbl.loadFail);
           setLoading(false);
+        })
+        .finally(() => {
+          clearTimeout(timeoutId);
         });
 
-      return () => controller.abort();
+      return () => {
+        clearTimeout(timeoutId);
+        controller.abort();
+      };
     },
     [lbl.loadFail],
   );

--- a/src/components/WeeklyLeaderboard.tsx
+++ b/src/components/WeeklyLeaderboard.tsx
@@ -92,11 +92,14 @@ export default function WeeklyLeaderboard({ lang }: Props) {
 
   useEffect(() => {
     const controller = new AbortController();
+    // 10s timeout — same reason as StrategyRanking. Without it a stuck
+    // API hangs the widget forever.
+    const timeoutId = setTimeout(() => controller.abort(), 10_000);
     fetch(`${API_BASE_URL}/rankings/daily?period=7d&group=top50`, {
       signal: controller.signal,
     })
       .then((r) => {
-        if (!r.ok) throw new Error(`API ${r.status}`);
+        if (!r.ok) throw new Error("fetch_not_ok");
         return r.json() as Promise<WeeklyData>;
       })
       .then((d) => {
@@ -104,11 +107,20 @@ export default function WeeklyLeaderboard({ lang }: Props) {
         setLoading(false);
       })
       .catch((err) => {
-        if (err.name === "AbortError") return;
+        if (err.name === "AbortError") {
+          setLoading(false);
+          return;
+        }
         setError(l.error);
         setLoading(false);
+      })
+      .finally(() => {
+        clearTimeout(timeoutId);
       });
-    return () => controller.abort();
+    return () => {
+      clearTimeout(timeoutId);
+      controller.abort();
+    };
   }, []);
 
   // Filter out 0-trade sentinel entries (PF=99.99 cap artifacts) and capped PF entries


### PR DESCRIPTION
## Summary
frontend audit (Explore agent) HIGH 2건.

1. **StrategyRanking · WeeklyLeaderboard** fetch 타임아웃 없음 — API stall 시 UI skeleton 무기한 spin. LivePositions·OptimizePanel 의 \`AbortSignal.timeout(15_000)\` 패턴과 통일하되 ranking 은 static JSON 경로라 10s.
2. **StrategyRanking** \`throw new Error(\`API ${res.status}: ${res.statusText}\`)\` → catch 에서 user-facing state 로 raw 노출. \"API 500: Internal Server Error\" 같은 tech detail.

## 변경
- \`setTimeout(() => controller.abort(), 10_000)\` + \`.finally(clearTimeout)\` + unmount cleanup
- error message 는 i18n \`lbl.loadFail\` 고정 (status code sentinel 은 내부만)
- AbortError catch 시 \`setLoading(false)\` 추가 (skeleton 고착 방지)

## Test plan
- [x] \`tsc --noEmit\` pass
- [ ] (CI) automerge

## Non-goals
- Partner fee 하드코딩 5+ 파일 중앙화 (\`config/partners.ts\` 신설 필요) — 별도 PR
- Hydration cost (dashboard 5 × client:load → client:visible) — 별도
- SEO 3 HIGH — 별도 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)