### PR TITLE
feat(deploy): auto-rollback on health failure + Telegram alert

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -115,6 +115,22 @@ jobs:
             fi
           fi
 
+      - name: Capture pre-deploy SHA for rollback
+        if: steps.guard.outputs.skip != 'true' && steps.drift.outputs.skip != 'true'
+        # Saved BEFORE git reset so the "Rollback on failure" step has a
+        # known-good target. If this step fails, the deploy still proceeds —
+        # worst case we lose auto-rollback for this one run (operator can
+        # roll back manually via DO SSH).
+        run: |
+          ssh -p "$DO_PORT" -o IdentitiesOnly=yes -i ~/.ssh/do_deploy \
+              "$DO_USER@$DO_HOST" "
+            set -e
+            git config --global --add safe.directory /opt/pruviq/current 2>/dev/null || true
+            mkdir -p /opt/pruviq/rollback
+            sudo -u pruviq bash -c 'cd /opt/pruviq/current && git rev-parse HEAD > /opt/pruviq/rollback/prev_sha'
+            echo \"pre-deploy SHA=\$(cat /opt/pruviq/rollback/prev_sha)\"
+          " || echo "::warning::could not capture prev SHA — rollback on failure will be skipped"
+
       - name: Pull latest code on DO
         if: steps.guard.outputs.skip != 'true' && steps.drift.outputs.skip != 'true'
         run: |
@@ -169,6 +185,7 @@ jobs:
               "systemctl restart pruviq-api.service"
 
       - name: Wait for health
+        id: wait_for_health
         if: steps.guard.outputs.skip != 'true' && steps.drift.outputs.skip != 'true'
         run: |
           ssh -p "$DO_PORT" -o IdentitiesOnly=yes -i ~/.ssh/do_deploy \
@@ -186,6 +203,71 @@ jobs:
             echo 'WARNING: backend slow to load — check journalctl -u pruviq-api'
             exit 1
           "
+
+      - name: Rollback on health failure
+        # Triggers only when the health gate failed — restores the pre-deploy
+        # SHA and restarts. If /opt/pruviq/rollback/prev_sha is absent
+        # (first run, or Capture step was skipped) this step no-ops and
+        # leaves the failed deploy in place for operator inspection.
+        if: failure() && steps.wait_for_health.outcome == 'failure' && steps.guard.outputs.skip != 'true' && steps.drift.outputs.skip != 'true'
+        run: |
+          ssh -p "$DO_PORT" -o IdentitiesOnly=yes -i ~/.ssh/do_deploy \
+              "$DO_USER@$DO_HOST" "
+            set -e
+            PREV_SHA_FILE=/opt/pruviq/rollback/prev_sha
+            if [ ! -s \"\$PREV_SHA_FILE\" ]; then
+              echo '::error::rollback skipped — prev_sha missing'
+              exit 1
+            fi
+            PREV=\$(cat \"\$PREV_SHA_FILE\")
+            CUR=\$(sudo -u pruviq bash -c 'cd /opt/pruviq/current && git rev-parse HEAD')
+            if [ \"\$PREV\" = \"\$CUR\" ]; then
+              echo 'rollback skipped — already on prev SHA (rollback-of-rollback loop guard)'
+              exit 1
+            fi
+            echo \"ROLLBACK: \$CUR → \$PREV\"
+            sudo -u pruviq bash -c \"cd /opt/pruviq/current && git reset --hard \$PREV\"
+            # Re-sync systemd units/wrappers from the prev commit so any
+            # post-reset state is consistent.
+            install -o pruviq -g pruviq -m 0755 \
+              /opt/pruviq/current/backend/deploy/systemd/bin/*.sh \
+              /opt/pruviq/bin/ 2>/dev/null || true
+            install -o root -g root -m 0644 \
+              /opt/pruviq/current/backend/deploy/systemd/pruviq-*.service \
+              /opt/pruviq/current/backend/deploy/systemd/pruviq-*.timer \
+              /etc/systemd/system/ 2>/dev/null || true
+            systemctl daemon-reload
+            systemctl restart pruviq-api.service
+            # Re-verify health after rollback — if this ALSO fails, alert
+            # with exit 1 so the operator intervenes.
+            sleep 10
+            for i in 1 2 3 4 5; do
+              coins=\$(curl -sf -m 5 http://127.0.0.1:8080/health 2>/dev/null \
+                | python3 -c 'import sys,json; print(json.load(sys.stdin).get(\"coins_loaded\",0))' 2>/dev/null || echo 0)
+              echo \"rollback health attempt \$i: coins=\$coins\"
+              if [ \"\$coins\" -ge ${{ env.MIN_COINS }} ] 2>/dev/null; then
+                echo '::notice::rolled back successfully'
+                exit 0
+              fi
+              sleep 5
+            done
+            echo '::error::rollback restart ALSO failed — manual SSH required'
+            exit 1
+          "
+
+      - name: Telegram alert on rollback
+        if: failure() && steps.wait_for_health.outcome == 'failure' && steps.guard.outputs.skip != 'true' && steps.drift.outputs.skip != 'true'
+        env:
+          TG_TOKEN: ${{ secrets.PRUVIQ_TELEGRAM_TOKEN }}
+          TG_CHAT:  ${{ secrets.PRUVIQ_TELEGRAM_CHAT_ID }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          [ -z "$TG_TOKEN" ] || [ -z "$TG_CHAT" ] && exit 0
+          MSG="🔁 PRUVIQ backend-deploy health-gate FAILED — auto-rollback attempted.
+Run: ${RUN_URL}
+Check ssh DO 'journalctl -u pruviq-api -n 100' for root cause."
+          curl -sf -m 10 -X POST "https://api.telegram.org/bot${TG_TOKEN}/sendMessage" \
+            -d chat_id="${TG_CHAT}" -d text="${MSG}" || true
 
       - name: Post-deploy sanity via public endpoint
         if: steps.guard.outputs.skip != 'true' && steps.drift.outputs.skip != 'true'

--- a/backend/tests/test_deploy_rollback_yaml.py
+++ b/backend/tests/test_deploy_rollback_yaml.py
@@ -1,0 +1,122 @@
+"""
+backend-deploy.yml rollback automation regression guard (PR 2026-04-19).
+
+Before this PR, a bad main commit that bricked `/health` left the broken
+SHA running until an operator SSH'd in to `git reset` + `systemctl restart`.
+architecture-audit agent flagged "배포 롤백 없음 — health gate 얕음" as HIGH.
+
+This test proves the workflow now:
+  1. Captures the prior SHA BEFORE `git reset --hard origin/main`
+  2. Triggers a rollback step on health-gate failure
+  3. Alerts via Telegram when rollback happens
+  4. Guards against rollback-of-rollback loops (prev == current short-circuit)
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent.parent
+WORKFLOW = REPO / ".github" / "workflows" / "backend-deploy.yml"
+
+
+def _yaml() -> str:
+    return WORKFLOW.read_text()
+
+
+def test_captures_prev_sha_before_reset():
+    """Step order matters: prev_sha must be saved BEFORE git reset."""
+    src = _yaml()
+    capture_pos = src.find("Capture pre-deploy SHA for rollback")
+    reset_pos = src.find("Pull latest code on DO")
+    assert 0 < capture_pos < reset_pos, (
+        "Capture pre-deploy SHA step must appear BEFORE 'Pull latest code'. "
+        "Otherwise reset overwrites HEAD and prev_sha points to the bad commit."
+    )
+    # prev_sha path agreed on
+    assert "/opt/pruviq/rollback/prev_sha" in src
+
+
+def test_rollback_step_runs_only_on_health_failure():
+    """Rollback must fire only when wait_for_health fails — not on unrelated
+    failures (deps install, ssh keyscan, etc.) which have their own signals."""
+    src = _yaml()
+    # Ensure wait_for_health has an id (required for outcome reference)
+    assert re.search(r"id:\s*wait_for_health", src), (
+        "Wait-for-health step must have `id: wait_for_health` so the "
+        "rollback condition can scope to it."
+    )
+    # The rollback `if:` must reference wait_for_health.outcome == 'failure'
+    assert re.search(
+        r"steps\.wait_for_health\.outcome\s*==\s*'failure'", src,
+    ), (
+        "Rollback `if:` must gate on wait_for_health.outcome == 'failure' "
+        "to avoid rolling back for unrelated failures."
+    )
+
+
+def test_rollback_has_loop_guard():
+    """prev == current short-circuit — prevents rollback-of-rollback loop
+    when the rollback commit itself triggers another bad deploy cycle."""
+    src = _yaml()
+    # The rollback block must compare PREV and CUR and abort if equal
+    assert re.search(r'PREV.*=.*CUR|CUR.*=.*PREV', src), (
+        "Rollback must compare current HEAD to prev SHA and short-circuit "
+        "if equal, else two consecutive bad deploys loop the rollback."
+    )
+    # And there should be a documented skip message
+    assert re.search(
+        r"(rollback-of-rollback|loop guard|already on prev)",
+        src,
+        re.IGNORECASE,
+    )
+
+
+def test_rollback_reruns_health_gate():
+    """After reset + restart, health must be re-verified. A failed rollback
+    must surface to the operator (exit 1 + Telegram), not silently success."""
+    src = _yaml()
+    # Expect the rollback block to include a second polling loop + an
+    # explicit "rollback restart ALSO failed" message.
+    assert re.search(
+        r"rollback restart ALSO failed",
+        src,
+    ), (
+        "Rollback step must re-verify /health and surface failure — "
+        "silent 'rollback OK' when rollback actually failed is worse "
+        "than the original bug."
+    )
+
+
+def test_rollback_alerts_via_telegram():
+    """Operator should know a rollback happened without polling the Actions UI."""
+    src = _yaml()
+    assert "Telegram alert on rollback" in src
+    assert "PRUVIQ_TELEGRAM_TOKEN" in src
+    assert "PRUVIQ_TELEGRAM_CHAT_ID" in src
+
+
+def test_rollback_syncs_systemd_units_on_revert():
+    """git reset doesn't propagate to /etc/systemd/system/ or /opt/pruviq/bin/.
+    Rollback must re-run `install` so unit definitions match prev SHA, else
+    a reverted code base runs with new unit files → mismatched env/timeouts."""
+    src = _yaml()
+    # The rollback run block must contain install -o ... for both wrapper
+    # scripts (pruviq:pruviq mode 0755) and unit files (root mode 0644).
+    # We assert both by looking for the familiar patterns inside the
+    # rollback step body (between "Rollback on health failure" and
+    # "Telegram alert on rollback").
+    m = re.search(
+        r"Rollback on health failure.*?Telegram alert on rollback",
+        src,
+        re.DOTALL,
+    )
+    assert m, "rollback block not found"
+    block = m.group(0)
+    assert "install -o pruviq -g pruviq" in block, (
+        "rollback block must re-install wrapper scripts from reverted tree"
+    )
+    assert "install -o root -g root" in block, (
+        "rollback block must re-install unit files from reverted tree"
+    )
+    assert "systemctl daemon-reload" in block


### PR DESCRIPTION
## Summary
architecture-audit HIGH. \`backend-deploy.yml\` 이 health gate 실패 시 operator SSH 수동 개입만 복구. 자동매매 서비스에서 이 downtime = 실거래 주문 차단 직결.

## 변경
1. Pre-deploy SHA capture → \`/opt/pruviq/rollback/prev_sha\`
2. Wait for health 에 \`id: wait_for_health\` 추가
3. Rollback step: \`git reset \$prev_sha\` + systemd unit 재동기 + restart + re-verify health
4. PREV == CUR loop guard
5. Telegram alert on rollback

## 사이드 이펙트 0
- 정상 deploy 경로 무변화 (3 step 추가만)
- capture 실패 → warning + deploy 계속 (graceful degrade)
- 성공 시 rollback skip (\`if: failure()\`)

## Test plan
- [x] \`pytest tests/test_deploy_rollback_yaml.py -v\` → **6/6 passed**
  - 순서·조건·loop guard·재검증·Telegram·systemd 재동기 전부 검증
- [ ] (CI) automerge
- [ ] (다음 deploy) 정상 흐름에서 rollback step skip 확인
- [ ] (임의 bad commit 시나리오) 수동 drill — 차후 별도 issue 로

🤖 Generated with [Claude Code](https://claude.com/claude-code)