### PR TITLE
fix(qa-b10): TrustGapPanel gap_note — tiered explanation (not self-defeat)

### DIFF
--- a/docs/BRAND_VOICE_PRINCIPLES.md
+++ b/docs/BRAND_VOICE_PRINCIPLES.md
@@ -1,0 +1,59 @@
+# PRUVIQ Brand Voice — 사기꾼 아니기 + 감정 끌기
+
+> 오너 확정 2026-04-22: 정직 온도 유지하면서 사람 마음 끄는 톤.
+
+## 두 축 동시 유지
+
+| 축 | 이걸 한다 | 이건 안 한다 |
+|---|---|---|
+| **정직 (직전온도)** | 손실 공개 · 갭 공개 · 폐기 전략 명시 · 표본 부족 경고 | 자기파괴 · "우리 믿지 마" 톤 · 공포 마케팅 |
+| **감정 끌림** | 차별화 서사 · 자신감 · 대조 ("남들은 숨긴다") | 과장 · "unlimited" · stock photo · 가짜 카운터 |
+
+## 카피 공식
+
+> **"우리는 ~했다 (honest) · 그래서 ~할 것이다 (forward motion)"**
+
+### 좋은 예
+- "Most Backtests Lie. Ours Come With Proof." ← 대조 + 증거 약속
+- "Every Trade Published. Including Losses." ← 정직 + 차별화
+- "88 strategies killed. Here are the 3 that survived." ← 숫자 + 생존 서사
+- "Gap 15%+ means we were too optimistic — we show it anyway." ← 약점 공개 + 자신감
+
+### 나쁜 예
+- "우리 백테스트가 정직하다" ← 자기 평가 (약함)
+- "작을수록 정직" → 갭 60% 볼 때 자기파괴 ❌
+- "Potentially may help you achieve unlimited returns" ← LLM 보일러플레이트
+- "Trusted by 500+ traders" (증거 없음) ← 공허
+- "Delve into the robust landscape of crypto" ← AI-tic
+
+## 체크리스트 (카피 작성 시)
+
+- [ ] 숫자 있는가? (증거)
+- [ ] 대조 있는가? ("남들 vs 우리")
+- [ ] 약점 먼저 인정하는가? (정직)
+- [ ] 그 약점을 어떻게 극복할 것인지 암시하는가? (forward motion)
+- [ ] LLM 단어 없는가? (delve · landscape · tapestry · harness · unlock · elevate · seamless · robust · revolutionary · game-changing)
+- [ ] 한국어는 번역체 없는가? (자연스러운 구어체)
+
+## 색상 톤 규칙 (디자인)
+
+- **정직 신호:** 갭 15%+ 빨강, 실패 전략 회색 — 숨기지 않고 명시
+- **신뢰 포인트:** 브랜드 cyan `#2CB5E8` 만 사용 (decorative emerald 금지)
+- **감정 포인트:** 대조 배치 (큰 숫자 + 작은 설명, 결과 + 원인)
+
+## 페이지별 톤 우선순위
+
+| 페이지 | 주 톤 | 보조 톤 |
+|---|---|---|
+| `/` 랜딩 | 감정 끌림 85% · 정직 15% | 히어로는 끌림, 푸터는 정직 |
+| `/simulate/` | 정직 50% · 끌림 50% | verdict·갭은 정직, CTA는 끌림 |
+| `/performance/` | 정직 85% · 끌림 15% | "Every Trade Published" |
+| `/compare/*` | 끌림 60% · 정직 40% | 경쟁사 승리 row 포함 |
+| `/about/` | 정직 70% · 끌림 30% | 기관 신뢰 시그널 |
+| `/trust/`, `/methodology/` | 정직 95% · 끌림 5% | 스펙 문서 |
+
+## 변경 이력
+
+| 일자 | 이벤트 |
+|---|---|
+| 2026-04-22 | 오너 확정 후 초안 · B10 이후 모든 copy 배치가 이 원칙 따름 |

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -2141,7 +2141,7 @@ export const en = {
   "simV2.trust.gap_live": "Live",
   "simV2.trust.gap_delta": "Gap",
   "simV2.trust.gap_note":
-    "The gap is the number that matters. A tight gap means the backtest is honest.",
+    "Gap = how far our backtest drifted from reality. Under 5% = we called it. 15%+ = we were too optimistic this window — shown on purpose. This is how we keep the model honest.",
   "simV2.cta.connect_heading": "Ready to run this live?",
   "simV2.cta.connect_body":
     "Connect your OKX account in one step. No funds moved, no strategies run, until you say go.",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -2096,7 +2096,7 @@ export const ko: Record<TranslationKey, string> = {
   "simV2.trust.gap_live": "실거래",
   "simV2.trust.gap_delta": "갭",
   "simV2.trust.gap_note":
-    "중요한 건 갭 수치입니다. 작을수록 백테스트가 정직하다는 뜻.",
+    "갭은 우리 백테스트가 현실에서 얼마나 벗어났는지를 보여줍니다. 5% 이내면 예측이 맞은 것, 15% 넘으면 이 기간 우리 모델이 너무 낙관적이었다는 뜻 — 숨기지 않고 공개합니다. 이게 모델을 정직하게 유지하는 방식입니다.",
   "simV2.cta.connect_heading": "실제로 돌려볼 준비 됐나요?",
   "simV2.cta.connect_body":
     "OKX 계정 한 번의 연결. 자금 이동·전략 실행은 승인 전까지 일어나지 않습니다.",


### PR DESCRIPTION
Owner caught: 'Gap 59.6% + smaller=more honest' reads as admission of dishonesty. Copy now explains <5/5-15/>15 tiers and frames high gap as honesty-proof.