### PR TITLE
fix(okx): Merkle audit hook for manual /execute/order path (closes audit gap)

### DIFF
--- a/backend/okx/orders.py
+++ b/backend/okx/orders.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import logging
 import math
+from datetime import datetime, timezone
 from typing import Optional
 
 from .client import OKXClient
@@ -211,6 +212,39 @@ async def execute_from_simulation(
                 f"SL/TP placement failed for {inst_id} (ordId={ord_id}), "
                 f"position closed as safety measure. Error: {algo_err}"
             )
+
+    # Moat-2: Merkle audit leaf for the manual /execute/order path.
+    # auto_executor records its own leaf (see auto_executor.py:677). Until
+    # this PR, manual orders went unrecorded — a gap users could point to
+    # to argue "the audit log is selective". Leaf pre-image here mirrors
+    # the auto-executor path exactly: session_id | ts_iso | inst_id |
+    # direction-in-OKX-terms | sz | entry_price | broker_code. Users can
+    # reproduce the hash off-line using the response dict below
+    # (`details.entry_price`, `details.inst_id`, etc.).
+    #
+    # NOTE: we use `current_price` (the mark price at order time) as the
+    # leaf's `fill_price`, NOT the actual OKX avgPx. That's a deliberate
+    # trade-off: avgPx requires a second OKX round-trip + a wait loop
+    # (auto_executor does it because it needs the number for SL/TP
+    # pricing; here we already set SL/TP from mark). Keeping it to
+    # mark-price keeps the manual path low-latency and the leaf pre-image
+    # is still derivable by the user from the response.
+    try:
+        from .merkle import record_order as _merkle_record
+        from .config import OKX_BROKER_CODE as _BROKER
+        _merkle_record(
+            session_id=session_id,
+            ts_iso=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            inst_id=inst_id,
+            side=side,
+            sz=sz,
+            fill_price=current_price,
+            broker_code=_BROKER or "",
+        )
+    except Exception as audit_err:
+        # Audit failure must not block the trading path — same invariant
+        # auto_executor honours. We log and move on.
+        logger.warning("merkle audit record failed (non-fatal): %s", audit_err)
 
     return {
         "order": order,

--- a/backend/tests/test_manual_order_merkle_audit.py
+++ b/backend/tests/test_manual_order_merkle_audit.py
@@ -1,0 +1,125 @@
+"""
+Merkle audit-log gap fix regression guard (PR 2026-04-20).
+
+Before this PR, only `auto_executor.py` recorded a Merkle leaf after a
+successful order — manual orders placed via `/execute/order` (routed
+through `okx.orders.execute_from_simulation`) completed silently with no
+`order_audit` row. That meant the daily Merkle root at
+`/trust/merkle/{YYYYMMDD}` was a selective summary: auto only, not all.
+A user executing manually had no way to prove their order hit the chain.
+
+Asserts:
+  1. `execute_from_simulation` now imports + calls `merkle.record_order`
+     after the market order succeeds.
+  2. The leaf pre-image matches auto-executor's canonical format — same
+     `session_id | ts_iso | inst_id | side | sz | fill_price |
+     broker_code` shape so users can reproduce it off-line.
+  3. Audit failure does NOT raise — the trading path must be uninterrupted
+     by a logging issue (same invariant auto-executor honours).
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import pytest
+
+ORDERS_SRC = (Path(__file__).resolve().parent.parent / "okx" / "orders.py").read_text()
+
+
+def test_orders_imports_record_order_from_merkle():
+    """Source-level: the import must live inside execute_from_simulation
+    (lazy import keeps module-load fast + avoids circular import with
+    storage.py which merkle.py depends on)."""
+    assert "from .merkle import record_order" in ORDERS_SRC, (
+        "execute_from_simulation must import merkle.record_order — "
+        "without it, manual /execute/order orders go unaudited"
+    )
+
+
+def test_orders_calls_record_order_after_place():
+    """The record_order call must come AFTER client.place_order() so we
+    only log orders that actually hit OKX. Logging a pre-submit payload
+    would record orders that never executed."""
+    place_pos = ORDERS_SRC.find("await client.place_order(")
+    record_pos = ORDERS_SRC.find("_merkle_record(")
+    assert 0 < place_pos < record_pos, (
+        "record_order must be called AFTER place_order succeeds; "
+        "record-before-place would log phantom orders"
+    )
+
+
+def test_leaf_preimage_matches_auto_executor_shape():
+    """The leaf pre-image must mirror auto_executor's exactly — same
+    7 fields in the same order — or the canonical leaf hash diverges
+    across the two code paths and users can't reliably verify
+    inclusion."""
+    # Grab the _merkle_record(...) block. The body contains a nested
+    # `datetime.now(timezone.utc)` paren, so a naive `.*?\)` regex would
+    # close early. Instead scan from `_merkle_record(` to the outer-paren
+    # match by counting depth.
+    start = ORDERS_SRC.find("_merkle_record(")
+    assert start > 0, "_merkle_record call not found"
+    depth = 0
+    open_pos = ORDERS_SRC.find("(", start)
+    i = open_pos
+    while i < len(ORDERS_SRC):
+        ch = ORDERS_SRC[i]
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                break
+        i += 1
+    assert depth == 0, "unbalanced parens in _merkle_record call"
+    body = ORDERS_SRC[open_pos + 1: i]
+    # Every canonical field must be a kwarg in the call
+    for field in ("session_id", "ts_iso", "inst_id", "side", "sz",
+                  "fill_price", "broker_code"):
+        assert f"{field}=" in body, (
+            f"{field} missing from manual-order leaf — pre-image would "
+            f"diverge from auto_executor, breaking user-side verification"
+        )
+
+
+def test_audit_failure_does_not_raise():
+    """The record_order call must live inside a try/except whose body
+    logs but swallows. Otherwise a broken audit path = dead trading
+    path, which is exactly the wrong failure mode for compliance
+    instrumentation."""
+    # Extract the block around _merkle_record
+    idx = ORDERS_SRC.find("_merkle_record(")
+    assert idx > 0
+    # Look ~1500 chars around the call for the try/except shape
+    window = ORDERS_SRC[max(0, idx - 800): idx + 800]
+    assert "try:" in window, "audit record must be inside a try block"
+    # Exception handler must log, not re-raise
+    assert re.search(
+        r"except\s+Exception\s+as\s+\w+:\s*\n\s*#.*\n\s*logger\.warning",
+        window,
+    ) or re.search(
+        r"except\s+Exception\s+as\s+\w+:[\s\S]{0,200}?logger\.(warning|error)",
+        window,
+    ), (
+        "audit record_order must log + swallow on failure — a raising "
+        "exception handler would kill the trading response after the "
+        "order actually placed"
+    )
+
+
+def test_still_uses_datetime_now_utc_not_naive():
+    """Audit timestamps must be timezone-aware UTC — a naive local clock
+    would produce leaves that disagree with auto_executor's UTC
+    timestamps, and external verifiers can't reproduce them without
+    knowing the server's local TZ."""
+    # The record call region should use datetime.now(timezone.utc)
+    idx = ORDERS_SRC.find("_merkle_record(")
+    window = ORDERS_SRC[max(0, idx - 400): idx + 400]
+    assert "datetime.now(timezone.utc)" in window, (
+        "audit leaf ts must use datetime.now(timezone.utc).isoformat() — "
+        "naive `datetime.now()` drifts with server TZ"
+    )


### PR DESCRIPTION
## Summary

Closes the Merkle audit-log gap: until now, only auto-executed orders were recorded in `order_audit`, leaving manual `/execute/order` trades invisible to the daily root at `/trust/merkle/{YYYYMMDD}`. The claim "we record every order" didn't hold because the manual path never called `merkle.record_order`.

Fix: one hook call in `backend/okx/orders.py:execute_from_simulation`, after SL/TP placement succeeds.

## Why not a bigger audit-log feature

The `order_audit` table, Merkle root endpoint, and leaf pre-image format were all shipped in Moat-2 — this PR is just the missing wire-up to the second code path. Not a new feature, a bug fix.

## Leaf pre-image (stable forever per merkle.py docstring)

```
sha256("session_id|ts_iso|inst_id|side|sz|fill_price|broker_code")
```

Same 7 fields, same order, same separator as `auto_executor.py:677` — users' existing off-line verifier scripts keep working.

## Trade-off: current_price vs avgPx

`auto_executor.py` waits 1-2s after `place_order` then queries OKX for actual `avgPx` because it needs the number for SL/TP sizing. The manual path already sets SL/TP from `current_price` (mark) before submitting, so the second OKX round-trip buys nothing. Documented inline in `orders.py`. Users verify using `response.details.entry_price`.

## Audit-path safety

Wrapped in `try/except Exception -> logger.warning` — same invariant as auto_executor: an audit failure must never kill a successful trade's 200 response. Covered by test `test_audit_failure_does_not_raise`.

## Test plan

`backend/tests/test_manual_order_merkle_audit.py` — 5 tests, all pass:

- [x] `test_orders_imports_record_order_from_merkle`
- [x] `test_orders_calls_record_order_after_place` (record AFTER place, never before)
- [x] `test_leaf_preimage_matches_auto_executor_shape` (paren-depth scan, not regex — handles nested `datetime.now(...)`)
- [x] `test_audit_failure_does_not_raise`
- [x] `test_still_uses_datetime_now_utc_not_naive` (tz-aware UTC)

## Non-goals

- Does NOT backfill historical manual orders (the daily root at `/trust/merkle/{old_date}` stays as-is)
- Does NOT change `auto_executor.py`'s leaf shape
- Does NOT add new audit fields (stable-forever commitment in merkle.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)