### PR TITLE
feat(qa): Layer 2 click-everything crawler

### DIFF
--- a/src/components/MarketDashboard.tsx
+++ b/src/components/MarketDashboard.tsx
@@ -729,8 +729,15 @@ export default function MarketDashboard({
               </span>
 
               {/* Crypto / Macro tab toggle */}
-              <div class="flex rounded-md overflow-hidden border border-[--color-border]">
+              <div
+                class="flex rounded-md overflow-hidden border border-[--color-border]"
+                data-testid="news-tabs"
+                role="tablist"
+              >
                 <button
+                  data-testid="news-tab-crypto"
+                  role="tab"
+                  aria-selected={newsTab === "crypto"}
                   onClick={() => {
                     setNewsTab("crypto");
                     setSourceFilter("");
@@ -749,6 +756,9 @@ export default function MarketDashboard({
                   {l.cryptoNews}
                 </button>
                 <button
+                  data-testid="news-tab-macro"
+                  role="tab"
+                  aria-selected={newsTab === "macro"}
                   onClick={() => {
                     setNewsTab("macro");
                     setSourceFilter("");
@@ -833,7 +843,12 @@ export default function MarketDashboard({
               </div>
             )}
             {news && filteredNews.length > 0 && (
-              <div class="fade-in">
+              <div
+                class="fade-in"
+                data-testid="news-list"
+                data-news-tab={newsTab}
+                data-news-count={filteredNews.length}
+              >
                 {(newsExpanded ? filteredNews : filteredNews.slice(0, 5)).map(
                   (item, i) => (
                     <a
@@ -883,7 +898,11 @@ export default function MarketDashboard({
               </div>
             )}
             {news && filteredNews.length === 0 && (
-              <div class="text-center py-8 text-[--color-text-muted] text-[13px]">
+              <div
+                class="text-center py-8 text-[--color-text-muted] text-[13px]"
+                data-testid="news-list-empty"
+                data-news-tab={newsTab}
+              >
                 {l.noResults}
               </div>
             )}

--- a/tests/e2e/crawl/click-all.spec.ts
+++ b/tests/e2e/crawl/click-all.spec.ts
@@ -1,0 +1,153 @@
+// Layer 2 — Click-Everything Crawler (MVP scope)
+//
+// Click every high-value interactive element on every critical route and assert
+// the result is POPULATED (not empty, not error, not loading). This is the
+// spec that would have caught the 2026-04-22 macro-news bug.
+//
+// Scope this PR covers:
+//   /market/ + /ko/market/ — news tabs (crypto ↔ macro) + source filters
+//   /simulate/ + /ko/simulate/ — preset cards + skill tabs
+//
+// Future layers (per /Users/jepo/.claude/plans/transient-munching-pine.md):
+//   - Full interactive inventory generation (Layer 1)
+//   - Hook contract validation (Layer 3)
+//   - Freshness monitoring (Layer 4)
+//
+// Run locally:
+//   npx playwright test tests/e2e/crawl/click-all.spec.ts --project=desktop
+
+import { expect, test, type Page } from "@playwright/test";
+import {
+  expectListHasItems,
+  expectPopulated,
+} from "../helpers/assert-populated";
+
+const MARKET_ROUTES = ["/market/", "/ko/market/"];
+const SIMULATE_ROUTES = ["/simulate/", "/ko/simulate/"];
+
+async function waitForMarketHydration(page: Page): Promise<void> {
+  // MarketDashboard is client:visible — scroll the news tabs into viewport
+  // to force island hydration before clicks.
+  await page
+    .evaluate(() => window.scrollTo(0, document.body.scrollHeight * 0.6))
+    .catch(() => {});
+  await page.waitForSelector('[data-testid="news-tabs"]', { timeout: 20000 });
+}
+
+test.describe("Layer 2 Crawl — Market news tabs produce populated lists", () => {
+  for (const route of MARKET_ROUTES) {
+    test(`${route} — crypto tab populated`, async ({ page }) => {
+      await page.goto(route, { waitUntil: "domcontentloaded" });
+      await waitForMarketHydration(page);
+
+      await page.click('[data-testid="news-tab-crypto"]');
+      // Either the list populates OR the empty sentinel shows. A populated
+      // list is the required invariant for the crypto tab, which has always
+      // had items.
+      await expectPopulated(page, '[data-testid="news-list"]');
+      await expectListHasItems(page, '[data-testid="news-list"] > a', 1);
+
+      // Badge sanity: data-news-count attribute should match rendered children
+      const listLoc = page.locator('[data-testid="news-list"]');
+      const declared = Number(await listLoc.getAttribute("data-news-count"));
+      const rendered = await page
+        .locator('[data-testid="news-list"] > a')
+        .count();
+      expect(
+        rendered,
+        `rendered children ${rendered} should be ≤ declared count ${declared}`,
+      ).toBeLessThanOrEqual(declared);
+    });
+
+    test(`${route} — macro tab populated (the /ko/market/ bug)`, async ({
+      page,
+    }) => {
+      await page.goto(route, { waitUntil: "domcontentloaded" });
+      await waitForMarketHydration(page);
+
+      await page.click('[data-testid="news-tab-macro"]');
+
+      // Critical assertion: macro news must have items. Before PR #1331 the
+      // useNews hook preferred the API (crypto-only, no category field) over
+      // the static JSON (which had 26 macro items). Macro tab always empty.
+      await expectPopulated(page, '[data-testid="news-list"]');
+      await expectListHasItems(page, '[data-testid="news-list"] > a', 1);
+
+      // Verify the active tab matches what we clicked (no silent UI swallow)
+      const tab = await page
+        .locator('[data-testid="news-list"]')
+        .getAttribute("data-news-tab");
+      expect(tab).toBe("macro");
+    });
+
+    test(`${route} — tab toggle crypto ↔ macro both populated`, async ({
+      page,
+    }) => {
+      await page.goto(route, { waitUntil: "domcontentloaded" });
+      await waitForMarketHydration(page);
+
+      // Start crypto → assert → click macro → assert → back to crypto → assert
+      await page.click('[data-testid="news-tab-crypto"]');
+      await expectListHasItems(page, '[data-testid="news-list"] > a', 1);
+      const cryptoCount = await page
+        .locator('[data-testid="news-list"] > a')
+        .count();
+
+      await page.click('[data-testid="news-tab-macro"]');
+      await expectListHasItems(page, '[data-testid="news-list"] > a', 1);
+      const macroCount = await page
+        .locator('[data-testid="news-list"] > a')
+        .count();
+
+      await page.click('[data-testid="news-tab-crypto"]');
+      await expectListHasItems(page, '[data-testid="news-list"] > a', 1);
+      const cryptoCountAgain = await page
+        .locator('[data-testid="news-list"] > a')
+        .count();
+
+      expect(
+        cryptoCount,
+        "crypto count should be stable across tab toggles",
+      ).toBe(cryptoCountAgain);
+
+      // Both tabs must distinct data sources; macro items should not equal
+      // crypto items (macro ≠ CoinDesk/Decrypt). Not checking identity —
+      // the fact that at least one of each exists is the core guarantee.
+      expect(macroCount).toBeGreaterThan(0);
+      expect(cryptoCount).toBeGreaterThan(0);
+    });
+  }
+});
+
+test.describe("Layer 2 Crawl — Simulator presets produce populated results", () => {
+  for (const route of SIMULATE_ROUTES) {
+    test(`${route} — clicking first preset lands on results`, async ({
+      page,
+    }) => {
+      await page.goto(route, { waitUntil: "domcontentloaded" });
+      await page.waitForSelector("[data-testid=sim-v1-root]", {
+        timeout: 15000,
+      });
+
+      const cards = page.locator(
+        "[data-testid^=sim-v1-preset-]:not([data-testid$=-grid])",
+      );
+      const count = await cards.count();
+      expect(count).toBeGreaterThanOrEqual(1);
+      await cards.first().click();
+
+      // Accept any of the three result states — but if it lands on error,
+      // the error panel must itself be populated (message + retry button).
+      const anyResult = page.locator(
+        "[data-testid=sim-v1-results-loading], [data-testid=sim-v1-results-ok], [data-testid=sim-v1-results-error]",
+      );
+      await expect(anyResult.first()).toBeVisible({ timeout: 30000 });
+
+      // If ok state appears, it must be populated (no blank metric shells)
+      const ok = page.locator("[data-testid=sim-v1-results-ok]");
+      if (await ok.isVisible().catch(() => false)) {
+        await expectPopulated(page, "[data-testid=sim-v1-results-ok]");
+      }
+    });
+  }
+});

--- a/tests/e2e/helpers/assert-populated.ts
+++ b/tests/e2e/helpers/assert-populated.ts
@@ -1,0 +1,141 @@
+// Populated-state assertions for Layer 2 click-everything crawler.
+//
+// Invariant: after a user interaction, the result must be a visible non-empty
+// list / populated panel — NOT "page loaded with empty body" (the class of bug
+// that let /ko/market/ macro tab show 0 items while 65/65 prior tests reported
+// PASS).
+//
+// Usage:
+//   await page.click('[data-testid=news-tab-macro]');
+//   await expectPopulated(page, '[data-testid=news-list]');
+//   await expectListHasItems(page, '[data-testid=news-list] > a', 1);
+
+import { expect, type Locator, type Page } from "@playwright/test";
+
+export interface PopulatedOpts {
+  /** Timeout for visibility check. Default 10s. */
+  timeout?: number;
+  /** Also fail if a sibling `[data-testid=<selector-base>-empty]` exists. Default true. */
+  rejectSiblingEmpty?: boolean;
+}
+
+/** Pass = locator visible AND has non-whitespace textContent AND no inner
+ *  `[data-testid*="-empty"]` or `[data-testid*="-error"]` AND no `[aria-busy="true"]`. */
+export async function expectPopulated(
+  page: Page,
+  selector: string,
+  opts: PopulatedOpts = {},
+): Promise<void> {
+  const { timeout = 10000, rejectSiblingEmpty = true } = opts;
+  const loc = page.locator(selector);
+  await expect(loc, `populated: ${selector} should be visible`).toBeVisible({
+    timeout,
+  });
+
+  const text = (await loc.textContent()) ?? "";
+  expect(
+    text.trim().length,
+    `populated: ${selector} must have non-empty textContent (got '${text.slice(0, 80)}')`,
+  ).toBeGreaterThan(0);
+
+  const innerEmpty = loc.locator('[data-testid*="-empty"]');
+  expect(
+    await innerEmpty.count(),
+    `populated: ${selector} contains an -empty sentinel`,
+  ).toBe(0);
+
+  const innerError = loc.locator('[data-testid*="-error"]');
+  expect(
+    await innerError.count(),
+    `populated: ${selector} contains an -error sentinel`,
+  ).toBe(0);
+
+  const busy = loc.locator('[aria-busy="true"]');
+  expect(
+    await busy.count(),
+    `populated: ${selector} still has aria-busy descendants`,
+  ).toBe(0);
+
+  if (rejectSiblingEmpty) {
+    const base = selector.match(/data-testid=([a-z0-9-]+)/)?.[1];
+    if (base) {
+      const siblingEmpty = page.locator(`[data-testid="${base}-empty"]`);
+      const visible = await siblingEmpty.isVisible().catch(() => false);
+      expect(
+        visible,
+        `populated: sibling [data-testid=${base}-empty] is visible — did list fail to populate?`,
+      ).toBe(false);
+    }
+  }
+}
+
+/** Counts direct or descendant children matching `itemSelector` inside `listSelector`;
+ *  fails with a diagnostic dump if fewer than `minItems` found. */
+export async function expectListHasItems(
+  page: Page,
+  listSelector: string,
+  minItems = 1,
+  opts: { timeout?: number } = {},
+): Promise<void> {
+  const { timeout = 10000 } = opts;
+  const list = page.locator(listSelector);
+  // Poll for count ≥ minItems; selectors resolving to multiple nodes are
+  // normal for list-item queries (e.g., "ul > li"), so we do not call
+  // toBeVisible on the aggregate locator (strict-mode violation).
+  const deadline = Date.now() + timeout;
+  let count = 0;
+  while (Date.now() < deadline) {
+    count = await list.count();
+    if (count >= minItems) break;
+    await page.waitForTimeout(200);
+  }
+
+  if (count < minItems) {
+    const dump = await dumpForDiagnostics(page, listSelector);
+    throw new Error(
+      `expectListHasItems: ${listSelector} has ${count} items, expected ≥${minItems}\n\n${dump}`,
+    );
+  }
+
+  // Sanity: at least the first matched element is visible
+  await expect(
+    list.first(),
+    `list: ${listSelector} first should be visible`,
+  ).toBeVisible();
+}
+
+/** Tab/pill has a count badge next to it (e.g., "Macro 26"); assert the
+ *  displayed number matches the actual rendered children. Guards against
+ *  stale caches and count/data drift. */
+export async function expectBadgeMatches(
+  tabLocator: Locator,
+  listLocator: Locator,
+): Promise<void> {
+  const tabText = (await tabLocator.textContent()) ?? "";
+  const badge = tabText.match(/(\d+)/)?.[1];
+  if (!badge) return; // no badge = skip
+  const actual = await listLocator.count();
+  expect(Number(badge), `badge ${badge} vs actual rendered ${actual}`).toBe(
+    actual,
+  );
+}
+
+async function dumpForDiagnostics(
+  page: Page,
+  selector: string,
+): Promise<string> {
+  const url = page.url();
+  const title = await page.title().catch(() => "?");
+  const rootHtml = await page
+    .locator(selector)
+    .first()
+    .innerHTML()
+    .catch(() => "(selector not found)");
+  const bodyLen = (await page.textContent("body").catch(() => ""))?.length ?? 0;
+  return [
+    `URL: ${url}`,
+    `Title: ${title}`,
+    `Body length: ${bodyLen}`,
+    `Selector HTML (trimmed 600):\n${rootHtml.slice(0, 600)}`,
+  ].join("\n");
+}


### PR DESCRIPTION
## Summary

Highest-ROI slice of the 8-layer QA automation plan (`/Users/jepo/.claude/plans/transient-munching-pine.md`). Catches the class of bug that let `/ko/market/` macro tab show 0 items while 65/65 prior tests reported PASS.

**3 files**:
- `src/components/MarketDashboard.tsx` — `data-testid` + ARIA roles on news tabs
- `tests/e2e/helpers/assert-populated.ts` — `expectPopulated` / `expectListHasItems` helpers
- `tests/e2e/crawl/click-all.spec.ts` — 16 tests (8 desktop + 8 mobile)

**Local verification**:
- 16/16 new crawl tests pass (~30s)
- 12/12 regression pass (data-render + smoke)
- Build 1183 pages OK

## Test plan
- [x] `npx playwright test tests/e2e/crawl/click-all.spec.ts --project=desktop` — 8/8 pass
- [x] `npx playwright test tests/e2e/crawl/click-all.spec.ts --project=mobile` — 8/8 pass
- [x] `npx playwright test tests/e2e/data-render.spec.ts tests/e2e/smoke.spec.ts --project=desktop` — 12/12 pass
- [x] `npm run build` — 0 errors, 1183 pages
- [ ] CI Playwright E2E + axe + Visual Regression green

🤖 Generated with [Claude Code](https://claude.com/claude-code)