### PR TITLE
fix(frontend): centralise OKX discount via exchanges.ts SSoT (5 files, 7 sites)

### DIFF
--- a/src/components/OKXConnectButton.tsx
+++ b/src/components/OKXConnectButton.tsx
@@ -5,6 +5,7 @@
  */
 import { useState, useEffect } from "preact/hooks";
 import { API_BASE_URL as API_BASE } from "../config/api";
+import { OKX_DISCOUNT_PCT } from "../config/exchanges";
 
 interface Props {
   lang?: "en" | "ko";
@@ -22,10 +23,10 @@ const labels = {
     connected: "OKX Connected",
     disconnect: "Disconnect",
     connecting: "Connecting...",
-    desc: "Link your OKX account to execute trades directly from simulations. 20% fee discount included.",
+    desc: `Link your OKX account to execute trades directly from simulations. ${OKX_DISCOUNT_PCT}% fee discount included.`,
     benefits: [
       "One-click trade execution",
-      "20% fee discount",
+      `${OKX_DISCOUNT_PCT}% fee discount`,
       "Secure OAuth — no API keys shared",
     ],
   },
@@ -34,10 +35,10 @@ const labels = {
     connected: "OKX 연결됨",
     disconnect: "연결 해제",
     connecting: "연결 중...",
-    desc: "OKX 계정을 연결하면 시뮬레이션 결과를 바로 실행할 수 있습니다. 20% 수수료 할인 포함.",
+    desc: `OKX 계정을 연결하면 시뮬레이션 결과를 바로 실행할 수 있습니다. ${OKX_DISCOUNT_PCT}% 수수료 할인 포함.`,
     benefits: [
       "원클릭 거래 실행",
-      "20% 수수료 할인",
+      `${OKX_DISCOUNT_PCT}% 수수료 할인`,
       "안전한 OAuth — API 키 공유 불필요",
     ],
   },

--- a/src/components/OKXExecuteButton.tsx
+++ b/src/components/OKXExecuteButton.tsx
@@ -4,6 +4,7 @@
  */
 import { useState, useEffect } from "preact/hooks";
 import { API_BASE_URL as API_BASE } from "../config/api";
+import { OKX_DISCOUNT_PCT } from "../config/exchanges";
 
 interface Props {
   strategy?: string;
@@ -39,7 +40,7 @@ const labels = {
     features: [
       "Automated SL/TP from simulation",
       "No API key sharing (OAuth)",
-      "20% fee discount",
+      `${OKX_DISCOUNT_PCT}% fee discount`,
     ],
     featureTitle: "One-Click Execution",
     featureDesc: "Execute simulation results directly on OKX",
@@ -68,7 +69,7 @@ const labels = {
     features: [
       "시뮬레이션 기반 자동 SL/TP",
       "API 키 공유 불필요 (OAuth)",
-      "20% 수수료 할인",
+      `${OKX_DISCOUNT_PCT}% 수수료 할인`,
     ],
     featureTitle: "원클릭 실행",
     featureDesc: "시뮬레이션 결과를 OKX에서 바로 실행",

--- a/src/components/ResultsCard.tsx
+++ b/src/components/ResultsCard.tsx
@@ -3,6 +3,7 @@ import { winRateColor, profitFactorColor, signColor } from "../utils/format";
 import { COLORS } from "./simulator-types";
 import Term from "./ui/Term";
 import CollapsibleSection from "./ui/CollapsibleSection";
+import { OKX_DISCOUNT_PCT } from "../config/exchanges";
 
 interface ResultsData {
   win_rate: number;
@@ -105,7 +106,7 @@ const labels = {
     tradingFee: "Trading Fee",
     fundingFee: "Funding Fee",
     totalCost: "Total Cost",
-    feeSaveTip: "Save up to 20% on fees",
+    feeSaveTip: `Save up to ${OKX_DISCOUNT_PCT}% on fees`,
     portfolio: "Portfolio",
     initialCapital: "Initial Capital",
     totalPnlUsd: "Total PnL",
@@ -153,7 +154,7 @@ const labels = {
     sectionValidation: "Validation",
     gradePrefix: "Grade",
     mcBeats: (pct: number) => `Beats ${pct}% of random strategies`,
-    referralCta: "Ready to trade this strategy? Save up to 20% on trading fees",
+    referralCta: `Ready to trade this strategy? Save up to ${OKX_DISCOUNT_PCT}% on trading fees`,
     survivorshipNote:
       "Results based on currently listed assets only. Delisted coins excluded (survivorship bias).",
   },
@@ -179,7 +180,7 @@ const labels = {
     tradingFee: "\uAC70\uB798 \uC218\uC218\uB8CC",
     fundingFee: "\uD380\uB529 \uC218\uC218\uB8CC",
     totalCost: "\uCD1D \uBE44\uC6A9",
-    feeSaveTip: "\uC218\uC218\uB8CC \uCD5C\uB300 20% \uC808\uAC10",
+    feeSaveTip: `\uC218\uC218\uB8CC \uCD5C\uB300 ${OKX_DISCOUNT_PCT}% \uC808\uAC10`,
     portfolio: "\uD3EC\uD2B8\uD3F4\uB9AC\uC624",
     initialCapital: "\uCD08\uAE30 \uC790\uBCF8",
     totalPnlUsd: "\uCD1D \uC190\uC775",
@@ -232,8 +233,7 @@ const labels = {
     gradePrefix: "\uB4F1\uAE09",
     mcBeats: (pct: number) =>
       `\uB79C\uB364 \uC804\uB7B5 \uC911 \uC0C1\uC704 ${(100 - pct).toFixed(0)}%`,
-    referralCta:
-      "\uC774 \uC804\uB7B5\uC73C\uB85C \uAC70\uB798 \uC900\uBE44\uB410\uB098\uC694? \uAC70\uB798 \uC218\uC218\uB8CC \uCD5C\uB300 20% \uC808\uC57D",
+    referralCta: `\uC774 \uC804\uB7B5\uC73C\uB85C \uAC70\uB798 \uC900\uBE44\uB410\uB098\uC694? \uAC70\uB798 \uC218\uC218\uB8CC \uCD5C\uB300 ${OKX_DISCOUNT_PCT}% \uC808\uC57D`,
     survivorshipNote:
       "\uD604\uC7AC \uC0C1\uC7A5\uB41C \uC790\uC0B0\uB9CC \uD14C\uC2A4\uD2B8\uB429\uB2C8\uB2E4. \uC0C1\uD3D0 \uCF54\uC778 \uC81C\uC678 (\uC0DD\uC874 \uD3B8\uD5A5).",
   },

--- a/src/config/exchanges.ts
+++ b/src/config/exchanges.ts
@@ -53,6 +53,17 @@ export function discountTooltip(ex: ExchangeFeeConfig): string {
   return `Futures: ${ex.futuresDiscountPct}% off (${from} → ${to}) · Spot: ${ex.spotDiscountPct}% off`;
 }
 
+/**
+ * Look up a configured exchange by id. Throws at module init time if the
+ * caller's id is not registered — this is intentional so downstream files
+ * can `import { OKX } from "../config/exchanges"` without null-checking.
+ */
+export function getExchange(id: string): ExchangeFeeConfig {
+  const e = EXCHANGES.find((x) => x.id === id);
+  if (!e) throw new Error(`Unknown exchange id: ${id}`);
+  return e;
+}
+
 export const EXCHANGES: ExchangeFeeConfig[] = [
   {
     id: "binance",
@@ -80,3 +91,12 @@ export const EXCHANGES: ExchangeFeeConfig[] = [
     brokerCode: "c12571e26a02OCDE",
   },
 ];
+
+/**
+ * OKX-specific shortcuts. Components previously hardcoded `20%` in five+
+ * places (ResultsCard, OKXConnectButton, OKXExecuteButton, i18n); switching
+ * the discount would have required a multi-file search-and-replace and was
+ * documented as an audit risk. These exports centralise the value.
+ */
+export const OKX = getExchange("okx");
+export const OKX_DISCOUNT_PCT: number = OKX.futuresDiscountPct;

--- a/tests/unit/partner-fee-ssot.test.ts
+++ b/tests/unit/partner-fee-ssot.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Partner fee SSoT regression guard (PR 2026-04-19).
+ *
+ * The frontend audit flagged OKX's 20% discount hardcoded across 5+
+ * components (ResultsCard, OKXConnectButton, OKXExecuteButton, plus
+ * i18n). A deal change would have required a grep-and-replace sweep
+ * across every file. This test enforces that:
+ *
+ *   1. The SSoT (exchanges.ts) exports OKX_DISCOUNT_PCT as a number.
+ *   2. The value matches the OKX entry in the EXCHANGES array (so a
+ *      refactor that renames either half doesn't silently drift).
+ *   3. The three target components source-reference OKX_DISCOUNT_PCT
+ *      rather than inline "20%" (and no literal `20%` discount hardcodes
+ *      remain in those files).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  EXCHANGES,
+  OKX,
+  OKX_DISCOUNT_PCT,
+  getExchange,
+} from "../../src/config/exchanges";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("partner fee SSoT", () => {
+  it("exports OKX with a numeric discount", () => {
+    expect(typeof OKX_DISCOUNT_PCT).toBe("number");
+    expect(OKX_DISCOUNT_PCT).toBeGreaterThan(0);
+    expect(OKX_DISCOUNT_PCT).toBeLessThanOrEqual(100);
+  });
+
+  it("OKX_DISCOUNT_PCT matches EXCHANGES entry", () => {
+    const inArray = EXCHANGES.find((e) => e.id === "okx");
+    expect(inArray).toBeDefined();
+    expect(OKX_DISCOUNT_PCT).toBe(inArray!.futuresDiscountPct);
+    expect(OKX).toBe(inArray);
+  });
+
+  it("getExchange throws on unknown id", () => {
+    expect(() => getExchange("nonesuch")).toThrow(/Unknown exchange/);
+  });
+
+  // Source-level: the three components that used to hardcode "20%" must
+  // now reference OKX_DISCOUNT_PCT instead. Read the file text and assert
+  // no bare `20%` discount literal remains.
+  const TARGETS = [
+    "src/components/OKXConnectButton.tsx",
+    "src/components/OKXExecuteButton.tsx",
+    "src/components/ResultsCard.tsx",
+  ];
+  const HARDCODE_PATTERNS: RegExp[] = [
+    /"20%\s+fee/i,
+    /"20%\s+수수료/,
+    /"Save up to 20%/i,
+    /"\uC218\uC218\uB8CC \uCD5C\uB300 20%/, // "수수료 최대 20%"
+    /up to 20% on trading fees/i,
+  ];
+
+  for (const rel of TARGETS) {
+    it(`${rel} imports OKX_DISCOUNT_PCT and has no 20% literal`, () => {
+      const abs = resolve(__dirname, "../..", rel);
+      const src = readFileSync(abs, "utf-8");
+      expect(src).toContain("OKX_DISCOUNT_PCT");
+      for (const pat of HARDCODE_PATTERNS) {
+        expect(
+          src,
+          `${rel} still matches ${pat} — partner-fee SSoT broken`,
+        ).not.toMatch(pat);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
frontend audit HIGH #1. \`src/config/exchanges.ts\` 에 이미 \`futuresDiscountPct: 20\` SSoT 있지만 3 component × EN/KO = **7 sites 하드코딩**.

## 변경
- \`exchanges.ts\`: \`getExchange()\` helper + \`OKX\`, \`OKX_DISCOUNT_PCT\` export
- \`OKXConnectButton.tsx\`, \`OKXExecuteButton.tsx\`, \`ResultsCard.tsx\`: 7 sites \`\"20%\"\` → \`\${OKX_DISCOUNT_PCT}%\` template
- \`tests/unit/partner-fee-ssot.test.ts\` (vitest · 6 tests)

## Test plan
- [x] \`vitest run tests/unit/partner-fee-ssot.test.ts\` → **6/6 passed**

## 효과
OKX dashboard rebate 수치 변경 시 \`exchanges.ts\` 한 줄만 수정. 이전엔 5+ 파일 수동 + 놓치면 UI 불일치.

🤖 Generated with [Claude Code](https://claude.com/claude-code)