### PR TITLE
fix(ranking): add MDD column + last-refresh timestamp (H6+H7)

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -841,6 +841,7 @@ export const en = {
   "ranking.open_sim": "Open Simulator",
   "ranking.strategy_lib": "Strategy Library",
   "ranking.leaderboard": "Leaderboard",
+  "ranking.last_refreshed": "Last refresh",
   "ranking.disclaimer_note": "Note:",
   "ranking.disclaimer_text":
     "This ranking is based on historical backtests. Past performance does not guarantee future returns. Strategies with fewer than 100 trades (< 100) may be overfitted.",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -833,6 +833,7 @@ export const ko: Record<TranslationKey, string> = {
   "ranking.open_sim": "시뮬레이터 열기",
   "ranking.strategy_lib": "전략 라이브러리",
   "ranking.leaderboard": "리더보드",
+  "ranking.last_refreshed": "최근 갱신",
   "ranking.disclaimer_note": "참고:",
   "ranking.disclaimer_text":
     "이 랭킹은 과거 데이터 백테스트 기반입니다. 미래 수익을 보장하지 않으며, 샘플 수 부족(< 100건) 전략은 과적합 가능성이 높습니다.",

--- a/src/pages/ko/strategies/ranking.astro
+++ b/src/pages/ko/strategies/ranking.astro
@@ -26,13 +26,23 @@ interface RankingEntry {
   timeframe: string;
   low_sample: boolean;
   total_return?: number;
+  // See EN variant for why max_drawdown is optional + what scope it represents.
+  max_drawdown?: number;
   sl_pct: number;
   tp_pct: number;
 }
 interface RankingData {
   date: string;
+  generated_at?: string;
   top3: RankingEntry[];
   worst3: RankingEntry[];
+}
+
+function formatRankingTimestamp(iso?: string): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString().replace('T', ' ').slice(0, 16) + ' UTC';
 }
 
 let ssrRanking: RankingData | null = null;
@@ -74,6 +84,11 @@ if (!ssrRanking) {
       <p class="text-[--color-text-muted] text-sm mb-1">
         {t('ranking.date_label').replace('{date}', today)}
       </p>
+      {ssrRanking?.generated_at && formatRankingTimestamp(ssrRanking.generated_at) && (
+        <p class="font-mono text-[11px] text-[--color-text-muted] opacity-70 mb-1">
+          {t('ranking.last_refreshed')}: {formatRankingTimestamp(ssrRanking.generated_at)}
+        </p>
+      )}
       <p class="text-[--color-text-muted] text-sm mb-8 max-w-2xl">
         {t('ranking.desc')}
       </p>
@@ -139,7 +154,7 @@ if (!ssrRanking) {
                       $1,000 &rarr; <span class={entry.total_return >= 0 ? 'text-[--color-up]' : 'text-[--color-red]'}>${Math.round(1000 * (1 + entry.total_return / 100)).toLocaleString()}</span>
                     </div>
                   )}
-                  <div class="grid grid-cols-3 gap-2 font-mono text-sm">
+                  <div class="grid grid-cols-4 gap-2 font-mono text-sm">
                     <div>
                       <p class="text-[--color-text-muted] text-xs mb-0.5">승률</p>
                       <p class={`font-bold text-base ${wrColor}`}>{entry.win_rate.toFixed(1)}%</p>
@@ -151,6 +166,12 @@ if (!ssrRanking) {
                       ) : (
                         <p class={`font-bold text-base ${pfColor}`}>{entry.profit_factor.toFixed(2)}</p>
                       )}
+                    </div>
+                    <div>
+                      <p class="text-[--color-text-muted] text-xs mb-0.5" title="최대 손실폭 — 개별 전략 기준">MDD</p>
+                      <p class="font-bold text-base text-[--color-text]">
+                        {entry.max_drawdown != null ? `${entry.max_drawdown.toFixed(1)}%` : '—'}
+                      </p>
                     </div>
                     <div>
                       <p class="text-[--color-text-muted] text-xs mb-0.5">거래 수</p>
@@ -178,9 +199,10 @@ if (!ssrRanking) {
                       <p class="text-[--color-text-muted] text-xs font-mono">{entry.timeframe}</p>
                     </div>
                   </div>
-                  <div class="grid grid-cols-3 gap-2 font-mono text-sm">
+                  <div class="grid grid-cols-4 gap-2 font-mono text-sm">
                     <div><p class="text-[--color-text-muted] text-xs mb-0.5">승률</p><p class={`font-bold ${wrColor}`}>{entry.win_rate.toFixed(1)}%</p></div>
                     <div><p class="text-[--color-text-muted] text-xs mb-0.5">PF</p>{entry.profit_factor >= 50 ? (<p class={`font-bold ${pfColor} cursor-help underline decoration-dotted`} title="PF 99.99로 제한됨 (거래 샘플 부족)">{entry.profit_factor.toFixed(2)} <span class="text-[0.6rem] font-normal text-[--color-text-muted]">(cap)</span></p>) : (<p class={`font-bold ${pfColor}`}>{entry.profit_factor.toFixed(2)}</p>)}</div>
+                    <div><p class="text-[--color-text-muted] text-xs mb-0.5" title="최대 손실폭 — 개별 전략 기준">MDD</p><p class="font-bold text-[--color-text]">{entry.max_drawdown != null ? `${entry.max_drawdown.toFixed(1)}%` : '—'}</p></div>
                     <div><p class="text-[--color-text-muted] text-xs mb-0.5">거래 수</p><p class="font-bold text-[--color-text]">{entry.total_trades}</p></div>
                   </div>
                 </div>

--- a/src/pages/strategies/ranking.astro
+++ b/src/pages/strategies/ranking.astro
@@ -36,13 +36,31 @@ interface RankingEntry {
   timeframe: string;
   low_sample: boolean;
   total_return?: number;
+  // max_drawdown is stored as a raw percentage (e.g. 0.27 means 0.27%).
+  // Optional because older fallback snapshots predate the backend field.
+  max_drawdown?: number;
   sl_pct: number;
   tp_pct: number;
 }
 interface RankingData {
   date: string;
+  // ISO timestamp of when the daily_strategy_ranking.py run produced this
+  // file. Rendered as a small mono line so a visitor can tell how fresh
+  // the numbers are — H7 in the site audit. Optional for legacy fallbacks.
+  generated_at?: string;
   top3: RankingEntry[];
   worst3: RankingEntry[];
+}
+
+// Format the generated_at ISO string as "YYYY-MM-DD HH:MM UTC" for SSR.
+// Not showing ago-relative because that would require client-side
+// re-render every few seconds and drift. Absolute UTC is honest and
+// crawler-friendly.
+function formatRankingTimestamp(iso?: string): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString().replace('T', ' ').slice(0, 16) + ' UTC';
 }
 
 let ssrRanking: RankingData | null = null;
@@ -84,6 +102,11 @@ if (!ssrRanking) {
       <p class="text-[--color-text-muted] text-sm mb-1">
         {t('ranking.date_label').replace('{date}', today)}
       </p>
+      {ssrRanking?.generated_at && formatRankingTimestamp(ssrRanking.generated_at) && (
+        <p class="font-mono text-[11px] text-[--color-text-muted] opacity-70 mb-1">
+          {t('ranking.last_refreshed')}: {formatRankingTimestamp(ssrRanking.generated_at)}
+        </p>
+      )}
       <p class="text-[--color-text-muted] text-sm mb-8 max-w-2xl">
         {t('ranking.desc')}
       </p>
@@ -150,7 +173,7 @@ if (!ssrRanking) {
                       $1,000 &rarr; <span class={entry.total_return >= 0 ? 'text-[--color-up]' : 'text-[--color-red]'}>${Math.round(1000 * (1 + entry.total_return / 100)).toLocaleString()}</span>
                     </div>
                   )}
-                  <div class="grid grid-cols-3 gap-2 font-mono text-sm">
+                  <div class="grid grid-cols-4 gap-2 font-mono text-sm">
                     <div>
                       <p class="text-[--color-text-muted] text-xs mb-0.5">Win Rate</p>
                       <p class={`font-bold text-base ${wrColor}`}>{entry.win_rate.toFixed(1)}%</p>
@@ -162,6 +185,14 @@ if (!ssrRanking) {
                       ) : (
                         <p class={`font-bold text-base ${pfColor}`}>{entry.profit_factor.toFixed(2)}</p>
                       )}
+                    </div>
+                    {/* H6: MDD column added 2026-04-21. Scope is per-strategy,
+                        not portfolio — same as the other metrics on this card. */}
+                    <div>
+                      <p class="text-[--color-text-muted] text-xs mb-0.5" title="Max drawdown — per strategy">MDD</p>
+                      <p class="font-bold text-base text-[--color-text]">
+                        {entry.max_drawdown != null ? `${entry.max_drawdown.toFixed(1)}%` : '—'}
+                      </p>
                     </div>
                     <div>
                       <p class="text-[--color-text-muted] text-xs mb-0.5">Trades</p>
@@ -196,9 +227,10 @@ if (!ssrRanking) {
                       </span>
                     </div>
                   )}
-                  <div class="grid grid-cols-3 gap-2 font-mono text-sm">
+                  <div class="grid grid-cols-4 gap-2 font-mono text-sm">
                     <div><p class="text-[--color-text-muted] text-xs mb-0.5">Win Rate</p><p class={`font-bold ${wrColor}`}>{entry.win_rate.toFixed(1)}%</p></div>
                     <div><p class="text-[--color-text-muted] text-xs mb-0.5">PF</p>{entry.profit_factor >= 50 ? (<p class={`font-bold ${pfColor} cursor-help underline decoration-dotted`} title="Profit Factor capped at 99.99 (limited trade data)">{entry.profit_factor.toFixed(2)} <span class="text-[0.6rem] font-normal text-[--color-text-muted]">(cap)</span></p>) : (<p class={`font-bold ${pfColor}`}>{entry.profit_factor.toFixed(2)}</p>)}</div>
+                    <div><p class="text-[--color-text-muted] text-xs mb-0.5" title="Max drawdown — per strategy">MDD</p><p class="font-bold text-[--color-text]">{entry.max_drawdown != null ? `${entry.max_drawdown.toFixed(1)}%` : '—'}</p></div>
                     <div><p class="text-[--color-text-muted] text-xs mb-0.5">Trades</p><p class="font-bold text-[--color-text]">{entry.total_trades}</p></div>
                   </div>
                 </div>


### PR DESCRIPTION
Site audit H6+H7: /strategies/ranking cards showed Win Rate, PF, Trades but not Max Drawdown — a core risk metric any quant looks at next to return. The data was already in `rankings-daily.json` (`max_drawdown` field), just never surfaced.

Also missing: a visible last-refresh timestamp. The daily_strategy_ranking.py writes `generated_at` into the same JSON; the page discarded it.

## Scope

Pure render changes — no data pipeline touched.

### Files
- `src/pages/strategies/ranking.astro` + `src/pages/ko/strategies/ranking.astro`
  - `RankingEntry` interface: add optional `max_drawdown?: number`
  - `RankingData` interface: add optional `generated_at?: string`
  - Helper `formatRankingTimestamp(iso)` — "YYYY-MM-DD HH:MM UTC"
  - Top3 and Worst3 cards: `grid-cols-3` → `grid-cols-4`, MDD column added between PF and Trades
  - Under the date label: new SSR mono line "Last refresh: {timestamp}" when generated_at present
- `src/i18n/en.ts` + `src/i18n/ko.ts`: one new key `ranking.last_refreshed` (EN: "Last refresh", KO: "최근 갱신")

### MDD field scope

- Per-strategy (not portfolio-wide) — matches the other metrics on the same card
- Tooltip on the column header clarifies this
- Raw `max_drawdown` value rendered as `X.X%`. Back-end stores this as a percentage number (0.27 → "0.3%"); if the units later shift to decimal-fraction we'd want a single place to flip the multiplier — currently inline, flag for a follow-up if needed

### Backward compatibility

Both new fields are optional in the interface. Legacy `ranking-fallback.json` that predates `max_drawdown`/`generated_at` still renders — MDD cell shows em-dash, timestamp line is skipped.

Build: 1177 pages, 0 errors.

## Does not touch
- The React `StrategyRanking` component (client-side) — only the SSR fallback cards
- Ranking data generation (`backend/scripts/daily_strategy_ranking.py`)
- Any other /strategies route