### PR TITLE
feat(cloudflared): staging-api.pruviq.com ingress + version-controlled config

### DIFF
--- a/backend/deploy/cloudflared/README.md
+++ b/backend/deploy/cloudflared/README.md
@@ -1,0 +1,91 @@
+# Cloudflared — Tunnel ingress config
+
+Version-controlled source-of-truth for the `cloudflared` ingress rules
+running on DO (`167.172.81.145:2222`). Mirrors the pattern used for
+`backend/deploy/alloy/` (Grafana Alloy) — a prod config that lived only
+on the box until someone audited it.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `config.yml` | Ingress rules. Deploy to `/etc/cloudflared/config.yml` on DO. |
+
+## What it routes
+
+- `api.pruviq.com` → `http://localhost:8080` (prod, `pruviq-api.service`)
+- `staging-api.pruviq.com` → `http://localhost:8081` (staging, `pruviq-api-staging.service`)
+
+## Deploy procedure
+
+**Config file update** (on DO, as root):
+
+```bash
+sudo cp /opt/pruviq/current/backend/deploy/cloudflared/config.yml \
+        /etc/cloudflared/config.yml
+sudo systemctl restart pruviq-cloudflared.service
+sudo journalctl -u pruviq-cloudflared -n 30 --no-pager
+# Expect "Registered tunnel connection" lines for each connector.
+```
+
+**DNS setup** (one-time per new hostname):
+
+Option A — via `cloudflared` CLI on DO (idempotent, recommended):
+
+```bash
+cloudflared tunnel route dns \
+  a3a723e9-be50-49d8-899b-f8ff41df5104 \
+  staging-api.pruviq.com
+```
+
+Option B — via Cloudflare dashboard:
+
+1. https://dash.cloudflare.com → pruviq.com → DNS → Records
+2. Add CNAME:
+   - Name: `staging-api`
+   - Target: `a3a723e9-be50-49d8-899b-f8ff41df5104.cfargotunnel.com`
+   - Proxy status: **Proxied** (orange cloud) — required for CF Access to intercept
+
+## Access control (for staging)
+
+Staging-api.pruviq.com is protected by Cloudflare Access (Zero Trust).
+
+- Application: `staging-api` (Self-hosted)
+- Policy: `staging-allowlist` (Allow, Emails: `jaepoong92@gmail.com`)
+- Identity provider: One-time PIN
+- Session: 24h
+
+Unauthenticated visitors land on the Zero Trust login page, get a PIN
+emailed, then redirect to staging if their email is in the allowlist.
+
+## Verification after deploy
+
+From any machine (not just DO):
+
+```bash
+# 1. DNS resolves via tunnel
+dig +short staging-api.pruviq.com CNAME
+# → ...cfargotunnel.com
+
+# 2. HTTPS lands on Access auth wall (HTTP 200 login page, not the API)
+curl -sI https://staging-api.pruviq.com/health
+# → Expect redirect/login headers, NOT 200-ok-JSON-from-app
+
+# 3. After logging in via browser, /health should return real JSON.
+```
+
+From DO (inside the network, bypassing CF Access):
+
+```bash
+curl -sf http://127.0.0.1:8081/health
+# → {"status":"ok","version":"0.3.0","coins_loaded":...}
+```
+
+## Not in repo (deliberate)
+
+- `/etc/cloudflared/a3a723e9-*.json` — tunnel credentials (secrets). Rotated via
+  `cloudflared tunnel create` on DO; not pushed to version control.
+- `pruviq-cloudflared.service` — the systemd unit lives at
+  `/etc/systemd/system/pruviq-cloudflared.service` on DO. If we ever move
+  it to the repo (similar to how `pruviq-api.service` lives under
+  `backend/deploy/systemd/`), reference it from here.

--- a/backend/deploy/cloudflared/config.yml
+++ b/backend/deploy/cloudflared/config.yml
@@ -1,0 +1,55 @@
+# PRUVIQ — Cloudflared Tunnel ingress config (source-of-truth for DO).
+#
+# Deploy to: /etc/cloudflared/config.yml on DO (167.172.81.145:2222).
+#
+# What this does:
+#   - Routes api.pruviq.com       → http://localhost:8080 (pruviq-api.service, prod)
+#   - Routes staging-api.pruviq.com → http://localhost:8081 (pruviq-api-staging.service, staging)
+#
+# Cloudflare Access protects staging-api.pruviq.com with an email allowlist
+# (configured via CF Zero Trust dashboard, Application: "staging-api").
+# The Access auth wall sits between the internet and this tunnel — users
+# must authenticate before traffic reaches :8081.
+#
+# Credentials file (on DO, NOT in repo):
+#   /etc/cloudflared/a3a723e9-be50-49d8-899b-f8ff41df5104.json
+# The tunnel UUID is not secret (visible in CF dashboard); the JSON file's
+# contents ARE secret and managed outside version control.
+#
+# Deploy (on DO):
+#   sudo cp /opt/pruviq/current/backend/deploy/cloudflared/config.yml /etc/cloudflared/config.yml
+#   sudo systemctl restart pruviq-cloudflared.service
+#   sudo journalctl -u pruviq-cloudflared -n 30 --no-pager  # verify "Registered tunnel connection"
+#
+# DNS (Cloudflare dashboard or CLI):
+#   Before staging-api starts resolving, a CNAME record must exist:
+#     staging-api.pruviq.com → a3a723e9-be50-49d8-899b-f8ff41df5104.cfargotunnel.com
+#   Easiest: run on DO: `cloudflared tunnel route dns a3a723e9-be50-49d8-899b-f8ff41df5104 staging-api.pruviq.com`
+#   (Idempotent — safe to re-run if already set.)
+
+tunnel: a3a723e9-be50-49d8-899b-f8ff41df5104
+credentials-file: /etc/cloudflared/a3a723e9-be50-49d8-899b-f8ff41df5104.json
+
+# Match order matters. Cloudflared evaluates ingress rules top-to-bottom
+# and picks the first hostname that matches. The catchall `service:
+# http_status:404` at the end returns 404 for any hostname we don't
+# explicitly route — safer than a permissive default.
+ingress:
+  # Production API (shipped 2026-03, never touched by staging changes)
+  - hostname: api.pruviq.com
+    service: http://localhost:8080
+    originRequest:
+      connectTimeout: 10s
+
+  # Staging API (added 2026-04-21 with PR <this>).
+  # Behind Cloudflare Access (Application: staging-api, Policy:
+  # staging-allowlist, Emails: jaepoong92@gmail.com). Anyone else hitting
+  # this hostname lands on the Zero Trust login page and gets denied.
+  - hostname: staging-api.pruviq.com
+    service: http://localhost:8081
+    originRequest:
+      connectTimeout: 10s
+
+  # Catchall — any unmapped hostname gets a clean 404 from the tunnel
+  # edge, not a leaked default service.
+  - service: http_status:404


### PR DESCRIPTION
## Purpose (PR 2 of staging env rollout)

Wire up the staging backend (shipped in #1245) behind Cloudflare Tunnel + Cloudflare Access so \`staging-api.pruviq.com\` resolves to the :8081 service, protected by an email allowlist.

## What this ships

- \`backend/deploy/cloudflared/config.yml\` — version-controlled tunnel ingress (mirrors the Alloy config pattern from #1237)
- \`backend/deploy/cloudflared/README.md\` — deploy recipe + DNS setup + verification

Adds the new ingress rule:
\`\`\`yaml
- hostname: staging-api.pruviq.com
  service: http://localhost:8081
  originRequest:
    connectTimeout: 10s
\`\`\`

Prod ingress (\`api.pruviq.com → :8080\`) unchanged.

## Security model

- **CF Access wall**: application \`staging-api\` with policy \`staging-allowlist\` (Allow / Emails / jaepoong92@gmail.com). Unauthenticated visitors hit the Zero Trust login; only whitelisted emails pass through.
- **Tunnel UUID in repo**: not secret (visible in CF dashboard).
- **Credentials JSON stays on DO**: \`/etc/cloudflared/<uuid>.json\` never in version control.
- **Prod isolation**: prod routing untouched. Restarting cloudflared drops connections to both prod and staging for ~2 seconds — acceptable for a staging rollout; can be done in low-traffic window.

## Deploy (manual, one-time after merge)

On DO:
\`\`\`bash
sudo cp /opt/pruviq/current/backend/deploy/cloudflared/config.yml /etc/cloudflared/config.yml
sudo systemctl restart pruviq-cloudflared.service
cloudflared tunnel route dns a3a723e9-be50-49d8-899b-f8ff41df5104 staging-api.pruviq.com
\`\`\`

## Verify

\`\`\`bash
# 1. DNS resolves via tunnel
dig +short staging-api.pruviq.com CNAME
# → a3a723e9-....cfargotunnel.com

# 2. External hit lands on CF Access login (auth wall working)
curl -sI https://staging-api.pruviq.com/health
# → 302/303 redirect to Access login, not 200 from API

# 3. Browser visit → One-time PIN flow → allowed email → staging API
\`\`\`

## Test plan (post-merge)

- [ ] Auto-merge fires
- [ ] \`deploy-backend.yml\` syncs repo to DO (auto on merge)
- [ ] Operator runs the 3 commands above on DO
- [ ] \`dig +short staging-api.pruviq.com CNAME\` shows cfargotunnel
- [ ] \`curl -sI https://staging-api.pruviq.com/health\` returns CF Access login (not raw 200)
- [ ] Browser visit with jaepoong92@gmail.com login → lands on \`{"status":"ok",...}\` from :8081

## Known follow-up

- Staging \`coins_loaded: 0\` — \`/opt/pruviq/staging/.env\` needs \`OHLCV_DATA_DIR\` pointed at shared \`/opt/pruviq/data/futures/\`. Separate 1-line PR.
- CF Tunnel multi-node redundancy (second DO droplet) — still queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)