### PR TITLE
fix(api): CORS-safe rate limit — skip OPTIONS + 429 headers

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -696,6 +696,16 @@ async def prometheus_instrumentation_middleware(request: Request, call_next):
 
 @app.middleware("http")
 async def rate_limit_middleware(request: Request, call_next):
+    # 2026-04-22: CORS preflight (OPTIONS) must NEVER be rate-limited or
+    # otherwise early-returned from middleware. When it is, the response
+    # lacks Access-Control-Allow-Origin headers (CORSMiddleware doesn't
+    # wrap early-returned JSONResponses), and the browser reports the
+    # request as CORS-blocked rather than 429. That broke every
+    # /simulate fetch from the production frontend because a page load
+    # can easily issue 5+ preflights (TrustGapPanel init + preset click
+    # + slider) and trip the per-IP limit.
+    if request.method == "OPTIONS":
+        return await call_next(request)
     if request.url.path in ("/simulate", "/simulate/coin", "/simulate/compare", "/simulate/validate", "/simulate/optimize", "/backtest", "/export/csv"):
         # Bypass rate limit for internal callers (sim-audit, signal-telegram, etc.)
         req_key = request.headers.get("X-Internal-Key", "")
@@ -708,10 +718,18 @@ async def rate_limit_middleware(request: Request, call_next):
             logger.warning(
                 f"Rate limit hit: {client_ip} on {request.url.path} — retry after {retry_after}s"
             )
+            # Include CORS headers manually so the browser sees 429 (and
+            # can surface "Rate limit exceeded") rather than CORS-blocked.
+            origin = request.headers.get("origin", "")
+            cors_headers: dict[str, str] = {"Retry-After": str(retry_after)}
+            if origin in _cors_origins:
+                cors_headers["Access-Control-Allow-Origin"] = origin
+                cors_headers["Access-Control-Allow-Credentials"] = "true"
+                cors_headers["Vary"] = "Origin"
             return JSONResponse(
                 status_code=429,
                 content={"detail": f"Rate limit exceeded. Retry after {retry_after}s."},
-                headers={"Retry-After": str(retry_after)},
+                headers=cors_headers,
             )
     # Light rate limit: /api/subscribe and /auth/okx/init (10 req/min per IP)
     if request.url.path in ("/api/subscribe", "/auth/okx/init"):


### PR DESCRIPTION
## Bug

Real-browser Playwright against prod caught that every preset click on pruviq.com/simulate intermittently failed with:

> Access to fetch at 'https://api.pruviq.com/simulate' from origin 'https://pruviq.com' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.

Root cause: `rate_limit_middleware` counted OPTIONS preflights AND the 429 response didn't carry CORS headers. Browser saw a no-CORS 429 → reported CORS-blocked. A single page load easily makes 5+ preflights (TrustGapPanel + preset clicks + slider commits) and trips the 30/min limit within one user session.

End result: users saw a silent `sim-v1-results-error` instead of metrics. Every preset looked broken even though the backend was healthy.

## Fix

1. **Skip rate limit for OPTIONS** — preflights are CORS gatekeepers, not quota-consuming work
2. **Attach CORS headers to 429 JSONResponse** — if a real POST trips the limit, browser sees the real error instead of misreading as CORS

## Deploy

Backend-only. After auto-merge, on Mac Mini (jepo account):
```bash
cd ~/pruviq && git pull && ~/Desktop/start-backend.command
```

## Test plan

- [x] Local reproduction: curl OPTIONS /simulate with `pruviq.com` origin → 200 + allow-origin
- [ ] CI green
- [ ] Post-deploy: Playwright prod test (P1/P2/P3/P6/P7) all pass — currently 3 fail due to CORS→429 cascade