### PR TITLE
fix: add missing strategy pages (ichimoku, keltner-squeeze, ma-cross)

### DIFF
--- a/src/content/strategies/ichimoku.md
+++ b/src/content/strategies/ichimoku.md
@@ -1,0 +1,50 @@
+---
+name: "Ichimoku Bearish"
+description: "Short crypto below the Ichimoku cloud on a Tenkan/Kijun cross. Verified — 953 trades, PF 1.21, Sharpe 0.85, measured 2026-04-22."
+status: "verified"
+category: "hybrid"
+direction: "short"
+difficulty: "intermediate"
+winRate: 40.61
+profitFactor: 1.21
+maxDrawdown: 42.2
+timeframe: "4H"
+coins: 235
+dateAdded: "2026-04-22"
+tags: ["ichimoku", "trend", "short", "verified"]
+---
+
+## Overview
+
+Ichimoku Kinko Hyo ("equilibrium chart at a glance") is a multi-component indicator that paints a forward-projected "cloud" (Kumo) from price-range midpoints. This preset inverts the classic long setup: it enters SHORT when price is trading **below the cloud** AND the Tenkan-sen (9) crosses below the Kijun-sen (26), confirming downside momentum against a bearish structural backdrop.
+
+## How It Works
+
+1. **Cloud filter** — price must be below both Senkou Span A and B (the cloud bottom)
+2. **Tenkan/Kijun cross** — short-term (9-period) midpoint crosses below medium-term (26-period) midpoint
+3. **Confirmation** — Chikou Span (lagging close, displaced −26) clear of cloud
+4. **Entry** — SHORT on bar close after the cross
+5. **Exit** — fixed TP 15% / SL 3% (tested tightest of the 5 verified presets)
+
+## Why It Works (Thesis)
+
+Crypto downtrends are often multi-week. The cloud catches regime; the Tenkan/Kijun cross catches timing. Combining them filters out bear-trap countertrends that break simpler moving-average systems.
+
+## Results (2-year backtest, measured 2026-04-22)
+
+| Metric | Value |
+|--------|-------|
+| Total trades | 953 |
+| Win rate | 40.61% |
+| Profit factor | 1.21 |
+| Sharpe | 0.85 |
+| Total return | +155.05% |
+| Max drawdown | 42.2% |
+
+Low win rate is expected for trend-following shorts — edge comes from average win size > average loss, visible in PF > 1.
+
+## Caveats
+
+- 42.2% max drawdown is substantial. Position-size accordingly.
+- Not live-tracked on OKX (backtest only). See the simulator's TrustGap panel for the difference this matters.
+- Tight 3% stop-loss means frequent stop-outs during noise — this is a feature (preserves capital for clean breaks), not a bug.

--- a/src/content/strategies/keltner-squeeze.md
+++ b/src/content/strategies/keltner-squeeze.md
@@ -1,0 +1,48 @@
+---
+name: "Keltner Fade"
+description: "Fade breakouts through the Keltner upper band back into the channel. Verified — 735 trades, PF 1.14, Sharpe 0.71, measured 2026-04-22."
+status: "verified"
+category: "volatility"
+direction: "short"
+difficulty: "intermediate"
+winRate: 53.47
+profitFactor: 1.14
+maxDrawdown: 44.8
+timeframe: "4H"
+coins: 235
+dateAdded: "2026-04-22"
+tags: ["keltner", "volatility", "mean-reversion", "short", "verified"]
+---
+
+## Overview
+
+Keltner Channels plot an ATR-scaled envelope around an exponential moving average. This preset takes the **counter-trend** side: when price pushes through the upper band, we fade the breakout and ride it back into the channel. It's a mean-reversion play on momentum exhaustion, not a breakout play.
+
+## How It Works
+
+1. **Channel setup** — 20 EMA center, ATR × 2 for upper / lower bands
+2. **Trigger** — close above the upper band
+3. **Entry** — SHORT on next-bar close (avoids intrabar wicks)
+4. **Exit** — TP when price re-enters the channel (~5% target) / SL at 7%
+5. **Filter** — only take signals when the center EMA is flat-to-down (no trend-following fades)
+
+## Why It Works (Thesis)
+
+Crypto overshoots. Momentum funds chase breakouts on the Keltner upper, but without a supporting structural trend the move often reverses within 1–3 bars. The ATR scaling keeps the edge stable across volatility regimes — tighter channels in calm markets, wider in stormy ones.
+
+## Results (2-year backtest, measured 2026-04-22)
+
+| Metric | Value |
+|--------|-------|
+| Total trades | 735 |
+| Win rate | 53.47% |
+| Profit factor | 1.14 |
+| Sharpe | 0.71 |
+| Total return | +88.22% |
+| Max drawdown | 44.8% |
+
+## Caveats
+
+- Fade strategies bleed hard in trending markets — the 44.8% drawdown sits in exactly those regimes.
+- Not live-tracked on OKX. Forward performance can diverge — see TrustGap.
+- Lower PF than Ichimoku but tighter win-rate dispersion (53% WR vs Ichimoku's 41%) makes the equity curve smoother.

--- a/src/content/strategies/ma-cross.md
+++ b/src/content/strategies/ma-cross.md
@@ -1,0 +1,50 @@
+---
+name: "MA Cross (50/200 EMA)"
+description: "Classic 50/200 EMA crossover. Lowest max drawdown (33.5%) of the 5 verified presets. 1,111 trades, PF 1.09, measured 2026-04-22."
+status: "verified"
+category: "momentum"
+direction: "both"
+difficulty: "beginner"
+winRate: 47.79
+profitFactor: 1.09
+maxDrawdown: 33.5
+timeframe: "4H"
+coins: 235
+dateAdded: "2026-04-22"
+tags: ["moving-average", "ema", "momentum", "verified", "beginner"]
+---
+
+## Overview
+
+The 50/200 EMA crossover is the oldest trend-following signal in trading. LONG when the 50 crosses above the 200 (golden cross), SHORT when below (death cross). This preset applies it to crypto 4H timeframe across 235 coins.
+
+We kept it in the verified set despite its modest PF (1.09) because **it has the lowest max drawdown of the 5 verified presets (33.5% vs 42–47% for the others)**. Useful as a defensive component in a portfolio.
+
+## How It Works
+
+1. **Setup** — compute 50-period and 200-period EMAs on 4H bars
+2. **Long entry** — 50 EMA crosses above 200 EMA
+3. **Short entry** — 50 EMA crosses below 200 EMA
+4. **Exit** — opposite cross OR TP 10% / SL 5%
+5. **Position sizing** — equal weight per signal (no leverage adjustment)
+
+## Why It Works (Thesis)
+
+Simple. Robust. The long EMAs smooth out whipsaw. Signal frequency is low (1,111 trades over 2 years across 235 coins = ~0.1 trades / coin / week), which keeps commission drag minimal. Profit comes from a small number of big-move regimes; the other 90% of the time it's flat.
+
+## Results (2-year backtest, measured 2026-04-22)
+
+| Metric | Value |
+|--------|-------|
+| Total trades | 1,111 |
+| Win rate | 47.79% |
+| Profit factor | 1.09 |
+| Sharpe | 0.54 |
+| Total return | +85.06% |
+| Max drawdown | 33.5% |
+
+## Caveats
+
+- Lowest edge of the 5 verified presets (PF 1.09). Use it for stability, not alpha.
+- Classic signal — unlikely to have any unique edge left. Included because its *drawdown profile* complements the higher-PF presets.
+- Not live-tracked. TrustGap applies.


### PR DESCRIPTION
3 strategy presets (simulator-presets.ts) referenced /strategies/<id>/ pages that did not exist → prod 404. Layer 1 inventory flagged these. Adds content/strategies/*.md for each. Build 1188 → 1191 pages.