### PR TITLE
feat(observability): OHLCV per-symbol failure classification + Grafana alerts

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -923,6 +923,47 @@ async def health():
     )
 
 
+_OHLCV_STATUS_FILE = Path(
+    os.environ.get(
+        "PRUVIQ_OHLCV_STATUS_FILE",
+        "/opt/pruviq/shared/ohlcv_last_run.json",
+    )
+)
+
+
+def _refresh_ohlcv_metrics_from_status_file() -> None:
+    """Pull the OHLCV refresh summary written by update_ohlcv_okx.py and
+    expose it as Prometheus gauges. Called lazily from /metrics so the
+    data is at most one scrape interval stale.
+
+    Swallows all errors — this is an observability channel, not a
+    critical path. If the file is missing or corrupt the metrics just
+    stay at whatever they were previously (Grafana's staleness check on
+    `pruviq_ohlcv_last_run_timestamp_seconds` catches that)."""
+    if not _PROM_AVAILABLE:
+        return
+    try:
+        if not _OHLCV_STATUS_FILE.exists():
+            return
+        raw = json.loads(_OHLCV_STATUS_FILE.read_text())
+    except Exception:
+        return
+
+    ts = raw.get("timestamp")
+    if isinstance(ts, (int, float)):
+        _pm.OHLCV_LAST_RUN_TIMESTAMP.set(float(ts))
+    updated = raw.get("total_updated")
+    if isinstance(updated, int):
+        _pm.OHLCV_LAST_RUN_UPDATED.set(updated)
+
+    failures = raw.get("failures_by_reason") or {}
+    if isinstance(failures, dict):
+        # Zero-out known buckets first so a reason that went 5→0 in the
+        # latest run is reflected instead of leaving the old label at 5.
+        for reason in ("rate_limit", "network", "http_error", "delisted", "other"):
+            _pm.OHLCV_LAST_RUN_ERRORS.labels(reason=reason).set(float(failures.get(reason, 0)))
+
+
 @app.get("/metrics")
 async def metrics_endpoint():
     """Prometheus exposition. Safe to hit every 15-60s (Grafana Cloud
@@ -931,6 +972,9 @@ async def metrics_endpoint():
     concern later, add X-Metrics-Token header gate."""
     if not _PROM_AVAILABLE:
         raise HTTPException(503, "Prometheus instrumentation not available")
+    # Pull OHLCV status right before rendering so the gauge reflects the
+    # most recent one-shot run, not process-startup state.
+    _refresh_ohlcv_metrics_from_status_file()
     body, content_type = _pm.render_exposition()
     return Response(content=body, media_type=content_type)
 

--- a/backend/api/metrics.py
+++ b/backend/api/metrics.py
@@ -106,6 +106,33 @@ AUTO_SESSIONS_ENABLED = Gauge(
 )
 
 
+# ── OHLCV refresh observability (2026-04-20) ──────────────────
+#
+# The OHLCV update script (update_ohlcv_okx.py) runs every 4h as a
+# one-shot systemd oneshot. Because it isn't a long-lived process, it
+# can't host a /metrics endpoint of its own. Instead it writes a status
+# JSON at PRUVIQ_OHLCV_STATUS_FILE; /metrics on this API process reads
+# it (via _refresh_ohlcv_metrics_from_status_file below) and re-emits
+# as gauges so Alloy/Prometheus/Grafana can alert on staleness or
+# per-reason failure surges.
+
+OHLCV_LAST_RUN_TIMESTAMP = Gauge(
+    "pruviq_ohlcv_last_run_timestamp_seconds",
+    "Unix timestamp of the last completed OHLCV refresh run",
+)
+
+OHLCV_LAST_RUN_ERRORS = Gauge(
+    "pruviq_ohlcv_last_run_failures",
+    "Per-symbol failures from the last OHLCV refresh run, labeled by reason",
+    ["reason"],
+)
+
+OHLCV_LAST_RUN_UPDATED = Gauge(
+    "pruviq_ohlcv_last_run_updated_symbols",
+    "How many symbol CSVs actually grew in the last refresh (progress signal)",
+)
+
+
 def render_exposition() -> tuple[bytes, str]:
     """Return (body, content_type) for the /metrics endpoint."""
     return generate_latest(), CONTENT_TYPE_LATEST

--- a/backend/deploy/grafana/alerts-pruviq-api.yaml
+++ b/backend/deploy/grafana/alerts-pruviq-api.yaml
@@ -245,3 +245,97 @@ groups:
           severity: warning
           service: pruviq-api
           component: sqlite
+
+      # ─────────────────────────────────────────────────────────
+      # 6. OHLCV refresh stale — last successful run older than 5h.
+      # Timer is every 4h, so >5h = one full cycle missed. Stronger
+      # signal than counting errors (catches "script stopped running
+      # entirely", which no error counter would detect).
+      # ─────────────────────────────────────────────────────────
+      - uid: pruviq_ohlcv_stale
+        title: PruviqOhlcvStale
+        condition: C
+        data:
+          - refId: A
+            queryType: ""
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: ${DS_PROMETHEUS_UID}
+            model:
+              # time() is seconds since epoch; timestamp gauge is also
+              # epoch seconds. Difference > 18000 = 5 hours.
+              expr: (time() - pruviq_ohlcv_last_run_timestamp_seconds)
+              intervalMs: 60000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            queryType: ""
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator: { params: [18000], type: gt }
+                  operator: { type: and }
+                  query: { params: [C] }
+                  reducer: { params: [], type: last }
+                  type: query
+              datasource: { type: __expr__, uid: __expr__ }
+              expression: A
+              refId: C
+              type: threshold
+        noDataState: Alerting
+        execErrState: Error
+        for: 10m
+        annotations:
+          summary: "OHLCV refresh hasn't run for 5+ hours"
+          description: "pruviq-update-ohlcv timer (every 4h) appears stopped. Check `ssh DO 'systemctl status pruviq-update-ohlcv.timer'` and the status file at /opt/pruviq/shared/ohlcv_last_run.json."
+        labels:
+          severity: warning
+          service: pruviq-api
+          component: ohlcv
+
+      # ─────────────────────────────────────────────────────────
+      # 7. OHLCV per-symbol failure surge — rate_limit spike.
+      # The script tolerates per-symbol failures (keeps going), but a
+      # sustained rate_limit count means we're hitting OKX budget
+      # ceiling or the window_sec in market_fetcher needs tuning.
+      # Threshold 20 = ~10% of 238 symbols, tuned to detect systemic
+      # 429 vs 1-2 transient ones.
+      # ─────────────────────────────────────────────────────────
+      - uid: pruviq_ohlcv_rate_limit_surge
+        title: PruviqOhlcvRateLimitSurge
+        condition: C
+        data:
+          - refId: A
+            queryType: ""
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: ${DS_PROMETHEUS_UID}
+            model:
+              expr: pruviq_ohlcv_last_run_failures{reason="rate_limit"}
+              intervalMs: 60000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            queryType: ""
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator: { params: [20], type: gt }
+                  operator: { type: and }
+                  query: { params: [C] }
+                  reducer: { params: [], type: last }
+                  type: query
+              datasource: { type: __expr__, uid: __expr__ }
+              expression: A
+              refId: C
+              type: threshold
+        noDataState: OK
+        execErrState: Error
+        for: 5m
+        annotations:
+          summary: "OHLCV refresh: >20 symbols hit rate_limit last run"
+          description: "OKX 429s dominated the last OHLCV refresh — either OKX tightened their budget or our window_sec in okx/market_fetcher.py is too aggressive."
+        labels:
+          severity: warning
+          service: pruviq-api
+          component: ohlcv

--- a/backend/scripts/update_ohlcv_okx.py
+++ b/backend/scripts/update_ohlcv_okx.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import logging
 import os
 import sys
@@ -31,6 +32,7 @@ import urllib.request
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import httpx
 import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -40,6 +42,38 @@ logger = logging.getLogger("pruviq.update_ohlcv_okx")
 
 CSV_HEADER = "timestamp,open,high,low,close,volume"
 OKX_INSTRUMENTS_URL = f"{OKX_PUBLIC_BASE}/api/v5/public/instruments?instType=SWAP"
+
+# 2026-04-20: per-symbol failure observability.
+# See api/main.py:_refresh_ohlcv_metrics_from_status_file for the consumer.
+OHLCV_STATUS_FILE = Path(
+    os.environ.get(
+        "PRUVIQ_OHLCV_STATUS_FILE",
+        "/opt/pruviq/shared/ohlcv_last_run.json",
+    )
+)
+
+
+def _classify_failure(exc: Exception) -> str:
+    """Map an exception to one of 5 bounded reasons for Prometheus.
+
+    Keep cardinality tight — adding a new bucket means updating the
+    zero-fill list in api/main.py too (test_ohlcv_failure_classification
+    ::test_bounded_cardinality enforces this).
+    """
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = getattr(exc.response, "status_code", 0) if exc.response is not None else 0
+        if status == 429:
+            return "rate_limit"
+        if 400 <= status < 600:
+            return "http_error"
+    if isinstance(exc, (httpx.ConnectError, httpx.ReadError, httpx.RemoteProtocolError,
+                        httpx.TimeoutException, asyncio.TimeoutError, ConnectionError)):
+        return "network"
+    if isinstance(exc, RuntimeError):
+        msg = str(exc).lower()
+        if "code" in msg and ("51000" in msg or "delisted" in msg or "not exist" in msg):
+            return "delisted"
+    return "other"
 
 
 def fetch_okx_usdt_swap_symbols(timeout: float = 15.0) -> set[str]:
@@ -251,6 +285,20 @@ async def run(args: argparse.Namespace) -> int:
     total_new_bars = 0
     total_seeded = 0
     errors = 0
+    failures_by_reason: dict[str, int] = {}
+    failed_symbols: list[dict] = []
+
+    def _record_failure(symbol: str, exc: Exception) -> None:
+        nonlocal errors
+        errors += 1
+        reason = _classify_failure(exc)
+        failures_by_reason[reason] = failures_by_reason.get(reason, 0) + 1
+        failed_symbols.append({
+            "symbol": symbol,
+            "reason": reason,
+            "error_type": type(exc).__name__,
+        })
+        print(f"  {symbol}: ERROR[{reason}] {type(exc).__name__}: {exc}")
 
     async with OkxMarketFetcher() as fetcher:
         for csv_path, symbol in targets_update:
@@ -261,8 +309,7 @@ async def run(args: argparse.Namespace) -> int:
                     total_new_bars += n
                     print(f"  update {symbol}: +{n} bars")
             except Exception as e:
-                errors += 1
-                print(f"  update {symbol}: ERROR {type(e).__name__}: {e}")
+                _record_failure(symbol, e)
 
         for symbol in seed_targets:
             try:
@@ -276,12 +323,37 @@ async def run(args: argparse.Namespace) -> int:
                 else:
                     print(f"  seed {symbol}: (no data returned)")
             except Exception as e:
-                errors += 1
-                print(f"  seed {symbol}: ERROR {type(e).__name__}: {e}")
+                _record_failure(symbol, e)
 
+    # Write summary JSON so api/main.py /metrics can re-emit as gauges.
+    # Swallow IO errors — the data (CSVs) is already on disk; observability
+    # is secondary and must never fail the run.
+    status = {
+        "timestamp": time.time(),
+        "iso": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "targets_update": len(targets_update),
+        "targets_seed": len(seed_targets),
+        "total_updated": total_updated,
+        "total_seeded": total_seeded,
+        "total_new_bars": total_new_bars,
+        "errors": errors,
+        "failures_by_reason": failures_by_reason,
+        "failed_symbols": failed_symbols[:50],
+        "dry_run": bool(args.dry_run),
+    }
+    if not args.dry_run:
+        try:
+            OHLCV_STATUS_FILE.parent.mkdir(parents=True, exist_ok=True)
+            OHLCV_STATUS_FILE.write_text(json.dumps(status, indent=2))
+            print(f"  status → {OHLCV_STATUS_FILE}")
+        except OSError as e:
+            print(f"  WARN: could not write status file: {e}")
+
+    summary_failures = " ".join(f"{k}={v}" for k, v in sorted(failures_by_reason.items()))
     print(
         f"\nDone: updated={total_updated}, seeded={total_seeded}, "
         f"new_bars={total_new_bars}, errors={errors}"
+        + (f" [{summary_failures}]" if summary_failures else "")
     )
     if args.dry_run:
         print("(dry run — no files modified)")

--- a/backend/tests/test_ohlcv_failure_classification.py
+++ b/backend/tests/test_ohlcv_failure_classification.py
@@ -1,0 +1,173 @@
+"""
+Regression guard for OHLCV per-symbol failure classification + status file.
+
+Covers the 2026-04-20 feature (update_ohlcv_okx.py):
+  - `_classify_failure` maps exceptions to one of 5 bounded buckets
+  - The classify helper is used (not shadowed by future refactors)
+  - `/metrics` gauge refresh helper pulls the status file if present
+    and zero-fills missing reasons (prevents stale labels)
+
+Not exercised here: the full end-to-end refresh against OKX. That path
+is covered by the existing `test_okx_market_fetcher.py` live suite.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import httpx
+import pytest
+
+
+def _import_script_module():
+    """Import `update_ohlcv_okx` as a module without running main()."""
+    import importlib.util
+    script = Path(__file__).parent.parent / "scripts" / "update_ohlcv_okx.py"
+    spec = importlib.util.spec_from_file_location("update_ohlcv_okx_test", script)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestClassifyFailure:
+    """_classify_failure must only ever return one of 5 known buckets.
+    This keeps Prometheus label cardinality bounded."""
+
+    def setup_method(self):
+        self.mod = _import_script_module()
+
+    def test_rate_limit_on_429(self):
+        req = httpx.Request("GET", "https://www.okx.com/api/v5/market/candles")
+        resp = httpx.Response(429, request=req)
+        exc = httpx.HTTPStatusError("429", request=req, response=resp)
+        assert self.mod._classify_failure(exc) == "rate_limit"
+
+    def test_http_error_on_5xx(self):
+        req = httpx.Request("GET", "https://www.okx.com")
+        resp = httpx.Response(503, request=req)
+        exc = httpx.HTTPStatusError("503", request=req, response=resp)
+        assert self.mod._classify_failure(exc) == "http_error"
+
+    def test_http_error_on_4xx_non_429(self):
+        req = httpx.Request("GET", "https://www.okx.com")
+        resp = httpx.Response(404, request=req)
+        exc = httpx.HTTPStatusError("404", request=req, response=resp)
+        assert self.mod._classify_failure(exc) == "http_error"
+
+    def test_network_on_timeout(self):
+        exc = httpx.ReadTimeout("timed out")
+        assert self.mod._classify_failure(exc) == "network"
+
+    def test_network_on_connect_error(self):
+        exc = httpx.ConnectError("connect refused")
+        assert self.mod._classify_failure(exc) == "network"
+
+    def test_network_on_asyncio_timeout(self):
+        exc = asyncio.TimeoutError()
+        assert self.mod._classify_failure(exc) == "network"
+
+    def test_delisted_from_okx_code(self):
+        exc = RuntimeError("OKX market error code=51000 msg=Instrument not exist")
+        assert self.mod._classify_failure(exc) == "delisted"
+
+    def test_other_as_fallback(self):
+        exc = ValueError("unexpected shape")
+        assert self.mod._classify_failure(exc) == "other"
+
+    def test_bounded_cardinality(self):
+        """Every reason this classifier can return must be in the 5-bucket
+        set. If someone adds a new bucket they must update the zero-fill
+        list in api/main.py:_refresh_ohlcv_metrics_from_status_file too —
+        this test + the matching list comparison keeps the two in sync."""
+        expected = {"rate_limit", "network", "http_error", "delisted", "other"}
+        main_src = (Path(__file__).parent.parent / "api" / "main.py").read_text()
+        # Extract the reason tuple from main.py's zero-fill loop
+        # (inline check — tolerates formatting variation but requires the
+        # canonical set to appear as a single parenthesized sequence).
+        import re
+        match = re.search(
+            r'for reason in \(([^)]+)\):',
+            main_src,
+        )
+        assert match, "zero-fill loop pattern not found in api/main.py"
+        reasons_in_main = {
+            r.strip().strip('"').strip("'") for r in match.group(1).split(",")
+        }
+        assert reasons_in_main == expected, (
+            f"main.py zero-fill buckets {reasons_in_main} diverged from "
+            f"classifier buckets {expected}. Update both or Grafana labels drift."
+        )
+
+
+class TestMetricsEndpointOhlcvRefresh:
+    """The /metrics endpoint must surface ohlcv status file contents as
+    gauges so Grafana can alert on staleness or failure surge."""
+
+    def test_refresh_reads_status_file(self, monkeypatch, tmp_path):
+        status_file = tmp_path / "ohlcv_last_run.json"
+        status_file.write_text(json.dumps({
+            "timestamp": 1713600000.0,
+            "total_updated": 230,
+            "failures_by_reason": {"rate_limit": 2, "network": 1},
+        }))
+        monkeypatch.setenv("PRUVIQ_OHLCV_STATUS_FILE", str(status_file))
+
+        import importlib
+        import api.main as main
+        importlib.reload(main)
+        main._refresh_ohlcv_metrics_from_status_file()
+
+        # Verify the gauges got set. `_pm` is the metrics module alias.
+        pm = main._pm
+        # prometheus_client's Gauge stores per-label values; read back via
+        # `_value.get()` on the default-no-label gauge and `.labels().get()`
+        # for the labeled one.
+        ts_value = pm.OHLCV_LAST_RUN_TIMESTAMP._value.get()
+        assert ts_value == 1713600000.0
+
+        updated_value = pm.OHLCV_LAST_RUN_UPDATED._value.get()
+        assert updated_value == 230.0
+
+        # Failure gauges: all 5 buckets must have a value (zero-fill)
+        for reason in ("rate_limit", "network", "http_error", "delisted", "other"):
+            v = pm.OHLCV_LAST_RUN_ERRORS.labels(reason=reason)._value.get()
+            assert v is not None, f"{reason} bucket not populated"
+
+        # Specific known values
+        rate = pm.OHLCV_LAST_RUN_ERRORS.labels(reason="rate_limit")._value.get()
+        assert rate == 2.0
+        net = pm.OHLCV_LAST_RUN_ERRORS.labels(reason="network")._value.get()
+        assert net == 1.0
+        # Missing reasons → zero (not stale)
+        http_err = pm.OHLCV_LAST_RUN_ERRORS.labels(reason="http_error")._value.get()
+        assert http_err == 0.0
+
+    def test_refresh_noop_when_file_missing(self, monkeypatch, tmp_path):
+        """If the file doesn't exist, the helper must not raise — it's an
+        observability channel, failures there must never affect /metrics
+        availability."""
+        monkeypatch.setenv(
+            "PRUVIQ_OHLCV_STATUS_FILE", str(tmp_path / "absent.json"),
+        )
+        import importlib
+        import api.main as main
+        importlib.reload(main)
+        # Should not raise
+        main._refresh_ohlcv_metrics_from_status_file()
+
+    def test_refresh_noop_on_corrupt_file(self, monkeypatch, tmp_path):
+        """Corrupt JSON should not crash /metrics either."""
+        status_file = tmp_path / "ohlcv_last_run.json"
+        status_file.write_text("{not valid json")
+        monkeypatch.setenv("PRUVIQ_OHLCV_STATUS_FILE", str(status_file))
+        import importlib
+        import api.main as main
+        importlib.reload(main)
+        main._refresh_ohlcv_metrics_from_status_file()  # must not raise


### PR DESCRIPTION
## Closes data-pipeline audit HIGH

> "OHLCV per-symbol failure detection — one bad symbol's 429 today stops the whole OHLCV refresh silently."

Per-audit finding from `memory/project_audit_sweep_20260419.md`.

## Changes

### `backend/scripts/update_ohlcv_okx.py`
- `_classify_failure()` maps exceptions → 5 bounded reasons (`rate_limit` / `network` / `http_error` / `delisted` / `other`)
- Per-symbol failures now recorded into `failures_by_reason` + `failed_symbols[:50]`
- After run, writes status JSON to `PRUVIQ_OHLCV_STATUS_FILE` (default `/opt/pruviq/shared/ohlcv_last_run.json`)
- Write failure swallowed — observability must never break data path
- Exit code semantics unchanged (0/2)

### `backend/api/metrics.py`
3 new gauges:
- `pruviq_ohlcv_last_run_timestamp_seconds` (staleness)
- `pruviq_ohlcv_last_run_failures{reason=}` (per-reason count)
- `pruviq_ohlcv_last_run_updated_symbols` (progress)

### `backend/api/main.py`
`/metrics` endpoint reads status file on each scrape, zero-fills all 5 reason buckets so `rate_limit went 5→0` registers correctly.

### `backend/deploy/grafana/alerts-pruviq-api.yaml`
+2 alert rules (now 7 total):
- `PruviqOhlcvStale`: `time() - last_run_ts > 5h` — catches "timer stopped entirely"
- `PruviqOhlcvRateLimitSurge`: `failures{reason="rate_limit"} > 20` — catches OKX budget pressure

## Why file-based bridge (not pushgateway / Alloy textfile collector)

Refresh is a systemd one-shot — can't host `/metrics` itself.

| Option | Con |
|--------|-----|
| Pushgateway | New infra dep, auth config |
| Alloy textfile collector | Requires DO `/etc/alloy/config.alloy` edit |
| **File + API re-emit** | Zero new deps; API already serves `/metrics` + has filesystem access |

## Test plan

- [x] `pytest tests/test_ohlcv_failure_classification.py` → **12/12 pass**
  - 9 classification tests (all 5 buckets + edge types)
  - 1 bounded-cardinality guard (greps api/main.py zero-fill list; keeps in sync)
  - 3 metrics-refresh tests (happy / missing / corrupt)
- [x] `pytest tests/ -m "not okx_live"` → **159/159 pass** (regression 0)
- [x] `yaml.safe_load('alerts-pruviq-api.yaml')` → 7 rules
- [ ] Post-merge: next 4h timer writes status file → `/metrics` surfaces gauges → Alloy scrapes → Grafana alert activates

🤖 Generated with [Claude Code](https://claude.com/claude-code)