### PR TITLE
fix(audit): hero CTA 44px + stale e2e assertions (prod re-audit)

### DIFF
--- a/src/pages/ko/simulate/index.astro
+++ b/src/pages/ko/simulate/index.astro
@@ -56,7 +56,7 @@ const simulateJsonLd = {
         </div>
         <div class="flex items-center gap-3 shrink-0">
           <a href="/ko/simulate?preset=atr-breakout"
-             class="btn btn-primary btn-sm inline-flex items-center gap-2 shadow-lg shadow-[--color-accent]/20 min-h-[44px]"
+             class="btn btn-primary btn-md inline-flex items-center gap-2 shadow-lg shadow-[--color-accent]/20"
              title={t('simulate.preset_verified_tooltip')}>
             {t('simulate.cta_preset')} &rarr;
           </a>

--- a/src/pages/simulate/index.astro
+++ b/src/pages/simulate/index.astro
@@ -61,7 +61,7 @@ const simulateJsonLd = {
         </div>
         <div class="flex items-center gap-3 shrink-0">
           <a href="/simulate?preset=atr-breakout"
-             class="btn btn-primary btn-sm inline-flex items-center gap-2 shadow-lg shadow-[--color-accent]/20 min-h-[44px]"
+             class="btn btn-primary btn-md inline-flex items-center gap-2 shadow-lg shadow-[--color-accent]/20"
              title={t('simulate.preset_verified_tooltip')}>
             {t('simulate.cta_preset')} &rarr;
           </a>

--- a/tests/e2e/interactive-qa-extra.spec.ts
+++ b/tests/e2e/interactive-qa-extra.spec.ts
@@ -16,6 +16,16 @@ const IS_PROD = (process.env.BASE_URL ?? "").includes("pruviq.com");
 
 test.describe("Interactive QA Extra", () => {
   test.skip(!IS_PROD, "Prod only (BASE_URL=https://pruviq.com)");
+  // 2026-04-22: entire file gated behind `legacy` grep. These 3 tests
+  // target the pre-V1 simulator (`quick-cat-breakout`, `copy-link`,
+  // `tab-summary` testids, Optimize tab, /ko labels at "승률"). The new
+  // /simulate (SimulatorV1) doesn't expose any of these affordances.
+  // Coverage is now provided by `tests/e2e/simulator-real-usage.spec.ts`
+  // (prod P1–P10) — which replaces these tests with V1-native equivalents.
+  test.skip(
+    true,
+    "Legacy simulator selectors removed in V1 redesign — covered by simulator-real-usage.spec.ts",
+  );
 
   // ── 1. URL Share: preset run → ?strategy= (not ?c=) ───────────────────────
 

--- a/tests/e2e/prod-axe-audit.spec.ts
+++ b/tests/e2e/prod-axe-audit.spec.ts
@@ -1,0 +1,42 @@
+// L3: axe-core WCAG audit against prod /simulate + /ko/simulate.
+// prod-only (skip in CI localhost due to CORS).
+
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+const BASE = process.env.BASE_URL || "http://localhost:4321";
+const IS_PROD_LIKE = /pruviq\.com/.test(BASE);
+test.skip(!IS_PROD_LIKE, "prod-only");
+
+for (const path of ["/simulate/", "/ko/simulate/"]) {
+  test(`axe WCAG 2.2 AA — ${path}`, async ({ page }) => {
+    await page.goto(path, { waitUntil: "domcontentloaded" });
+    await page.waitForSelector("[data-testid=sim-v1-root]", { timeout: 15000 });
+    // Wait for the first preset grid card to render so axe sees the full
+    // hydrated DOM.
+    await page.waitForSelector("[data-testid=sim-v1-preset-atr-breakout]", {
+      timeout: 15000,
+    });
+    await page.waitForTimeout(1500); // let TrustGap backtest fetch complete
+
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"])
+      .analyze();
+
+    const critical = results.violations.filter(
+      (v) => v.impact === "critical" || v.impact === "serious",
+    );
+    const minor = results.violations.filter(
+      (v) => v.impact === "moderate" || v.impact === "minor",
+    );
+    console.log(
+      `[${path}] critical+serious: ${critical.length}, moderate+minor: ${minor.length}`,
+    );
+    for (const v of results.violations) {
+      console.log(
+        ` ${v.impact?.toUpperCase()} ${v.id} — ${v.description} (${v.nodes.length} nodes)`,
+      );
+    }
+    expect(critical).toHaveLength(0);
+  });
+}

--- a/tests/e2e/prod-mobile-flow.spec.ts
+++ b/tests/e2e/prod-mobile-flow.spec.ts
@@ -1,0 +1,95 @@
+// L4: mobile-only 375×812 end-to-end flow against prod.
+
+import { expect, test } from "@playwright/test";
+
+const BASE = process.env.BASE_URL || "http://localhost:4321";
+const IS_PROD_LIKE = /pruviq\.com/.test(BASE);
+test.skip(!IS_PROD_LIKE, "prod-only");
+
+test.describe("L4 mobile 375×812 prod", () => {
+  test.use({ viewport: { width: 375, height: 812 } });
+
+  test("no horizontal scroll on /simulate/", async ({ page }) => {
+    await page.goto("/simulate/", { waitUntil: "domcontentloaded" });
+    await page.waitForSelector("[data-testid=sim-v1-root]");
+    const overflow = await page.evaluate(() => {
+      const d = document.documentElement;
+      return {
+        scrollWidth: d.scrollWidth,
+        clientWidth: d.clientWidth,
+        overflows: d.scrollWidth > d.clientWidth,
+      };
+    });
+    expect(overflow.overflows).toBe(false);
+  });
+
+  test("sticky CTA present + within bottom 100px", async ({ page }) => {
+    await page.goto("/simulate/", { waitUntil: "domcontentloaded" });
+    await page.waitForSelector("[data-testid=sim-v1-root]");
+    // MobileStickyCTA uses testid `sim-v1-sticky-cta` (v1 naming).
+    const sticky = await page.$("[data-testid=sim-v1-sticky-cta]");
+    expect(sticky).not.toBeNull();
+  });
+
+  test("all 5 preset cards ≥44px tall + ≥44px wide tap targets", async ({
+    page,
+  }) => {
+    await page.goto("/simulate/", { waitUntil: "domcontentloaded" });
+    await page.waitForSelector("[data-testid=sim-v1-root]");
+    const presets = [
+      "atr-breakout",
+      "ichimoku",
+      "bb-squeeze-short",
+      "keltner-squeeze",
+      "ma-cross",
+    ];
+    for (const id of presets) {
+      const box = await page
+        .locator(`[data-testid=sim-v1-preset-${id}]`)
+        .boundingBox();
+      expect(box?.width).toBeGreaterThanOrEqual(44);
+      expect(box?.height).toBeGreaterThanOrEqual(44);
+    }
+  });
+
+  test("tapping preset → results ENTERS viewport within 3s", async ({
+    page,
+  }) => {
+    await page.goto("/simulate/", { waitUntil: "domcontentloaded" });
+    await page.waitForSelector("[data-testid=sim-v1-root]");
+    await page.click("[data-testid=sim-v1-preset-ichimoku]");
+    await page.waitForSelector("[data-testid=sim-v1-results-ok]", {
+      timeout: 20000,
+    });
+    await page.waitForFunction(
+      () => {
+        const el = document.querySelector<HTMLElement>(
+          "[data-testid=sim-v1-results-ok]",
+        );
+        if (!el) return false;
+        const r = el.getBoundingClientRect();
+        return r.bottom > 0 && r.top < (window.innerHeight || 0);
+      },
+      { timeout: 3000 },
+    );
+  });
+
+  test("skill switcher tabs ≥44px tall on mobile", async ({ page }) => {
+    await page.goto("/simulate/", { waitUntil: "domcontentloaded" });
+    await page.waitForSelector("[data-testid=sim-v1-skill-switcher]");
+    for (const m of ["quick", "standard", "expert"]) {
+      const box = await page
+        .locator(`[data-testid=sim-v1-skill-${m}]`)
+        .boundingBox();
+      expect(box?.height).toBeGreaterThanOrEqual(44);
+    }
+  });
+
+  test("hero CTA ≥44px tall", async ({ page }) => {
+    await page.goto("/simulate/", { waitUntil: "domcontentloaded" });
+    // Hero CTA is the first <a> containing ATR Breakout text
+    const cta = page.locator('a:has-text("ATR Breakout")').first();
+    const box = await cta.boundingBox();
+    expect(box?.height).toBeGreaterThanOrEqual(44);
+  });
+});

--- a/tests/e2e/seo-api-contract.spec.ts
+++ b/tests/e2e/seo-api-contract.spec.ts
@@ -70,8 +70,12 @@ test.describe("SEO Validation", () => {
 
   test("Homepage has og:image", async ({ page }) => {
     await page.goto("/");
+    // 2026-04-22: page now ships og:image twice (jpg + webp for modern
+    // clients). Strict locator would fail on duplicates — .first() is
+    // fine because both satisfy the contract (non-empty + http URL).
     const ogImage = await page
       .locator('meta[property="og:image"]')
+      .first()
       .getAttribute("content");
     expect(ogImage, "og:image must be set").toBeTruthy();
     expect(ogImage).toMatch(/^https?:\/\//);
@@ -160,13 +164,16 @@ test.describe("API Schema Contract", () => {
     expect(data).toHaveProperty("status");
     expect(data.status).toBe("ok");
     expect(data).toHaveProperty("coins_loaded");
-    expect(data.coins_loaded).toBeGreaterThan(500);
+    // 2026-04-22: bound relaxed after Binance→OKX migration (238 coins,
+    // previously 574). Canonical source: backend STRATEGY_REGISTRY +
+    // OKX perpetual listings. ~200 is safe floor for regressions.
+    expect(data.coins_loaded).toBeGreaterThanOrEqual(200);
     expect(data).toHaveProperty("version");
     expect(data).toHaveProperty("uptime_seconds");
     expect(data.uptime_seconds).toBeGreaterThan(0);
   });
 
-  test("GET /coins returns 500+ coins with required fields", async ({
+  test("GET /coins returns 200+ coins with required fields", async ({
     request,
   }) => {
     const resp = await request.get(`${API}/coins`);
@@ -174,7 +181,7 @@ test.describe("API Schema Contract", () => {
     const data = await resp.json();
 
     expect(Array.isArray(data)).toBe(true);
-    expect(data.length).toBeGreaterThan(500);
+    expect(data.length).toBeGreaterThanOrEqual(200);
 
     // Sample coin structure
     const coin = data[0];


### PR DESCRIPTION
Full prod re-audit surfaced 1 real mobile-UX bug (hero CTA 36px) + 5 stale test assertions.

## Real bug
- Hero CTA measured 36px on 375×812 viewport (global.css `btn-sm min-height: 36px` won over Tailwind `min-h-[44px]`). Now uses `btn-md` (native 44px). Fails WCAG 2.5.8 AAA target size without this.

## Stale assertions
- `/health.coins_loaded > 500` → >= 200 (Binance→OKX dropped to 238)
- `/coins.length > 500` → >= 200
- og:image strict locator → `.first()` (prod ships jpg + webp)
- 3 interactive-qa-extra tests target pre-V1 simulator testids (`quick-cat-breakout`, `tab-summary`, Optimize tab, 승률 label). Gated — coverage moved to simulator-real-usage.spec.ts

## New prod-only audit suites
- axe WCAG 2.2 AA: /simulate + /ko → 0 violations
- mobile 375×812: preset taps ≥44px, skill tabs ≥44px, scroll into viewport <3s

After this PR, full e2e on prod should be 142+ passed, 0 failed (excluding the intentionally-skipped 3 legacy-sim tests).