### PR TITLE
feat(simulator): D6 — v2 probe route proves D1+D2+D4 foundation

### DIFF
--- a/src/components/SimV2Probe.tsx
+++ b/src/components/SimV2Probe.tsx
@@ -1,0 +1,148 @@
+// D6: probe component that wires D1 (presets) + D2 (tokens) + D4 (hook).
+//
+// Purpose: prove the foundation reads/writes URL correctly in a real
+// browser before any Quick Start UI is built on top of it. Not shown in
+// navigation; reached only via the /simulate/v2-probe route.
+//
+// What it renders:
+// - Current config as pretty-printed JSON
+// - A row of 7 preset buttons (calls setPreset)
+// - SL +/- buttons (calls setSL), same for TP
+// - Skill mode switcher (calls setMode)
+// - Reset button
+//
+// A successful load = click → URL search params update → JSON re-renders
+// with new values. Playwright can assert on both screen text and
+// window.location.search.
+
+import { SIMULATOR_PRESETS } from "../config/simulator-presets";
+import {
+  RISK_TOKENS,
+  SIMULATOR_SKILL_MODES,
+  SKILL_MODE_META,
+} from "../config/simulator-tokens";
+import { useSimConfig } from "../hooks/useSimConfig";
+
+export default function SimV2Probe() {
+  const { config, setMode, setPreset, setSL, setTP, reset } = useSimConfig();
+
+  return (
+    <div class="mx-auto max-w-3xl p-6 font-mono text-sm">
+      <h1 class="mb-4 text-xl font-bold" data-testid="probe-title">
+        /simulate v2 foundation probe
+      </h1>
+      <p class="mb-4 text-zinc-400">
+        Internal diagnostic — verifies D1 presets + D2 tokens + D4 useSimConfig
+        work together. Not linked from nav.
+      </p>
+
+      <pre
+        class="mb-6 overflow-auto rounded border border-zinc-700 bg-zinc-900 p-4 text-emerald-300"
+        data-testid="probe-config-json"
+      >
+        {JSON.stringify(config, null, 2)}
+      </pre>
+
+      <section class="mb-6">
+        <h2 class="mb-2 font-bold">Skill mode</h2>
+        <div class="flex flex-wrap gap-2">
+          {SIMULATOR_SKILL_MODES.map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setMode(m)}
+              data-testid={`probe-mode-${m}`}
+              class={`rounded border px-3 py-2 text-xs ${
+                config.mode === m
+                  ? "border-emerald-500 bg-emerald-500/10 text-emerald-300"
+                  : "border-zinc-700 text-zinc-300 hover:border-zinc-500"
+              }`}
+            >
+              {SKILL_MODE_META[m].label.en}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section class="mb-6">
+        <h2 class="mb-2 font-bold">
+          Preset ({SIMULATOR_PRESETS.length} curated)
+        </h2>
+        <div class="flex flex-wrap gap-2">
+          {SIMULATOR_PRESETS.map((p) => (
+            <button
+              key={p.id}
+              type="button"
+              onClick={() => setPreset(p.id)}
+              data-testid={`probe-preset-${p.id}`}
+              class={`rounded border px-3 py-2 text-xs ${
+                config.presetId === p.id
+                  ? "border-emerald-500 bg-emerald-500/10 text-emerald-300"
+                  : "border-zinc-700 text-zinc-300 hover:border-zinc-500"
+              }`}
+            >
+              <span
+                class={`mr-2 inline-block h-2 w-2 rounded-full ${RISK_TOKENS[p.risk].dot}`}
+              />
+              {p.labels.en}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section class="mb-6 flex gap-6">
+        <div>
+          <h2 class="mb-2 font-bold">SL: {config.sl}%</h2>
+          <div class="flex gap-2">
+            <button
+              type="button"
+              data-testid="probe-sl-down"
+              onClick={() => setSL(config.sl - 1)}
+              class="rounded border border-zinc-700 px-3 py-2 text-xs"
+            >
+              −1
+            </button>
+            <button
+              type="button"
+              data-testid="probe-sl-up"
+              onClick={() => setSL(config.sl + 1)}
+              class="rounded border border-zinc-700 px-3 py-2 text-xs"
+            >
+              +1
+            </button>
+          </div>
+        </div>
+        <div>
+          <h2 class="mb-2 font-bold">TP: {config.tp}%</h2>
+          <div class="flex gap-2">
+            <button
+              type="button"
+              data-testid="probe-tp-down"
+              onClick={() => setTP(config.tp - 1)}
+              class="rounded border border-zinc-700 px-3 py-2 text-xs"
+            >
+              −1
+            </button>
+            <button
+              type="button"
+              data-testid="probe-tp-up"
+              onClick={() => setTP(config.tp + 1)}
+              class="rounded border border-zinc-700 px-3 py-2 text-xs"
+            >
+              +1
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <button
+        type="button"
+        data-testid="probe-reset"
+        onClick={reset}
+        class="rounded border border-rose-500/50 bg-rose-500/10 px-3 py-2 text-xs text-rose-300"
+      >
+        Reset to default
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/useSimConfig.ts
+++ b/src/hooks/useSimConfig.ts
@@ -1,0 +1,199 @@
+// URL ↔ state SSoT for the /simulate redesign.
+//
+// Purpose: every Quick Start / Standard interaction (pick preset, change SL,
+// switch skill mode) writes to the URL. Reload / share-link / browser back
+// all reproduce the same screen. Becomes the one place that owns the
+// "current simulation config" across the new simulator components.
+//
+// Boundaries:
+// - Does NOT fetch from /simulate. Consumers do that themselves, keyed on
+//   the config this hook returns.
+// - Does NOT manage Expert builder state (indicators/conditions). Those
+//   stay inside SimulatorPage.tsx legacy paths until Phase 3.
+// - Uses history.replaceState so rapid param changes (e.g. slider drags)
+//   don't pollute browser history.
+
+import { useCallback, useEffect, useState } from "preact/hooks";
+import {
+  findPreset,
+  QUICK_START_DEFAULT_PRESET_ID,
+  type PresetDirection,
+} from "../config/simulator-presets";
+import {
+  DEFAULT_SKILL_MODE,
+  SIMULATOR_SKILL_MODES,
+  type SimulatorSkillMode,
+} from "../config/simulator-tokens";
+
+export interface SimConfig {
+  mode: SimulatorSkillMode;
+  presetId: string | null;
+  direction: PresetDirection;
+  sl: number;
+  tp: number;
+  coin: string;
+}
+
+const SL_MIN = 1;
+const SL_MAX = 30;
+const TP_MIN = 1;
+const TP_MAX = 50;
+const DIRECTIONS: readonly PresetDirection[] = ["long", "short", "both"];
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, value));
+}
+
+function parseDirection(raw: string | null): PresetDirection | null {
+  if (!raw) return null;
+  const lower = raw.toLowerCase();
+  return (DIRECTIONS as readonly string[]).includes(lower)
+    ? (lower as PresetDirection)
+    : null;
+}
+
+function parseMode(raw: string | null): SimulatorSkillMode | null {
+  if (!raw) return null;
+  const lower = raw.toLowerCase();
+  return (SIMULATOR_SKILL_MODES as readonly string[]).includes(lower)
+    ? (lower as SimulatorSkillMode)
+    : null;
+}
+
+function parseNum(raw: string | null, min: number, max: number): number | null {
+  if (!raw) return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return null;
+  return clamp(n, min, max);
+}
+
+function defaultsFromPreset(presetId: string | null): Omit<SimConfig, "mode"> {
+  const preset = presetId ? findPreset(presetId) : undefined;
+  if (preset) {
+    return {
+      presetId: preset.id,
+      direction: preset.direction,
+      sl: preset.defaults.sl,
+      tp: preset.defaults.tp,
+      coin: preset.defaults.coin,
+    };
+  }
+  const fallback = findPreset(QUICK_START_DEFAULT_PRESET_ID);
+  return {
+    presetId: fallback?.id ?? QUICK_START_DEFAULT_PRESET_ID,
+    direction: fallback?.direction ?? "short",
+    sl: fallback?.defaults.sl ?? 10,
+    tp: fallback?.defaults.tp ?? 8,
+    coin: fallback?.defaults.coin ?? "BTC",
+  };
+}
+
+function readFromURL(): SimConfig {
+  if (typeof window === "undefined") {
+    return { mode: DEFAULT_SKILL_MODE, ...defaultsFromPreset(null) };
+  }
+  const params = new URLSearchParams(window.location.search);
+  const rawPreset = params.get("preset");
+  const preset = rawPreset && findPreset(rawPreset) ? rawPreset : null;
+  const base = defaultsFromPreset(preset);
+
+  const mode = parseMode(params.get("mode")) ?? DEFAULT_SKILL_MODE;
+  const direction = parseDirection(params.get("dir")) ?? base.direction;
+  const sl = parseNum(params.get("sl"), SL_MIN, SL_MAX) ?? base.sl;
+  const tp = parseNum(params.get("tp"), TP_MIN, TP_MAX) ?? base.tp;
+  const coinRaw = params.get("coin");
+  const coin = coinRaw ? coinRaw.toUpperCase().slice(0, 12) : base.coin;
+
+  return { mode, presetId: base.presetId, direction, sl, tp, coin };
+}
+
+function writeToURL(next: SimConfig): void {
+  if (typeof window === "undefined") return;
+  const url = new URL(window.location.href);
+  const p = url.searchParams;
+  if (next.presetId) p.set("preset", next.presetId);
+  else p.delete("preset");
+  p.set("dir", next.direction);
+  p.set("sl", String(next.sl));
+  p.set("tp", String(next.tp));
+  p.set("coin", next.coin);
+  if (next.mode !== DEFAULT_SKILL_MODE) p.set("mode", next.mode);
+  else p.delete("mode");
+  const qs = p.toString();
+  const newPath = `${url.pathname}${qs ? `?${qs}` : ""}${url.hash}`;
+  window.history.replaceState(null, "", newPath);
+}
+
+export interface UseSimConfig {
+  config: SimConfig;
+  setMode: (mode: SimulatorSkillMode) => void;
+  setPreset: (presetId: string) => void;
+  setDirection: (direction: PresetDirection) => void;
+  setSL: (sl: number) => void;
+  setTP: (tp: number) => void;
+  setCoin: (coin: string) => void;
+  reset: () => void;
+}
+
+export function useSimConfig(): UseSimConfig {
+  const [config, setConfig] = useState<SimConfig>(() => readFromURL());
+
+  useEffect(() => {
+    writeToURL(config);
+  }, [config]);
+
+  const setMode = useCallback((mode: SimulatorSkillMode) => {
+    setConfig((prev) => ({ ...prev, mode }));
+  }, []);
+
+  const setPreset = useCallback((presetId: string) => {
+    const preset = findPreset(presetId);
+    if (!preset) return;
+    setConfig((prev) => ({
+      ...prev,
+      presetId: preset.id,
+      direction: preset.direction,
+      sl: preset.defaults.sl,
+      tp: preset.defaults.tp,
+      coin: preset.defaults.coin,
+    }));
+  }, []);
+
+  const setDirection = useCallback((direction: PresetDirection) => {
+    setConfig((prev) => ({ ...prev, direction }));
+  }, []);
+
+  const setSL = useCallback((sl: number) => {
+    setConfig((prev) => ({ ...prev, sl: clamp(sl, SL_MIN, SL_MAX) }));
+  }, []);
+
+  const setTP = useCallback((tp: number) => {
+    setConfig((prev) => ({ ...prev, tp: clamp(tp, TP_MIN, TP_MAX) }));
+  }, []);
+
+  const setCoin = useCallback((coin: string) => {
+    const clean = coin.trim().toUpperCase().slice(0, 12);
+    if (!clean) return;
+    setConfig((prev) => ({ ...prev, coin: clean }));
+  }, []);
+
+  const reset = useCallback(() => {
+    const defaults = {
+      mode: DEFAULT_SKILL_MODE,
+      ...defaultsFromPreset(QUICK_START_DEFAULT_PRESET_ID),
+    };
+    setConfig(defaults);
+  }, []);
+
+  return {
+    config,
+    setMode,
+    setPreset,
+    setDirection,
+    setSL,
+    setTP,
+    setCoin,
+    reset,
+  };
+}

--- a/src/pages/simulate/v2-probe.astro
+++ b/src/pages/simulate/v2-probe.astro
@@ -1,0 +1,11 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import SimV2Probe from "../../components/SimV2Probe";
+---
+
+<Layout title="sim v2 probe — internal" description="Internal diagnostic page for /simulate redesign foundation. Not indexed.">
+  <meta slot="head" name="robots" content="noindex, nofollow" />
+  <main class="min-h-screen bg-zinc-950 text-zinc-100">
+    <SimV2Probe client:only="preact" />
+  </main>
+</Layout>


### PR DESCRIPTION
## Summary
Verifies the /simulate redesign foundation (presets + tokens + hook) works end-to-end in a real browser before any Quick Start UI ships. Route is internal — `/simulate/v2-probe/` with robots noindex, not linked from navigation.

## Why this PR exists
D1 presets, D2 tokens, D4 hook passed "tsc + build" individually but nothing proved they *worked together in a browser*. This PR closes that gap. When PresetCard ships next, we already know the hook it depends on is correct.

## What the probe tests (16/16 passing)
```
✓ initial preset = bb-squeeze-short
✓ initial mode = quick
✓ initial sl = 10, tp = 8
✓ preset click → presetId updates + URL updates
✓ preset click applies SL/TP defaults (RSI → sl=5, tp=10)
✓ SL +1 button → value increments + URL updates
✓ mode click → URL ?mode= tracks
✓ ?preset=X in URL on load → starts selected
✓ invalid preset id → falls back to default
✓ ?sl=999 → clamped to 30 (max)
```

## Depends on
- #1259 (D4 useSimConfig hook — open)
- D2 tokens — merged ✅
- D1 presets — merged ✅

When D4 merges, this branch's diff against main remains only the probe component + route.

## Test plan
- [x] `npm run build` → 1179 pages
- [x] Playwright script `node .tmp-probe-verify.mjs` → 16/16 pass
- [x] Preview served `/simulate/v2-probe/` with 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)