### PR TITLE
fix(qa-b8): fees Binance badge — split Spot 19% · Futures 9%

### DIFF
--- a/src/pages/fees.astro
+++ b/src/pages/fees.astro
@@ -131,7 +131,7 @@ const t = useTranslations('en');
 
             <div class="flex flex-wrap items-center gap-2 pt-2">
               <span class="inline-flex items-center gap-1 text-xs font-mono px-2 py-1 rounded border border-[--color-up]/40 bg-[--color-up]/5 text-[--color-up] font-semibold">
-                Up to 19% Trade Rebates
+                Spot 19% · Futures 9% rebate
               </span>
               <span class="inline-flex items-center gap-1 text-xs font-mono px-2 py-1 rounded border border-[--color-yellow]/40 bg-[--color-yellow]/5 text-[--color-yellow] font-semibold">
                 Up to $600 Bonus

--- a/src/pages/ko/fees.astro
+++ b/src/pages/ko/fees.astro
@@ -118,7 +118,7 @@ const t = useTranslations('ko');
 
             <div class="flex flex-wrap items-center gap-2 pt-2">
               <span class="inline-flex items-center gap-1 text-xs font-mono px-2 py-1 rounded border border-[--color-up]/40 bg-[--color-up]/5 text-[--color-up] font-semibold">
-                최대 19% 거래 리베이트
+                현물 19% · 선물 9% 리베이트
               </span>
               <span class="inline-flex items-center gap-1 text-xs font-mono px-2 py-1 rounded border border-[--color-yellow]/40 bg-[--color-yellow]/5 text-[--color-yellow] font-semibold">
                 최대 $600 보너스


### PR DESCRIPTION
P3 fee-claim honesty fix. Badge no longer hides the Futures 9% rate behind 'Up to 19%'.