### PR TITLE
ci: force backend-deploy workflow re-registration (recover stuck trigger)

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -7,6 +7,13 @@ on:
     # Drift detector: runs every 30 min as a safety net in case the push
     # event is silently dropped by GitHub (root cause of the 2026-04-18
     # PR #1122 incident where scope=fast_api ran for hours).
+    #
+    # 2026-04-19: after PR #1194 (auto-rollback) merged, GitHub's workflow
+    # registry got stuck on a stale SHA — neither push nor schedule fired
+    # for 2h+, and workflow_dispatch API returned 422 "no workflow_dispatch
+    # trigger" despite the file having one. Had to manually SSH-deploy 5
+    # merged PRs (#1195/1197/1200/1201/1202). Touching this file in a new
+    # PR forces re-registration. If it recurs, repeat the same fix.
     - cron: "*/30 * * * *"
   workflow_dispatch: {}
 


### PR DESCRIPTION
## Summary

Forces GitHub to re-register the `backend-deploy.yml` workflow — trigger got stuck after PR #1194 merged at 12:47 UTC, leaving 5 merged PRs un-deployed on DO for 2+ hours.

## Symptoms

- No `backend-deploy.yml` runs on main since 12:47 UTC despite 5 backend-touching merges (#1195 / #1197 / #1200 / #1201 / #1202)
- `gh workflow run --ref main` + raw API both returned **HTTP 422 "Workflow does not have 'workflow_dispatch' trigger"** even though line 11 has `workflow_dispatch: {}`
- 30-min schedule cron also silent — not just push events

## Impact (contained)

Already resolved via manual SSH deploy before this PR:
- DO synced `36c62946` → `16df33f2`
- `/metrics=200` confirmed live (PR #1197)
- 238 coins loaded post-restart
- Alloy `prometheus.remote_write` replay completed to Grafana Cloud

## Fix

Adds 7-line comment inside the `schedule` block documenting the incident for the next operator. The comment edit alone forces GitHub to re-scan and re-register the workflow triggers. No behavioural change.

## Test plan

- [x] YAML still parses — comment-only edit
- [ ] After merge, push any main-branch commit touching `backend/` — `backend-deploy.yml` should fire (first validation)
- [ ] Next `*/30` schedule tick should also fire (second validation)

## Why comment + not a dummy logic change

Operator-facing comment doubles as post-mortem note. If this recurs the next on-call can immediately recognize the pattern and repeat the fix instead of re-diagnosing the 422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)