### PR TITLE
feat(seo): SoftwareApplication JSON-LD on /simulate + /ko/simulate

### DIFF
--- a/src/pages/ko/simulate/index.astro
+++ b/src/pages/ko/simulate/index.astro
@@ -13,9 +13,37 @@ const coinsAnalyzed = (siteStats as { coins_analyzed: number }).coins_analyzed;
 // Quick Start: top 3 from rankings
 const rankingsData = rankingsJson as { top3?: Array<{rank: number; name_ko: string; strategy: string; direction: string; win_rate: number; profit_factor: number; total_return: number; timeframe: string}> };
 const quickStartPresets = (rankingsData.top3 || []).slice(0, 3);
+
+// SEO: SoftwareApplication JSON-LD (ko). See EN variant for rationale.
+const simulateJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "PRUVIQ — 크립토 전략 시뮬레이터",
+  "applicationCategory": "FinanceApplication",
+  "operatingSystem": "Web",
+  "url": "https://pruviq.com/ko/simulate",
+  "description": t('meta.simulate_desc'),
+  "softwareVersion": "0.3.0",
+  "inLanguage": ["ko", "en"],
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD",
+    "availability": "https://schema.org/InStock"
+  },
+  "featureList": [
+    `${coinsAnalyzed}+ 코인`,
+    `${presetCount}개 사전 구축 전략`,
+    "2년+ 과거 OHLCV 데이터",
+    "실거래 수수료 + 펀딩비 반영",
+    "회원가입 불필요"
+  ],
+  "publisher": { "@type": "Organization", "name": "PRUVIQ", "url": "https://pruviq.com" }
+};
 ---
 
 <Layout title={t('meta.simulate_title')} description={t('meta.simulate_desc')}>
+  <script type="application/ld+json" set:html={JSON.stringify(simulateJsonLd)} />
   <!-- Onboarding header -->
   <!-- Compact Hero -->
   <section id="simulator-onboarding" class="pt-6 pb-4 md:pt-8 md:pb-6">

--- a/src/pages/simulate/index.astro
+++ b/src/pages/simulate/index.astro
@@ -13,9 +13,40 @@ const coinsAnalyzed = (siteStats as { coins_analyzed: number }).coins_analyzed;
 // Quick Start: top 3 from rankings
 const rankingsData = rankingsJson as { top3?: Array<{rank: number; name_en: string; strategy: string; direction: string; win_rate: number; profit_factor: number; total_return: number; timeframe: string}> };
 const quickStartPresets = (rankingsData.top3 || []).slice(0, 3);
+
+// SEO: SoftwareApplication JSON-LD. /simulate IS the tool — Google uses
+// this to surface it in rich-result carousels (SaaS/app listings) vs.
+// treating it as a generic article. "offers: Free" is key for
+// discoverability against the paid-simulator competitors.
+const simulateJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "PRUVIQ — Crypto Strategy Simulator",
+  "applicationCategory": "FinanceApplication",
+  "operatingSystem": "Web",
+  "url": "https://pruviq.com/simulate",
+  "description": t('meta.simulate_desc'),
+  "softwareVersion": "0.3.0",
+  "inLanguage": ["en", "ko"],
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD",
+    "availability": "https://schema.org/InStock"
+  },
+  "featureList": [
+    `${coinsAnalyzed}+ crypto pairs`,
+    `${presetCount} pre-built strategies`,
+    "2+ years historical OHLCV data",
+    "Realistic fees + funding rates",
+    "No signup required"
+  ],
+  "publisher": { "@type": "Organization", "name": "PRUVIQ", "url": "https://pruviq.com" }
+};
 ---
 
 <Layout title={t('meta.simulate_title')} description={t('meta.simulate_desc')}>
+  <script type="application/ld+json" set:html={JSON.stringify(simulateJsonLd)} />
   <!-- Onboarding header -->
   <!-- Compact Hero -->
   <section id="simulator-onboarding" class="pt-6 pb-4 md:pt-8 md:pb-6">


### PR DESCRIPTION
## Summary

Adds SoftwareApplication structured data to the simulator tool — Google treats /simulate as the SaaS core of the site, not a generic HTML page. Schema includes a free Offer (key for discoverability vs paid-simulator competitors).

## Files changed

- `src/pages/simulate/index.astro` — +37 lines (JSON-LD block, `simulationsRun` inlining tweaked)
- `src/pages/ko/simulate/index.astro` — +36 lines (ko variant, same schema)

## Schema

```jsonc
{
  "@type": "SoftwareApplication",
  "applicationCategory": "FinanceApplication",
  "operatingSystem": "Web",
  "inLanguage": ["en", "ko"],
  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
  "featureList": [
    "240+ crypto pairs",      // from site-stats.json
    "N pre-built strategies", // from builder-presets.json (SSoT)
    "2+ years historical OHLCV data",
    "Realistic fees + funding rates",
    "No signup required"
  ]
}
```

## Why not aggregateRating

No real review flow yet. Fake ratings = Google penalty. Add later if we ship reviews.

## Test plan

- [x] `npm run build` → 1172 pages, 0 errors
- [x] `grep SoftwareApplication dist/simulate/index.html` → 1 match (EN)
- [x] `grep SoftwareApplication dist/ko/simulate/index.html` → 1 match (KO)
- [x] featureList numbers interpolate from site-stats.json + builder-presets.json (auto-updates with data refresh)
- [ ] Post-deploy: validate via [Google Rich Results Test](https://search.google.com/test/rich-results?url=https://pruviq.com/simulate)

## Non-goals

- screenshot / softwareRequirements / aggregateRating — follow-up
- WebApplication schema on `/crypto-trading-simulator.astro` — already has Article, separate PR if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)