### PR TITLE
fix(qa-b2): site-wide a11y — 44px nav + prefers-reduced-motion respected

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -472,7 +472,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
               </div>
             </div>
           ) : (
-            <a href={item.href} aria-current={isActive(item.match) ? "page" : undefined} class="transition-colors nav-slide-underline flex items-center gap-1.5" style={isActive(item.match) ? 'color:var(--color-accent);font-weight:500' : 'color:var(--color-text-muted)'}>{item.label}{item.badge && <span class="text-[9px] font-bold px-1 py-0.5 rounded bg-[--color-accent] text-white leading-none tracking-wide">{item.badge}</span>}</a>
+            <a href={item.href} aria-current={isActive(item.match) ? "page" : undefined} class="transition-colors nav-slide-underline inline-flex items-center gap-1.5 min-h-11" style={isActive(item.match) ? 'color:var(--color-accent);font-weight:500' : 'color:var(--color-text-muted)'}>{item.label}{item.badge && <span class="text-[9px] font-bold px-1 py-0.5 rounded bg-[--color-accent] text-white leading-none tracking-wide">{item.badge}</span>}</a>
           ))}
         </div>
         <!-- 3열: Lang (지구본) + Mobile hamburger (우측) -->

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1894,3 +1894,33 @@ a:not(.btn):not(.card-hover):not(nav a):hover {
   font-weight: 700;
   padding: 0 0.5rem;
 }
+
+/* ─── Reduced-motion global override ─────────────────────────────────
+ * Respects user's OS-level `prefers-reduced-motion: reduce` setting.
+ * Disables Tailwind animate-*, transitions, and scroll-triggered fades.
+ * Flagged by P4 accessibility audit (2026-04-22): animate-pulse/ping
+ * still running on landing + dashboard + signals under reduce mode.
+ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+  .animate-pulse,
+  .animate-ping,
+  .animate-bounce,
+  .animate-spin {
+    animation: none !important;
+  }
+  /* Reveal sections — make them instantly visible instead of animating in */
+  .reveal,
+  .reveal-child > * {
+    opacity: 1 !important;
+    transform: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
B2 of 6-batch sweep. Fixes P1+P4+P5 persona findings on global a11y.

- Desktop nav links: +min-h-11 (9 items × every page)
- Global prefers-reduced-motion media query: disables animate-pulse/ping/bounce/spin + shortens all animations/transitions to 0.01ms