### PR TITLE
content: update methodology/disclaimers from Binance→OKX (post-migration cleanup)

### DIFF
--- a/src/components/ChartPanel.tsx
+++ b/src/components/ChartPanel.tsx
@@ -238,7 +238,7 @@ export default function ChartPanel({
           <span class="font-mono text-sm font-bold">{chartSymbol}</span>
           <span class="text-[--color-text-muted] text-xs">{timeframe}</span>
           <span class="text-[--color-text-muted] text-[9px] font-mono opacity-50 hidden sm:inline">
-            Binance Futures
+            OKX USDT-SWAP
           </span>
         </div>
         <div class="flex items-center gap-1.5">

--- a/src/components/SimulatorPage.tsx
+++ b/src/components/SimulatorPage.tsx
@@ -122,7 +122,7 @@ const L = {
       "Past performance does not guarantee future results. This is not financial advice.",
     simNotes: [
       "No duplicate entries — if a coin already has an open position, new signals for that coin are skipped until it closes.",
-      "Fees included — results are net of trading fees (0.04%/side) and funding (0.01%/8h).",
+      "Fees included — results are net of trading fees (0.05%/side) and funding (0.01%/8h).",
       "Slippage 0.02% per side included — real fills may still differ from simulated prices.",
     ],
     simNotesTitle: "How it works",
@@ -339,7 +339,7 @@ const L = {
       "과거 성과가 미래 수익을 보장하지 않습니다. 이것은 투자 조언이 아닙니다.",
     simNotes: [
       "중복 진입 불가 — 코인에 열린 포지션이 있으면 청산될 때까지 새 신호는 무시됩니다.",
-      "수수료 포함 — 결과는 거래 수수료(0.04%/편도) + 펀딩(0.01%/8h) 차감 후 순수익입니다.",
+      "수수료 포함 — 결과는 거래 수수료(0.05%/편도) + 펀딩(0.01%/8h) 차감 후 순수익입니다.",
       "슬리피지 0.02%/편도 포함 — 실제 체결가는 시뮬레이션과 다를 수 있습니다.",
     ],
     simNotesTitle: "시뮬레이션 안내",

--- a/src/components/SimulatorPreview.tsx
+++ b/src/components/SimulatorPreview.tsx
@@ -114,7 +114,7 @@ export default function SimulatorPreview() {
         <div class="flex items-center gap-1.5">
           <span class="w-1.5 h-1.5 rounded-full bg-[--color-up] animate-pulse"></span>
           <span class="text-[--color-text-muted] text-[10px]">
-            1H · Binance Futures
+            1H · OKX USDT-SWAP
           </span>
         </div>
       </div>

--- a/src/components/StrategyComparison.tsx
+++ b/src/components/StrategyComparison.tsx
@@ -81,7 +81,7 @@ const labels = {
     noData: "Run comparison to see results.",
     error: "Failed to load strategies.",
     disclaimer:
-      "* All strategies simulated on 50 coins with identical fees (0.04% + 0.02% slippage). Past performance does not guarantee future results.",
+      "* All strategies simulated on 50 coins with identical fees (0.05% + 0.02% slippage). Past performance does not guarantee future results.",
     computeTime: "Computed in",
     useDefault: "Use each strategy's default SL/TP",
     view: "Details",
@@ -108,7 +108,7 @@ const labels = {
     noData: "비교를 실행하면 결과가 표시됩니다.",
     error: "전략 데이터 로딩 실패.",
     disclaimer:
-      "* 모든 전략은 50개 코인, 동일한 수수료(0.04% + 0.02% 슬리피지)로 시뮬레이션됩니다. 과거 성과는 미래 결과를 보장하지 않습니다.",
+      "* 모든 전략은 50개 코인, 동일한 수수료(0.05% + 0.02% 슬리피지)로 시뮬레이션됩니다. 과거 성과는 미래 결과를 보장하지 않습니다.",
     computeTime: "계산 시간",
     useDefault: "각 전략의 기본 SL/TP 사용",
     view: "자세히 보기",

--- a/src/components/StrategyDemo.tsx
+++ b/src/components/StrategyDemo.tsx
@@ -57,7 +57,7 @@ const labels = {
     retry: "Retry",
     noData: "No data for this combination.",
     disclaimer:
-      "* Simulation includes 0.04% futures fees + 0.02% slippage per trade. Past performance does not guarantee future results.",
+      "* Simulation includes 0.05% futures fees + 0.02% slippage per trade. Past performance does not guarantee future results.",
     ctaTitle: "Run this strategy live?",
     ctaDesc:
       "You'll need an exchange account. Sign up through PRUVIQ to save on fees.",
@@ -78,7 +78,7 @@ const labels = {
     retry: "다시 시도",
     noData: "이 조합에 대한 데이터가 없습니다.",
     disclaimer:
-      "* 시뮬레이션은 0.04% 선물 수수료 + 0.02% 슬리피지를 포함합니다. 과거 성과는 미래 결과를 보장하지 않습니다.",
+      "* 시뮬레이션은 0.05% 선물 수수료 + 0.02% 슬리피지를 포함합니다. 과거 성과는 미래 결과를 보장하지 않습니다.",
     ctaTitle: "이 전략을 실제로 실행하려면?",
     ctaDesc:
       "거래소 계정이 필요합니다. PRUVIQ를 통해 가입하면 수수료를 절약할 수 있습니다.",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -327,7 +327,7 @@ export const en = {
   "demo.error": "Failed to load demo data.",
   "demo.no_data": "No data for this combination.",
   "demo.disclaimer":
-    "* Default parameter (SL=10%, TP=8%) is the current verified live setting. Simulation includes 0.04% futures fees + 0.02% slippage per trade. Past performance does not guarantee future results.",
+    "* Default parameter (SL=10%, TP=8%) is the current verified live setting. Simulation includes 0.05% futures fees + 0.02% slippage per trade. Past performance does not guarantee future results.",
   "demo.live_badge": "CURRENT LIVE SETTINGS",
   "demo.total_return": "Total Return",
   "demo.trades_simulated": "trades simulated",
@@ -765,7 +765,7 @@ export const en = {
     "Performance data is from backtests using 2+ years of historical data with realistic fees and slippage. If the dashboard is not loading, please enable JavaScript or try refreshing.",
   "perf.results_title": "Backtest Results",
   "perf.results_desc":
-    "2+ years, {coins} coins, 2,898 trades. Includes 0.08%/side fees.",
+    "2+ years, {coins} coins, 2,898 trades. Includes 0.05%/side fees.",
   "perf.gap_title": "Backtest vs Reality",
   "perf.gap_desc":
     "Every backtest has a gap with live trading. We experienced it firsthand — and stopped trading when it exceeded our limits.",
@@ -857,7 +857,7 @@ export const en = {
   "compare.noscript_desc":
     "Compare 5 backtested strategies (BB Squeeze SHORT, BB Squeeze LONG, RSI Reversal, MACD Momentum, and more) across 50 coins with identical conditions. Adjust SL/TP parameters and see win rate, profit factor, max drawdown, and return side by side.",
   "compare.noscript_strategies":
-    "Available strategies: BB Squeeze SHORT (verified, live trading), BB Squeeze LONG, RSI Reversal LONG, MACD Momentum LONG, and ATR Breakout LONG. All simulated with 0.04% fee + 0.02% slippage on 2+ years of data.",
+    "Available strategies: BB Squeeze SHORT (verified, live trading), BB Squeeze LONG, RSI Reversal LONG, MACD Momentum LONG, and ATR Breakout LONG. All simulated with 0.05% fee + 0.02% slippage on 2+ years of data.",
 
   // Blog article CTA
   "blog.cta_title": "Ready to test strategies yourself?",
@@ -876,7 +876,7 @@ export const en = {
   "compare.desc":
     "Same conditions, same data. See which strategy fits your style. Adjust SL/TP and watch all 5 strategies respond in real time.",
   "compare.disclaimer":
-    "* All strategies simulated on 50 coins with identical fees (0.04% + 0.02% slippage). Past performance does not guarantee future results.",
+    "* All strategies simulated on 50 coins with identical fees (0.05% + 0.02% slippage). Past performance does not guarantee future results.",
   "compare.loading": "Loading comparison data...",
   "compare.error": "Failed to load comparison data.",
   "compare.name": "Strategy",
@@ -1031,7 +1031,7 @@ export const en = {
     "20-candle high breakout — catastrophic loss",
   "simulate.view_all": "View all 5 strategies",
   "simulate.disclaimer":
-    "Simulations include 0.04% futures fees + 0.02% slippage per trade. Past performance does not guarantee future results. Not financial advice.",
+    "Simulations include 0.05% futures fees + 0.02% slippage per trade. Past performance does not guarantee future results. Not financial advice.",
   "simulate.step1_title": "Choose a preset or pick indicators",
   "simulate.step1_desc": "14 indicators, AND/OR logic",
   "simulate.step2_title": "Set entry conditions and risk",
@@ -1063,19 +1063,19 @@ export const en = {
   "methodology.backtest_title": "How We Backtest",
   "methodology.data_label": "Data",
   "methodology.data_desc":
-    "2+ years of 1-hour OHLCV candles sourced from Binance Futures. All candles are complete (closed) — no partial or in-progress data is used to avoid look-ahead bias.",
+    "2+ years of 1-hour OHLCV candles sourced from OKX USDT-SWAP. All candles are complete (closed) — no partial or in-progress data is used to avoid look-ahead bias.",
   "methodology.universe_label": "Universe",
   "methodology.universe_desc":
-    "{coins}+ USDT perpetual futures pairs listed on Binance. Stablecoins, delisted, and illiquid pairs are excluded. Daily rankings use the top 50 coins by market cap. The exact count varies by strategy version.",
+    "{coins}+ USDT perpetual futures pairs listed on OKX. Stablecoins, delisted, and illiquid pairs are excluded. Daily rankings use the top 50 coins by market cap. The exact count varies by strategy version.",
   "methodology.execution_label": "Execution",
   "methodology.execution_desc":
     "Entry is assumed at the candle close price. This is conservative — real fills may differ by a small amount due to timing and order book depth.",
   "methodology.fees_label": "Fees",
   "methodology.fees_desc":
-    "0.04% taker fee per side (0.08% round-trip). This is the Binance Futures default for VIP 0 tier.",
+    "0.05% taker fee per side (0.10% round-trip). This is the OKX USDT-SWAP default for VIP 0 tier.",
   "methodology.slippage_label": "Slippage",
   "methodology.slippage_desc":
-    "Not modeled by default. Limit orders are assumed. In practice, entry slippage is typically under 0.05% for most trades on Binance Futures.",
+    "Not modeled by default. Limit orders are assumed. In practice, entry slippage is typically under 0.05% for most trades on OKX USDT-SWAP.",
   "methodology.position_label": "Position Sizing",
   "methodology.position_desc":
     "Fixed $60 per trade with 5x leverage ($300 notional). No compounding — each trade uses the same dollar amount regardless of account equity.",
@@ -1572,7 +1572,7 @@ export const en = {
     "The BB Squeeze SHORT strategy detects Bollinger Band compression on {display} and enters a short position when a downward breakout occurs. It uses a 10% stop-loss and 8% take-profit with up to 48-hour holding periods.",
   "coin_detail.faq_q2": "How reliable is the {name} backtest?",
   "coin_detail.faq_a2":
-    "PRUVIQ backtests use 2+ years of 1-hour OHLCV data from Binance Futures. All results are out-of-sample tested with Monte Carlo validation (10,000 iterations). No look-ahead bias — only completed candles are used for signals.",
+    "PRUVIQ backtests use 2+ years of 1-hour OHLCV data from OKX USDT-SWAP. All results are out-of-sample tested with Monte Carlo validation (10,000 iterations). No look-ahead bias — only completed candles are used for signals.",
   "coin_detail.faq_q3": "Is it free to simulate {name}?",
   "coin_detail.faq_a3":
     "Yes. PRUVIQ is 100% free. You can simulate the BB Squeeze strategy on any supported coin, adjust parameters, and view detailed equity curves and trade logs — no account required.",
@@ -1628,7 +1628,7 @@ export const en = {
   // Changelog context callout
   "changelog.context_title": "What\u2019s versioned here?",
   "changelog.context_desc":
-    'This changelog tracks the <strong class="text-[--color-text]">BB Squeeze SHORT trading strategy</strong> running live on Binance Futures. Platform version (website, simulator, API) is managed separately.',
+    'This changelog tracks the <strong class="text-[--color-text]">BB Squeeze SHORT trading strategy</strong> running live on OKX USDT-SWAP. Platform version (website, simulator, API) is managed separately.',
 
   // Meta: Privacy & Terms
   "meta.privacy_title": "Privacy Policy - PRUVIQ",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -323,7 +323,7 @@ export const ko: Record<TranslationKey, string> = {
   "demo.error": "데모 데이터 로딩 실패.",
   "demo.no_data": "이 조합에 대한 데이터가 없습니다.",
   "demo.disclaimer":
-    "* 기본 파라미터 (SL=10%, TP=8%)는 현재 검증된 라이브 설정입니다. 시뮬레이션은 0.04% 선물 수수료 + 0.02% 슬리피지를 포함합니다. 과거 성과는 미래 결과를 보장하지 않습니다.",
+    "* 기본 파라미터 (SL=10%, TP=8%)는 현재 검증된 라이브 설정입니다. 시뮬레이션은 0.05% 선물 수수료 + 0.02% 슬리피지를 포함합니다. 과거 성과는 미래 결과를 보장하지 않습니다.",
   "demo.live_badge": "현재 라이브 설정",
   "demo.total_return": "총 수익률",
   "demo.trades_simulated": "건 시뮬레이션됨",
@@ -756,7 +756,7 @@ export const ko: Record<TranslationKey, string> = {
     "성과 데이터는 2년 이상의 과거 데이터를 사용한 백테스트에서 수집되며, 수수료와 슬리피지를 포함합니다. 대시보드가 로딩되지 않으면 JavaScript를 활성화하거나 새로고침해 주세요.",
   "perf.results_title": "백테스트 결과",
   "perf.results_desc":
-    "2년+, {coins}개 코인, 2,898건 거래. 0.08%/side 수수료 포함.",
+    "2년+, {coins}개 코인, 2,898건 거래. 0.05%/side 수수료 포함.",
   "perf.gap_title": "백테스트 vs 현실",
   "perf.gap_desc":
     "모든 백테스트에는 실거래와의 괴리가 있습니다. 직접 경험했고 — 한계를 초과했을 때 즉시 중단했습니다.",
@@ -849,7 +849,7 @@ export const ko: Record<TranslationKey, string> = {
   "compare.noscript_desc":
     "BB Squeeze SHORT, BB Squeeze LONG, RSI Reversal, MACD Momentum 등 5개 백테스트된 전략을 50개 코인에서 동일 조건으로 비교합니다. SL/TP 파라미터를 조정하고 승률, 수익 팩터, 최대 드로다운, 수익률을 나란히 확인하세요.",
   "compare.noscript_strategies":
-    "제공 전략: BB Squeeze SHORT (검증 완료, 실거래 중), BB Squeeze LONG, RSI Reversal LONG, MACD Momentum LONG, ATR Breakout LONG. 모두 0.04% 수수료 + 0.02% 슬리피지, 2년 이상 데이터로 시뮬레이션.",
+    "제공 전략: BB Squeeze SHORT (검증 완료, 실거래 중), BB Squeeze LONG, RSI Reversal LONG, MACD Momentum LONG, ATR Breakout LONG. 모두 0.05% 수수료 + 0.02% 슬리피지, 2년 이상 데이터로 시뮬레이션.",
 
   // Blog article CTA
   "blog.cta_title": "직접 전략을 테스트해 보시겠습니까?",
@@ -868,7 +868,7 @@ export const ko: Record<TranslationKey, string> = {
   "compare.desc":
     "동일한 조건, 동일한 데이터. 어떤 전략이 나에게 맞는지 확인하세요. SL/TP를 조정하면 5개 전략이 실시간으로 변합니다.",
   "compare.disclaimer":
-    "* 모든 전략은 50개 코인, 동일한 수수료(0.04% + 0.02% 슬리피지)로 시뮬레이션됩니다. 과거 성과는 미래 결과를 보장하지 않습니다.",
+    "* 모든 전략은 50개 코인, 동일한 수수료(0.05% + 0.02% 슬리피지)로 시뮬레이션됩니다. 과거 성과는 미래 결과를 보장하지 않습니다.",
   "compare.loading": "비교 데이터 로딩 중...",
   "compare.error": "비교 데이터 로딩 실패.",
   "compare.name": "전략",
@@ -1018,7 +1018,7 @@ export const ko: Record<TranslationKey, string> = {
   "simulate.strategy_desc_momentum": "20캔들 최고가 돌파 — 대규모 손실",
   "simulate.view_all": "전체 5개 전략 보기",
   "simulate.disclaimer":
-    "시뮬레이션에는 거래당 0.04% 선물 수수료 + 0.02% 슬리피지가 포함됩니다. 과거 성과가 미래 수익을 보장하지 않습니다. 투자 조언이 아닙니다.",
+    "시뮬레이션에는 거래당 0.05% 선물 수수료 + 0.02% 슬리피지가 포함됩니다. 과거 성과가 미래 수익을 보장하지 않습니다. 투자 조언이 아닙니다.",
   "simulate.step1_title": "프리셋을 선택하거나 지표를 고르세요",
   "simulate.step1_desc": "14개 지표, AND/OR 로직",
   "simulate.step2_title": "진입 조건과 리스크를 설정하세요",
@@ -1050,19 +1050,19 @@ export const ko: Record<TranslationKey, string> = {
   "methodology.backtest_title": "백테스트 방법",
   "methodology.data_label": "데이터",
   "methodology.data_desc":
-    "바이낸스 선물에서 수집한 2년 이상의 1시간 OHLCV 캔들 데이터. 모든 캔들은 완성된(종료된) 데이터만 사용하며, 선행 편향(look-ahead bias)을 방지하기 위해 미완성 데이터는 사용하지 않습니다.",
+    "OKX USDT-SWAP에서 수집한 2년 이상의 1시간 OHLCV 캔들 데이터. 모든 캔들은 완성된(종료된) 데이터만 사용하며, 선행 편향(look-ahead bias)을 방지하기 위해 미완성 데이터는 사용하지 않습니다.",
   "methodology.universe_label": "유니버스",
   "methodology.universe_desc":
-    "바이낸스에 상장된 {coins}개 이상의 USDT 무기한 선물 페어. 스테이블코인, 상장 폐지 코인, 유동성이 낮은 페어는 제외됩니다. 데일리 랭킹은 시가총액 상위 50개 코인 기준으로 산출됩니다. 정확한 수는 전략 버전에 따라 다릅니다.",
+    "OKX에 상장된 {coins}개 이상의 USDT 무기한 선물 페어. 스테이블코인, 상장 폐지 코인, 유동성이 낮은 페어는 제외됩니다. 데일리 랭킹은 시가총액 상위 50개 코인 기준으로 산출됩니다. 정확한 수는 전략 버전에 따라 다릅니다.",
   "methodology.execution_label": "체결",
   "methodology.execution_desc":
     "진입은 캔들 종가에서 체결되는 것으로 가정합니다. 이는 보수적인 가정입니다 — 실제 체결가는 타이밍과 호가창 깊이에 따라 소폭 차이가 날 수 있습니다.",
   "methodology.fees_label": "수수료",
   "methodology.fees_desc":
-    "편도 0.04% 테이커 수수료 (왕복 0.08%). 바이낸스 선물 VIP 0 등급 기본 수수료입니다.",
+    "편도 0.05% 테이커 수수료 (왕복 0.10%). OKX USDT-SWAP VIP 0 등급 기본 수수료입니다.",
   "methodology.slippage_label": "슬리피지",
   "methodology.slippage_desc":
-    "기본적으로 모델링하지 않습니다. 지정가 주문을 가정합니다. 바이낸스 선물에서 대부분의 거래의 진입 슬리피지는 일반적으로 0.05% 미만입니다.",
+    "기본적으로 모델링하지 않습니다. 지정가 주문을 가정합니다. OKX USDT-SWAP에서 대부분의 거래의 진입 슬리피지는 일반적으로 0.05% 미만입니다.",
   "methodology.position_label": "포지션 사이징",
   "methodology.position_desc":
     "거래당 고정 $60, 5배 레버리지 (명목가 $300). 복리 없음 — 계좌 잔고와 관계없이 매 거래마다 동일한 금액을 사용합니다.",
@@ -1536,7 +1536,7 @@ export const ko: Record<TranslationKey, string> = {
     "BB Squeeze SHORT 전략은 {display}에서 볼린저밴드 압축을 감지하고, 하향 돌파 시 숏 포지션에 진입합니다. 손절 10%, 익절 8%, 최대 48시간 보유합니다.",
   "coin_detail.faq_q2": "{name} 백테스트는 신뢰할 수 있나요?",
   "coin_detail.faq_a2":
-    "PRUVIQ 백테스트는 바이낸스 선물 2년 이상의 1시간 OHLCV 데이터를 사용합니다. 모든 결과는 Out-of-Sample 테스트와 몬테카를로 시뮬레이션(10,000회)으로 검증됩니다. Look-ahead bias 없이 완성된 캔들만 신호에 사용합니다.",
+    "PRUVIQ 백테스트는 OKX USDT-SWAP 2년 이상의 1시간 OHLCV 데이터를 사용합니다. 모든 결과는 Out-of-Sample 테스트와 몬테카를로 시뮬레이션(10,000회)으로 검증됩니다. Look-ahead bias 없이 완성된 캔들만 신호에 사용합니다.",
   "coin_detail.faq_q3": "{name} 시뮬레이션은 무료인가요?",
   "coin_detail.faq_a3":
     "네. PRUVIQ는 100% 무료입니다. 모든 지원 코인에서 BB Squeeze 전략을 시뮬레이션하고, 파라미터를 조정하고, 상세 에퀴티 커브와 거래 로그를 확인할 수 있습니다. 가입 불필요.",
@@ -1593,7 +1593,7 @@ export const ko: Record<TranslationKey, string> = {
   // Changelog context callout
   "changelog.context_title": "여기서 추적하는 버전은?",
   "changelog.context_desc":
-    '이 변경 기록은 바이낸스 선물에서 실시간 운영 중인 <strong class="text-[--color-text]">BB Squeeze SHORT 매매 전략</strong>을 추적합니다. 플랫폼 버전(웹사이트, 시뮬레이터, API)은 별도로 관리됩니다.',
+    '이 변경 기록은 OKX USDT-SWAP에서 실시간 운영 중인 <strong class="text-[--color-text]">BB Squeeze SHORT 매매 전략</strong>을 추적합니다. 플랫폼 버전(웹사이트, 시뮬레이터, API)은 별도로 관리됩니다.',
 
   // Meta: Privacy & Terms
   "meta.privacy_title": "개인정보처리방침 - 프루빅(PRUVIQ)",


### PR DESCRIPTION
## Problem (Critical 5 + 6 from site audit)

The Binance→OKX data migration (Phase A-E, 2026-03 to 2026-04-11) moved the backtest engine and live trading to OKX USDT-SWAP, but the user-facing copy still said \"Binance Futures\" with old fee numbers. A skeptic hitting \`/methodology\` would read that and immediately flag trust loss — even though the engine CostModel has \`fee_pct=0.0005\` (0.05%, matching OKX).

## Scope

Pure string replacement — no logic change. Grep-verifiable.

### Replaced
- \`\"Binance Futures\"\` → \`\"OKX USDT-SWAP\"\` (7 sites)
- \`\"listed on Binance\"\` → \`\"listed on OKX\"\` (2 sites, EN + KO)
- \`\"0.04%\" / \"0.08%\"\` → \`\"0.05%\" / \"0.10%\"\` (10 sites — matches engine CostModel)

### Files touched (7)
- \`src/i18n/en.ts\` + \`src/i18n/ko.ts\` — methodology, simulator disclaimer, compare disclaimer, perf summary, changelog callout
- \`src/components/ChartPanel.tsx\` + \`SimulatorPreview.tsx\` — visible chart labels
- \`src/components/StrategyComparison.tsx\` + \`StrategyDemo.tsx\` + \`SimulatorPage.tsx\` — embedded disclaimers

### Deliberately NOT changed
- **Blog posts** in \`src/content/blog/\` that specifically reference Binance (e.g. \"How to Save on Binance Futures Fees\" — historical tutorials, still accurate in their own scope)
- **\`vs_3commas\` / \`vs_coinrule\` / etc.** competitor comparison keys — \"0.08% built-in\" framing there is a marketing decision, tracked as follow-up
- **Coin count SSoT** (240+/235 hardcoded across homepage/simulate) — deferred to dedicated PR: build-time \`/api/site-stats\` dependency needs a fallback constant so CF Pages build doesn't fail when API is down
- **\`/market\` empty data** + **\`/trust\` \"—\" placeholders** — missing backend endpoints, product decision not copy fix

## Related

Site audit findings tracked in \`memory/project_audit_sweep_20260419.md\`. This PR closes C5 + C6 from that list. Remaining Critical items (C1 SSoT, C2 KO compare content, C3 /coins noscript, C4 /signals fallback — shipped separately in #1242, C7 /market, C8 /trust) queued.

## Build check

\`npm run build\` → 1177 pages, 0 errors. Simulator smoke check passed.

## Test plan

- [ ] CI passes (visual regression may show methodology page text diff — expected)
- [ ] Post-merge: /methodology shows \"OKX USDT-SWAP\" as data source
- [ ] /simulate + /compare disclaimers show 0.05% fee (matches engine)
- [ ] No remaining \"Binance Futures\" string outside of blog/ or vs_ keys: \`grep -rn 'Binance Futures\\|바이낸스 선물' src/i18n src/components | grep -vE 'vs_|row_fees_p'\` returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)