### PR TITLE
cleanup(pr6): expert review fix-ups — 4 blockers + docs-lint-allow markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,7 @@ Test strategies on real historical data with realistic market conditions.
 - **Yearly Breakdown**: Performance metrics split by year to detect overfitting
 
 ### Strategy Library
-5 pre-built strategies with full transparency - including the ones that failed.
-
-| Strategy | Direction | Status | Win Rate | Profit Factor |
-|----------|-----------|--------|----------|---------------|
-| BB Squeeze SHORT | Short | **Verified** (live trading) | 70.4% | 2.55 |
-| BB Squeeze LONG | Long | Killed | 51.0% | 0.98 |
-| Momentum LONG | Long | Killed (-$14,115) | 37.5% | 0.71 |
-| ATR Breakout | Long | Shelved | - | - |
-| HV Squeeze | Short | Shelved | - | - |
+PRUVIQ ships transparency: verified strategies with fresh metrics + the ones that failed. Live numbers (Win Rate / PF / Sharpe / MDD) are tracked in [`src/config/simulator-presets.ts`](src/config/simulator-presets.ts) and surfaced on [pruviq.com/strategies](https://pruviq.com/strategies). Static snapshots in this README are intentionally omitted to avoid drift — see the live site for current values.
 
 ### Interactive Simulations
 - **Strategy Comparison**: Compare all strategies side-by-side under identical conditions

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,7 +30,7 @@
 │  │                       │                                            │     │
 │  │                       ▼                                            │     │
 │  │  ┌─────────────────────────────────────────────────┐              │     │
-│  │  │             Storage (Parquet + Registry)         │              │     │
+│  │  │             Storage — 현재 CSV / 계획 Parquet         │              │     │
 │  │  │  data/                                           │              │     │
 │  │  │  ├── ohlcv/                                      │              │     │
 │  │  │  │   ├── binance/spot/BTCUSDT_1h.parquet        │              │     │
@@ -188,7 +188,7 @@ pruviq/
 │       └── schemas.py                 # Pydantic 모델
 │
 ├── data/                              # 데이터 저장소 (gitignore)
-│   ├── ohlcv/                         # OHLCV 데이터 (Parquet)
+│   ├── ohlcv/                         # OHLCV 데이터 (현재 CSV — Parquet 마이그레이션은 Phase 2 계획)
 │   │   ├── binance/
 │   │   │   ├── spot/                  # BTCUSDT_1h.parquet, ...
 │   │   │   └── futures/

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -38,7 +38,7 @@
     │                     │    │  서비스:                           │       │
     │  Python venvs:      │    │   - n8n       :5678               │       │
     │   - .venv-at/       │    │   - Ollama    :11434              │       │
-    │   - .venv-pv/       │    │   - PRUVIQ API:8400 (Phase 1+)   │       │
+    │   - .venv-pv/       │    │   (PRUVIQ API는 DO :8080 — Mac Mini 호스팅 안 함)│       │ <!-- docs-lint-allow: 명시적 부정문 — Mac Mini가 호스팅 안 한다는 사실을 다이어그램에 못 박는 것이 의도 -->
     │                     │    │                                    │       │
     └──────────┬──────────┘    └────────────────────────────────────┘       │
                │                                                           │
@@ -187,7 +187,7 @@ pip install -r requirements.txt
 |--------|------|-----------|------|
 | n8n | 5678 | com.n8n.server.plist | 자동화 파이프라인 |
 | Ollama | 11434 | com.ollama.server.plist | AI 시황 요약 |
-| PRUVIQ API | 8400 | com.pruviq.api.plist (Phase 1+) | 웹 API 서빙 |
+| (구 계획) PRUVIQ API on Mac Mini 8400 | — | — | **이행 안 됨**. 실제 PRUVIQ API는 DigitalOcean :8080 (systemd `pruviq-api.service`) — 자세한 건 § 3.3 포트 표 참조 | <!-- docs-lint-allow: 의도적 역사 기록 — "이행 안 됨" 명시 -->
 
 #### Mac Mini에서 하지 않는 것
 - autotrader 실거래 봇 실행 (DO 서버 전용)
@@ -251,7 +251,7 @@ pip install -r requirements.txt
 | MacBook | DO 서버 | SSH | `ssh root@167.172.81.145` |
 | Mac Mini | DO 서버 | SSH | `ssh root@167.172.81.145` |
 | MacBook | n8n UI | 브라우저 | `http://100.93.138.124:5678` |
-| MacBook | PRUVIQ API | HTTP | `http://100.93.138.124:8400` (Phase 1+) |
+| MacBook | PRUVIQ API | HTTP | `https://api.pruviq.com/health` (DO via Cloudflare Tunnel) |
 
 ### 3.3 포트 할당표
 
@@ -476,9 +476,9 @@ OLLAMA_HOST=http://127.0.0.1:11434
 # n8n Webhook
 N8N_WEBHOOK_BASE=http://127.0.0.1:5678/webhook
 
-# PRUVIQ API (Phase 1+)
+# PRUVIQ API (DigitalOcean — host in DO_HOST secret)
 PRUVIQ_API_HOST=0.0.0.0
-PRUVIQ_API_PORT=8400
+PRUVIQ_API_PORT=8080
 ```
 
 ---

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -47,20 +47,19 @@
 ## 3. 인프라 (Infrastructure Architect)
 
 ```
-(2026-02 초기 계획 — 역사적 기록)
-MacBook (jplee)          Mac Mini (jepo)           DO Server
-~/Desktop/pruviq    →    ~/pruviq              167.172.81.145
-개발 전용                 운영/자동화/AI            autotrader ONLY
-git push                 git pull               Docker
-                         n8n (5678)
-                         Ollama (11434)
-                         PRUVIQ API (8400)
-                         크론: 매시 데이터수집
-
-⚠️ 이행 완료 (2026-04): PRUVIQ API는 별도 DigitalOcean droplet
-(host in DO_HOST secret)으로 이관. Mac Mini는 dev + OHLCV 수집 cron +
-autotrader 백업만. 현행 세부는 docs/INFRASTRUCTURE.md + QA_AUTOMATION.md.
+(현행 — 2026-04 이행 완료)
+MacBook (jplee)       Mac Mini (jepo)          DO PRUVIQ droplet           DO autotrader (별개)
+~/Desktop/pruviq  →   ~/pruviq                 host in DO_HOST secret      167.172.81.145
+개발 전용              dev + cron + 백업        PRUVIQ API :8080            autotrader ONLY
+git push              OHLCV 수집 (cron)        systemd pruviq-api.service  Docker
+                      autotrader 데이터 백업    cloudflared (api.pruviq.com)
+                      n8n (5678) · Ollama
+                                                cloudflared
 ```
+
+원래 2026-02 초기 계획에서는 Mac Mini 가 PRUVIQ API 까지 호스팅할 예정이었으나, <!-- docs-lint-allow: 의도적 역사 기록 — 초기 계획 vs 실제 이행 차이 명시 -->
+2026-04 운영 이슈 (안정성 + 격리)로 PRUVIQ API 만 별도 DigitalOcean droplet 으로
+이관. 자세한 인프라는 docs/INFRASTRUCTURE.md, QA 자동화는 docs/QA_AUTOMATION.md.
 
 **환경 분리:** Python venv 분리, API 키 분리, Git repo 분리
 **크론 스케줄:**

--- a/docs/QA_AUTOMATION.md
+++ b/docs/QA_AUTOMATION.md
@@ -18,7 +18,7 @@ PRUVIQ 사이트의 자동 검증 인프라. "65/65 tests PASS 인데 유저가 
 | **5** Scenario flows | `tests/e2e/scenarios/user-flows.spec.ts` | 매 PR | 4 핵심 유저 여정 step-by-step (preset→결과, macro 뉴스 탭, 등) |
 | **6** A11y interactive | `tests/accessibility/interactive-a11y.spec.ts` | 매 PR | 버튼 클릭 후 axe — 신규 위반 0 |
 | **7** Nightly sweep | `.github/workflows/nightly-qa.yml` | 매일 02:00 UTC | prod 전체 재실행 + auto-issue |
-| **8** Flake classifier | `scripts/classify-flake.mjs`, `.github/workflows/flake-report.yml` | 재시도 발생 시 | passed-after-retry 기록 + 주간 리포트 |
+| **8** Flake classifier | `scripts/classify-flake.mjs`, `.github/workflows/flake-report.yml` | 매주 월 04:00 UTC | passed-after-retry 기록 + 주간 리포트 (Issue 자동 생성) |
 
 **Lighthouse budget gate** (레이어 번호 외 독립):
 - `lighthouserc.json`, `.github/workflows/lighthouse-budget.yml`


### PR DESCRIPTION
## Summary

Three-expert post-merge review (PR1-PR5: #1358-#1362) verdict: **RELEASE READY, Risk Score: ZERO**.

This PR addresses the 1 BLOCKER + 2 WARN findings from that review, plus a couple of bonus consistency fixes, plus 3 \`docs-lint-allow\` markers for legitimate historical records.

## Changes

**BLOCKER** — \`docs/INFRASTRUCTURE.md\` had 4 stale "Mac Mini PRUVIQ API :8400" references that survived PR4:
- L41 diagram body — explicit "Mac Mini 호스팅 안 함" negation
- L190 port table — "(구 계획) ... 이행 안 됨" historical record
- L254 HTTP URL → \`https://api.pruviq.com/health\`
- L481 \`PRUVIQ_API_PORT\` 8400 → 8080

**WARN** — \`docs/ARCHITECTURE.md\` claimed "Storage (Parquet + Registry)" while reality is CSV in \`public/data/\`. Updated to "현재 CSV / 계획 Parquet" + per-file annotation.

**WARN** — \`docs/MASTER_PLAN.md\` infrastructure diagram still showed 2026-02 plan. Rewrote body to current state with a separate "DO PRUVIQ droplet" column.

**Bonus** — \`docs/QA_AUTOMATION.md\` Layer 8 trigger corrected to "매주 월 04:00 UTC" matching \`flake-report.yml\` cron.

**Bonus** — \`README.md\` removed drift-prone preset metric table; points to \`src/config/simulator-presets.ts\` SSoT + \`pruviq.com/strategies\`.

**docs-lint-allow markers** — 3 lines that legitimately mention "Mac Mini" with "PRUVIQ API" together (historical records or explicit negations) tagged with \`<!-- docs-lint-allow: <reason> -->\`.

## Test plan

- [x] Guard 1 (\`/Users/openclaw/\`): 0 matches outside \`docs-lint.yml\` itself
- [x] Guard 2 (openclaw refs outside archive/): 0 matches
- [x] Guard 3 (Mac Mini backend, post-marker): 0 matches
- [x] Guard 5 (DOC_INDEX coverage): 0 missing
- [x] \`npm run build\`: 1192 pages OK (zero diff vs PR5 merge)
- [ ] CI: docs-lint, validate-skills, lighthouse-budget, build all green