### PR TITLE
fix(builder): axe 4→0 — contrast + label + nested + tab

### DIFF
--- a/src/components/BuilderPanel.tsx
+++ b/src/components/BuilderPanel.tsx
@@ -596,6 +596,10 @@ export default function BuilderPanel(props: Props) {
                 {t.startDate}
               </label>
               <input
+                aria-label={
+                  (props.lang === "ko" ? "시작일" : "Start date") +
+                  " (YYYY-MM-DD)"
+                }
                 type="date"
                 value={props.startDate}
                 onChange={(e: Event) =>
@@ -606,15 +610,19 @@ export default function BuilderPanel(props: Props) {
             </div>
             {/* End Date */}
             <div>
-              <label class="text-[10px] text-[--color-text-muted]">
+              <label class="text-xs text-[--color-text-muted]">
                 {t.endDate}
                 {!props.endDate && (
-                  <span class="ml-1 opacity-50">
+                  <span class="ml-1 text-[--color-text-muted]">
                     ({props.lang === "ko" ? "현재까지" : "present"})
                   </span>
                 )}
               </label>
               <input
+                aria-label={
+                  (props.lang === "ko" ? "종료일" : "End date") +
+                  " (YYYY-MM-DD)"
+                }
                 type="date"
                 value={props.endDate}
                 onChange={(e: Event) =>
@@ -771,7 +779,7 @@ export default function BuilderPanel(props: Props) {
         <details class="border-b border-[--color-border]" open>
           <summary class="px-4 py-2 text-xs font-mono text-[--color-text-muted] uppercase cursor-pointer select-none hover:text-[--color-text] transition-colors list-none flex items-center justify-between">
             <span>{t.avoidHours}</span>
-            <span class="text-[10px] opacity-50">
+            <span class="text-xs text-[--color-text-muted]">
               {props.avoidHours.size > 0
                 ? t.hoursSelected
                   ? t.hoursSelected(props.avoidHours.size)

--- a/src/components/BuilderPanel.tsx
+++ b/src/components/BuilderPanel.tsx
@@ -592,7 +592,7 @@ export default function BuilderPanel(props: Props) {
             )}
             {/* Start Date */}
             <div>
-              <label class="text-[10px] text-[--color-text-muted]">
+              <label class="text-xs text-[--color-text-muted]">
                 {t.startDate}
               </label>
               <input

--- a/src/components/ChartPanel.tsx
+++ b/src/components/ChartPanel.tsx
@@ -237,7 +237,7 @@ export default function ChartPanel({
         <div class="flex items-center gap-2">
           <span class="font-mono text-sm font-bold">{chartSymbol}</span>
           <span class="text-[--color-text-muted] text-xs">{timeframe}</span>
-          <span class="text-[--color-text-muted] text-[9px] font-mono opacity-50 hidden sm:inline">
+          <span class="text-[--color-text-muted] text-xs font-mono hidden sm:inline">
             OKX USDT-SWAP
           </span>
         </div>
@@ -280,10 +280,14 @@ export default function ChartPanel({
           />
         </div>
       </div>
-      {/* Chart body — responsive height: 360px mobile, 640px desktop */}
+      {/* Chart body — responsive height: 360px mobile, 640px desktop.
+          2026-04-23 (a11y): role="img" removed because lightweight-charts
+          inserts focusable canvas/tooltip inside, which axe flags as
+          nested-interactive. role="region" + aria-label is the correct
+          pattern for a named landmark that contains interactive controls. */}
       <div
         ref={chartContainerRef}
-        role="img"
+        role="region"
         aria-label={`${chartSymbol} price chart with strategy signals`}
         class={`h-[360px] md:h-[640px]${chartData.length > 0 && !chartLoading ? " chart-draw-in" : ""}`}
         style={{ minHeight: "300px" }}

--- a/src/components/SimulatorPage.tsx
+++ b/src/components/SimulatorPage.tsx
@@ -1522,9 +1522,12 @@ export default function SimulatorPage({
               style={
                 mobileTab === tab
                   ? {
-                      color: COLORS.accentBright,
+                      // 2026-04-23: accentBright (#5CC8ED) on accentBg (12%
+                      // accent over dark) yields contrast 1.23 — same hue.
+                      // Use white on solid accent for 5.7:1 contrast.
+                      color: "#fff",
                       borderColor: COLORS.accent,
-                      background: COLORS.accentBg,
+                      background: COLORS.accent,
                     }
                   : undefined
               }


### PR DESCRIPTION
Targeted fixes for 4 axe violations found after batch A: opacity-50 on small text × 3, unlabeled date inputs × 2, role=img with focusable descendants × 1, accentBright-on-accentBg tab active 1.23 × 1.