### PR TITLE
feat(okx-storage): MultiFernet rotation + migration script

### DIFF
--- a/backend/okx/config.py
+++ b/backend/okx/config.py
@@ -19,6 +19,14 @@ if not OKX_BROKER_CODE:
 
 # ── Encryption ──
 OKX_ENCRYPTION_KEY = os.environ.get("OKX_ENCRYPTION_KEY", "")
+# Multi-key rotation support. Comma-separated Fernet keys, newest first.
+# When non-empty, takes precedence over OKX_ENCRYPTION_KEY. During rotation,
+# operator runs with `OKX_ENCRYPTION_KEYS=new_key,old_key` — MultiFernet
+# encrypts new writes with new_key and still decrypts rows written with
+# either. After `migrate_okx_encryption_keys.py` re-encrypts all rows under
+# new_key, operator removes old_key from env and restarts. Graceful rotation
+# with zero forced re-OAuth (architecture-audit HIGH #9).
+OKX_ENCRYPTION_KEYS = os.environ.get("OKX_ENCRYPTION_KEYS", "")
 
 # ── OKX API v5 URLs ──
 OKX_BASE_URL = "https://www.okx.com"

--- a/backend/okx/storage.py
+++ b/backend/okx/storage.py
@@ -10,18 +10,55 @@ import sqlite3
 import time
 from pathlib import Path
 
-from cryptography.fernet import Fernet, InvalidToken
+from cryptography.fernet import Fernet, InvalidToken, MultiFernet
 
-from .config import OKX_DB_PATH, OKX_ENCRYPTION_KEY
+from .config import OKX_DB_PATH, OKX_ENCRYPTION_KEY, OKX_ENCRYPTION_KEYS
 
 logger = logging.getLogger("okx_storage")
 
-_fernet: Fernet | None = None
-if OKX_ENCRYPTION_KEY:
-    try:
-        _fernet = Fernet(OKX_ENCRYPTION_KEY.encode())
-    except Exception:
-        logger.error("Invalid OKX_ENCRYPTION_KEY — token encryption disabled")
+
+def _build_fernet() -> MultiFernet | Fernet | None:
+    """Build the active Fernet (or MultiFernet) from env.
+
+    Precedence:
+      1. OKX_ENCRYPTION_KEYS (comma-separated, newest first) — rotation mode
+      2. OKX_ENCRYPTION_KEY (single key) — legacy / steady state
+
+    MultiFernet encrypts new data with the first key; decrypts by trying each
+    in order. Empty/whitespace keys are skipped so an operator can set
+    `OKX_ENCRYPTION_KEYS=new,` (trailing comma) without breakage during
+    phase-out.
+    """
+    if OKX_ENCRYPTION_KEYS:
+        raw_keys = [k.strip() for k in OKX_ENCRYPTION_KEYS.split(",") if k.strip()]
+        fernets: list[Fernet] = []
+        for idx, k in enumerate(raw_keys):
+            try:
+                fernets.append(Fernet(k.encode()))
+            except Exception as e:
+                # One bad key must not take down the rest — log and skip.
+                logger.error(
+                    "OKX_ENCRYPTION_KEYS[%d] is invalid (%s) — skipping",
+                    idx, e.__class__.__name__,
+                )
+        if not fernets:
+            logger.error(
+                "OKX_ENCRYPTION_KEYS set but all keys invalid — "
+                "token encryption disabled"
+            )
+            return None
+        if len(fernets) == 1:
+            return fernets[0]
+        return MultiFernet(fernets)
+    if OKX_ENCRYPTION_KEY:
+        try:
+            return Fernet(OKX_ENCRYPTION_KEY.encode())
+        except Exception:
+            logger.error("Invalid OKX_ENCRYPTION_KEY — token encryption disabled")
+    return None
+
+
+_fernet: MultiFernet | Fernet | None = _build_fernet()
 
 
 def _db_path() -> str:

--- a/backend/scripts/migrate_okx_encryption_keys.py
+++ b/backend/scripts/migrate_okx_encryption_keys.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+Re-encrypt every row in the OKX sessions DB under the newest Fernet key.
+
+Usage on DO:
+    # 1. Operator generates a new key and updates `.env`:
+    #    OKX_ENCRYPTION_KEYS=new_key,old_key    (newest first)
+    # 2. Restart API (new writes now under new_key, reads tolerant of either)
+    #    systemctl restart pruviq-api
+    # 3. Run this script to re-encrypt existing rows:
+    #    sudo -u pruviq /opt/pruviq/app/.venv/bin/python \
+    #         /opt/pruviq/current/backend/scripts/migrate_okx_encryption_keys.py
+    # 4. After success, operator drops old_key from `.env`:
+    #    OKX_ENCRYPTION_KEYS=new_key
+    # 5. Restart API to remove in-memory copy of old_key.
+
+Safety:
+    - Idempotent. MultiFernet.rotate() re-encrypts with the newest key;
+      running twice is a no-op after the first success.
+    - Per-row commit. If a single row is corrupt (key neither old nor new
+      can decrypt), it is logged and skipped — other rows still migrate.
+    - Dry-run by default. Pass `--apply` to actually write.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+from pathlib import Path
+
+# Allow running directly: add backend/ to sys.path.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from cryptography.fernet import InvalidToken  # noqa: E402
+
+from okx.storage import _fernet, _get_conn  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+logger = logging.getLogger("migrate_keys")
+
+
+def rotate_rows(apply_changes: bool) -> dict:
+    """Iterate all `okx_sessions` rows; rotate user_data under newest key."""
+    if _fernet is None:
+        raise SystemExit(
+            "OKX encryption not configured. Set OKX_ENCRYPTION_KEYS= in env."
+        )
+
+    # MultiFernet.rotate() is the canonical way; single Fernet has no rotate.
+    if not hasattr(_fernet, "rotate"):
+        logger.warning(
+            "Encryption is a single Fernet (no rotation keys). "
+            "Set OKX_ENCRYPTION_KEYS=new,old to enable rotation, then re-run."
+        )
+        return {"total": 0, "rotated": 0, "skipped": 0, "failed": 0}
+
+    total = rotated = skipped = failed = 0
+    with _get_conn() as conn:
+        rows = conn.execute(
+            "SELECT session_id, user_data FROM okx_sessions"
+        ).fetchall()
+    total = len(rows)
+    logger.info("Found %d rows to examine", total)
+
+    for session_id, token in rows:
+        try:
+            new_token = _fernet.rotate(token.encode()).decode()
+        except InvalidToken:
+            logger.error(
+                "session %s: InvalidToken — skipping (neither key decrypts)",
+                str(session_id)[:8],
+            )
+            failed += 1
+            continue
+        except Exception as e:
+            logger.error(
+                "session %s: rotate failed (%s) — skipping",
+                str(session_id)[:8], e,
+            )
+            failed += 1
+            continue
+        if new_token == token:
+            skipped += 1
+            continue
+        if apply_changes:
+            try:
+                with _get_conn() as conn:
+                    conn.execute(
+                        "UPDATE okx_sessions SET user_data = ?, updated_at = ? "
+                        "WHERE session_id = ?",
+                        (new_token, time.time(), session_id),
+                    )
+            except Exception as e:
+                logger.error(
+                    "session %s: DB write failed (%s)",
+                    str(session_id)[:8], e,
+                )
+                failed += 1
+                continue
+        rotated += 1
+
+    logger.info(
+        "Summary: total=%d rotated=%d skipped=%d failed=%d apply=%s",
+        total, rotated, skipped, failed, apply_changes,
+    )
+    return {
+        "total": total,
+        "rotated": rotated,
+        "skipped": skipped,
+        "failed": failed,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually write rotated rows. Without this, script runs dry.",
+    )
+    args = parser.parse_args()
+    stats = rotate_rows(apply_changes=args.apply)
+    if stats["failed"] > 0:
+        # Surface to caller so wrapping cron can alert.
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_fernet_rotation.py
+++ b/backend/tests/test_fernet_rotation.py
@@ -1,0 +1,184 @@
+"""
+Fernet multi-key rotation regression guard (PR 2026-04-19).
+
+architecture-audit HIGH #9: single-key `OKX_ENCRYPTION_KEY` had no rotation
+path. Key leak forced ALL users to re-OAuth. Now:
+
+  - `OKX_ENCRYPTION_KEYS=new,old` uses `MultiFernet` (encrypt under new,
+    decrypt under either)
+  - `migrate_okx_encryption_keys.py --apply` re-encrypts every row under
+    the newest key
+  - After migration, operator drops old key from env
+
+Tested behaviour:
+  1. Single-key mode still works (back-compat)
+  2. Multi-key decrypts both old and new
+  3. New writes encrypt under newest key
+  4. `rotate()` re-encrypts old rows under new key
+  5. Bad keys in OKX_ENCRYPTION_KEYS are skipped, not fatal
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import pytest
+from cryptography.fernet import Fernet
+
+
+def _fresh_storage(tmp_db: str, old_key: str | None, keys: str | None):
+    """Reload okx.config + okx.storage with a clean env."""
+    os.environ["OKX_DB_PATH"] = tmp_db
+    for k in ("OKX_ENCRYPTION_KEY", "OKX_ENCRYPTION_KEYS"):
+        os.environ.pop(k, None)
+    if old_key:
+        os.environ["OKX_ENCRYPTION_KEY"] = old_key
+    if keys:
+        os.environ["OKX_ENCRYPTION_KEYS"] = keys
+    import okx.config as cfg
+    import okx.storage as storage
+    importlib.reload(cfg)
+    importlib.reload(storage)
+    return storage
+
+
+def test_single_key_still_works():
+    """Back-compat: operators without KEYS env keep using KEY."""
+    k = Fernet.generate_key().decode()
+    with tempfile.TemporaryDirectory() as tmp:
+        db = str(Path(tmp) / "a.db")
+        storage = _fresh_storage(db, old_key=k, keys=None)
+        enc = storage._encrypt({"api_key": "k1"})
+        dec = storage._decrypt(enc)
+        assert dec == {"api_key": "k1"}
+
+
+def test_multi_key_encrypts_under_newest_decrypts_either():
+    """Rotation mode: writes under new_key, reads tolerant of both."""
+    old = Fernet.generate_key().decode()
+    new = Fernet.generate_key().decode()
+    with tempfile.TemporaryDirectory() as tmp:
+        db = str(Path(tmp) / "b.db")
+        # Phase 1: single-key old
+        storage = _fresh_storage(db, old_key=old, keys=None)
+        old_ciphertext = storage._encrypt({"api_key": "pre-rotation"})
+
+        # Phase 2: reload with both keys (new first) — old ciphertext must
+        # still decrypt, and new writes use new_key.
+        storage = _fresh_storage(db, old_key=None, keys=f"{new},{old}")
+        assert storage._decrypt(old_ciphertext) == {"api_key": "pre-rotation"}
+        new_ciphertext = storage._encrypt({"api_key": "post-rotation"})
+        assert storage._decrypt(new_ciphertext) == {"api_key": "post-rotation"}
+        # The new ciphertext must be decryptable under new_key alone (proof
+        # new writes are under new_key, not old_key).
+        storage2 = _fresh_storage(db, old_key=None, keys=new)
+        assert storage2._decrypt(new_ciphertext) == {"api_key": "post-rotation"}
+        # And the old ciphertext must FAIL under new_key alone.
+        import cryptography.fernet as fm
+        with pytest.raises(fm.InvalidToken):
+            storage2._decrypt(old_ciphertext)
+
+
+def test_migration_script_rotates_all_rows():
+    """migrate_okx_encryption_keys.py --apply rotates existing rows."""
+    old = Fernet.generate_key().decode()
+    new = Fernet.generate_key().decode()
+    with tempfile.TemporaryDirectory() as tmp:
+        db = str(Path(tmp) / "c.db")
+
+        # Seed 3 sessions under old key
+        storage = _fresh_storage(db, old_key=old, keys=None)
+        import time
+        with storage._get_conn() as conn:
+            for i in range(3):
+                enc = storage._encrypt({"api_key": f"k{i}"})
+                conn.execute(
+                    "INSERT INTO okx_sessions "
+                    "(session_id, user_data, created_at, updated_at) "
+                    "VALUES (?, ?, ?, ?)",
+                    (f"sess-{i}", enc, time.time(), time.time()),
+                )
+
+        # Reload with both keys and run migration
+        _fresh_storage(db, old_key=None, keys=f"{new},{old}")
+        import importlib
+        import scripts.migrate_okx_encryption_keys as mig
+        importlib.reload(mig)
+        stats = mig.rotate_rows(apply_changes=True)
+        assert stats["total"] == 3
+        assert stats["rotated"] == 3
+        assert stats["failed"] == 0
+
+        # Now reload with new_key ONLY — all rows must still decrypt.
+        storage = _fresh_storage(db, old_key=None, keys=new)
+        with storage._get_conn() as conn:
+            rows = conn.execute(
+                "SELECT session_id, user_data FROM okx_sessions"
+            ).fetchall()
+        assert len(rows) == 3
+        for sess_id, token in rows:
+            assert storage._decrypt(token)["api_key"].startswith("k")
+
+
+def test_bad_key_in_keys_env_is_skipped_not_fatal():
+    """A malformed key in the comma list logs + skips, doesn't break the rest."""
+    good = Fernet.generate_key().decode()
+    bad = "not-a-valid-fernet-key"
+    with tempfile.TemporaryDirectory() as tmp:
+        db = str(Path(tmp) / "d.db")
+        storage = _fresh_storage(db, old_key=None, keys=f"{good},{bad}")
+        # _fernet should be built from good only (single Fernet after skip)
+        assert storage._fernet is not None
+        enc = storage._encrypt({"api_key": "x"})
+        assert storage._decrypt(enc) == {"api_key": "x"}
+
+
+def test_all_bad_keys_disables_encryption():
+    """If every key is invalid, _fernet is None — no silent half-encryption."""
+    with tempfile.TemporaryDirectory() as tmp:
+        db = str(Path(tmp) / "e.db")
+        storage = _fresh_storage(db, old_key=None, keys="bad1,bad2")
+        assert storage._fernet is None
+        with pytest.raises(RuntimeError, match="not configured"):
+            storage._encrypt({"k": "v"})
+
+
+def test_keys_env_takes_precedence_over_key():
+    """If both KEY and KEYS are set, KEYS wins (explicit rotation mode)."""
+    k1 = Fernet.generate_key().decode()
+    k2 = Fernet.generate_key().decode()
+    with tempfile.TemporaryDirectory() as tmp:
+        db = str(Path(tmp) / "f.db")
+        storage = _fresh_storage(db, old_key=k1, keys=k2)
+        enc = storage._encrypt({"k": "v"})
+        # Should decrypt under k2 only
+        storage2 = _fresh_storage(db, old_key=None, keys=k2)
+        assert storage2._decrypt(enc) == {"k": "v"}
+        # Not under k1
+        storage3 = _fresh_storage(db, old_key=k1, keys=None)
+        import cryptography.fernet as fm
+        with pytest.raises(fm.InvalidToken):
+            storage3._decrypt(enc)
+
+
+def test_whitespace_and_trailing_comma_tolerated():
+    """Operator can leave `KEYS=new,` to mark phase-out without empty token."""
+    k = Fernet.generate_key().decode()
+    with tempfile.TemporaryDirectory() as tmp:
+        db = str(Path(tmp) / "g.db")
+        storage = _fresh_storage(db, old_key=None, keys=f" {k} , ")
+        assert storage._fernet is not None
+        enc = storage._encrypt({"x": 1})
+        assert storage._decrypt(enc) == {"x": 1}
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_env():
+    yield
+    for k in ("OKX_DB_PATH", "OKX_ENCRYPTION_KEY", "OKX_ENCRYPTION_KEYS"):
+        os.environ.pop(k, None)


### PR DESCRIPTION
## Summary
architecture-audit HIGH #9: \`OKX_ENCRYPTION_KEY\` 단일키 · 유출 대응 없음 · SOC2/ISO 감사 요구 위반.

## 변경
- \`OKX_ENCRYPTION_KEYS\` 신 env (쉼표 구분 · 최신 먼저) → MultiFernet (encrypt: newest · decrypt: any)
- \`_build_fernet()\` — KEYS 존재 시 MultiFernet · bad key log+skip · all-bad 시 None
- \`migrate_okx_encryption_keys.py\` 신규 · dry-run 기본 · \`--apply\` 실제 rotate

## 운영 흐름
1. new key 생성 → \`.env\` \`OKX_ENCRYPTION_KEYS=new,old\`
2. restart → 새 write = new · 기존 decrypt 유지
3. \`migrate ... --apply\` → 전 row new_key 로 rotate
4. \`.env\` old 제거 → restart (in-memory 제거)
전 과정 유저 재OAuth 0

## Test plan
- [x] \`pytest tests/test_fernet_rotation.py -v\` → **7/7 passed**
- [ ] automerge

## 사이드 이펙트 0
\`KEYS\` 미설정 시 단일 키 동일 동작 (현재 prod 상태 무변화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)