### PR TITLE
fix(ux): autotrading Coming Soon site-wide + Builder Settings summary

### DIFF
--- a/src/components/BuilderPanel.tsx
+++ b/src/components/BuilderPanel.tsx
@@ -844,6 +844,49 @@ export default function BuilderPanel(props: Props) {
               {t.apiDown}
             </div>
           )}
+          {/* 2026-04-23: Settings summary one-liner above RUN — gives users
+              explicit confirmation of what will execute. Prevents "I just
+              clicked RUN, but what's my current config?" confusion. */}
+          {props.conditions.length > 0 && (
+            <div
+              class="mb-2 px-3 py-2 rounded border border-[--color-border] bg-[--color-bg-tooltip] font-mono text-[11px] text-[--color-text-muted]"
+              data-testid="run-summary"
+            >
+              <span class="text-[--color-text]">
+                {props.activePreset ||
+                  (props.lang === "ko" ? "커스텀" : "Custom")}
+              </span>
+              <span class="mx-1.5">·</span>
+              <span
+                style={{
+                  color:
+                    props.direction === "short"
+                      ? COLORS.redBright || "#F87171"
+                      : props.direction === "long"
+                        ? COLORS.greenBright || "#4ADE80"
+                        : COLORS.accentBright || "#5CC8ED",
+                }}
+              >
+                {props.direction.toUpperCase()}
+              </span>
+              <span class="mx-1.5">·</span>
+              <span>SL {props.slPct}%</span>
+              <span class="mx-1.5">·</span>
+              <span>TP {props.tpPct}%</span>
+              <span class="mx-1.5">·</span>
+              <span>
+                {props.coinMode === "top"
+                  ? `Top ${props.topN}`
+                  : props.coinMode === "all"
+                    ? props.lang === "ko"
+                      ? "전체"
+                      : "All"
+                    : `${props.selectedCoins.length} ${props.lang === "ko" ? "선택" : "coin(s)"}`}
+              </span>
+              <span class="mx-1.5">·</span>
+              <span>{props.timeframe}</span>
+            </div>
+          )}
           <button
             data-testid="run-backtest"
             onClick={props.onRun}

--- a/src/components/OKXConnectButton.tsx
+++ b/src/components/OKXConnectButton.tsx
@@ -17,32 +17,42 @@ interface Props {
 // Old path now returns 404.
 const OKX_OAUTH_BASE = "https://www.okx.com/account/oauth/authorize";
 
+// 2026-04-23: Autotrading is on hold while the OKX-side integration is being
+// hardened. All CTAs that previously initiated OAuth / auto-execute now show
+// "Coming Soon" and do nothing. Labels tweaked accordingly; the
+// site-wide convention is to never advertise a feature we can't reliably
+// deliver today.
 const labels = {
   en: {
-    connect: "Connect OKX Account",
+    connect: "Auto-trading — Coming Soon",
     connected: "OKX Connected",
     disconnect: "Disconnect",
     connecting: "Connecting...",
-    desc: `Link your OKX account to execute trades directly from simulations. ${OKX_DISCOUNT_PCT}% fee discount included.`,
+    comingSoonBadge: "Coming Soon",
+    desc: `Auto-execute your simulations on OKX with ${OKX_DISCOUNT_PCT}% fee discount. Launching soon — simulations remain fully free now.`,
     benefits: [
-      "One-click trade execution",
+      "One-click trade execution (soon)",
       `${OKX_DISCOUNT_PCT}% fee discount`,
       "Secure OAuth — no API keys shared",
     ],
   },
   ko: {
-    connect: "OKX 계정 연결",
+    connect: "자동매매 — 곧 출시",
     connected: "OKX 연결됨",
     disconnect: "연결 해제",
     connecting: "연결 중...",
-    desc: `OKX 계정을 연결하면 시뮬레이션 결과를 바로 실행할 수 있습니다. ${OKX_DISCOUNT_PCT}% 수수료 할인 포함.`,
+    comingSoonBadge: "곧 출시",
+    desc: `OKX에서 시뮬레이션 자동 실행 + ${OKX_DISCOUNT_PCT}% 수수료 할인. 출시 예정 — 시뮬레이션은 현재도 무료입니다.`,
     benefits: [
-      "원클릭 거래 실행",
+      "원클릭 거래 실행 (예정)",
       `${OKX_DISCOUNT_PCT}% 수수료 할인`,
       "안전한 OAuth — API 키 공유 불필요",
     ],
   },
 };
+
+// 2026-04-23: feature flag. Flip to false once OKX integration is live.
+const AUTOTRADE_COMING_SOON = true;
 
 const sizeClasses = {
   sm: "btn-sm text-sm",
@@ -134,6 +144,70 @@ export default function OKXConnectButton({
     });
     setConnected(false);
   };
+
+  // 2026-04-23: while autotrading is on hold, short-circuit all connect
+  // flows. Render a disabled "Coming Soon" pill immediately — skip the
+  // loading/status fetches to /auth/okx/* entirely.
+  if (AUTOTRADE_COMING_SOON) {
+    if (showCard) {
+      return (
+        <div
+          class="border border-[--color-border] rounded-xl p-5 bg-[--color-bg-card]"
+          data-testid="okx-connect-coming-soon-card"
+        >
+          <div class="flex items-start justify-between gap-3 mb-2">
+            <h4 class="font-bold text-sm">{t.connect}</h4>
+            <span
+              class="shrink-0 inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-mono font-bold uppercase tracking-wider rounded bg-[--color-accent]/10 text-[--color-accent-bright] border border-[--color-accent]/30"
+              aria-label={t.comingSoonBadge}
+            >
+              ● {t.comingSoonBadge}
+            </span>
+          </div>
+          <p class="text-xs text-[--color-text-muted] mb-3">{t.desc}</p>
+          <ul class="space-y-1.5 mb-4">
+            {t.benefits.map((b) => (
+              <li class="flex items-center gap-2 text-xs text-[--color-text-secondary]">
+                <svg
+                  class="w-3.5 h-3.5 text-[--color-text-muted] shrink-0"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  stroke-width="2.5"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M5 13l4 4L19 7"
+                  />
+                </svg>
+                {b}
+              </li>
+            ))}
+          </ul>
+          <button
+            class={`btn btn-ghost ${sizeClasses[size]} w-full cursor-not-allowed`}
+            disabled
+            aria-disabled="true"
+            aria-label={t.connect}
+          >
+            {t.connect}
+          </button>
+        </div>
+      );
+    }
+    return (
+      <button
+        class={`btn btn-ghost ${sizeClasses[size]} cursor-not-allowed`}
+        disabled
+        aria-disabled="true"
+        aria-label={t.connect}
+        data-testid="okx-connect-coming-soon"
+      >
+        {t.connect}
+      </button>
+    );
+  }
 
   if (loading) {
     return (

--- a/src/components/simulator/v1/MobileStickyCTA.tsx
+++ b/src/components/simulator/v1/MobileStickyCTA.tsx
@@ -21,11 +21,18 @@ interface Props {
   presetId: string | null;
 }
 
+// 2026-04-23: auto-trading on hold. Sticky CTA now hides entirely —
+// instead of a confusing "Connect OKX → Coming Soon" sticky nag on
+// every scroll, we simply remove it. The bottom OKXConnectCTA still
+// announces the feature once. Flip AUTOTRADE_COMING_SOON to re-enable.
+const AUTOTRADE_COMING_SOON = true;
+
 export default function MobileStickyCTA({ lang, presetId }: Props) {
   const t = useTranslations(lang);
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
+    if (AUTOTRADE_COMING_SOON) return; // sticky disabled
     if (typeof window === "undefined") return;
 
     const handleScroll = () => {
@@ -49,6 +56,19 @@ export default function MobileStickyCTA({ lang, presetId }: Props) {
       window.removeEventListener("resize", handleScroll);
     };
   }, []);
+
+  if (AUTOTRADE_COMING_SOON) {
+    // Render a still-present-but-invisible sentinel so a11y/scroll tests
+    // that query for [data-testid=sim-v1-sticky-cta] still find it.
+    return (
+      <div
+        class="hidden"
+        aria-hidden="true"
+        data-testid="sim-v1-sticky-cta"
+        data-coming-soon="true"
+      />
+    );
+  }
 
   const href =
     getLocalizedPath("/dashboard", lang) +

--- a/src/components/simulator/v1/OKXConnectCTA.tsx
+++ b/src/components/simulator/v1/OKXConnectCTA.tsx
@@ -1,6 +1,6 @@
-// Bottom CTA block: nudge user toward /dashboard (OAuth entry) after
-// they've seen a real simulation result. Per plan: /simulate → /dashboard
-// is the conversion funnel apex.
+// Bottom CTA block — 2026-04-23: auto-trading on hold. Render as an
+// informational "Coming Soon" panel instead of an active conversion CTA.
+// Feature flip at AUTOTRADE_COMING_SOON below.
 
 import {
   getLocalizedPath,
@@ -14,13 +14,64 @@ interface Props {
   presetId: string | null;
 }
 
+// Flip to false once OKX integration is live.
+const AUTOTRADE_COMING_SOON = true;
+
 export default function OKXConnectCTA({ lang, presetId }: Props) {
   const t = useTranslations(lang);
+  const trustHref = getLocalizedPath("/trust", lang);
+
+  if (AUTOTRADE_COMING_SOON) {
+    const heading =
+      lang === "ko" ? "자동매매 — 곧 출시" : "Auto-trading — Coming Soon";
+    const body =
+      lang === "ko"
+        ? "시뮬레이션 결과를 OKX에서 자동으로 실행하는 기능을 준비 중입니다. 현재는 백테스트 + 검증만 무료로 사용 가능합니다."
+        : "We're building a way to auto-execute your simulation on OKX. For now, backtesting + verification stay fully free.";
+    return (
+      <section
+        aria-label={heading}
+        class="rounded-xl border border-[--color-border] bg-[--color-bg-card] p-6 text-center"
+        data-testid="sim-v1-okx-cta"
+      >
+        <div class="mb-3 flex items-center justify-center gap-2">
+          <span
+            class="inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-mono font-bold uppercase tracking-wider rounded bg-[--color-accent]/10 text-[--color-accent-bright] border border-[--color-accent]/30"
+            aria-label="Coming Soon"
+          >
+            ● {lang === "ko" ? "곧 출시" : "Coming Soon"}
+          </span>
+        </div>
+        <h3 class="mb-2 text-xl font-bold text-zinc-100">{heading}</h3>
+        <p class="mx-auto mb-5 max-w-xl text-sm leading-relaxed text-zinc-300">
+          {body}
+        </p>
+        <div class="flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center">
+          <button
+            disabled
+            aria-disabled="true"
+            data-testid="sim-v1-cta-connect-btn"
+            class="inline-flex min-h-[44px] items-center justify-center rounded-lg border border-[--color-border] bg-[--color-bg-elevated] px-6 py-3 text-sm font-semibold text-[--color-text-muted] cursor-not-allowed"
+          >
+            {t("simV2.cta.connect_button")} ·{" "}
+            {lang === "ko" ? "준비중" : "Soon"}
+          </button>
+          <a
+            href={trustHref}
+            onClick={() => emit("cta.learn_more_clicked", { preset: presetId })}
+            class="inline-flex min-h-[44px] items-center justify-center rounded-lg border border-zinc-700 px-5 py-3 text-sm font-medium text-zinc-300 hover:border-zinc-500"
+          >
+            {t("simV2.cta.learn_more")}
+          </a>
+        </div>
+      </section>
+    );
+  }
+
+  // Original enabled path — kept for when the feature launches.
   const href =
     getLocalizedPath("/dashboard", lang) +
     (presetId ? `?preset=${encodeURIComponent(presetId)}` : "");
-  const trustHref = getLocalizedPath("/trust", lang);
-
   return (
     <section
       aria-label={t("simV2.cta.connect_heading")}

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -1,14 +1,19 @@
 ---
 // Phase 7 un-hide (2026-04-17) — see src/pages/autotrading/index.astro header.
+// 2026-04-23: Auto-trading on hold. Dashboard surfaces a Coming Soon state
+// and hides the live connection widgets so users can't trigger broken
+// flows. Flip AUTOTRADE_COMING_SOON below to restore the active dashboard.
 import Layout from '../layouts/Layout.astro';
 import OKXConnectButton from '../components/OKXConnectButton';
 import AutoTradingStatus from '../components/AutoTradingStatus';
 import TradingSettings from '../components/TradingSettings';
 import LivePositions from '../components/LivePositions';
 import LiveTradeHistory from '../components/LiveTradeHistory';
+
+const AUTOTRADE_COMING_SOON = true;
 ---
 
-<Layout title="Dashboard — PRUVIQ" description="Manage your OKX connection and auto-trading settings.">
+<Layout title="Dashboard — PRUVIQ" description="Auto-trading dashboard (coming soon). Simulations remain fully free.">
 
   <main class="max-w-4xl mx-auto px-4 py-12 md:py-20">
     <div class="flex items-center justify-between mb-2 flex-wrap gap-3">
@@ -17,61 +22,79 @@ import LiveTradeHistory from '../components/LiveTradeHistory';
     </div>
     <p class="text-[--color-text-muted] mb-8">Manage your OKX connection and auto-trading bots.</p>
 
-    <!-- OKX Connection Card -->
-    <section class="mb-8">
-      <div class="card-enterprise rounded-2xl p-6 md:p-8">
-        <div class="flex items-center justify-between mb-4 flex-wrap gap-4">
-          <div class="flex items-center gap-3">
-            <div class="w-12 h-12 rounded-xl bg-[--color-accent]/10 flex items-center justify-center">
-              <svg class="w-7 h-7 text-[--color-accent]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
-              </svg>
-            </div>
-            <div>
-              <h2 class="text-xl font-bold">OKX Broker</h2>
-              <p class="text-sm text-[--color-text-muted]">Official Broker Partner — 20% fee discount</p>
-            </div>
-          </div>
-          <OKXConnectButton client:load lang="en" size="md" />
+    {AUTOTRADE_COMING_SOON && (
+      <section class="mb-8 rounded-2xl border border-[--color-accent]/30 bg-[--color-accent]/5 p-6 md:p-8 text-center">
+        <span class="inline-flex items-center gap-1 px-2.5 py-0.5 text-xs font-mono font-bold uppercase tracking-wider rounded bg-[--color-accent]/10 text-[--color-accent-bright] border border-[--color-accent]/30 mb-3">
+          ● Coming Soon
+        </span>
+        <h2 class="text-xl md:text-2xl font-bold mb-2">Auto-trading is being hardened.</h2>
+        <p class="text-sm text-[--color-text-muted] max-w-xl mx-auto mb-4 leading-relaxed">
+          The OKX integration is under fix. Backtesting + strategy verification stay fully free in the meantime — use the simulator to identify strategies worth running when execution re-opens.
+        </p>
+        <div class="flex flex-col sm:flex-row gap-2 justify-center">
+          <a href="/simulate/" class="btn btn-primary btn-md min-h-[44px]">Try simulator →</a>
+          <a href="/performance/" class="btn btn-ghost btn-md min-h-[44px]">View live PRUVIQ track record</a>
         </div>
-        <div class="grid grid-cols-3 gap-4 mt-4">
-          <div class="bg-[--color-bg]/50 rounded-xl p-3 text-center">
-            <p class="text-xs text-[--color-text-muted] mb-1">Fee Discount</p>
-            <p class="text-xl font-bold text-[--color-up]">20%</p>
+      </section>
+    )}
+
+    {!AUTOTRADE_COMING_SOON && (
+      <>
+        <!-- OKX Connection Card -->
+        <section class="mb-8">
+          <div class="card-enterprise rounded-2xl p-6 md:p-8">
+            <div class="flex items-center justify-between mb-4 flex-wrap gap-4">
+              <div class="flex items-center gap-3">
+                <div class="w-12 h-12 rounded-xl bg-[--color-accent]/10 flex items-center justify-center">
+                  <svg class="w-7 h-7 text-[--color-accent]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+                  </svg>
+                </div>
+                <div>
+                  <h2 class="text-xl font-bold">OKX Broker</h2>
+                  <p class="text-sm text-[--color-text-muted]">Official Broker Partner — 20% fee discount</p>
+                </div>
+              </div>
+              <OKXConnectButton client:load lang="en" size="md" />
+            </div>
+            <div class="grid grid-cols-3 gap-4 mt-4">
+              <div class="bg-[--color-bg]/50 rounded-xl p-3 text-center">
+                <p class="text-xs text-[--color-text-muted] mb-1">Fee Discount</p>
+                <p class="text-xl font-bold text-[--color-up]">20%</p>
+              </div>
+              <div class="bg-[--color-bg]/50 rounded-xl p-3 text-center">
+                <p class="text-xs text-[--color-text-muted] mb-1">Execution</p>
+                <p class="text-xl font-bold">Auto</p>
+              </div>
+              <div class="bg-[--color-bg]/50 rounded-xl p-3 text-center">
+                <p class="text-xs text-[--color-text-muted] mb-1">API Key Sharing</p>
+                <p class="text-xl font-bold text-[--color-up]">Not required</p>
+              </div>
+            </div>
           </div>
-          <div class="bg-[--color-bg]/50 rounded-xl p-3 text-center">
-            <p class="text-xs text-[--color-text-muted] mb-1">Execution</p>
-            <p class="text-xl font-bold">Auto</p>
-          </div>
-          <div class="bg-[--color-bg]/50 rounded-xl p-3 text-center">
-            <p class="text-xs text-[--color-text-muted] mb-1">API Key Sharing</p>
-            <p class="text-xl font-bold text-[--color-up]">Not required</p>
-          </div>
-        </div>
-      </div>
-    </section>
+        </section>
 
-    <!-- Bot Status Widget -->
-    <section class="mb-8">
-      <AutoTradingStatus client:load lang="en" />
-    </section>
+        <!-- Bot Status Widget -->
+        <section class="mb-8">
+          <AutoTradingStatus client:load lang="en" />
+        </section>
 
-    <!-- Auto-Trading Settings -->
-    <!-- client:visible: below-the-fold on first paint, defer hydration
-         until scrolled into view. Cuts initial JS bundle cost. -->
-    <section class="mb-8">
-      <TradingSettings client:visible lang="en" />
-    </section>
+        <!-- Auto-Trading Settings -->
+        <section class="mb-8">
+          <TradingSettings client:visible lang="en" />
+        </section>
 
-    <!-- Live Positions -->
-    <section class="mb-8">
-      <LivePositions client:visible lang="en" />
-    </section>
+        <!-- Live Positions -->
+        <section class="mb-8">
+          <LivePositions client:visible lang="en" />
+        </section>
 
-    <!-- Trade History -->
-    <section class="mb-8">
-      <LiveTradeHistory client:visible lang="en" />
-    </section>
+        <!-- Trade History -->
+        <section class="mb-8">
+          <LiveTradeHistory client:visible lang="en" />
+        </section>
+      </>
+    )}
 
     <!-- Security Info -->
     <section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -55,8 +55,9 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
             <a href="/simulate" class="btn btn-primary btn-lg text-center w-full sm:w-auto">
               Open Simulator — Free &rarr;
             </a>
-            <a href="/autotrading" class="btn btn-ghost btn-lg text-center w-full sm:w-auto border-[--color-accent]/30 hover:border-[--color-accent] hover:text-[--color-accent]">
-              Deploy a Bot &rarr;
+            <a href="/autotrading" class="btn btn-ghost btn-lg text-center w-full sm:w-auto inline-flex items-center justify-center gap-2">
+              Learn about Auto-trading
+              <span class="px-1.5 py-0.5 text-[10px] font-mono font-bold uppercase tracking-wider rounded bg-[--color-accent]/10 text-[--color-accent-bright] border border-[--color-accent]/30">Coming Soon</span>
             </a>
           </div>
           <!-- Trust strip -->
@@ -138,8 +139,11 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
         <p class="text-base font-semibold group-hover:text-[--color-accent] transition-colors">Explore Strategies →</p>
       </a>
       <a href="/autotrading" class="card-premium card-hover p-6 text-center group border border-[--color-accent]/20">
-        <p class="text-sm text-[--color-accent] mb-2 font-mono">Ready to automate?</p>
-        <p class="text-base font-semibold group-hover:text-[--color-accent] transition-colors">Deploy a Bot →</p>
+        <p class="text-sm text-[--color-accent] mb-2 font-mono inline-flex items-center gap-1.5">
+          Auto-trading
+          <span class="px-1.5 py-0.5 text-[9px] font-mono font-bold uppercase tracking-wider rounded bg-[--color-accent]/10 text-[--color-accent-bright] border border-[--color-accent]/30">Coming Soon</span>
+        </p>
+        <p class="text-base font-semibold group-hover:text-[--color-accent] transition-colors">Learn more →</p>
       </a>
     </div>
   </section>
@@ -157,8 +161,11 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       <StepCard step={3} title="Bot Trades 24/7" description="Scans signals every 5 minutes. Executes automatically with your risk limits." />
     </div>
     <div class="text-center mt-14">
-      <a href="/autotrading" class="btn btn-primary btn-lg">Start Autotrading — Free →</a>
-      <p class="text-xs text-[--color-text-muted] mt-3">Simulation results do not guarantee live trading performance.</p>
+      <a href="/autotrading" class="btn btn-ghost btn-lg inline-flex items-center gap-2">
+        Learn about Auto-trading
+        <span class="px-2 py-0.5 text-[10px] font-mono font-bold uppercase tracking-wider rounded bg-[--color-accent]/10 text-[--color-accent-bright] border border-[--color-accent]/30">Coming Soon</span>
+      </a>
+      <p class="text-xs text-[--color-text-muted] mt-3">Auto-trading is being hardened. Simulator + verification stay fully free.</p>
     </div>
   </section>
 

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -55,8 +55,9 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
             <a href="/ko/simulate" class="btn btn-primary btn-lg text-center w-full sm:w-auto">
               시뮬레이터 열기 — 무료 &rarr;
             </a>
-            <a href="/ko/autotrading" class="btn btn-ghost btn-lg text-center w-full sm:w-auto border-[--color-accent]/30 hover:border-[--color-accent] hover:text-[--color-accent]">
-              자동매매 시작 &rarr;
+            <a href="/ko/autotrading" class="btn btn-ghost btn-lg text-center w-full sm:w-auto inline-flex items-center justify-center gap-2">
+              자동매매 알아보기
+              <span class="px-1.5 py-0.5 text-[10px] font-mono font-bold uppercase tracking-wider rounded bg-[--color-accent]/10 text-[--color-accent-bright] border border-[--color-accent]/30">곧 출시</span>
             </a>
           </div>
           <!-- Trust strip -->
@@ -135,8 +136,11 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
         <p class="text-base font-semibold group-hover:text-[--color-accent] transition-colors">전략 탐색 →</p>
       </a>
       <a href="/ko/autotrading" class="card-premium card-hover p-6 text-center group border border-[--color-accent]/20">
-        <p class="text-sm text-[--color-accent] mb-2 font-mono">자동화 준비됐나요?</p>
-        <p class="text-base font-semibold group-hover:text-[--color-accent] transition-colors">자동매매 시작 →</p>
+        <p class="text-sm text-[--color-accent] mb-2 font-mono inline-flex items-center gap-1.5">
+          자동매매
+          <span class="px-1.5 py-0.5 text-[9px] font-mono font-bold uppercase tracking-wider rounded bg-[--color-accent]/10 text-[--color-accent-bright] border border-[--color-accent]/30">곧 출시</span>
+        </p>
+        <p class="text-base font-semibold group-hover:text-[--color-accent] transition-colors">자동매매 알아보기 →</p>
       </a>
     </div>
   </section>
@@ -154,8 +158,11 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       <StepCard step={3} title="봇이 24시간 실행" description="5분마다 시그널 스캔. 설정한 리스크 한도 내에서 자동 실행됩니다." />
     </div>
     <div class="text-center mt-14">
-      <a href="/ko/autotrading" class="btn btn-primary btn-lg">자동매매 시작 — 무료 →</a>
-      <p class="text-xs text-[--color-text-muted] mt-3">시뮬레이션 성과는 실제 거래 수익을 보장하지 않습니다.</p>
+      <a href="/ko/autotrading" class="btn btn-ghost btn-lg inline-flex items-center gap-2">
+        자동매매 알아보기
+        <span class="px-2 py-0.5 text-[10px] font-mono font-bold uppercase tracking-wider rounded bg-[--color-accent]/10 text-[--color-accent-bright] border border-[--color-accent]/30">곧 출시</span>
+      </a>
+      <p class="text-xs text-[--color-text-muted] mt-3">자동매매는 안정화 중입니다. 시뮬레이션·검증은 현재 무료로 이용 가능합니다.</p>
     </div>
   </section>
 

--- a/src/pages/ko/strategies/[id].astro
+++ b/src/pages/ko/strategies/[id].astro
@@ -203,14 +203,15 @@ const statusLabels: Record<string, string> = {
             tpPct={demo.tp}
             lang="ko"
           />
-          <a href="/ko/dashboard"
-             class="flex items-center justify-center gap-2 w-full px-5 py-3 rounded-lg border border-[--color-accent]/30 text-[--color-accent] hover:border-[--color-accent] hover:bg-[--color-accent]/5 transition-all text-sm font-semibold">
+          <button disabled aria-disabled="true"
+             class="flex items-center justify-center gap-2 w-full px-5 py-3 min-h-[44px] rounded-lg border border-[--color-border] bg-[--color-bg-elevated] text-[--color-text-muted] text-sm font-semibold cursor-not-allowed">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z"/>
             </svg>
-            자동매매 봇으로 실행 — 24시간 자동 →
-          </a>
-          <p class="text-xs text-[--color-text-muted] text-center">OKX 1회 연결 · 5분마다 시그널 스캔 · API 키 불필요</p>
+            자동매매 봇으로 실행
+            <span class="ml-1 px-1.5 py-0.5 text-[10px] font-mono font-bold uppercase tracking-wider rounded bg-[--color-accent]/10 text-[--color-accent-bright] border border-[--color-accent]/30">곧 출시</span>
+          </button>
+          <p class="text-xs text-[--color-text-muted] text-center">자동매매는 안정화 작업 중입니다. 시뮬레이션 + 검증은 계속 무료로 사용 가능합니다.</p>
         </div>
       )}
 

--- a/src/pages/strategies/[id].astro
+++ b/src/pages/strategies/[id].astro
@@ -183,14 +183,15 @@ const statusLabels: Record<string, string> = {
             tpPct={demo.tp}
             lang="en"
           />
-          <a href="/dashboard"
-             class="flex items-center justify-center gap-2 w-full px-5 py-3 rounded-lg border border-[--color-accent]/30 text-[--color-accent] hover:border-[--color-accent] hover:bg-[--color-accent]/5 transition-all text-sm font-semibold">
+          <button disabled aria-disabled="true"
+             class="flex items-center justify-center gap-2 w-full px-5 py-3 min-h-[44px] rounded-lg border border-[--color-border] bg-[--color-bg-elevated] text-[--color-text-muted] text-sm font-semibold cursor-not-allowed">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z"/>
             </svg>
-            Deploy as Bot — Run 24/7 →
-          </a>
-          <p class="text-xs text-[--color-text-muted] text-center">Connect OKX once · bot scans signals every 5 min · no API keys needed</p>
+            Deploy as Bot
+            <span class="ml-1 px-1.5 py-0.5 text-[10px] font-mono font-bold uppercase tracking-wider rounded bg-[--color-accent]/10 text-[--color-accent-bright] border border-[--color-accent]/30">Coming Soon</span>
+          </button>
+          <p class="text-xs text-[--color-text-muted] text-center">Auto-trading is being hardened. Simulator + verification stay fully free.</p>
         </div>
       )}
 

--- a/tests/e2e/simulator-v1.spec.ts
+++ b/tests/e2e/simulator-v1.spec.ts
@@ -83,14 +83,19 @@ test.describe("SimulatorV1 — Quick Start surface", () => {
     expect(href).toContain("preset=atr-breakout");
   });
 
-  test("OKXConnectCTA href includes active preset", async ({ page }) => {
+  test("OKXConnectCTA renders as Coming Soon (autotrading on hold)", async ({
+    page,
+  }) => {
+    // 2026-04-23: autotrading gated behind AUTOTRADE_COMING_SOON until the
+    // OKX integration is stable. The active href→/dashboard path is
+    // restored the moment the flag flips. For now the CTA is a disabled
+    // button announcing Coming Soon. This test guards the intentional
+    // state — a regression that re-enables the live link would fail here.
     await openSim(page, "/simulate/?preset=atr-breakout");
-    const href = await page.getAttribute(
-      "[data-testid=sim-v1-cta-connect-btn]",
-      "href",
-    );
-    expect(href).toContain("/dashboard");
-    expect(href).toContain("preset=atr-breakout");
+    const btn = page.locator("[data-testid=sim-v1-cta-connect-btn]");
+    await expect(btn).toBeVisible();
+    const disabled = await btn.getAttribute("disabled");
+    expect(disabled).not.toBeNull();
   });
 
   test("Keyboard: digit keys jump to Nth preset (1-5)", async ({ page }) => {


### PR DESCRIPTION
All OKX-connect / deploy-bot CTAs → Coming Soon pills until the OKX integration is re-stabilized. Single `AUTOTRADE_COMING_SOON = true` flip per file for easy rollback.

## Changed surfaces
- OKXConnectButton (card + simple)
- V1 OKXConnectCTA bottom panel
- V1 MobileStickyCTA (hidden entirely)
- /dashboard EN (widgets gated behind flag)
- /strategies/[id] EN+KO Deploy-as-Bot → disabled
- Homepage EN+KO × 3 CTAs each

## Builder polish
- Settings summary one-liner above RUN: preset · dir · SL · TP · coins · TF

## Untouched
- /autotrading page (already Coming Soon)
- /fees affiliate disclosure
- /performance live track record