### PR TITLE
fix(okx): parse confirm field + opt-in filter for unconfirmed candles

### DIFF
--- a/backend/okx/market_fetcher.py
+++ b/backend/okx/market_fetcher.py
@@ -47,6 +47,7 @@ class OkxCandle:
     close: float
     volume: float
     volume_ccy: float  # quote-currency volume (USDT for USDT-SWAP)
+    is_confirmed: bool  # OKX `confirm` == "1" → closed candle. False = still forming.
 
     @classmethod
     def from_row(cls, row: list) -> "OkxCandle":
@@ -54,6 +55,12 @@ class OkxCandle:
         # vol     = base currency volume (BTC for BTC-USDT-SWAP)
         # volCcy  = contract count
         # volCcyQuote = quote currency volume (USDT)
+        # confirm = "1" when the candle has closed (confirmed, immutable),
+        #           "0" when still forming. /market/candles returns the
+        #           forming candle as the first row in its newest-first
+        #           response — callers doing signal detection on the
+        #           final row would otherwise eat an unfinished bar.
+        confirm_str = str(row[8]) if len(row) > 8 else "1"
         return cls(
             ts_ms=int(row[0]),
             open=float(row[1]),
@@ -62,6 +69,7 @@ class OkxCandle:
             close=float(row[4]),
             volume=float(row[5]),
             volume_ccy=float(row[7]) if len(row) > 7 else float(row[6]),
+            is_confirmed=(confirm_str == "1"),
         )
 
 
@@ -174,11 +182,18 @@ class OkxMarketFetcher:
         symbol: str,
         interval: str = "1h",
         limit: int = 300,
+        include_unconfirmed: bool = True,
     ) -> list[OkxCandle]:
         """Fetch recent candles. Returned old→new (sorted).
 
         OKX /market/candles gives newest-first; we reverse before returning so
         strategy code can iterate chronologically.
+
+        `include_unconfirmed=True` (default) keeps the still-forming last
+        bar. Signal-detection code must either skip it (e.g. `idx = len(df)
+        - 2`) or pass `include_unconfirmed=False` so only closed candles
+        come back. Default stays True because we don't want to silently
+        drop the most-recent data for callers that handle it correctly.
         """
         inst_id = self.to_okx_inst_id(symbol)
         bar = self.to_okx_bar(interval)
@@ -192,6 +207,8 @@ class OkxMarketFetcher:
             )
         rows = data.get("data") or []
         candles = [OkxCandle.from_row(r) for r in rows]
+        if not include_unconfirmed:
+            candles = [c for c in candles if c.is_confirmed]
         candles.reverse()
         return candles
 
@@ -200,12 +217,17 @@ class OkxMarketFetcher:
         symbol: str,
         interval: str = "1h",
         limit: int = 300,
+        include_unconfirmed: bool = True,
     ) -> pd.DataFrame:
         """Return a DataFrame matching the Binance CSV schema used by
         DataManager/signal_scanner:
           columns: timestamp (UTC tz-aware), open, high, low, close, volume
+
+        See `fetch_candles` for the `include_unconfirmed` semantics.
         """
-        candles = await self.fetch_candles(symbol, interval, limit)
+        candles = await self.fetch_candles(
+            symbol, interval, limit, include_unconfirmed=include_unconfirmed
+        )
         if not candles:
             return pd.DataFrame(columns=["timestamp", "open", "high", "low", "close", "volume"])
         return pd.DataFrame(

--- a/backend/tests/test_okx_market_fetcher.py
+++ b/backend/tests/test_okx_market_fetcher.py
@@ -70,13 +70,81 @@ class TestOkxCandleParse:
         assert c.close == 102.0
         assert c.volume == 10.5
         assert c.volume_ccy == 1071.0  # from col-7 (volCcyQuote)
+        assert c.is_confirmed is True
 
     def test_7col_fallback(self):
-        # Legacy 7-column response — fall back to col-6
+        # Legacy 7-column response — fall back to col-6, and default
+        # is_confirmed=True since no confirm column is present.
         row = ["1700000000000", "100.0", "105.0", "95.0", "102.0",
                "10.5", "11.0"]
         c = OkxCandle.from_row(row)
         assert c.volume_ccy == 11.0
+        assert c.is_confirmed is True, "missing confirm col should default to True"
+
+    def test_unconfirmed_candle_flagged(self):
+        # OKX /market/candles returns the still-forming candle as the
+        # first row in its newest-first response, with confirm="0".
+        # Callers doing signal detection on the last row would otherwise
+        # eat an unfinished bar — is_confirmed must be False so they can
+        # skip it.
+        row = ["1700000000000", "100.0", "105.0", "95.0", "102.0",
+               "10.5", "11.0", "1071.0", "0"]
+        c = OkxCandle.from_row(row)
+        assert c.is_confirmed is False
+
+    def test_confirm_accepts_string_or_int(self):
+        # OKX sometimes serializes `confirm` as the string "1"/"0",
+        # sometimes as the raw int. Our parser coerces via str() so both
+        # forms collapse to the same boolean.
+        row_str = ["1700000000000", "1", "1", "1", "1", "1", "1", "1", "1"]
+        row_int = ["1700000000000", "1", "1", "1", "1", "1", "1", "1", 1]
+        assert OkxCandle.from_row(row_str).is_confirmed is True
+        assert OkxCandle.from_row(row_int).is_confirmed is True
+
+
+class TestFetchCandlesUnconfirmedFilter:
+    def test_include_unconfirmed_false_drops_forming_bar(self, monkeypatch):
+        """fetch_candles(include_unconfirmed=False) must strip the forming
+        bar so callers that use `df[-1]` don't read an in-progress candle."""
+        async def _run():
+            fetcher = OkxMarketFetcher()
+            try:
+                async def fake_get(path, params):
+                    return {
+                        "code": "0",
+                        "data": [
+                            # OKX returns newest-first; [0] is the still-forming
+                            # candle. Following rows are closed.
+                            ["1700000000000", "100", "105", "95", "102",
+                             "10", "11", "1020", "0"],
+                            ["1699999964000", "99", "101", "97", "100",
+                             "9",  "10", "900",  "1"],
+                            ["1699999928000", "98", "100", "96", "99",
+                             "8",  "9",  "800",  "1"],
+                        ],
+                    }
+
+                monkeypatch.setattr(fetcher, "_get_with_backoff", fake_get)
+
+                all_candles = await fetcher.fetch_candles(
+                    "BTCUSDT", "1h", 3, include_unconfirmed=True
+                )
+                confirmed_only = await fetcher.fetch_candles(
+                    "BTCUSDT", "1h", 3, include_unconfirmed=False
+                )
+                return all_candles, confirmed_only
+            finally:
+                await fetcher.close()
+
+        all_candles, confirmed_only = asyncio.run(_run())
+
+        assert len(all_candles) == 3
+        assert len(confirmed_only) == 2, (
+            "forming bar must be dropped when include_unconfirmed=False"
+        )
+        # Ordering guarantee preserved (old→new) in both cases.
+        assert all_candles[-1].is_confirmed is False
+        assert all(c.is_confirmed for c in confirmed_only)
 
 
 class TestThrottle:


### PR DESCRIPTION
## Summary

`OkxCandle.from_row` dropped OKX's `confirm` field (column 8). OKX returns the still-forming candle as the first row of its newest-first `/market/candles` response with `confirm="0"` — any caller using the last row directly reads a half-formed bar with mutating OHLC values.

signal_scanner's `idx = len(df) - 2` happens to skip it, but that's an invisible workaround; future callers would silently corrupt results.

## Changes

- `OkxCandle.is_confirmed: bool` — parsed from `confirm == "1"`; defaults True when column is absent (legacy 7-col rows).
- `fetch_candles` / `fetch_df` gain `include_unconfirmed: bool` parameter. Default `True` (backward-compatible); callers that want closed-only data pass `False`.
- Docstrings document the semantics.

## Non-goals

- No behaviour change for existing callers — signal_scanner still sees the same data.
- Doesn't touch `/history-candles` (that endpoint never returns a forming bar).

## Test plan

`backend/tests/test_okx_market_fetcher.py` — 19 tests total, all passing locally:

- [x] `test_unconfirmed_candle_flagged` — `confirm="0"` → `is_confirmed=False`
- [x] `test_confirm_accepts_string_or_int` — coerces either form
- [x] `test_9col_row` + `test_7col_fallback` — existing rows assert `is_confirmed=True`
- [x] `test_include_unconfirmed_false_drops_forming_bar` — 3 rows in (1 forming + 2 closed), filter returns 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)