### PR TITLE
feat(qa): Layer 3 hook-contract validation

### DIFF
--- a/src/schemas/data-contracts.ts
+++ b/src/schemas/data-contracts.ts
@@ -1,0 +1,233 @@
+// Data-contract validators for the /data/*.json pipeline and backing API.
+//
+// These are single-source-of-truth shape checks shared by:
+//   - unit tests (tests/unit/hook-contract.test.ts) — validate static JSON files
+//   - contract tests — validate live API responses
+//   - future CI freshness job
+//
+// Intentionally no external dep (no zod). Plain predicates match the project's
+// "dependency-adding-antipattern" rule (llm-anti-patterns #12).
+//
+// Each validator returns { ok, errors } instead of throwing, so callers can
+// report multiple issues at once.
+
+export type ValidationResult = {
+  ok: boolean;
+  errors: string[];
+};
+
+function err(path: string, msg: string): string {
+  return `${path}: ${msg}`;
+}
+
+function isString(v: unknown): v is string {
+  return typeof v === "string" && v.length > 0;
+}
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === "number" && Number.isFinite(v);
+}
+
+function isIsoTimestamp(v: unknown): v is string {
+  if (!isString(v)) return false;
+  const d = new Date(v);
+  return !Number.isNaN(d.getTime());
+}
+
+// ─── useNews contract ────────────────────────────────────────────────
+
+export type NewsCategory = "macro" | "crypto";
+export type NewsItem = {
+  title: string;
+  link: string;
+  source: string;
+  category: NewsCategory;
+  published: string;
+  summary: string;
+};
+export type NewsData = {
+  items: NewsItem[];
+  generated: string;
+};
+
+export function validateNewsData(raw: unknown): ValidationResult {
+  const errors: string[] = [];
+  if (typeof raw !== "object" || raw === null)
+    return { ok: false, errors: ["news: not an object"] };
+  const d = raw as Record<string, unknown>;
+
+  if (!Array.isArray(d.items)) errors.push(err("news.items", "not an array"));
+  if (!isIsoTimestamp(d.generated))
+    errors.push(err("news.generated", "missing/invalid ISO timestamp"));
+
+  if (Array.isArray(d.items)) {
+    d.items.forEach((it: unknown, i: number) => {
+      const p = `news.items[${i}]`;
+      if (typeof it !== "object" || it === null) {
+        errors.push(err(p, "not an object"));
+        return;
+      }
+      const item = it as Record<string, unknown>;
+      if (!isString(item.title)) errors.push(err(p, "title missing/empty"));
+      if (!isString(item.link)) errors.push(err(p, "link missing/empty"));
+      if (!isString(item.source)) errors.push(err(p, "source missing/empty"));
+      if (item.category !== "macro" && item.category !== "crypto")
+        errors.push(
+          err(
+            p,
+            `category must be 'macro'|'crypto', got ${JSON.stringify(item.category)}`,
+          ),
+        );
+      if (!isIsoTimestamp(item.published))
+        errors.push(err(p, "published invalid ISO"));
+      if (typeof item.summary !== "string")
+        errors.push(err(p, "summary must be string"));
+    });
+
+    // Business invariant: BOTH tab tabs must have data.
+    // This is exactly the check that would have caught the macro-news bug
+    // (API path lost the `category` field so all items classified as crypto).
+    const macros = d.items.filter(
+      (it: unknown) =>
+        typeof it === "object" &&
+        it !== null &&
+        (it as { category?: unknown }).category === "macro",
+    ).length;
+    const cryptos = d.items.filter(
+      (it: unknown) =>
+        typeof it === "object" &&
+        it !== null &&
+        (it as { category?: unknown }).category === "crypto",
+    ).length;
+    if (macros < 1)
+      errors.push(
+        err("news.items", "zero macro items — macro tab would be empty"),
+      );
+    if (cryptos < 1)
+      errors.push(
+        err("news.items", "zero crypto items — crypto tab would be empty"),
+      );
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+// ─── useMacro contract ───────────────────────────────────────────────
+
+export type MacroIndicator = {
+  id: string;
+  name: string;
+  value: number;
+  change: number | null;
+  previous?: number | null;
+  unit: string;
+  updated: string;
+  source: string;
+};
+export type MacroData = {
+  indicators: MacroIndicator[];
+  generated: string;
+};
+
+export function validateMacroData(raw: unknown): ValidationResult {
+  const errors: string[] = [];
+  if (typeof raw !== "object" || raw === null)
+    return { ok: false, errors: ["macro: not an object"] };
+  const d = raw as Record<string, unknown>;
+
+  if (!Array.isArray(d.indicators))
+    errors.push(err("macro.indicators", "not an array"));
+  if (!isIsoTimestamp(d.generated))
+    errors.push(err("macro.generated", "invalid ISO"));
+
+  if (Array.isArray(d.indicators)) {
+    d.indicators.forEach((ind: unknown, i: number) => {
+      const p = `macro.indicators[${i}]`;
+      if (typeof ind !== "object" || ind === null) {
+        errors.push(err(p, "not an object"));
+        return;
+      }
+      const x = ind as Record<string, unknown>;
+      if (!isString(x.id)) errors.push(err(p, "id missing"));
+      if (!isString(x.name)) errors.push(err(p, "name missing"));
+      if (!isFiniteNumber(x.value)) errors.push(err(p, "value not finite"));
+      if (x.change !== null && !isFiniteNumber(x.change))
+        errors.push(err(p, "change must be number|null"));
+      if (!isString(x.unit)) errors.push(err(p, "unit missing"));
+      if (!isString(x.source)) errors.push(err(p, "source missing"));
+    });
+    if (d.indicators.length < 3)
+      errors.push(
+        err(
+          "macro.indicators",
+          `expected ≥3 indicators, got ${d.indicators.length}`,
+        ),
+      );
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+// ─── useMarketOverview contract ──────────────────────────────────────
+
+export type MarketData = {
+  btc_price: number;
+  btc_change_24h: number;
+  eth_price: number;
+  eth_change_24h: number;
+  fear_greed_index: number;
+  fear_greed_label: string;
+  total_market_cap_b: number;
+  btc_dominance: number;
+  total_volume_24h_b: number;
+  generated: string;
+};
+
+export function validateMarketData(raw: unknown): ValidationResult {
+  const errors: string[] = [];
+  if (typeof raw !== "object" || raw === null)
+    return { ok: false, errors: ["market: not an object"] };
+  const d = raw as Record<string, unknown>;
+
+  const numericFields: (keyof MarketData)[] = [
+    "btc_price",
+    "btc_change_24h",
+    "eth_price",
+    "eth_change_24h",
+    "fear_greed_index",
+    "total_market_cap_b",
+    "btc_dominance",
+    "total_volume_24h_b",
+  ];
+  for (const f of numericFields) {
+    if (!isFiniteNumber(d[f]))
+      errors.push(
+        err(`market.${f}`, `not a finite number (got ${JSON.stringify(d[f])})`),
+      );
+  }
+  if (!isString(d.fear_greed_label))
+    errors.push(err("market.fear_greed_label", "missing"));
+  if (!isIsoTimestamp(d.generated))
+    errors.push(err("market.generated", "invalid ISO"));
+
+  // Sanity bounds
+  if (
+    isFiniteNumber(d.btc_price) &&
+    (d.btc_price < 1000 || d.btc_price > 1_000_000)
+  )
+    errors.push(err("market.btc_price", `out-of-range: ${d.btc_price}`));
+  if (
+    isFiniteNumber(d.fear_greed_index) &&
+    (d.fear_greed_index < 0 || d.fear_greed_index > 100)
+  )
+    errors.push(
+      err("market.fear_greed_index", `not 0..100: ${d.fear_greed_index}`),
+    );
+  if (
+    isFiniteNumber(d.btc_dominance) &&
+    (d.btc_dominance < 0 || d.btc_dominance > 100)
+  )
+    errors.push(err("market.btc_dominance", `not 0..100%: ${d.btc_dominance}`));
+
+  return { ok: errors.length === 0, errors };
+}

--- a/tests/unit/hook-contract.test.ts
+++ b/tests/unit/hook-contract.test.ts
@@ -1,0 +1,125 @@
+// Layer 3 — Hook-Contract Validation (unit)
+//
+// Validates public/data/*.json against the shape + invariants that the
+// corresponding Preact hooks (src/hooks/useXxx.ts) consume. Catches the
+// class of bug where a new data source (API vs static JSON) silently drops
+// a field the UI depends on — the exact mechanism behind the 2026-04-22
+// /ko/market/ macro-tab-empty bug.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import {
+  validateMacroData,
+  validateMarketData,
+  validateNewsData,
+} from "../../src/schemas/data-contracts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DATA_DIR = resolve(__dirname, "../../public/data");
+
+function loadJson(name: string): unknown {
+  return JSON.parse(readFileSync(resolve(DATA_DIR, name), "utf-8"));
+}
+
+describe("Layer 3 contract — static JSON pipeline must match hook expectations", () => {
+  describe("news.json ↔ useNews()", () => {
+    const data = loadJson("news.json");
+    const result = validateNewsData(data);
+
+    it("conforms to the full useNews schema", () => {
+      expect(result.ok, result.errors.join("\n")).toBe(true);
+    });
+
+    it("has both categories populated (the macro-tab-empty regression check)", () => {
+      // This is the literal retroactive catch for PR #1331.
+      const items = (data as { items: Array<{ category?: string }> }).items;
+      const macros = items.filter((i) => i.category === "macro").length;
+      const cryptos = items.filter((i) => i.category === "crypto").length;
+      expect(
+        macros,
+        "news.json must have ≥1 macro item",
+      ).toBeGreaterThanOrEqual(1);
+      expect(
+        cryptos,
+        "news.json must have ≥1 crypto item",
+      ).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("macro.json ↔ useMacro()", () => {
+    const data = loadJson("macro.json");
+    const result = validateMacroData(data);
+
+    it("conforms to useMacro schema", () => {
+      expect(result.ok, result.errors.join("\n")).toBe(true);
+    });
+  });
+
+  describe("market.json ↔ useMarketOverview()", () => {
+    const data = loadJson("market.json");
+    const result = validateMarketData(data);
+
+    it("conforms to useMarketOverview schema + sanity bounds", () => {
+      expect(result.ok, result.errors.join("\n")).toBe(true);
+    });
+  });
+});
+
+describe("Layer 3 contract — validators reject obvious drift", () => {
+  it("rejects news without category field (the actual 2026-04-22 bug)", () => {
+    const bad = {
+      generated: "2026-04-22T00:00:00Z",
+      items: [
+        {
+          title: "X",
+          link: "https://x",
+          source: "CoinDesk",
+          published: "2026-04-22T00:00:00Z",
+          summary: "",
+        },
+      ],
+    };
+    const r = validateNewsData(bad);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some((e) => e.includes("category"))).toBe(true);
+  });
+
+  it("rejects news with only crypto items (macro tab would render empty)", () => {
+    const cryptoOnly = {
+      generated: "2026-04-22T00:00:00Z",
+      items: [
+        {
+          title: "Crypto news",
+          link: "https://x",
+          source: "CoinDesk",
+          category: "crypto",
+          published: "2026-04-22T00:00:00Z",
+          summary: "",
+        },
+      ],
+    };
+    const r = validateNewsData(cryptoOnly);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some((e) => e.includes("zero macro items"))).toBe(true);
+  });
+
+  it("rejects market with out-of-range fear_greed_index", () => {
+    const bad = {
+      btc_price: 70000,
+      btc_change_24h: 1,
+      eth_price: 3500,
+      eth_change_24h: 1,
+      fear_greed_index: 150,
+      fear_greed_label: "Greed",
+      total_market_cap_b: 2500,
+      btc_dominance: 55,
+      total_volume_24h_b: 80,
+      generated: "2026-04-22T00:00:00Z",
+    };
+    const r = validateMarketData(bad);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some((e) => e.includes("fear_greed_index"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Layer 3 of 8-layer QA automation plan. Adds contract validators that run on every PR + CI via vitest. No new deps.

**Retroactive catch proven**: live API /news currently returns 50 items with NO \`category\` field. If \`useNews\` were pointed at the API, the validator's "zero macro items" invariant would fail immediately.

**2 files**:
- \`src/schemas/data-contracts.ts\` — validateNewsData / validateMacroData / validateMarketData (plain predicates, no zod)
- \`tests/unit/hook-contract.test.ts\` — 7 vitest tests: 3 schema pass + 4 drift rejection

## Test plan
- [x] \`npx vitest run tests/unit/hook-contract.test.ts\` — 7/7 pass (637ms)
- [x] \`npm run build\` — 0 errors, 1185 pages
- [ ] CI Vitest + Playwright + axe green

🤖 Generated with [Claude Code](https://claude.com/claude-code)