### PR TITLE
perf(ohlcv): refresh hourly (was 4h) + tighten stale alert

### DIFF
--- a/backend/deploy/grafana/alerts-pruviq-api.yaml
+++ b/backend/deploy/grafana/alerts-pruviq-api.yaml
@@ -247,10 +247,13 @@ groups:
           component: sqlite
 
       # ─────────────────────────────────────────────────────────
-      # 6. OHLCV refresh stale — last successful run older than 5h.
-      # Timer is every 4h, so >5h = one full cycle missed. Stronger
-      # signal than counting errors (catches "script stopped running
-      # entirely", which no error counter would detect).
+      # 6. OHLCV refresh stale — last successful run older than 2h.
+      # Timer is hourly (changed from 4h on 2026-04-21). >2h = at least
+      # one full cycle missed plus buffer. Stronger signal than counting
+      # errors (catches "script stopped running entirely", which no error
+      # counter would detect). Threshold tightened from 5h to 2h to match
+      # the new hourly cadence — otherwise we'd silently tolerate 3-4
+      # consecutive missed refreshes.
       # ─────────────────────────────────────────────────────────
       - uid: pruviq_ohlcv_stale
         title: PruviqOhlcvStale
@@ -262,7 +265,7 @@ groups:
             datasourceUid: ${DS_PROMETHEUS_UID}
             model:
               # time() is seconds since epoch; timestamp gauge is also
-              # epoch seconds. Difference > 18000 = 5 hours.
+              # epoch seconds. Difference > 7200 = 2 hours.
               expr: (time() - pruviq_ohlcv_last_run_timestamp_seconds)
               intervalMs: 60000
               maxDataPoints: 43200
@@ -273,7 +276,7 @@ groups:
             datasourceUid: __expr__
             model:
               conditions:
-                - evaluator: { params: [18000], type: gt }
+                - evaluator: { params: [7200], type: gt }
                   operator: { type: and }
                   query: { params: [C] }
                   reducer: { params: [], type: last }
@@ -286,7 +289,7 @@ groups:
         execErrState: Error
         for: 10m
         annotations:
-          summary: "OHLCV refresh hasn't run for 5+ hours"
+          summary: "OHLCV refresh hasn't run for 2+ hours"
           description: "pruviq-update-ohlcv timer (every 4h) appears stopped. Check `ssh DO 'systemctl status pruviq-update-ohlcv.timer'` and the status file at /opt/pruviq/shared/ohlcv_last_run.json."
         labels:
           severity: warning

--- a/backend/deploy/systemd/pruviq-update-ohlcv.timer
+++ b/backend/deploy/systemd/pruviq-update-ohlcv.timer
@@ -1,9 +1,26 @@
 [Unit]
-Description=PRUVIQ OHLCV Update timer (every 4h at :15)
+Description=PRUVIQ OHLCV Update timer (hourly at :15)
 Requires=pruviq-update-ohlcv.service
 
 [Timer]
-OnCalendar=*-*-* 00/4:15:00
+# Fires every hour at :15 past. Changed from "every 4h" on 2026-04-21.
+#
+# Why hourly is the practical maximum (not faster):
+#   PRUVIQ backtests use 1-hour candles (*_1h.csv). A new closed bar is
+#   only published by OKX once per hour on the :00 boundary. Refreshing
+#   at 30m/15m/5m intervals receives the same candle multiple times —
+#   pure API waste, zero data-quality gain.
+#
+# Why :15 past (not :05):
+#   OKX typically publishes the just-closed bar within 1-3 minutes, but
+#   occasionally lags up to 5. Firing at :15 gives a 15-min safety margin
+#   so we never chase an unpublished bar.
+#
+# Rate-limit envelope (well under):
+#   market/candles endpoint: 40 req/2s per IP = 20 req/s sustained.
+#   240 symbols × 1 req = ~12s of API time per run.
+#   Hourly = 24 runs/day × ~30s = 12 min/day of API activity. Trivial.
+OnCalendar=*-*-* *:15:00
 RandomizedDelaySec=60
 Persistent=true
 Unit=pruviq-update-ohlcv.service


### PR DESCRIPTION
Site-audit follow-up. /signals/live and /simulate read from OHLCV CSVs refreshed by pruviq-update-ohlcv.timer. At 4h cadence those pages served data up to 4h behind OKX.

## Why hourly is the maximum

PRUVIQ uses 1-hour candles. A new closed bar arrives once per hour on :00. More frequent than hourly = refetch same candle = pure API waste, zero data-quality gain.

## Rate-limit envelope (trivial)

- `market/candles` endpoint: 40 req/2s per IP = 20 req/s
- 240 symbols × 1 req = ~12s API time per run
- Hourly → 24 runs × ~30s = ~12 min/day of API activity

## Changes

- `pruviq-update-ohlcv.timer`: `OnCalendar=*-*-* 00/4:15:00` → `*-*-* *:15:00`
- `PruviqOhlcvStale` alert threshold: 5h → 2h (matches new cadence — one missed cycle + buffer)

## Why :15 past (not :05)

OKX typically publishes closed bar within 1-3 min; occasionally up to 5. :15 = 15-min safety buffer.

## Deploy

Automatic via `deploy-backend.yml` (rsyncs `pruviq-*.timer` + runs daemon-reload).

## Verify post-merge

```bash
ssh -p 2222 root@167.172.81.145 \
  "systemctl list-timers pruviq-update-ohlcv --no-pager"
# NEXT column → next :15 within this hour, not 4h out
```