### PR TITLE
ci(seo-check): bump Node 18→22 + --include=optional for tailwind-oxide native binding

### DIFF
--- a/.github/workflows/seo-check.yml
+++ b/.github/workflows/seo-check.yml
@@ -21,10 +21,17 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          # Bumped 18 → 22 to match the rest of CI (unit/e2e/visual) and
+          # avoid a long-standing npm optional-deps bug that left the
+          # @tailwindcss/oxide-linux-x64-gnu native binding uninstalled on
+          # Node 18 — every PR hit "Cannot find native binding" at build.
+          node-version: '22'
 
       - name: Install
-        run: npm ci
+        # --include=optional is a belt-and-suspenders guard so the native
+        # tailwind binding installs even if npm's optional-deps resolver
+        # regresses again (see npm/cli#4828).
+        run: npm ci --include=optional
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
## Summary

Unblocks automerge on recent PRs by fixing the perpetually-failing `seo-check` job.

## Problem

Every PR since Tailwind v4 landed has seen `seo-check` (the "Check titles & meta descriptions" CI job) fail with:

```
Error: Cannot find native binding.
Cannot find module '@tailwindcss/oxide-linux-x64-gnu'
```

Two compounding issues:
1. Node 18 hits [npm/cli#4828](https://github.com/npm/cli/issues/4828) more often — optional deps silently skipped on Linux runners.
2. `npm ci` doesn't always install optional platform-specific native bindings unless explicitly requested.

Main CI (unit/e2e/visual/validate) has been on Node 22 for months; seo-check was the last Node-18 holdout, which is why **only** it failed while everything else passed.

## Fix

- Bump `actions/setup-node@v4` to `node-version: '22'` (matches the rest of CI)
- Add `--include=optional` to `npm ci` as belt-and-suspenders if the resolver regresses again

## Why this matters now

Recent PRs #1211 (SEO JSON-LD) and #1213 (KO redirect) are currently blocked by this check even though it's unrelated to their content. Fixing the job unblocks the automerge cascade.

## Test plan

- [x] Local `npm run build` works (production builds are on Node 22)
- [ ] Post-merge: PRs #1211 and #1213 should auto-retry and pass seo-check on their next CI run (or label-toggle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)