### PR TITLE
feat(okx): manual API key paste auth path (backend)

### DIFF
--- a/backend/okx/config.py
+++ b/backend/okx/config.py
@@ -42,6 +42,14 @@ OKX_OAUTH_TOKEN = f"{OKX_BASE_URL}/v5/users/oauth/token"
 # ── Demo mode (testnet headers) ──
 OKX_DEMO_MODE = os.environ.get("OKX_DEMO_MODE", "false").lower() == "true"
 
+# ── Manual API key paste kill switch ──
+# Backend-only revert path independent of frontend AUTOTRADE_MANUAL_ENABLED
+# flag. Flip to "false" + restart pruviq-api to disable the manual-connect
+# endpoint without redeploying frontend. Default true (live).
+OKX_MANUAL_PASTE_ENABLED = (
+    os.environ.get("OKX_MANUAL_PASTE_ENABLED", "true").lower() == "true"
+)
+
 # ── Database path (SQLite) ──
 OKX_DB_PATH = os.environ.get("OKX_DB_PATH", "")
 

--- a/backend/okx/manual_auth.py
+++ b/backend/okx/manual_auth.py
@@ -1,0 +1,102 @@
+"""
+Manual API key paste auth path for OKX.
+
+Owner decision (2026-04-25): ship manual paste FIRST while OAuth Broker (Fast
+API) approval is pending. Industry-standard pattern — 3Commas, Cryptohopper,
+BitsGap, Altrady, WunderTrading all prioritize manual-paste over OAuth.
+
+Flow: user pastes API key + secret + passphrase → we validate by calling
+OKX `GET /api/v5/account/balance` with HMAC-signed credentials → on success,
+persist via storage.save_session() with the same dict shape OAuth produces.
+The trading engine sees an identical session row regardless of how it was
+created — `is_authenticated()`, `get_api_credentials()`, `MAX_PER_TRADE_USDT`
+cap, clOrdId idempotency, /halt killswitch all work unchanged.
+"""
+from __future__ import annotations
+
+import logging
+import secrets
+import time
+
+import httpx
+
+from .client import OKXClient
+from .storage import save_session
+
+logger = logging.getLogger("okx_manual_auth")
+
+# Length sanity guards so we don't burn an OKX rate-limit slot on garbage.
+# OKX API keys are typically 36-char UUIDs; secrets 32-char base64; passphrases
+# user-defined 8-32 chars. Allow comfortable margin on both sides.
+_API_KEY_MIN, _API_KEY_MAX = 20, 80
+_SECRET_MIN, _SECRET_MAX = 20, 80
+_PASSPHRASE_MIN, _PASSPHRASE_MAX = 8, 64
+
+
+def _validate_input(api_key: str, secret_key: str, passphrase: str) -> tuple[str, str, str]:
+    fields = {"api_key": api_key, "secret_key": secret_key, "passphrase": passphrase}
+    cleaned = {}
+    for name, raw in fields.items():
+        if not isinstance(raw, str):
+            raise ValueError(f"missing_field: {name}")
+        v = raw.strip()
+        if not v:
+            raise ValueError(f"missing_field: {name}")
+        cleaned[name] = v
+
+    bounds = {
+        "api_key": (_API_KEY_MIN, _API_KEY_MAX),
+        "secret_key": (_SECRET_MIN, _SECRET_MAX),
+        "passphrase": (_PASSPHRASE_MIN, _PASSPHRASE_MAX),
+    }
+    for name, v in cleaned.items():
+        lo, hi = bounds[name]
+        if len(v) < lo or len(v) > hi:
+            raise ValueError(f"malformed_field: {name}")
+    return cleaned["api_key"], cleaned["secret_key"], cleaned["passphrase"]
+
+
+async def validate_and_store(api_key: str, secret_key: str, passphrase: str) -> str:
+    """Validate user-pasted OKX credentials and persist a new session.
+
+    Returns: session_id (32+ char URL-safe token).
+    Raises: ValueError with one of:
+      - "missing_field: <name>"
+      - "malformed_field: <name>"
+      - "invalid_credentials: <okx_msg>"
+    """
+    api_key, secret_key, passphrase = _validate_input(api_key, secret_key, passphrase)
+
+    client = OKXClient(api_key=api_key, secret_key=secret_key, passphrase=passphrase)
+    try:
+        try:
+            await client.get_balance("USDT")
+        except httpx.HTTPStatusError as e:
+            # OKX returns 401/403 on bad signature — surface a clean error.
+            raise ValueError(
+                f"invalid_credentials: HTTP {e.response.status_code} from OKX"
+            ) from e
+        except ValueError as e:
+            # OKXClient raises ValueError("OKX API error <code>: <msg>") on
+            # non-zero codes (50111 Invalid Sign, 50113 Invalid passphrase, etc.)
+            msg = str(e)
+            if msg.startswith("OKX API error"):
+                raise ValueError(f"invalid_credentials: {msg}") from e
+            raise
+        except httpx.HTTPError as e:
+            # Network / TLS failure — distinct from invalid creds.
+            raise ValueError(f"invalid_credentials: network error contacting OKX") from e
+    finally:
+        await client.close()
+
+    credentials = {
+        "api_key": api_key,
+        "secret_key": secret_key,
+        "passphrase": passphrase,
+        "perm": "manual_paste",
+        "created_at": time.time(),
+    }
+    session_id = secrets.token_urlsafe(32)
+    save_session(session_id, credentials)
+    logger.info("manual session created: %s perm=manual_paste", session_id[:8])
+    return session_id

--- a/backend/okx/router.py
+++ b/backend/okx/router.py
@@ -21,7 +21,7 @@ from typing import Optional
 from fastapi import APIRouter, Header, HTTPException, Query, Request, Response
 from fastapi.responses import RedirectResponse
 
-from .config import COOKIE_DOMAIN, FRONTEND_URL, OKX_CLIENT_ID
+from .config import COOKIE_DOMAIN, FRONTEND_URL, OKX_CLIENT_ID, OKX_MANUAL_PASTE_ENABLED
 
 ADMIN_KEY = os.environ.get("ADMIN_API_KEY", "")
 
@@ -177,6 +177,39 @@ async def oauth_disconnect(request: Request):
         content='{"status":"disconnected"}', media_type="application/json"
     )
     _clear_session_cookie(response)
+    return response
+
+
+@router.post("/auth/okx/manual-connect")
+async def oauth_manual_connect(request: Request):
+    """Manual API key paste path — alternative to OAuth.
+
+    Body: {api_key, secret_key, passphrase}.
+    Validates by calling OKX /api/v5/account/balance with HMAC; on success
+    persists via save_session() with the same dict shape OAuth produces, so
+    every downstream /execute/* endpoint sees an identical session row.
+    """
+    if not OKX_MANUAL_PASTE_ENABLED:
+        raise HTTPException(503, "manual_paste_disabled")
+    try:
+        body = await request.json()
+    except ValueError:
+        raise HTTPException(400, "body must be JSON")
+    if not isinstance(body, dict):
+        raise HTTPException(400, "body must be JSON object")
+    from .manual_auth import validate_and_store
+    try:
+        session_id = await validate_and_store(
+            body.get("api_key", ""),
+            body.get("secret_key", ""),
+            body.get("passphrase", ""),
+        )
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+    response = Response(
+        content='{"status":"connected"}', media_type="application/json"
+    )
+    _set_session_cookie(response, session_id)
     return response
 
 

--- a/backend/tests/test_okx_manual_auth.py
+++ b/backend/tests/test_okx_manual_auth.py
@@ -1,0 +1,204 @@
+"""
+Manual API key paste auth path — regression guards.
+
+Owner shipped manual paste 2026-04-25 to unblock OKX trading without waiting
+on Fast API approval. The trading critical path (auto_executor, orders,
+reconciler, /execute/*) reads from get_api_credentials() which only checks
+that the session row contains an `api_key`. Manual paste must produce a row
+with bit-identical shape to OAuth output — otherwise the cap, idempotency,
+and /halt killswitch silently bypass.
+
+Tests:
+  1. Source guard — module imports save_session, references client.get_balance,
+     and contains no `bare except`.
+  2. Happy path — valid creds → session_id + storage round-trip.
+  3. Rejection — OKX-side error (50111 Invalid Sign) → ValueError surfaces it
+     under `invalid_credentials:` prefix and writes nothing to storage.
+  4. Input validation — empty / oversize fields short-circuit before OKXClient.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+BACKEND = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND))
+
+MANUAL_AUTH_PY = BACKEND / "okx" / "manual_auth.py"
+
+
+def test_source_imports_save_session_and_get_balance_no_bare_except():
+    """The implementation must reuse storage.save_session (single SSoT) and
+    OKXClient.get_balance (single auth primitive). bare-except would silently
+    swallow OKX errors — explicitly forbidden by CLAUDE.md rule 5."""
+    src = MANUAL_AUTH_PY.read_text(encoding="utf-8")
+    assert re.search(r"from\s+\.storage\s+import\s+.*save_session", src), (
+        "manual_auth.py must import save_session from .storage — no parallel "
+        "credential store. Found imports do not include save_session."
+    )
+    assert "client.get_balance" in src or ".get_balance(" in src, (
+        "manual_auth.py must call OKXClient.get_balance to validate creds "
+        "before persisting them. Reference not found."
+    )
+    # bare `except:` and `except Exception:` (no name) are forbidden — both
+    # would mask OKX errors that we MUST surface to the user.
+    assert not re.search(r"^\s*except\s*:\s*$", src, re.M), (
+        "bare `except:` found — must catch specific exception types."
+    )
+    assert not re.search(r"^\s*except\s+Exception\s*:\s*$", src, re.M), (
+        "bare `except Exception:` (without `as e`) is forbidden — silently "
+        "swallowing OKX failures defeats the validation step."
+    )
+
+
+@pytest.mark.anyio
+async def test_validate_and_store_happy_path(monkeypatch):
+    """Valid creds → OKXClient.get_balance returns → save_session persists →
+    round-trip via get_session yields identical credential dict."""
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ["OKX_DB_PATH"] = str(Path(tmp) / "test.db")
+        # Fernet key for storage.encrypt — Fernet.generate_key()-equivalent.
+        os.environ["OKX_ENCRYPTION_KEY"] = (
+            "ZmDfcTF7_60GrrY167zsiPd67pEvs0aGOv2oasOM1Pg="
+        )
+        # Reload modules to pick up env.
+        import importlib
+        import okx.storage as storage
+        import okx.manual_auth as manual_auth
+        import okx.client as client_mod
+        importlib.reload(storage)
+        importlib.reload(manual_auth)
+
+        async def fake_get_balance(self, ccy: str = "USDT"):
+            return [{"ccy": "USDT", "bal": "100", "avail_bal": "100"}]
+
+        async def fake_close(self):
+            return None
+
+        monkeypatch.setattr(client_mod.OKXClient, "get_balance", fake_get_balance)
+        monkeypatch.setattr(client_mod.OKXClient, "close", fake_close)
+
+        api_key = "okx-fake-key-1234567890abcdef-aaaa"
+        secret = "okx-fake-secret-1234567890abcdef"
+        passphrase = "Pa$$w0rd!"
+
+        sid = await manual_auth.validate_and_store(api_key, secret, passphrase)
+        assert isinstance(sid, str) and len(sid) >= 32
+
+        creds = storage.get_session(sid)
+        assert creds is not None
+        assert creds["api_key"] == api_key
+        assert creds["secret_key"] == secret
+        assert creds["passphrase"] == passphrase
+        assert creds["perm"] == "manual_paste"
+        assert "created_at" in creds
+
+    os.environ.pop("OKX_DB_PATH", None)
+    os.environ.pop("OKX_ENCRYPTION_KEY", None)
+
+
+@pytest.mark.anyio
+async def test_validate_and_store_rejects_invalid_credentials(monkeypatch):
+    """OKX returns code 50111 'Invalid Sign' → OKXClient raises
+    ValueError('OKX API error 50111: ...') → manual_auth must re-raise as
+    ValueError starting with 'invalid_credentials:' AND must NOT call
+    save_session (so a bad-creds attempt leaves no row behind)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ["OKX_DB_PATH"] = str(Path(tmp) / "test.db")
+        os.environ["OKX_ENCRYPTION_KEY"] = (
+            "ZmDfcTF7_60GrrY167zsiPd67pEvs0aGOv2oasOM1Pg="
+        )
+        import importlib
+        import okx.storage as storage
+        import okx.manual_auth as manual_auth
+        import okx.client as client_mod
+        importlib.reload(storage)
+        importlib.reload(manual_auth)
+
+        save_calls: list = []
+        original_save = storage.save_session
+
+        def tracked_save(session_id, data):
+            save_calls.append(session_id)
+            return original_save(session_id, data)
+
+        monkeypatch.setattr(storage, "save_session", tracked_save)
+        # manual_auth imported save_session from .storage — patch its module
+        # binding too (Python's `from X import Y` copies the reference).
+        monkeypatch.setattr(manual_auth, "save_session", tracked_save)
+
+        async def failing_get_balance(self, ccy: str = "USDT"):
+            raise ValueError("OKX API error 50111: Invalid Sign")
+
+        async def fake_close(self):
+            return None
+
+        monkeypatch.setattr(client_mod.OKXClient, "get_balance", failing_get_balance)
+        monkeypatch.setattr(client_mod.OKXClient, "close", fake_close)
+
+        with pytest.raises(ValueError) as exc_info:
+            await manual_auth.validate_and_store(
+                "okx-fake-key-1234567890abcdef-aaaa",
+                "okx-fake-secret-1234567890abcdef",
+                "Pa$$w0rd!",
+            )
+
+        msg = str(exc_info.value)
+        assert msg.startswith("invalid_credentials:"), (
+            f"error must start with 'invalid_credentials:' so the HTTP layer "
+            f"can surface it; got: {msg!r}"
+        )
+        assert "50111" in msg or "Invalid Sign" in msg, (
+            f"OKX-side error code/message must be preserved for debugging; "
+            f"got: {msg!r}"
+        )
+        assert save_calls == [], (
+            f"save_session must NOT be called on rejection — got calls: "
+            f"{save_calls}"
+        )
+
+    os.environ.pop("OKX_DB_PATH", None)
+    os.environ.pop("OKX_ENCRYPTION_KEY", None)
+
+
+@pytest.mark.anyio
+async def test_validate_and_store_input_validation_short_circuits(monkeypatch):
+    """Empty / oversize inputs must reject BEFORE OKXClient is even
+    instantiated — protects OKX rate limit + reduces attack surface."""
+    import okx.client as client_mod
+    import okx.manual_auth as manual_auth
+
+    instantiated: list = []
+    original_init = client_mod.OKXClient.__init__
+
+    def tracked_init(self, *args, **kwargs):
+        instantiated.append((args, kwargs))
+        return original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(client_mod.OKXClient, "__init__", tracked_init)
+
+    # Empty fields
+    for empty in ("", "   ", None):
+        with pytest.raises(ValueError) as exc_info:
+            await manual_auth.validate_and_store(empty, "x" * 30, "x" * 12)
+        assert "missing_field" in str(exc_info.value)
+
+    # Oversize api_key
+    with pytest.raises(ValueError) as exc_info:
+        await manual_auth.validate_and_store("x" * 1000, "x" * 30, "x" * 12)
+    assert "malformed_field" in str(exc_info.value)
+
+    # Undersize passphrase
+    with pytest.raises(ValueError) as exc_info:
+        await manual_auth.validate_and_store("x" * 30, "x" * 30, "ab")
+    assert "malformed_field" in str(exc_info.value)
+
+    assert instantiated == [], (
+        f"OKXClient must not be instantiated when input fails validation; "
+        f"got {len(instantiated)} instantiations: {instantiated}"
+    )


### PR DESCRIPTION
## Summary

- `POST /auth/okx/manual-connect` — backend endpoint to validate user-pasted OKX API key+secret+passphrase via OKX `/api/v5/account/balance`, then persist via the existing Fernet-encrypted session store
- Industry-standard pattern (3Commas, Cryptohopper, BitsGap, Altrady, WunderTrading all prioritize manual paste over OAuth) — unblocks PRUVIQ trading without waiting on OKX Fast API broker approval
- Trading critical path **bit-identical** to OAuth: `oauth.py`, `client.py`, `storage.py`, `auto_executor.py`, `orders.py`, `reconciler.py` all untouched. Manual paste produces a session row with the same shape (`{api_key, secret_key, passphrase, perm, created_at}`) — so `MAX_PER_TRADE_USDT` cap, `clOrdId` idempotency, `/halt` killswitch, and `is_authenticated()` work unchanged
- `OKX_MANUAL_PASTE_ENABLED` env (default `true`) — backend kill switch independent of any frontend flag

## Why now

Owner audit 2026-04-25: "다른 사람들 잘 하는 거 보면 우리쪽 문제다." External research confirmed every successful third-party OKX automation product ships manual paste as the first-class path. Our OAuth-Broker dependency was a self-imposed bottleneck.

## Files

| File | Change |
|------|--------|
| `backend/okx/manual_auth.py` | NEW — `validate_and_store(api_key, secret_key, passphrase) -> session_id` |
| `backend/okx/router.py` | Add `POST /auth/okx/manual-connect` (kill-switch checked) |
| `backend/okx/config.py` | Add `OKX_MANUAL_PASTE_ENABLED` env (default true) |
| `backend/tests/test_okx_manual_auth.py` | NEW — 4 tests (source guard / happy / reject / input validation) |

## Safety

- Validates BEFORE persisting (OKX API call → 401/error → `ValueError("invalid_credentials: <msg>")` → HTTP 400, nothing written)
- Length sanity guards short-circuit garbage before OKX rate-limit slot is consumed
- No `bare except: pass` (CLAUDE.md rule 5) — explicitly enforced by `test_source_imports_save_session_and_get_balance_no_bare_except`
- OKX-side error message preserved (`50111 Invalid Sign` etc.) so users know which field is wrong
- Session shape identical to OAuth output — guarantees existing safety controls apply uniformly

## Day 2~5 (separate PRs, not in this one)

- Day 2: Frontend form (gated `AUTOTRADE_MANUAL_ENABLED=false` so production stays hidden until owner dogfood)
- Day 3 (Mon): Owner pastes own OKX API key via curl, runs first dust trade, verifies `tag=OKX_BROKER_CODE` attribution
- Day 4-5: Flip frontend flag to public after 24~48h owner stable

## Test plan

- [x] `pytest tests/test_okx_manual_auth.py -v` → 4/4 pass (local)
- [x] `pytest tests/test_okx_oauth_scope.py tests/test_okx_oauth_security.py tests/test_okx_idempotency_and_busy_timeout.py -v` → 12/12 pass (regression)
- [x] Full backend suite → 170 pass + 3 pre-existing failures (test_strategies, test_cost_model_futures_parity, test_cost_model — already in CLAUDE.md `--deselect` list)
- [ ] After deploy: `curl -X POST https://api.pruviq.com/auth/okx/manual-connect -d '{}' -H 'Content-Type: application/json'` → expect 400 `missing_field`
- [ ] `curl -X POST https://api.pruviq.com/auth/okx/manual-connect -d '{"api_key":"x","secret_key":"y","passphrase":"z"}' -H 'Content-Type: application/json'` → expect 400 `malformed_field`

🤖 Generated with [Claude Code](https://claude.com/claude-code)