### PR TITLE
perf(frontend): defer below-fold dashboard islands + CSP-safe ErrorFallback + safer localStorage

### DIFF
--- a/src/components/EmailCapture.tsx
+++ b/src/components/EmailCapture.tsx
@@ -60,20 +60,36 @@ export default function EmailCapture({ lang }: Props) {
     setSubmitting(true);
 
     // 1. Always save to localStorage first (guaranteed offline-safe)
+    // 2026-04-19: parse + validate without throwing. The old `throw new Error`
+    // on non-array sent us to the `catch` block which OVERWROTE any pre-existing
+    // entries with a single-element array — losing prior captures on corruption.
+    // Now: treat corruption as "start fresh with what we have", preserving any
+    // valid entries we can salvage.
     try {
-      const existing = JSON.parse(
-        localStorage.getItem("captured-emails") || "[]",
-      );
-      if (!Array.isArray(existing)) throw new Error("corrupt");
+      const raw = localStorage.getItem("captured-emails");
+      let existing: string[] = [];
+      if (raw) {
+        try {
+          const parsed = JSON.parse(raw);
+          if (Array.isArray(parsed)) {
+            existing = parsed.filter((v) => typeof v === "string");
+          }
+        } catch {
+          // parsed value corrupt — existing stays []
+        }
+      }
       if (!existing.includes(email)) {
         existing.push(email);
-        localStorage.setItem("captured-emails", JSON.stringify(existing));
       }
+      localStorage.setItem("captured-emails", JSON.stringify(existing));
       localStorage.setItem("email-captured", "true");
     } catch {
-      // fallback: just set the flag
-      localStorage.setItem("captured-emails", JSON.stringify([email]));
-      localStorage.setItem("email-captured", "true");
+      // localStorage itself blocked (private mode, quota) — last-resort flag only
+      try {
+        localStorage.setItem("email-captured", "true");
+      } catch {
+        // nothing else we can do client-side
+      }
     }
 
     // 2. Send to backend (fire-and-forget, failure does not block UX)

--- a/src/components/ui/ErrorFallback.astro
+++ b/src/components/ui/ErrorFallback.astro
@@ -8,10 +8,20 @@ const {
   detail = 'Rankings update daily. Try refreshing or check back shortly.'
 } = Astro.props;
 ---
-<div class="rounded-lg border border-[--color-warning]/20 p-6 bg-[--color-warning]/5 text-center my-4">
+<div class="rounded-lg border border-[--color-warning]/20 p-6 bg-[--color-warning]/5 text-center my-4" data-error-fallback>
   <p class="text-[--color-warning] font-medium mb-2">{message}</p>
   <p class="text-sm text-[--color-text-secondary] mb-4">{detail}</p>
-  <button onclick="location.reload()" class="btn btn-ghost btn-sm cursor-pointer">
+  <!-- Delegated event handler instead of inline onclick — CSP-strict friendly
+       (inline event attributes require 'unsafe-inline' which weakens XSS defense). -->
+  <button type="button" data-error-refresh class="btn btn-ghost btn-sm cursor-pointer">
     ↻ Refresh page
   </button>
 </div>
+
+<script>
+  document.querySelectorAll<HTMLButtonElement>('[data-error-refresh]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      window.location.reload();
+    });
+  });
+</script>

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -57,18 +57,20 @@ import LiveTradeHistory from '../components/LiveTradeHistory';
     </section>
 
     <!-- Auto-Trading Settings -->
+    <!-- client:visible: below-the-fold on first paint, defer hydration
+         until scrolled into view. Cuts initial JS bundle cost. -->
     <section class="mb-8">
-      <TradingSettings client:load lang="en" />
+      <TradingSettings client:visible lang="en" />
     </section>
 
     <!-- Live Positions -->
     <section class="mb-8">
-      <LivePositions client:load lang="en" />
+      <LivePositions client:visible lang="en" />
     </section>
 
     <!-- Trade History -->
     <section class="mb-8">
-      <LiveTradeHistory client:load lang="en" />
+      <LiveTradeHistory client:visible lang="en" />
     </section>
 
     <!-- Security Info -->

--- a/src/pages/ko/dashboard.astro
+++ b/src/pages/ko/dashboard.astro
@@ -58,18 +58,19 @@ import LiveTradeHistory from '../../components/LiveTradeHistory';
     </section>
 
     <!-- 자동매매 설정 -->
+    <!-- client:visible: below-fold, defer hydration until scrolled. -->
     <section class="mb-8">
-      <TradingSettings client:load lang="ko" />
+      <TradingSettings client:visible lang="ko" />
     </section>
 
     <!-- 오픈 포지션 -->
     <section class="mb-8">
-      <LivePositions client:load lang="ko" />
+      <LivePositions client:visible lang="ko" />
     </section>
 
     <!-- 거래 내역 -->
     <section class="mb-8">
-      <LiveTradeHistory client:load lang="ko" />
+      <LiveTradeHistory client:visible lang="ko" />
     </section>
 
     <!-- 보안 정보 -->

--- a/tests/unit/dashboard-hydration-and-fallback.test.ts
+++ b/tests/unit/dashboard-hydration-and-fallback.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Dashboard hydration + frontend LOW-tier hardening (PR 2026-04-19).
+ *
+ * frontend audit findings:
+ *   - dashboard.astro hydrated 5 islands with `client:load` — TradingSettings,
+ *     LivePositions, LiveTradeHistory are below-fold and should defer.
+ *   - ErrorFallback.astro used an inline `onclick="location.reload()"` which
+ *     blocks strict CSP (no 'unsafe-inline' possible).
+ *   - EmailCapture.tsx threw on non-array corruption, which fell through
+ *     to a `catch` that OVERWROTE the stored list with just the current
+ *     email — losing any prior captures.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const R = (p: string) => readFileSync(resolve(__dirname, "../..", p), "utf-8");
+
+describe("dashboard hydration defers below-fold islands", () => {
+  // Components that should hydrate immediately (first-paint semantics).
+  const IMMEDIATE = ["OKXConnectButton", "AutoTradingStatus"];
+  // Components that should defer to client:visible.
+  const DEFERRED = ["TradingSettings", "LivePositions", "LiveTradeHistory"];
+
+  for (const page of [
+    "src/pages/dashboard.astro",
+    "src/pages/ko/dashboard.astro",
+  ]) {
+    it(`${page} — deferred components use client:visible`, () => {
+      const src = R(page);
+      for (const c of DEFERRED) {
+        const loadPat = new RegExp(`<${c}\\s+client:load\\b`);
+        const visPat = new RegExp(`<${c}\\s+client:visible\\b`);
+        expect(src, `${page}: ${c} still uses client:load`).not.toMatch(
+          loadPat,
+        );
+        expect(src, `${page}: ${c} missing client:visible`).toMatch(visPat);
+      }
+    });
+
+    it(`${page} — immediate components remain client:load`, () => {
+      const src = R(page);
+      for (const c of IMMEDIATE) {
+        // Must have a client:load usage somewhere
+        const pat = new RegExp(`<${c}\\s+client:load\\b`);
+        expect(
+          src,
+          `${page}: ${c} lost client:load (should stay immediate)`,
+        ).toMatch(pat);
+      }
+    });
+  }
+});
+
+describe("ErrorFallback uses CSP-friendly event binding", () => {
+  const file = "src/components/ui/ErrorFallback.astro";
+  const src = R(file);
+
+  it("no inline onclick attribute", () => {
+    // Inline onclick would require CSP 'unsafe-inline' for script execution.
+    expect(src).not.toMatch(/onclick\s*=\s*"/);
+  });
+
+  it("uses delegated listener via data attribute", () => {
+    expect(src).toMatch(/data-error-refresh/);
+    expect(src).toMatch(/addEventListener\s*\(\s*["']click["']/);
+  });
+});
+
+describe("EmailCapture corruption-safe localStorage handling", () => {
+  const src = R("src/components/EmailCapture.tsx");
+
+  it("does not throw on non-array — filters + keeps valid entries", () => {
+    // Old pattern: `if (!Array.isArray(existing)) throw new Error("corrupt")`
+    // which then fell through to a catch that overwrote the whole list.
+    expect(src, "old throw-on-corrupt pattern still present").not.toMatch(
+      /throw new Error\(\s*["']corrupt["']/,
+    );
+  });
+
+  it("filters non-string entries defensively", () => {
+    // The new logic: `.filter((v) => typeof v === "string")`
+    expect(src).toMatch(/typeof\s+v\s*===\s*["']string["']/);
+  });
+
+  it("fallback no longer overwrites prior list with single email", () => {
+    // The old catch wrote `JSON.stringify([email])` which destroyed prior
+    // captures. New path preserves whatever was salvageable.
+    const badFallback =
+      /localStorage\.setItem\(\s*["']captured-emails["']\s*,\s*JSON\.stringify\(\[email\]\)\s*\)/;
+    expect(src, "old destructive fallback still present").not.toMatch(
+      badFallback,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
frontend audit MEDIUM + 2 LOW.

| 심각도 | 항목 |
|---|---|
| MEDIUM | Dashboard: TradingSettings · LivePositions · LiveTradeHistory 를 \`client:load\` → \`client:visible\` (EN + KO · 6 sites) |
| LOW | \`ErrorFallback.astro\` inline \`onclick\` → \`data-error-refresh\` + \`addEventListener\` (strict CSP 대비) |
| LOW | \`EmailCapture.tsx\` corruption fallback 이 prior 이메일 list overwrite → inner try/catch + \`filter(typeof === 'string')\` 로 부분 복구 |

## Test plan
- [x] \`vitest run tests/unit/dashboard-hydration-and-fallback.test.ts\` → **9/9 passed**
- [x] \`tsc --noEmit\` → 0 errors (in changed files)
- [ ] (CI) automerge

## Non-goals
- CommandPalette client:idle → client:only
- Touch targets 44px → 48px
- OptimizePanel JSON parse 분기

🤖 Generated with [Claude Code](https://claude.com/claude-code)