### PR TITLE
feat(grafana): versioned dashboard + 5 alert rules for pruviq-api

### DIFF
--- a/backend/deploy/grafana/README.md
+++ b/backend/deploy/grafana/README.md
@@ -1,0 +1,64 @@
+# PRUVIQ — Grafana Cloud Observability
+
+Versioned Grafana artifacts for the DO-hosted pruviq-api:
+
+| File | Purpose | Import path |
+|------|---------|-------------|
+| `dashboard-pruviq-api.json` | Single-page overview — HTTP, Signal Scanner, OKX, SQLite, Auto-trading | Grafana → Dashboards → Import → Upload JSON |
+| `alerts-pruviq-api.yaml` | 5 alert rules (API Down, 5xx spike, scan slow, OKX error rate, SQLite contention) | Grafana → Alerting → Alert rules → Import |
+
+## Data flow
+
+```
+pruviq-api :8080 /metrics  ──scraped by──►  Alloy (localhost)  ──remote_write──►  Grafana Cloud Prometheus (ap-northeast-0)
+```
+
+Alloy config lives on DO at `/etc/alloy/config.alloy`. Grafana stack: `pruviq`.
+Prometheus remote_write URL: `https://prometheus-prod-49-prod-ap-northeast-0.grafana.net/api/prom/push`.
+
+## Panels covered by `dashboard-pruviq-api.json`
+
+Row 1 — **Overview**:
+- Request rate (sum by status_class)
+- p95 latency (overall)
+- In-flight requests gauge
+- Auto-trading sessions enabled
+- Active signals in cache
+
+Row 2 — **HTTP**:
+- Request duration heatmap (by endpoint)
+- Top 5 slowest endpoints table
+- Error rate (4xx vs 5xx)
+
+Row 3 — **Signal Scanner**:
+- Scan duration p50/p95/p99 timeseries
+- Scan timeouts per minute (by caller)
+
+Row 4 — **OKX**:
+- API calls by category (rate)
+- Order execution outcomes (stacked area)
+
+Row 5 — **SQLite**:
+- busy_retries rate
+
+## Alerts (`alerts-pruviq-api.yaml`)
+
+| Name | PromQL | Threshold | For | Severity |
+|------|--------|-----------|-----|----------|
+| `PruviqApiDown` | `up{job="pruviq_api"}` | `== 0` | 2m | critical |
+| `PruviqHttp5xxSpike` | `sum(rate(pruviq_http_request_duration_seconds_count{status_class="5xx"}[5m]))` | `> 0.05` (3 per min) | 5m | warning |
+| `PruviqScanSlow` | `histogram_quantile(0.95, sum(rate(pruviq_signal_scan_duration_seconds_bucket[5m])) by (le))` | `> 45s` | 10m | warning |
+| `PruviqOkxErrorRate` | `sum(rate(pruviq_okx_api_calls_total{status_class!="2xx"}[5m])) / sum(rate(pruviq_okx_api_calls_total[5m]))` | `> 0.1` (10%) | 5m | warning |
+| `PruviqSqliteContention` | `rate(pruviq_sqlite_busy_retries_total[5m])` | `> 1.0/s` | 5m | warning |
+
+Contact point: Telegram (via webhook → `PRUVIQ_TELEGRAM_CHAT_ID`) — wire in Grafana UI under Alerting → Contact points.
+
+## Updating the dashboard
+
+1. Edit panels in Grafana UI
+2. Export JSON: Dashboard settings → JSON Model → copy
+3. Overwrite `dashboard-pruviq-api.json`
+4. Commit with `feat(grafana): ...` prefix
+5. On next import, use "Replace" option to overwrite live dashboard
+
+Dashboards in Grafana Cloud can also be provisioned via API, but manual import works fine at current scale (single environment, single dashboard).

--- a/backend/deploy/grafana/README.md
+++ b/backend/deploy/grafana/README.md
@@ -45,7 +45,7 @@ Row 5 — **SQLite**:
 
 | Name | PromQL | Threshold | For | Severity |
 |------|--------|-----------|-----|----------|
-| `PruviqApiDown` | `up{job="pruviq_api"}` | `== 0` | 2m | critical |
+| `PruviqApiDown` | `up{job="pruviq-api"}` | `== 0` | 2m | critical |
 | `PruviqHttp5xxSpike` | `sum(rate(pruviq_http_request_duration_seconds_count{status_class="5xx"}[5m]))` | `> 0.05` (3 per min) | 5m | warning |
 | `PruviqScanSlow` | `histogram_quantile(0.95, sum(rate(pruviq_signal_scan_duration_seconds_bucket[5m])) by (le))` | `> 45s` | 10m | warning |
 | `PruviqOkxErrorRate` | `sum(rate(pruviq_okx_api_calls_total{status_class!="2xx"}[5m])) / sum(rate(pruviq_okx_api_calls_total[5m]))` | `> 0.1` (10%) | 5m | warning |

--- a/backend/deploy/grafana/alerts-pruviq-api.yaml
+++ b/backend/deploy/grafana/alerts-pruviq-api.yaml
@@ -1,0 +1,242 @@
+# PRUVIQ API — Grafana Cloud alert rules
+#
+# Import path: Grafana → Alerting → Alert rules → Import file
+# Contact point: separate (wire in UI to Telegram webhook)
+#
+# Design notes:
+#   - 5 rules covering: API down, HTTP 5xx, scan slow, OKX error rate,
+#     SQLite contention. All driven off `/metrics` exposed by the
+#     prometheus_client instrumentation shipped in PR #1197.
+#   - "for" durations are tuned to absorb single scrape misses (Alloy
+#     scrape_interval=60s → 2m minimum to dedupe a single drop).
+#   - Only PruviqApiDown is "critical"; the rest are "warning" because
+#     they're degradations, not outages.
+
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: pruviq-api-core
+    folder: PRUVIQ
+    interval: 1m
+    rules:
+      # ─────────────────────────────────────────────────────────
+      # 1. API Down — the scrape target itself is unreachable.
+      # Triggers when Alloy's prometheus.scrape component can't reach
+      # :8080/metrics for 2 consecutive minutes (i.e., 2+ failed scrapes).
+      # ─────────────────────────────────────────────────────────
+      - uid: pruviq_api_down
+        title: PruviqApiDown
+        condition: C
+        data:
+          - refId: A
+            queryType: ""
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: ${DS_PROMETHEUS_UID}
+            model:
+              expr: up{job="pruviq_api"}
+              intervalMs: 60000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            queryType: ""
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator: { params: [1], type: lt }
+                  operator: { type: and }
+                  query: { params: [C] }
+                  reducer: { params: [], type: last }
+                  type: query
+              datasource: { type: __expr__, uid: __expr__ }
+              expression: A
+              refId: C
+              type: threshold
+        noDataState: Alerting
+        execErrState: Error
+        for: 2m
+        annotations:
+          summary: "pruviq-api :8080 unreachable"
+          description: "Alloy cannot scrape http://127.0.0.1:8080/metrics for 2 minutes. Check `systemctl status pruviq-api`."
+          runbook_url: "https://github.com/pruviq/pruviq/blob/main/backend/deploy/grafana/README.md#pruviqapidown"
+        labels:
+          severity: critical
+          service: pruviq-api
+
+      # ─────────────────────────────────────────────────────────
+      # 2. HTTP 5xx spike — server errors > 3 per minute for 5 minutes.
+      # Detects regressions faster than the user-facing /health probe.
+      # ─────────────────────────────────────────────────────────
+      - uid: pruviq_http_5xx_spike
+        title: PruviqHttp5xxSpike
+        condition: C
+        data:
+          - refId: A
+            queryType: ""
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: ${DS_PROMETHEUS_UID}
+            model:
+              expr: sum(rate(pruviq_http_request_duration_seconds_count{status_class="5xx"}[5m]))
+              intervalMs: 60000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            queryType: ""
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator: { params: [0.05], type: gt }
+                  operator: { type: and }
+                  query: { params: [C] }
+                  reducer: { params: [], type: last }
+                  type: query
+              datasource: { type: __expr__, uid: __expr__ }
+              expression: A
+              refId: C
+              type: threshold
+        noDataState: OK
+        execErrState: Error
+        for: 5m
+        annotations:
+          summary: "Server 5xx error rate > 3/min"
+          description: "pruviq-api is serving 5xx responses at > 0.05 req/s for 5+ minutes. Check journalctl -u pruviq-api and recent deploys."
+        labels:
+          severity: warning
+          service: pruviq-api
+
+      # ─────────────────────────────────────────────────────────
+      # 3. Signal scan slow — p95 > 45s for 10 minutes.
+      # Scanner has a 60s wait_for budget in the auto-trade loop.
+      # 45s p95 = eating 75% of the budget, one bad scan pushes timeout.
+      # ─────────────────────────────────────────────────────────
+      - uid: pruviq_scan_slow
+        title: PruviqScanSlow
+        condition: C
+        data:
+          - refId: A
+            queryType: ""
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: ${DS_PROMETHEUS_UID}
+            model:
+              expr: histogram_quantile(0.95, sum(rate(pruviq_signal_scan_duration_seconds_bucket[5m])) by (le))
+              intervalMs: 60000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            queryType: ""
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator: { params: [45], type: gt }
+                  operator: { type: and }
+                  query: { params: [C] }
+                  reducer: { params: [], type: last }
+                  type: query
+              datasource: { type: __expr__, uid: __expr__ }
+              expression: A
+              refId: C
+              type: threshold
+        noDataState: OK
+        execErrState: Error
+        for: 10m
+        annotations:
+          summary: "Signal scan p95 > 45s"
+          description: "signal_scanner.scan() p95 is > 45s for 10+ minutes — approaching the 60s auto-trade wait_for timeout. Check OHLCV freshness and GIL contention (top coins × strategies = CPU-bound)."
+        labels:
+          severity: warning
+          service: pruviq-api
+          component: signal-scanner
+
+      # ─────────────────────────────────────────────────────────
+      # 4. OKX error rate — non-2xx OKX API calls > 10% for 5 minutes.
+      # OKX transient errors are normal; sustained 10%+ = broken auth,
+      # rate limit burn, or a broken endpoint assumption.
+      # ─────────────────────────────────────────────────────────
+      - uid: pruviq_okx_error_rate
+        title: PruviqOkxErrorRate
+        condition: C
+        data:
+          - refId: A
+            queryType: ""
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: ${DS_PROMETHEUS_UID}
+            model:
+              expr: |
+                sum(rate(pruviq_okx_api_calls_total{status_class!="2xx"}[5m]))
+                /
+                (sum(rate(pruviq_okx_api_calls_total[5m])) > 0)
+              intervalMs: 60000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            queryType: ""
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator: { params: [0.1], type: gt }
+                  operator: { type: and }
+                  query: { params: [C] }
+                  reducer: { params: [], type: last }
+                  type: query
+              datasource: { type: __expr__, uid: __expr__ }
+              expression: A
+              refId: C
+              type: threshold
+        noDataState: OK
+        execErrState: Error
+        for: 5m
+        annotations:
+          summary: "OKX API error rate > 10%"
+          description: "More than 10% of OKX v5 API calls are returning non-2xx for 5+ minutes. Check OAuth token, rate limits, or recent OKX endpoint changes."
+        labels:
+          severity: warning
+          service: pruviq-api
+          component: okx
+
+      # ─────────────────────────────────────────────────────────
+      # 5. SQLite contention — busy_retries > 1/s for 5 minutes.
+      # Steady non-zero means we're hitting the busy_timeout ceiling —
+      # time to consider uvicorn workers>=2 tuning or async storage.
+      # ─────────────────────────────────────────────────────────
+      - uid: pruviq_sqlite_contention
+        title: PruviqSqliteContention
+        condition: C
+        data:
+          - refId: A
+            queryType: ""
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: ${DS_PROMETHEUS_UID}
+            model:
+              expr: rate(pruviq_sqlite_busy_retries_total[5m])
+              intervalMs: 60000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            queryType: ""
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator: { params: [1.0], type: gt }
+                  operator: { type: and }
+                  query: { params: [C] }
+                  reducer: { params: [], type: last }
+                  type: query
+              datasource: { type: __expr__, uid: __expr__ }
+              expression: A
+              refId: C
+              type: threshold
+        noDataState: OK
+        execErrState: Error
+        for: 5m
+        annotations:
+          summary: "SQLite busy_retries > 1/s"
+          description: "SQLite writer lock contention is persistent. Check autotrade_live.db usage; consider tuning busy_timeout or moving to a single writer pattern."
+        labels:
+          severity: warning
+          service: pruviq-api
+          component: sqlite

--- a/backend/deploy/grafana/alerts-pruviq-api.yaml
+++ b/backend/deploy/grafana/alerts-pruviq-api.yaml
@@ -34,7 +34,12 @@ groups:
             relativeTimeRange: { from: 300, to: 0 }
             datasourceUid: ${DS_PROMETHEUS_UID}
             model:
-              expr: up{job="pruviq_api"}
+              # The `job` label is set by Alloy's scrape target to "pruviq-api"
+              # (hyphen) in /etc/alloy/config.alloy — NOT the component name
+              # `pruviq_api` (underscore). Mismatch here would permanently
+              # produce NoData — a critical alert that never fires is worse
+              # than no alert, because it looks like coverage you don't have.
+              expr: up{job="pruviq-api"}
               intervalMs: 60000
               maxDataPoints: 43200
               refId: A

--- a/backend/deploy/grafana/dashboard-pruviq-api.json
+++ b/backend/deploy/grafana/dashboard-pruviq-api.json
@@ -1,0 +1,617 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "PRUVIQ API — request latency, signal scanner, OKX calls, SQLite, auto-trading. Data source: Grafana Cloud Prometheus (ap-northeast-0) via Alloy remote_write.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Request rate by HTTP status class — 2xx/4xx/5xx should be visible at a glance.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "req/s",
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "normal" }
+          },
+          "unit": "reqps"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "id": 1,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "expr": "sum by (status_class) (rate(pruviq_http_request_duration_seconds_count[5m]))",
+          "legendFormat": "{{status_class}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request rate by status class",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "p50 / p95 / p99 latency across all endpoints.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "seconds",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "id": 2,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum(rate(pruviq_http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(pruviq_http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(pruviq_http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Latency quantiles (all endpoints)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Uvicorn worker saturation. Single-worker setup caps at ~10 concurrent before queueing shows up as p99 latency.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 15 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 9 },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "pruviq_http_requests_in_flight",
+          "legendFormat": "in-flight",
+          "refId": "A"
+        }
+      ],
+      "title": "In-flight requests",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Count of OKX sessions with auto-trading enabled (gauge). 0 = everyone opted out; spikes indicate enable bursts.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "blue", "value": null }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 9 },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "pruviq_auto_sessions_enabled",
+          "legendFormat": "sessions",
+          "refId": "A"
+        }
+      ],
+      "title": "Auto-trading sessions",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Active signals currently cached by the scanner.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 9 },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "pruviq_signal_cache_active",
+          "legendFormat": "signals",
+          "refId": "A"
+        }
+      ],
+      "title": "Active signals (cache)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Signal scan timeouts by caller loop. Any non-zero steady rate = over-budget scans.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.5 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 9 },
+      "id": 6,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(pruviq_signal_scan_timeouts_total[5m]))",
+          "legendFormat": "timeouts/5m",
+          "refId": "A"
+        }
+      ],
+      "title": "Scan timeouts (last 5m)",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 13 },
+      "id": 101,
+      "panels": [],
+      "title": "HTTP",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Top 10 slowest endpoints by p95 over the last 15 minutes. Sortable table.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "endpoint" },
+            "properties": [{ "id": "custom.width", "value": 400 }]
+          }
+        ]
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 14 },
+      "id": 7,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true,
+        "sortBy": [{ "desc": true, "displayName": "p95" }]
+      },
+      "targets": [
+        {
+          "expr": "topk(10, histogram_quantile(0.95, sum(rate(pruviq_http_request_duration_seconds_bucket[15m])) by (le, endpoint)))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 slowest endpoints (p95)",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true, "__name__": true, "instance": true, "job": true, "le": true, "method": true, "status_class": true },
+            "renameByName": { "Value": "p95" }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "4xx (client errors) vs 5xx (server errors) request rate. 5xx > 0 sustained = regression.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "req/s",
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "unit": "reqps"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "5xx" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "4xx" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 14 },
+      "id": 8,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max", "sum"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(pruviq_http_request_duration_seconds_count{status_class=~\"4xx|5xx\"}[5m])) by (status_class)",
+          "legendFormat": "{{status_class}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Error rate (4xx / 5xx)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 24 },
+      "id": 102,
+      "panels": [],
+      "title": "Signal Scanner",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Signal scan wall-clock duration. p95 >45s = approaching auto-trading loop timeout.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "seconds",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "p95" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 25 },
+      "id": 9,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum(rate(pruviq_signal_scan_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(pruviq_signal_scan_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(pruviq_signal_scan_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Signal scan duration (quantiles)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Scan timeouts per caller loop. Non-zero sustained = signal scan is overshooting the wait_for budget.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "timeouts/min",
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "lineWidth": 0,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 25 },
+      "id": 10,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(pruviq_signal_scan_timeouts_total[1m])) by (caller)",
+          "legendFormat": "{{caller}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Scan timeouts by caller (/min)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 33 },
+      "id": 103,
+      "panels": [],
+      "title": "OKX",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "OKX REST v5 calls grouped by API category (account, trade, market, public). Tracks rate limit burn.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "calls/s",
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "unit": "reqps"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 34 },
+      "id": 11,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "expr": "sum by (category) (rate(pruviq_okx_api_calls_total[5m]))",
+          "legendFormat": "{{category}}",
+          "refId": "A"
+        }
+      ],
+      "title": "OKX API call rate by category",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "End-to-end order execution outcomes (NOT just API calls). Tracks executed vs rate_limited vs position_cap vs error.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "orders/min",
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "normal" }
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "executed" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "error" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "rate_limited" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 34 },
+      "id": 12,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(pruviq_okx_order_executions_total[1m])) by (outcome)",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "title": "OKX order outcomes (/min)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 42 },
+      "id": 104,
+      "panels": [],
+      "title": "SQLite",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Rate of SQLite BUSY retries — non-zero sustained means writer contention is hitting the busy_timeout ceiling.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "custom": {
+            "axisLabel": "retries/s",
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.1 },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 43 },
+      "id": 13,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "expr": "rate(pruviq_sqlite_busy_retries_total[5m])",
+          "legendFormat": "busy retries",
+          "refId": "A"
+        }
+      ],
+      "title": "SQLite busy retries (rate)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["pruviq", "api", "observability"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "grafanacloud-prom", "value": "grafanacloud-prom" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus data source",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "PRUVIQ API — Observability",
+  "uid": "pruviq-api-obs",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## Summary

Ships the Grafana Cloud side of the observability story: a versioned, import-ready dashboard + 5 alert rules driven by the `/metrics` endpoint (#1197) that Alloy is already scraping and remote-writing to Grafana Cloud Prometheus.

## What's new

- **`dashboard-pruviq-api.json`** — 5 rows / 13 data panels
  - Overview: request rate by status, p50/p95/p99 latency, in-flight gauge, sessions, cache size, timeout count
  - HTTP: top-10 slowest endpoints table, 4xx vs 5xx error rate
  - Signal Scanner: scan duration quantiles, timeouts/min by caller
  - OKX: API calls by category, order execution outcomes (executed / error / rate_limited / position_cap)
  - SQLite: busy_retries rate
- **`alerts-pruviq-api.yaml`** — 5 rules:
  | Rule | Threshold | For | Severity |
  |------|-----------|-----|----------|
  | `PruviqApiDown` | `up{job="pruviq_api"}==0` | 2m | critical |
  | `PruviqHttp5xxSpike` | `rate(5xx)>0.05/s` | 5m | warning |
  | `PruviqScanSlow` | `p95(scan_duration)>45s` | 10m | warning |
  | `PruviqOkxErrorRate` | `non-2xx/total>10%` | 5m | warning |
  | `PruviqSqliteContention` | `rate(busy_retries)>1/s` | 5m | warning |
- **`README.md`** — data-flow, panel inventory, threshold table, update procedure

## Rationale for versioned in-repo

Dashboard/alert drift in Grafana UI has been a recurring pain point. Versioning the JSON/YAML gives:
1. Audit trail — every threshold change is a commit
2. DR — Grafana org wipe is recoverable from main
3. Review — alert thresholds get same scrutiny as app code

## Scope

- Pure additions, no existing code touched
- No runtime deploy needed — artifacts consumed by Grafana Cloud, not DO
- Operator manually wires Telegram contact point once (docs in README)

## Test plan

- [x] Dashboard JSON validates (18 panels, 5 rows, UID `pruviq-api-obs`)
- [x] Alerts YAML parses (5 rules in `pruviq-api-core` group)
- [ ] Post-merge: import to Grafana, confirm all panels render data
- [ ] Trigger a manual `PruviqHttp5xxSpike` via `curl -X GET http://127.0.0.1:8080/nope` repeated → verify alert fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)