### PR TITLE
fix(frontend): add missing /ko/compare/binance-vs-okx redirect

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -32,5 +32,9 @@
 # /ko/performance page exists — no redirect needed
 /ko/rankings /ko/strategies/ranking 301
 /ko/rankings/ /ko/strategies/ranking 301
-/ko/compare/binance-vs-okx /ko/fees 301
-/ko/compare/binance-vs-okx/ /ko/fees 301
+# /ko/compare/binance-vs-okx → /ko/fees handled by Astro.redirect() in
+# src/pages/ko/compare/binance-vs-okx.astro. Not mirrored here because
+# _redirects is in the automerge restricted-files list — keeping this
+# change out keeps the PR auto-mergeable. If direct-edge hits ever need
+# the Cloudflare layer (TOFU race before Astro resolves), add it in a
+# separate owner-approved PR.

--- a/public/_redirects
+++ b/public/_redirects
@@ -32,9 +32,3 @@
 # /ko/performance page exists — no redirect needed
 /ko/rankings /ko/strategies/ranking 301
 /ko/rankings/ /ko/strategies/ranking 301
-# /ko/compare/binance-vs-okx → /ko/fees handled by Astro.redirect() in
-# src/pages/ko/compare/binance-vs-okx.astro. Not mirrored here because
-# _redirects is in the automerge restricted-files list — keeping this
-# change out keeps the PR auto-mergeable. If direct-edge hits ever need
-# the Cloudflare layer (TOFU race before Astro resolves), add it in a
-# separate owner-approved PR.

--- a/public/_redirects
+++ b/public/_redirects
@@ -32,3 +32,5 @@
 # /ko/performance page exists — no redirect needed
 /ko/rankings /ko/strategies/ranking 301
 /ko/rankings/ /ko/strategies/ranking 301
+/ko/compare/binance-vs-okx /ko/fees 301
+/ko/compare/binance-vs-okx/ /ko/fees 301

--- a/src/pages/ko/compare/binance-vs-okx.astro
+++ b/src/pages/ko/compare/binance-vs-okx.astro
@@ -1,0 +1,3 @@
+---
+return Astro.redirect('/ko/fees', 301);
+---


### PR DESCRIPTION
## Summary

EN has `/compare/binance-vs-okx` (301 → `/fees`) but KO was missing the equivalent — Korean users landing on `/ko/compare/binance-vs-okx` (backlinks, social shares, stale sitemap entries) hit a 404.

## Files

- **NEW** `src/pages/ko/compare/binance-vs-okx.astro` — one-line `Astro.redirect('/ko/fees', 301)` mirroring the EN stub
- **UPDATED** `public/_redirects` — added 2 belt-and-suspenders edge lines (Cloudflare resolves before Astro route on direct hits)

## Rules honored

- CLAUDE.md 룰 1: dir under `src/pages/` needs index/redirect — new file satisfies it
- _redirects 규칙: only `Astro.redirect()` pages go in `_redirects` — new file is an Astro.redirect stub, so it qualifies

## Test plan

- [x] `npm run build` → 1173 pages (was 1172), 0 errors
- [x] `dist/ko/compare/binance-vs-okx/index.html` exists with `http-equiv="refresh"` + canonical → `/ko/fees`
- [x] `bash scripts/qa-redirects.sh` → PASS, 0 content conflicts
- [ ] Post-deploy: `curl -I https://pruviq.com/ko/compare/binance-vs-okx` → 301

🤖 Generated with [Claude Code](https://claude.com/claude-code)