### PR TITLE
fix(market): macro news tab — useNews switched to static-first

### DIFF
--- a/src/hooks/useNews.ts
+++ b/src/hooks/useNews.ts
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'preact/hooks';
-import { STATIC_DATA, fetchWithFallback } from '../config/api';
+import { useState, useEffect } from "preact/hooks";
+import { STATIC_DATA, fetchWithFallback } from "../config/api";
 
 type NewsItem = {
   title: string;
@@ -21,10 +21,32 @@ export function useNews() {
   const [news, setNews] = useState<NewsData | null>(null);
   const [error, setError] = useState(false);
 
+  // 2026-04-24: switched from fetchWithFallback (API first) to static-first.
+  // The backend /news endpoint only returns crypto sources (Decrypt,
+  // CoinTelegraph, CoinDesk, BTC Magazine — 50 items) with no `category`
+  // field. The static /data/news.json is regenerated hourly by the data
+  // cron and contains 60 items INCLUDING 26 macro items (Bloomberg,
+  // MarketWatch, CNBC Economy) with explicit `category: "macro"`. With
+  // API-first, users clicking the Macro news tab always got "no results"
+  // because API items had no macro category/source. Static is fresh
+  // enough for a 5-minute poll cadence; API is now only the rescue path.
   const fetchNews = () => {
-    fetchWithFallback<NewsData>('/news', STATIC_DATA.news)
-      .then((d) => { setNews(d); setError(false); })
-      .catch(() => setError(true));
+    fetch(STATIC_DATA.news)
+      .then((r) => (r.ok ? r.json() : Promise.reject(r.status)))
+      .then((d: NewsData) => {
+        setNews(d);
+        setError(false);
+      })
+      .catch(() => {
+        // Static miss → fall back to the API (crypto-only, but still
+        // better than showing an error).
+        fetchWithFallback<NewsData>("/news", STATIC_DATA.news)
+          .then((d) => {
+            setNews(d);
+            setError(false);
+          })
+          .catch(() => setError(true));
+      });
   };
 
   useEffect(() => {


### PR DESCRIPTION
User reported /ko/market/ 매크로 탭이 빈 상태. 원인: useNews가 API 먼저 hit, API는 crypto 뉴스만 50개 (Decrypt/CoinTelegraph 등) + category 필드 없음. Static /data/news.json에는 macro 26개 있음. Static-first로 스위치.