### PR TITLE
feat(qa): Layer 4 data-freshness monitor

### DIFF
--- a/.github/workflows/freshness-monitor.yml
+++ b/.github/workflows/freshness-monitor.yml
@@ -1,0 +1,92 @@
+name: QA Layer 4 — Data Freshness Monitor
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"   # every 15 min
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: freshness-monitor
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Run freshness check
+        id: check
+        run: |
+          BASE_URL=https://pruviq.com node scripts/check-freshness.mjs > events.ndjson
+          cat events.ndjson
+
+      - name: Open / close issues based on events
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const lines = fs.readFileSync('events.ndjson', 'utf8')
+              .trim().split('\n').filter(Boolean);
+            const events = lines.map(l => JSON.parse(l));
+
+            async function findOpenIssue(source) {
+              const { data } = await github.rest.issues.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                labels: 'freshness',
+                per_page: 100,
+              });
+              return data.find(i => i.title.includes(`[FRESHNESS] ${source}`));
+            }
+
+            for (const ev of events) {
+              const bad = ev.status === 'stale' || ev.status === 'invariant_fail' || ev.status === 'error';
+              const existing = await findOpenIssue(ev.source);
+
+              if (bad && !existing) {
+                const title = `[FRESHNESS] ${ev.source} ${ev.status}`;
+                const body = [
+                  `Source: \`${ev.source}\``,
+                  `Status: **${ev.status}**`,
+                  ev.age_s != null ? `Age: ${ev.age_s}s (budget ${ev.budget_s}s)` : '',
+                  ev.generated ? `Last generated: ${ev.generated}` : '',
+                  ev.invariant_fail ? `Invariant failure: **${ev.invariant_fail}**` : '',
+                  ev.error ? `Error: ${ev.error}` : '',
+                  '',
+                  `Auto-opened by freshness-monitor.yml. Will auto-close on recovery.`,
+                ].filter(Boolean).join('\n');
+
+                await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title,
+                  body,
+                  labels: ['freshness', 'auto-generated'],
+                });
+                core.info(`Opened issue for ${ev.source}`);
+              } else if (!bad && existing) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: existing.number,
+                  body: `Auto-resolved: ${ev.source} is now \`${ev.status}\` (age ${ev.age_s}s ≤ budget ${ev.budget_s}s).`,
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: existing.number,
+                  state: 'closed',
+                });
+                core.info(`Closed issue #${existing.number} for ${ev.source}`);
+              }
+            }

--- a/scripts/check-freshness.mjs
+++ b/scripts/check-freshness.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+// Layer 4 — Data Freshness Monitor
+//
+// For each hourly-refreshed data source, compare `.generated` timestamp (or
+// mtime for API responses) against a per-source max-age budget.
+//
+// Output: newline-delimited JSON events on stdout. Exit 0 always; the GitHub
+// workflow parses events and opens/closes issues.
+//
+// Usage:
+//   BASE_URL=https://pruviq.com node scripts/check-freshness.mjs
+//   BASE_URL=https://pruviq.com node scripts/check-freshness.mjs --verbose
+//
+// Each event:
+//   {"source": "news.json", "status": "fresh"|"stale", "age_s": 123,
+//    "budget_s": 1800, "generated": "2026-..."}
+
+import process from "node:process";
+
+const BASE = process.env.BASE_URL || "https://pruviq.com";
+const VERBOSE = process.argv.includes("--verbose");
+
+// Per-file budgets (seconds). Crypto news tighter than macro news because
+// crypto sources refresh more frequently.
+const BUDGETS = [
+  { path: "/data/news.json", budget_s: 30 * 60, invariant: "news-any" },
+  { path: "/data/market.json", budget_s: 15 * 60, invariant: null },
+  { path: "/data/coins-stats.json", budget_s: 15 * 60, invariant: null },
+  { path: "/data/macro.json", budget_s: 2 * 60 * 60, invariant: null },
+  { path: "/data/rankings-daily.json", budget_s: 26 * 60 * 60, invariant: null },
+];
+
+async function checkOne({ path, budget_s, invariant }) {
+  const url = `${BASE}${path}`;
+  const res = await fetch(url).catch((e) => ({ ok: false, _err: String(e) }));
+  if (!res.ok) {
+    return {
+      source: path,
+      status: "error",
+      error: res._err || `http_${res.status}`,
+      budget_s,
+    };
+  }
+  const data = await res.json().catch(() => null);
+  // Some files use `generated_at` instead of `generated` (rankings-daily)
+  const generated = data?.generated || data?.generated_at;
+  if (!generated) {
+    return { source: path, status: "no_timestamp", budget_s };
+  }
+  const ageMs = Date.now() - new Date(generated).getTime();
+  const age_s = Math.floor(ageMs / 1000);
+  const status = age_s > budget_s ? "stale" : "fresh";
+
+  // Secondary invariant checks (e.g., news must have both categories)
+  let invariant_fail = null;
+  if (invariant === "news-any" && Array.isArray(data.items)) {
+    const macros = data.items.filter((i) => i.category === "macro").length;
+    const cryptos = data.items.filter((i) => i.category === "crypto").length;
+    if (macros === 0) invariant_fail = "zero-macro-items";
+    else if (cryptos === 0) invariant_fail = "zero-crypto-items";
+  }
+
+  return {
+    source: path,
+    status: invariant_fail ? "invariant_fail" : status,
+    age_s,
+    budget_s,
+    generated,
+    invariant_fail,
+  };
+}
+
+async function main() {
+  const results = await Promise.all(BUDGETS.map(checkOne));
+  let exit = 0;
+  for (const r of results) {
+    process.stdout.write(JSON.stringify(r) + "\n");
+    if (r.status === "stale" || r.status === "invariant_fail" || r.status === "error") {
+      exit = 0; // still exit 0 — let workflow parse + decide
+    }
+    if (VERBOSE && r.age_s != null) {
+      process.stderr.write(
+        `  ${r.source}: ${r.status} age=${r.age_s}s budget=${r.budget_s}s\n`,
+      );
+    }
+  }
+  process.exit(exit);
+}
+
+main().catch((e) => {
+  process.stderr.write(`fatal: ${e}\n`);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

Layer 4 of 8-layer QA automation plan. Every 15 min, checks 5 data files against per-budget thresholds + opens/closes GitHub Issues automatically. No new deps.

**Files**:
- \`scripts/check-freshness.mjs\` — NDJSON event emitter
- \`.github/workflows/freshness-monitor.yml\` — schedule + issue open/close via github-script

**Budgets**:
| File | Threshold | Invariant |
|------|-----------|-----------|
| news.json | 30 min | ≥1 macro AND ≥1 crypto |
| market.json | 15 min | — |
| coins-stats.json | 15 min | — |
| macro.json | 2 h | — |
| rankings-daily.json | 26 h | — |

**Live dry-run**: all 5 fresh against https://pruviq.com/data/.

## Test plan
- [x] \`BASE_URL=https://pruviq.com node scripts/check-freshness.mjs\` — 5/5 fresh
- [ ] Workflow fires within 15 min of merge; no false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)