### PR TITLE
fix(api): atomic subscribers mutations under fcntl.flock + timing-safe token compare

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -4442,6 +4442,13 @@ def _mutate_subscribers_atomic(mutator):
 
     Python's `fcntl.flock` is advisory — a non-cooperating writer can bypass
     it. That's fine here: all writers are in this repo and call this helper.
+
+    Trade-off: the blocking `flock()` + `write_text()` calls here serialize
+    subscribe/unsubscribe across async workers by momentarily blocking the
+    event loop. Acceptable at current traffic (a few subscribes/day). If
+    traffic ever justifies `workers >= 2` at scale, move this to a
+    threadpool (`anyio.to_thread.run_sync`) or a proper DB row — otherwise
+    every worker will pile up on the same lock file.
     """
     import fcntl
 

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -4421,46 +4421,78 @@ SUBSCRIBERS_FILE = Path(
 )
 
 
+def _mutate_subscribers_atomic(mutator):
+    """Read → mutate → atomic write under fcntl.flock.
+
+    The previous read-modify-write sequence was safe only under a single-worker
+    uvicorn because the sections contain no `await` points. As soon as we
+    scale workers (or a sibling process — say a cron or migration script —
+    wants to write) two requests could interleave read/write and drop updates.
+
+    This helper:
+      1. opens a sibling `.lock` file for fcntl.LOCK_EX (advisory, but honored
+         by every writer that uses this helper — single-writer discipline).
+      2. reads the live JSON inside the lock,
+      3. invokes `mutator(data)` which may mutate in place and return
+         (data, result) where `data` is the new state and `result` is passed
+         back to the caller,
+      4. writes to `SUBSCRIBERS_FILE.with_suffix('.tmp')` + rename (POSIX
+         atomic so readers never see a torn write),
+      5. releases the lock via the context manager.
+
+    Python's `fcntl.flock` is advisory — a non-cooperating writer can bypass
+    it. That's fine here: all writers are in this repo and call this helper.
+    """
+    import fcntl
+
+    SUBSCRIBERS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = SUBSCRIBERS_FILE.with_suffix(".lock")
+    # Open in a+ so the lock file is created if missing but we don't truncate.
+    with open(lock_path, "a+") as lock_fh:
+        fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+        try:
+            if SUBSCRIBERS_FILE.exists():
+                data = json.loads(SUBSCRIBERS_FILE.read_text())
+            else:
+                data = {"subscribers": []}
+
+            data, result = mutator(data)
+
+            tmp = SUBSCRIBERS_FILE.with_suffix(".tmp")
+            tmp.write_text(json.dumps(data, indent=2))
+            tmp.rename(SUBSCRIBERS_FILE)
+            return result
+        finally:
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+
+
 @app.post("/api/subscribe")
 async def subscribe_email(req: SubscribeRequest):
     """Subscribe an email to weekly strategy alerts."""
     import re
 
-    # Validate email format
     if not re.match(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$', req.email):
         raise HTTPException(422, detail="Invalid email format")
 
     email = req.email.lower().strip()
 
-    # Read / write with file lock
-    SUBSCRIBERS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    if SUBSCRIBERS_FILE.exists():
-        data = json.loads(SUBSCRIBERS_FILE.read_text())
-    else:
-        data = {"subscribers": []}
-
-    # Duplicate check
-    existing = [s for s in data["subscribers"] if s["email"] == email]
-    if existing:
-        if existing[0].get("active", True):
-            return {"ok": True, "message": "Already subscribed"}
-        else:
+    def _apply(data):
+        existing = [s for s in data["subscribers"] if s["email"] == email]
+        if existing:
+            if existing[0].get("active", True):
+                return data, {"ok": True, "message": "Already subscribed"}
             existing[0]["active"] = True
             existing[0]["resubscribed_at"] = datetime.utcnow().isoformat()
-    else:
-        data["subscribers"].append({
-            "email": email,
-            "lang": req.lang,
-            "subscribed_at": datetime.utcnow().isoformat(),
-            "active": True,
-        })
+        else:
+            data["subscribers"].append({
+                "email": email,
+                "lang": req.lang,
+                "subscribed_at": datetime.utcnow().isoformat(),
+                "active": True,
+            })
+        return data, {"ok": True, "message": "Subscribed successfully"}
 
-    # Atomic write
-    tmp = SUBSCRIBERS_FILE.with_suffix(".tmp")
-    tmp.write_text(json.dumps(data, indent=2))
-    tmp.rename(SUBSCRIBERS_FILE)
-
-    return {"ok": True, "message": "Subscribed successfully"}
+    return _mutate_subscribers_atomic(_apply)
 
 
 @app.get("/api/unsubscribe")
@@ -4474,18 +4506,22 @@ async def unsubscribe_email(email: str, token: str):
     if not secret:
         raise HTTPException(503, detail="Unsubscribe service misconfigured")
     expected_full = hmac.new(secret.encode(), email.lower().encode(), hashlib.sha256).hexdigest()
-    # Accept legacy 16-char tokens (old emails) and new full 64-char tokens
+    # Accept legacy 16-char tokens (old emails) and new full 64-char tokens.
+    # Use compare_digest to avoid early-exit timing leaks on mismatched prefixes.
     expected_legacy = expected_full[:16]
-
-    if token not in (expected_full, expected_legacy):
+    token_ok = hmac.compare_digest(token, expected_full) or hmac.compare_digest(
+        token, expected_legacy
+    )
+    if not token_ok:
         raise HTTPException(403, detail="Invalid unsubscribe token")
 
-    if SUBSCRIBERS_FILE.exists():
-        data = json.loads(SUBSCRIBERS_FILE.read_text())
+    def _apply(data):
         for s in data["subscribers"]:
             if s["email"] == email.lower():
                 s["active"] = False
-        SUBSCRIBERS_FILE.write_text(json.dumps(data, indent=2))
+        return data, None
+
+    _mutate_subscribers_atomic(_apply)
 
     return HTMLResponse(
         "<html><body style=\"font-family:sans-serif;text-align:center;padding:60px\">"

--- a/backend/tests/test_subscribers_atomic_flock.py
+++ b/backend/tests/test_subscribers_atomic_flock.py
@@ -1,0 +1,161 @@
+"""
+Regression guard for /api/subscribe + /api/unsubscribe atomic-write +
+fcntl.flock hardening (PR 2026-04-19).
+
+Three things this file asserts:
+  1. `_mutate_subscribers_atomic` uses fcntl.flock and tmp+rename (not
+     direct write_text) — prevents torn reads on crash and drop-on-race
+     on multi-worker uvicorn.
+  2. /api/unsubscribe uses hmac.compare_digest (no timing leak on
+     mismatched prefixes).
+  3. Concurrent subscribe requests from threaded clients don't lose
+     updates — this would fail if the helper were removed and we went
+     back to read-modify-write without a lock.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import tempfile
+import threading
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client_with_temp_subscribers(monkeypatch):
+    """Point SUBSCRIBERS_FILE at a fresh tempdir + reload the app."""
+    tmp = tempfile.TemporaryDirectory()
+    sub_path = Path(tmp.name) / "subs.json"
+    monkeypatch.setenv("SUBSCRIBERS_FILE", str(sub_path))
+    monkeypatch.setenv("UNSUBSCRIBE_SECRET", "x" * 32)
+
+    # Re-import main under the env overrides (module-level constant)
+    import importlib
+
+    import api.main as main
+
+    importlib.reload(main)
+    client = TestClient(main.app)
+    yield client, sub_path, main
+    tmp.cleanup()
+    importlib.reload(main)  # restore for other tests
+
+
+def test_helper_uses_flock_and_atomic_rename():
+    """Source-level guard: if someone rips out the lock or the tmp+rename
+    discipline, they have to change this test too (making the regression
+    visible in the PR)."""
+    src = Path(__file__).resolve().parent.parent / "api" / "main.py"
+    body = src.read_text()
+    # Helper exists
+    assert "_mutate_subscribers_atomic" in body, (
+        "the read-modify-write helper must exist; do not inline the "
+        "sequence again — it's the single choke-point for the flock"
+    )
+    # Inside the helper: fcntl.flock with LOCK_EX + LOCK_UN
+    assert "fcntl.LOCK_EX" in body, (
+        "helper must acquire an exclusive flock to serialize writers"
+    )
+    assert "fcntl.LOCK_UN" in body, (
+        "helper must release the flock in a finally block"
+    )
+    # Still writes via tmp+rename (not direct write_text on the canonical file)
+    # This assertion is strict: the lock guards concurrency, the rename
+    # guards reader-visible atomicity on POSIX.
+    helper_body = body.split("_mutate_subscribers_atomic", 1)[1].split("\n\n\n", 1)[0]
+    assert ".with_suffix(\".tmp\")" in helper_body, (
+        "helper must stage the write in a .tmp file"
+    )
+    assert "tmp.rename(SUBSCRIBERS_FILE)" in helper_body, (
+        "helper must atomically rename .tmp → canonical"
+    )
+
+
+def test_unsubscribe_uses_compare_digest():
+    """hmac.compare_digest avoids byte-by-byte early exit on mismatched
+    tokens. The previous `if token not in (full, legacy)` had a timing
+    leak proportional to prefix-match length."""
+    src = Path(__file__).resolve().parent.parent / "api" / "main.py"
+    body = src.read_text()
+    # Locate the unsubscribe function body
+    match = re.search(r"async def unsubscribe_email.*?(?=\n@app\.|\nasync def |\ndef )", body, re.DOTALL)
+    assert match, "unsubscribe_email function not found"
+    fn_body = match.group(0)
+    assert "hmac.compare_digest" in fn_body, (
+        "unsubscribe must use hmac.compare_digest for token comparison — "
+        "`==` / `in` on HMAC values leaks prefix match length via timing"
+    )
+    # Double guard: make sure the old vulnerable form didn't creep back
+    assert "token not in (expected_full, expected_legacy)" not in fn_body, (
+        "the non-constant-time comparison is back — revert the regression"
+    )
+
+
+def test_subscribe_writes_via_tmp_rename_not_partial_file(client_with_temp_subscribers):
+    """End-to-end: POST to /api/subscribe lands the email in the canonical
+    file. The `.tmp` sibling should NOT exist afterwards (it was renamed)."""
+    client, sub_path, _ = client_with_temp_subscribers
+    resp = client.post("/api/subscribe", json={"email": "a@example.com", "lang": "en"})
+    assert resp.status_code == 200
+    assert sub_path.exists(), "canonical subscribers file must exist after subscribe"
+    tmp_sibling = sub_path.with_suffix(".tmp")
+    assert not tmp_sibling.exists(), (
+        ".tmp must be gone after rename — stranded .tmp indicates a crash "
+        "between write and rename"
+    )
+    data = json.loads(sub_path.read_text())
+    assert any(s["email"] == "a@example.com" for s in data["subscribers"])
+
+
+def test_concurrent_mutations_do_not_lose_updates(client_with_temp_subscribers):
+    """Call `_mutate_subscribers_atomic` directly from N threads. All N
+    appends must survive — without the flock, a lost-update race is
+    visible here.
+
+    Calling the helper directly (not via HTTP) dodges the route-level
+    rate limiter that correctly caps /api/subscribe at a few req/min per
+    client. This test is about concurrency correctness, not rate-limit
+    behaviour."""
+    _, sub_path, main = client_with_temp_subscribers
+
+    N = 20
+    errors: list[Exception] = []
+
+    def _append(i: int) -> None:
+        def mutator(data):
+            data["subscribers"].append({
+                "email": f"user{i:03d}@example.com",
+                "lang": "en",
+                "subscribed_at": "2026-04-19T00:00:00",
+                "active": True,
+            })
+            return data, None
+
+        try:
+            main._mutate_subscribers_atomic(mutator)
+        except Exception as e:  # pragma: no cover — captured for assert
+            errors.append(e)
+
+    threads = [threading.Thread(target=_append, args=(i,)) for i in range(N)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"one or more mutations raised: {errors[:3]}"
+
+    data = json.loads(sub_path.read_text())
+    emails = {s["email"] for s in data["subscribers"]}
+    expected = {f"user{i:03d}@example.com" for i in range(N)}
+    missing = expected - emails
+    assert not missing, (
+        f"lost {len(missing)} emails to the read-modify-write race: "
+        f"{sorted(missing)[:5]}"
+    )


### PR DESCRIPTION
## Summary

Hardens `/api/subscribe` + `/api/unsubscribe` against two audit findings: a read-modify-write race on multi-worker deploys, and a timing-leak on HMAC token comparison.

## 1. Read-modify-write race

Both endpoints inlined `read_text → json.loads → mutate → write_text`. Safe today (single-worker uvicorn, no `await` between steps), but:
- Silently broken on `workers>=2`
- Silently broken if a sibling writer (cron, migration) touches the file
- Silently broken if the function grows an `await` between read and write

Fix: `_mutate_subscribers_atomic(mutator)` — single choke-point that acquires `fcntl.flock(LOCK_EX)` on a `subscribers.lock` sibling, reads → calls mutator → writes via `.tmp` + atomic POSIX rename, then `LOCK_UN` in `finally`.

Both endpoints now call the helper. Direct `write_text` path on `/api/unsubscribe` (which skipped the `.tmp` dance) is gone.

## 2. HMAC token comparison leaked prefix match length

`if token not in (expected_full, expected_legacy)` — the `in` operator uses `str.__eq__` which short-circuits at the first mismatched byte. Attacker with timing access can learn token byte-by-byte.

Fix: `hmac.compare_digest(token, expected_full) or hmac.compare_digest(token, expected_legacy)` — constant-time in both branches.

## Test plan

`tests/test_subscribers_atomic_flock.py` — 4 tests, all green:

- [x] `test_helper_uses_flock_and_atomic_rename` — source-level: helper exists, `LOCK_EX`/`LOCK_UN` present, tmp+rename intact
- [x] `test_unsubscribe_uses_compare_digest` — source-level: no `token not in (...)` regression
- [x] `test_subscribe_writes_via_tmp_rename_not_partial_file` — end-to-end: POST lands in canonical, no stranded `.tmp`
- [x] `test_concurrent_mutations_do_not_lose_updates` — 20 threads call helper directly; all 20 appends survive

## Non-goals

- Email validation, duplicate-subscriber semantics, rate-limiting — unchanged
- On-disk JSON shape — unchanged
- Unsubscribe HTML response — unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)