### PR TITLE
fix(ci): repair deploy-backend.yml YAML (resolves task #11, not a GitHub bug)

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -298,11 +298,15 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           [ -z "$TG_TOKEN" ] || [ -z "$TG_CHAT" ] && exit 0
-          MSG="🔁 PRUVIQ backend-deploy health-gate FAILED — auto-rollback attempted.
-Run: ${RUN_URL}
-Check ssh DO 'journalctl -u pruviq-api -n 100' for root cause."
+          # Single-line MSG on purpose: the previous multi-line form had
+          # line 2-3 at column 1 which escaped YAML's `run: |` block
+          # scalar, producing "workflow file issue" parse failures on
+          # every main push + schedule + workflow_dispatch since PR #1194
+          # merged at 2026-04-19 12:52 UTC. Escape newlines inline with
+          # \n so Telegram still shows line breaks.
+          MSG=$'🔁 PRUVIQ backend-deploy health-gate FAILED — auto-rollback attempted.\nRun: '"${RUN_URL}"$'\nCheck ssh DO `journalctl -u pruviq-api -n 100` for root cause.'
           curl -sf -m 10 -X POST "https://api.telegram.org/bot${TG_TOKEN}/sendMessage" \
-            -d chat_id="${TG_CHAT}" -d text="${MSG}" || true
+            -d chat_id="${TG_CHAT}" --data-urlencode text="${MSG}" || true
 
       - name: Post-deploy sanity via public endpoint
         if: steps.guard.outputs.skip != 'true' && steps.drift.outputs.skip != 'true'


### PR DESCRIPTION
## TL;DR

Task #11 was misdiagnosed for 8 hours. **`deploy-backend.yml` has a YAML syntax error** — the Telegram alert MSG string had lines at column-0 that broke out of the `run: |` block scalar. Once YAML doesn't parse, GitHub silently skips push/schedule events and returns 422 on `workflow_dispatch`.

Three earlier fix attempts missed this because they didn't touch the broken lines:
- #1207 comment edit — unrelated lines
- API disable/enable — YAML still broken
- #1217 file rename — copied the broken content to a new filename

## Evidence

```bash
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-backend.yml'))"
yaml.scanner.ScannerError: while scanning a simple key
  in ".github/workflows/deploy-backend.yml", line 303, column 1
  could not find expected ':'
```

The broken section (pre-fix):
```yaml
run: |
  [ -z "$TG_TOKEN" ] || [ -z "$TG_CHAT" ] && exit 0
  MSG="🔁 PRUVIQ backend-deploy health-gate FAILED — auto-rollback attempted.
Run: ${RUN_URL}                    ← column 0, escapes block scalar
Check ssh DO 'journalctl...'"      ← column 0, YAML tries to parse as mapping
```

## Fix

One-liner using `$'...\n...'` ANSI-C escape so the MSG never needs a continuation line. Added `--data-urlencode` on curl so Telegram still renders line breaks.

## Verification

- [x] `yaml.safe_load` parses clean
- [x] All 3 triggers recognized (`push`, `schedule`, `workflow_dispatch`)
- [x] `pytest tests/test_deploy_rollback_yaml.py tests/test_dead_units_and_smoke.py` → 10/10 green (no regression on rollback step structure)

## Expected post-merge behaviour

| Signal | Before | After |
|--------|--------|-------|
| push to main fires workflow | ❌ "workflow file issue" | ✅ runs |
| schedule cron `*/30` | ❌ silent | ✅ fires |
| `workflow_dispatch` API | ❌ 422 | ✅ 204 |

## Impact

Once this merges, backend/ PRs will auto-deploy again. The manual SSH deploy recipe stays documented in `memory/project_audit_sweep_20260419.md` as a break-glass, but won't be needed for routine deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)