### PR TITLE
fix(coins): OKX data-source label + SSR last-refresh timestamp (H1+H2)

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -542,7 +542,7 @@ export const en = {
   "coins.tag": "COIN EXPLORER",
   "coins.title": "Browse All Coins",
   "coins.desc":
-    "Real-time market data for {coins}+ cryptocurrencies. Prices, market cap, volume, 7-day sparklines — updated every 15 minutes.",
+    "Real-time market data for {coins}+ cryptocurrencies from OKX USDT-SWAP. Prices, market cap, volume, 7-day sparklines — updated every 15 minutes.",
   "coins.search": "Search coins...",
   "coins.apply": "Apply Strategy",
   "coins.resim": "Re-simulate",
@@ -1621,9 +1621,11 @@ export const en = {
 
   // Coins page
   "coins.explore_next": "Found interesting coins? Test them in a strategy.",
-  "coins.noscript_title": "JavaScript required to browse coins.",
+  "coins.noscript_title": "Browse coins (JavaScript enables search + filter).",
   "coins.noscript_desc":
-    "Enable JavaScript to search and filter 240+ coins. Popular coins:",
+    "Full interactive search, sort, and filter for {coins}+ coins requires JavaScript. Without JS you can still follow these popular coin links:",
+  "coins.source_label": "Data: OKX USDT-SWAP",
+  "coins.last_refreshed": "Last refresh",
 
   // Changelog context callout
   "changelog.context_title": "What\u2019s versioned here?",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -535,7 +535,7 @@ export const ko: Record<TranslationKey, string> = {
   "coins.tag": "코인 탐색기",
   "coins.title": "전체 코인 탐색",
   "coins.desc":
-    "{coins}개 이상 암호화폐의 실시간 시장 데이터. 가격, 시가총액, 거래량, 7일 차트 — 15분마다 갱신.",
+    "OKX USDT-SWAP 의 {coins}개 이상 암호화폐 실시간 시장 데이터. 가격, 시가총액, 거래량, 7일 차트 — 15분마다 갱신.",
   "coins.search": "코인 검색...",
   "coins.apply": "전략 적용",
   "coins.resim": "재시뮬레이션",
@@ -1586,9 +1586,12 @@ export const ko: Record<TranslationKey, string> = {
   // Coins page
   "coins.explore_next":
     "관심 있는 코인을 찾으셨나요? 전략에서 테스트해 보세요.",
-  "coins.noscript_title": "코인 목록을 보려면 JavaScript가 필요합니다.",
+  "coins.noscript_title":
+    "코인 둘러보기 (검색·필터는 JavaScript 로 활성화됩니다)",
   "coins.noscript_desc":
-    "{coins}개 이상의 코인을 탐색하려면 JavaScript를 활성화하세요. 인기 코인:",
+    "{coins}개 이상 코인의 전체 검색·정렬·필터 기능은 JavaScript 가 필요합니다. JS 없이도 아래 인기 코인 링크는 열 수 있습니다:",
+  "coins.source_label": "데이터: OKX USDT-SWAP",
+  "coins.last_refreshed": "최근 갱신",
 
   // Changelog context callout
   "changelog.context_title": "여기서 추적하는 버전은?",

--- a/src/pages/coins/index.astro
+++ b/src/pages/coins/index.astro
@@ -1,8 +1,24 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import { useTranslations } from '../../i18n/index';
+import coinsStats from '../../../public/data/coins-stats.json';
 
 const t = useTranslations('en');
+
+// Read data freshness at build time from the static JSON snapshot that
+// refresh-static commits on every data update. Rendered as SSR so crawlers
+// and JS-disabled users see a concrete "when" instead of the vague
+// "updated every 15 minutes" in the body copy. Format: "YYYY-MM-DD HH:MM UTC".
+//
+// If `generated` is missing (unlikely — the refresh-static pipeline always
+// writes it), we render without the timestamp line rather than crashing.
+const generatedAt: string | null = (() => {
+  const iso = (coinsStats as { generated?: string }).generated;
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString().replace('T', ' ').slice(0, 16) + ' UTC';
+})();
 
 // Static top coins for noscript/Googlebot crawlability (85 coins)
 const TOP_COINS = [
@@ -40,8 +56,12 @@ const TOP_COINS = [
     <div class="max-w-7xl mx-auto px-6">
       <p class="font-mono text-[--color-accent] text-sm mb-3 tracking-wider">{t('coins.tag')}</p>
       <h1 class="text-4xl md:text-5xl lg:text-6xl font-extrabold mb-5">{t('coins.title')}</h1>
-      <p class="text-[--color-text-muted] text-lg md:text-xl mb-10 max-w-2xl leading-relaxed">
+      <p class="text-[--color-text-muted] text-lg md:text-xl mb-3 max-w-2xl leading-relaxed">
         {t('coins.desc')}
+      </p>
+      <p class="font-mono text-[11px] text-[--color-text-muted] opacity-70 mb-10">
+        {t('coins.source_label')}
+        {generatedAt && <> · {t('coins.last_refreshed')}: {generatedAt}</>}
       </p>
       <div id="coins-mount" class="shadow-[var(--shadow-md)] rounded-xl overflow-hidden">
         <div class="animate-pulse space-y-4 p-6">

--- a/src/pages/ko/coins/index.astro
+++ b/src/pages/ko/coins/index.astro
@@ -1,8 +1,20 @@
 ---
 import Layout from '../../../layouts/Layout.astro';
 import { useTranslations } from '../../../i18n/index';
+import coinsStats from '../../../../public/data/coins-stats.json';
 
 const t = useTranslations('ko');
+
+// Same SSR data-freshness render pattern as /coins/index.astro — see that
+// file for the design note. Same source file, same format, identical on
+// both language variants so crawlers see consistent freshness signals.
+const generatedAt: string | null = (() => {
+  const iso = (coinsStats as { generated?: string }).generated;
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString().replace('T', ' ').slice(0, 16) + ' UTC';
+})();
 
 // Static top coins for noscript/Googlebot crawlability (85 coins)
 const TOP_COINS = [
@@ -40,8 +52,12 @@ const TOP_COINS = [
     <div class="max-w-7xl mx-auto px-6">
       <p class="font-mono text-[--color-accent] text-sm mb-3 tracking-wider">{t('coins.tag')}</p>
       <h1 class="text-4xl md:text-5xl lg:text-6xl font-extrabold mb-5">{t('coins.title')}</h1>
-      <p class="text-[--color-text-muted] text-lg md:text-xl mb-10 max-w-2xl leading-relaxed">
+      <p class="text-[--color-text-muted] text-lg md:text-xl mb-3 max-w-2xl leading-relaxed">
         {t('coins.desc')}
+      </p>
+      <p class="font-mono text-[11px] text-[--color-text-muted] opacity-70 mb-10">
+        {t('coins.source_label')}
+        {generatedAt && <> · {t('coins.last_refreshed')}: {generatedAt}</>}
       </p>
       <div id="coins-mount">
         <div class="animate-pulse space-y-4">


### PR DESCRIPTION
Site audit H1+H2: /coins was missing two facts a skeptical visitor looks for in 5s — data source and snapshot freshness. Both knowable at build time but only rendered after JS loaded in CoinListTable, invisible to crawlers + JS-disabled users.

**Changes (i18n + Astro frontmatter, no new pipelines):**
- `coins.desc` (EN+KO): append 'from OKX USDT-SWAP'
- `coins.noscript_title/desc` (EN+KO): rewrite from 'JavaScript required' dead-end to actionable fallback; replace hardcoded '240+' with `{coins}` placeholder
- 2 new i18n keys: `coins.source_label`, `coins.last_refreshed`
- Astro pages: read `public/data/coins-stats.json` at build time, render 'Data: OKX USDT-SWAP · Last refresh: YYYY-MM-DD HH:MM UTC' as SSR metadata line

**Not closed:** C3 (noscript already existed; site audit WebFetch couldn't see `<noscript>` tags — confirmed on re-read).

Build: 1177 pages, 0 errors.