### PR TITLE
fix(nav): autotrade GNB badge NEW → SOON (until OKX OAuth restored)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -77,7 +77,7 @@ const navItems = [
   { href: simulatePath, match: '/simulate', label: t('nav.simulate') },
   { href: strategiesPath, match: '/strategies', label: t('nav.strategies') },
   { href: signalsPath, match: '/signals', label: t('nav.signals') },
-  { href: autotradingPath, match: '/autotrading', label: t('nav.autotrading'), badge: 'NEW' },
+  { href: autotradingPath, match: '/autotrading', label: t('nav.autotrading'), badge: 'SOON' },
   { href: marketPath, match: '/market', label: t('nav.market') },
   { href: coinsPath, match: '/coins', label: t('nav.coins') },
   { href: learnPath, match: '/learn', label: t('nav.learn') },


### PR DESCRIPTION
Owner directive during /simulate redesign. Until OKX OAuth is re-enabled, advertising autotrade as "NEW" sets wrong expectations.

- 1 char change (NEW → SOON)
- No functional difference
- Reverts when autotrade is fully live

Build: 1178 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)