### PR TITLE
fix(qa-b12): KO fake counter + axe color-contrast + KO grammar

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -59,8 +59,8 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
         <p class="text-xs text-[--color-text-muted] mt-2 font-mono uppercase tracking-wider">{t('about.num_data')}</p>
       </div>
       <div class="stat-glass text-center">
-        <p class="font-mono text-3xl md:text-4xl font-bold gradient-text">{simulationsRun}+</p>
-        <p class="text-xs text-[--color-text-muted] mt-2 font-mono uppercase tracking-wider">{t('about.num_sims')}</p>
+        <p class="font-mono text-3xl md:text-4xl font-bold gradient-text">{(siteStats as { strategies_tested: number }).strategies_tested}+</p>
+        <p class="text-xs text-[--color-text-muted] mt-2 font-mono uppercase tracking-wider">Strategies Tested</p>
       </div>
     </div>
   </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -97,11 +97,11 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       </div>
     </div>
     <div class="flex items-center justify-center gap-3 md:gap-8 text-[--color-text-muted] text-xs font-mono mt-6">
-      <span class="opacity-50 text-[10px] uppercase tracking-widest">Powered by data from</span>
+      <span class="opacity-80 text-xs uppercase tracking-widest">Powered by data from</span>
       <span class="hidden md:inline opacity-20">|</span>
-      <span class="opacity-50 hover:opacity-90 transition-opacity text-sm font-semibold tracking-wide">OKX Futures</span>
+      <span class="opacity-80 hover:opacity-100 transition-opacity text-sm font-semibold tracking-wide">OKX Futures</span>
       <span class="opacity-20">&middot;</span>
-      <span class="opacity-50 hover:opacity-90 transition-opacity text-sm font-semibold tracking-wide">CoinGecko</span>
+      <span class="opacity-80 hover:opacity-100 transition-opacity text-sm font-semibold tracking-wide">CoinGecko</span>
     </div>
     <p class="text-xs text-[--color-text-muted] font-mono text-center mt-3 opacity-60">Updated live · Last simulation: 2 min ago</p>
   </div>

--- a/src/pages/ko/about.astro
+++ b/src/pages/ko/about.astro
@@ -58,8 +58,8 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
         <p class="text-xs text-[--color-text-muted] mt-2 font-mono uppercase tracking-wider">{t('about.num_data')}</p>
       </div>
       <div class="stat-glass text-center">
-        <p class="font-mono text-3xl md:text-4xl font-bold gradient-text">{simulationsRun}+</p>
-        <p class="text-xs text-[--color-text-muted] mt-2 font-mono uppercase tracking-wider">{t('about.num_sims')}</p>
+        <p class="font-mono text-3xl md:text-4xl font-bold gradient-text">{(siteStats as { strategies_tested: number }).strategies_tested}+</p>
+        <p class="text-xs text-[--color-text-muted] mt-2 font-mono uppercase tracking-wider">검증 전략</p>
       </div>
     </div>
   </section>

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -35,10 +35,10 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       <div class="grid md:grid-cols-[3fr_2fr] gap-12 md:gap-16 items-start">
         <!-- Left: Text + CTA -->
         <div>
-          <HeroBadge stat={simulationsRun} label="시뮬레이션 실행" cta="무료 체험 →" />
+          <HeroBadge stat={`${coinsAnalyzed}+`} label="코인 · 2년 데이터 · 88 전략 검증" cta="무료 체험 →" />
           <p class="font-mono text-[--color-accent] text-sm tracking-wider mb-5 opacity-90">검증하고. 실행하고. 수익내고.</p>
           <h1 class="text-[1.7rem] sm:text-4xl md:text-5xl lg:text-5xl font-extrabold tracking-[-0.04em]" style="line-height:1.1">
-            대부분의 백테스트는 거짓말합니다.<br/><span class="gradient-text-shimmer">우리는 증거를 공개합니다.</span>
+            대부분의 백테스트는 거짓말입니다.<br/><span class="gradient-text-shimmer">우리는 증거를 공개합니다.</span>
           </h1>
           <p class="mt-10 text-xl md:text-2xl text-[--color-text-secondary] leading-relaxed max-w-lg">
             <strong class="text-[--color-text]">{coinsAnalyzed}개 이상의 코인</strong>에서 실제 수수료를 포함한 전략 검증. 실패를 확인하고, 살아남은 전략만 남기세요. 코딩 불필요. 가입 불필요.
@@ -88,8 +88,8 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
         <p class="metric-label mt-2">코인 테스트</p>
       </div>
       <div class="stat-glass text-center shadow-[var(--shadow-md)]">
-        <p class="metric-value-lg text-[--color-accent]"><CountUp client:visible target={(siteStats as { simulations_run: number }).simulations_run} suffix="+" locale="ko-KR" /></p>
-        <p class="metric-label mt-2">시뮬레이션</p>
+        <p class="metric-value-lg text-[--color-accent]"><CountUp client:visible target={(siteStats as { strategies_tested: number }).strategies_tested} suffix="+" /></p>
+        <p class="metric-label mt-2">검증 전략</p>
       </div>
       <div class="stat-glass text-center shadow-[var(--shadow-md)]">
         <p class="metric-value-lg text-[--color-accent]"><CountUp client:visible target={simulatorPresetCount} suffix="+" /></p>
@@ -97,11 +97,11 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       </div>
     </div>
     <div class="flex items-center justify-center gap-3 md:gap-8 text-[--color-text-muted] text-xs font-mono mt-6">
-      <span class="opacity-50 text-[10px] uppercase tracking-widest">데이터 출처</span>
+      <span class="opacity-80 text-xs uppercase tracking-widest">데이터 출처</span>
       <span class="hidden md:inline opacity-20">|</span>
-      <span class="opacity-50 hover:opacity-90 transition-opacity text-sm font-semibold tracking-wide">OKX Futures</span>
+      <span class="opacity-80 hover:opacity-100 transition-opacity text-sm font-semibold tracking-wide">OKX Futures</span>
       <span class="opacity-20">&middot;</span>
-      <span class="opacity-50 hover:opacity-90 transition-opacity text-sm font-semibold tracking-wide">CoinGecko</span>
+      <span class="opacity-80 hover:opacity-100 transition-opacity text-sm font-semibold tracking-wide">CoinGecko</span>
     </div>
     <p class="text-xs text-[--color-text-muted] font-mono text-center mt-3 opacity-60">실시간 업데이트 · 마지막 시뮬레이션: 2분 전</p>
   </div>

--- a/src/pages/ko/simulate/index.astro
+++ b/src/pages/ko/simulate/index.astro
@@ -71,13 +71,13 @@ const simulateJsonLd = {
         </div>
       </div>
 
-      <!-- Social proof counters -->
+      <!-- Social proof counters — 12,847 fake counter removed (B12) -->
       <div class="flex flex-wrap gap-x-4 gap-y-1 font-mono text-sm">
-        <span class="text-[--color-text-muted]"><span class="text-[--color-accent] font-bold">{simulationsRun}</span> 회 시뮬레이션 실행</span>
-        <span class="text-[--color-text-muted] hidden sm:inline">·</span>
         <span class="text-[--color-text-muted]"><span class="text-[--color-accent] font-bold">{coinsAnalyzed}</span> 코인 분석</span>
         <span class="text-[--color-text-muted] hidden sm:inline">·</span>
-        <span class="text-[--color-text-muted]"><span class="text-[--color-accent] font-bold">{presetCount}</span> 개 전략 이용 가능</span>
+        <span class="text-[--color-text-muted]"><span class="text-[--color-accent] font-bold">{presetCount}</span> 개 전략</span>
+        <span class="text-[--color-text-muted] hidden sm:inline">·</span>
+        <span class="text-[--color-text-muted]">2년 데이터 · 실 수수료</span>
       </div>
     </div>
   </section>

--- a/src/pages/simulate/index.astro
+++ b/src/pages/simulate/index.astro
@@ -74,13 +74,13 @@ const simulateJsonLd = {
         </div>
       </div>
 
-      <!-- Social proof counters -->
+      <!-- Social proof counters — 12,847 fake counter removed (B12) -->
       <div class="flex flex-wrap gap-x-4 gap-y-1 font-mono text-sm divide-x-0">
-        <span class="text-[--color-text-muted]"><span class="text-[--color-accent] font-bold">{simulationsRun}</span> simulations run</span>
-        <span class="text-[--color-text-muted] hidden sm:inline">·</span>
         <span class="text-[--color-text-muted]"><span class="text-[--color-accent] font-bold">{coinsAnalyzed}</span> coins analyzed</span>
         <span class="text-[--color-text-muted] hidden sm:inline">·</span>
-        <span class="text-[--color-text-muted]"><span class="text-[--color-accent] font-bold">{presetCount}</span> strategies available</span>
+        <span class="text-[--color-text-muted]"><span class="text-[--color-accent] font-bold">{presetCount}</span> strategies</span>
+        <span class="text-[--color-text-muted] hidden sm:inline">·</span>
+        <span class="text-[--color-text-muted]">2yr data · real fees</span>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
Resolves 2 HIGH blockers from the final QA sweep audit that were preventing nav-unhide readiness. B11 only cleaned EN; KO side still surfaced '12,847 simulations' fake counter in 3 places.

## What changed
**HIGH 1 — Fake counter kill (KO mirror of B11)**
- `ko/index.astro` HeroBadge stat → `${coinsAnalyzed}+` (real)
- `ko/index.astro` CountUp stat → `strategies_tested` instead of `simulations_run`
- `ko/simulate/index.astro` social proof: dropped 'N회 시뮬레이션 실행', added '2년 데이터 · 실 수수료'
- `simulate/index.astro` EN mirror same pattern
- `about.astro` + `ko/about.astro`: `simulationsRun` → `strategies_tested` ('Strategies Tested' / '검증 전략')

**HIGH 2 — `/` color-contrast (axe 3 nodes)**
'Powered by data from' / OKX Futures / CoinGecko chip row failed WCAG 2.2 AA (contrast 4.45 < 4.5) on both `/` and `/ko`. Applied:
- `opacity-50` → `opacity-80`
- `text-[10px]` → `text-xs`
- `hover:opacity-90` → `hover:opacity-100`

**MED — KO grammar**
'거짓말합니다' (ungrammatical verb form) → '거짓말입니다' (correct noun form).

## Build
`npm run build` → 1183 pages clean, no TypeScript errors.

## Test plan
- [x] Build passes
- [ ] CI green
- [ ] Live: `/` + `/ko` no '12,847'; no 'Powered by data from' contrast fail; `/ko` hero reads '거짓말입니다'