### PR TITLE
feat(okx): manual paste form (gated, flag=false)

### DIFF
--- a/src/components/OKXConnectButton.tsx
+++ b/src/components/OKXConnectButton.tsx
@@ -2,15 +2,29 @@
  * OKX Connect/Disconnect button.
  * OAuth flow: fetch /auth/okx/init → build URL → window.location.assign()
  * Mirrors OKX JS SDK behavior (domain + /account/oauth + queryString) without loading SDK.
+ *
+ * 2026-04-25: Added manual API key paste path as alternative to OAuth (which
+ * is still pending OKX Fast API approval). Industry standard — 3Commas /
+ * Cryptohopper / BitsGap / Altrady / WunderTrading all prioritize manual
+ * paste. Backend POST /auth/okx/manual-connect produces a session row
+ * identical to OAuth output, so all /execute/* endpoints work unchanged.
  */
 import { useState, useEffect } from "preact/hooks";
 import { API_BASE_URL as API_BASE } from "../config/api";
 import { OKX_DISCOUNT_PCT } from "../config/exchanges";
+import OKXManualPasteForm from "./OKXManualPasteForm";
 
 interface Props {
   lang?: "en" | "ko";
   size?: "sm" | "md" | "lg";
   showCard?: boolean;
+  /**
+   * "cta-only": always render the disabled "Coming Soon" pill regardless of
+   * AUTOTRADE_MANUAL_ENABLED. Used on marketing surfaces (e.g. /fees) where
+   * we don't want to advertise a credentials form. Default: standard variant
+   * which honors the manual-paste flag.
+   */
+  variant?: "default" | "cta-only";
 }
 
 // OKX moved OAuth endpoint from /api/v5/oauth/* to /account/oauth/* in 2026.
@@ -51,8 +65,14 @@ const labels = {
   },
 };
 
-// 2026-04-23: feature flag. Flip to false once OKX integration is live.
-const AUTOTRADE_COMING_SOON = true;
+// 2026-04-25: split flags. Manual paste ships first (industry standard);
+// OAuth Broker (Fast API) stays gated until OKX-side approval lands.
+//
+// To revert publicly, flip AUTOTRADE_MANUAL_ENABLED back to false (3-min
+// Cloudflare push). The backend endpoint stays live (harmless without UI)
+// or can be killed independently via OKX_MANUAL_PASTE_ENABLED=false on DO.
+const AUTOTRADE_OAUTH_COMING_SOON = true;
+const AUTOTRADE_MANUAL_ENABLED = false;
 
 const sizeClasses = {
   sm: "btn-sm text-sm",
@@ -64,12 +84,18 @@ export default function OKXConnectButton({
   lang = "en",
   size = "md",
   showCard = false,
+  variant = "default",
 }: Props) {
   const t = labels[lang];
   const [connected, setConnected] = useState(false);
   const [loading, setLoading] = useState(true);
   const [connecting, setConnecting] = useState(false);
   const [error, setError] = useState("");
+
+  // Marketing surface short-circuit: never advertise the form here.
+  // (Hooks below still need to be declared before any return — keep this
+  // gate inline at the rendering decisions, not before the hooks.)
+  const ctaOnly = variant === "cta-only";
 
   useEffect(() => {
     // Handle OAuth callback result (?okx=success|error)
@@ -145,10 +171,14 @@ export default function OKXConnectButton({
     setConnected(false);
   };
 
-  // 2026-04-23: while autotrading is on hold, short-circuit all connect
-  // flows. Render a disabled "Coming Soon" pill immediately — skip the
-  // loading/status fetches to /auth/okx/* entirely.
-  if (AUTOTRADE_COMING_SOON) {
+  // 2026-04-25: short-circuit to "Coming Soon" when:
+  //   - This is a marketing surface (variant=cta-only), OR
+  //   - Manual paste is gated AND OAuth is pending (current default).
+  // When AUTOTRADE_MANUAL_ENABLED flips to true, the disconnected branch
+  // below renders the paste form instead.
+  const showComingSoon =
+    ctaOnly || (!AUTOTRADE_MANUAL_ENABLED && AUTOTRADE_OAUTH_COMING_SOON);
+  if (showComingSoon) {
     if (showCard) {
       return (
         <div
@@ -232,6 +262,14 @@ export default function OKXConnectButton({
           {t.disconnect}
         </button>
       </div>
+    );
+  }
+
+  // 2026-04-25: when manual paste is enabled (and the user isn't connected),
+  // render the paste form inline. Replaces the OAuth-only Connect button.
+  if (AUTOTRADE_MANUAL_ENABLED) {
+    return (
+      <OKXManualPasteForm lang={lang} onSuccess={() => setConnected(true)} />
     );
   }
 

--- a/src/components/OKXManualPasteForm.tsx
+++ b/src/components/OKXManualPasteForm.tsx
@@ -1,0 +1,263 @@
+/**
+ * OKX manual API key paste form.
+ *
+ * Posts to backend POST /auth/okx/manual-connect, which validates the
+ * credentials with OKX before persisting them. On success, the backend sets
+ * the same `pruviq_okx_session` cookie as OAuth — so all /execute/* endpoints
+ * see an identical session row regardless of how the user connected.
+ *
+ * The form is rendered inline by OKXConnectButton when AUTOTRADE_MANUAL_ENABLED
+ * is true and the user is disconnected. It is NOT a standalone route.
+ */
+import { useState } from "preact/hooks";
+import { API_BASE_URL as API_BASE } from "../config/api";
+import { PRUVIQ_BACKEND_IP } from "../config/exchanges";
+import { useTranslations, type Lang } from "../i18n/index";
+
+interface Props {
+  lang?: Lang;
+  onSuccess?: () => void;
+}
+
+export default function OKXManualPasteForm({ lang = "en", onSuccess }: Props) {
+  const t = useTranslations(lang);
+  const [apiKey, setApiKey] = useState("");
+  const [secretKey, setSecretKey] = useState("");
+  const [passphrase, setPassphrase] = useState("");
+  const [showSecret, setShowSecret] = useState(false);
+  const [showPassphrase, setShowPassphrase] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = async (e: Event) => {
+    e.preventDefault();
+    if (submitting) return;
+
+    const ak = apiKey.trim();
+    const sk = secretKey.trim();
+    const pp = passphrase.trim();
+    if (!ak || !sk || !pp) {
+      setError(t("okxManual.error.missing_field"));
+      return;
+    }
+
+    setError("");
+    setSubmitting(true);
+
+    try {
+      const resp = await fetch(`${API_BASE}/auth/okx/manual-connect`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          api_key: ak,
+          secret_key: sk,
+          passphrase: pp,
+        }),
+        signal: AbortSignal.timeout(15000),
+      });
+
+      if (resp.ok) {
+        setSuccess(true);
+        // Hand control back to the parent; OKXConnectButton flips to the
+        // connected pill, then redirect after a short success flash.
+        if (onSuccess) onSuccess();
+        setTimeout(() => {
+          const target = lang === "ko" ? "/ko/autotrading" : "/autotrading";
+          window.location.assign(target);
+        }, 800);
+        return;
+      }
+
+      let detail = "";
+      try {
+        const body = await resp.json();
+        detail = typeof body?.detail === "string" ? body.detail : "";
+      } catch {
+        // Non-JSON error body — fall back to status-only message.
+      }
+
+      // Map known backend error shapes to localized strings; surface anything
+      // unknown verbatim so the user sees the OKX-side message rather than a
+      // black-box "something went wrong".
+      if (detail.startsWith("missing_field")) {
+        setError(t("okxManual.error.missing_field"));
+      } else if (
+        detail.startsWith("invalid_credentials") ||
+        detail.startsWith("malformed_field")
+      ) {
+        setError(`${t("okxManual.error.invalid_credentials")} (${detail})`);
+      } else if (detail) {
+        setError(detail);
+      } else {
+        setError(`${t("okxManual.error.network")} (HTTP ${resp.status})`);
+      }
+    } catch (err) {
+      setError(t("okxManual.error.network"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      class="border border-[--color-accent]/20 rounded-xl p-5 bg-[--color-accent]/5"
+      onSubmit={handleSubmit}
+      data-testid="okx-manual-paste-form"
+      noValidate
+    >
+      <h4 class="font-bold text-sm mb-1">{t("okxManual.heading")}</h4>
+      <p class="text-xs text-[--color-text-muted] mb-3">
+        {t("okxManual.subtitle")}
+      </p>
+
+      <div
+        class="text-xs space-y-1.5 mb-4 p-3 rounded bg-[--color-bg-card] border border-[--color-border]"
+        id="okx-manual-perms-info"
+      >
+        <p class="text-[--color-text-secondary]">
+          <strong>{t("okxManual.perms.required")}</strong>
+        </p>
+        <p class="text-[--color-text-muted]">
+          {t("okxManual.ip.recommend")}{" "}
+          <code class="font-mono text-[--color-accent-bright]">
+            {PRUVIQ_BACKEND_IP}
+          </code>
+        </p>
+        <p class="text-[10px] text-[--color-text-muted]">
+          {t("okxManual.ip.warning")}
+        </p>
+        <a
+          href="https://www.okx.com/account/my-api"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-xs text-[--color-accent-bright] hover:underline inline-flex items-center gap-1 mt-1"
+        >
+          {t("okxManual.help.docs")} →
+        </a>
+      </div>
+
+      <div class="space-y-3">
+        <div>
+          <label
+            htmlFor="okx-manual-api-key"
+            class="block text-xs font-medium text-[--color-text-secondary] mb-1"
+          >
+            {t("okxManual.field.api_key")}
+          </label>
+          <input
+            id="okx-manual-api-key"
+            type="text"
+            class="w-full px-3 py-2.5 text-sm font-mono rounded border border-[--color-border] bg-[--color-bg-card] focus:border-[--color-accent] outline-none min-h-[44px]"
+            placeholder={t("okxManual.placeholder.api_key")}
+            value={apiKey}
+            onInput={(e) => setApiKey((e.target as HTMLInputElement).value)}
+            autoComplete="off"
+            spellcheck={false}
+            aria-describedby="okx-manual-perms-info"
+            disabled={submitting || success}
+            required
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="okx-manual-secret-key"
+            class="block text-xs font-medium text-[--color-text-secondary] mb-1 flex items-center justify-between"
+          >
+            <span>{t("okxManual.field.secret_key")}</span>
+            <button
+              type="button"
+              class="text-[10px] text-[--color-accent-bright] hover:underline"
+              onClick={() => setShowSecret(!showSecret)}
+              aria-pressed={showSecret}
+            >
+              {showSecret ? t("okxManual.hide") : t("okxManual.show")}
+            </button>
+          </label>
+          <input
+            id="okx-manual-secret-key"
+            type={showSecret ? "text" : "password"}
+            class="w-full px-3 py-2.5 text-sm font-mono rounded border border-[--color-border] bg-[--color-bg-card] focus:border-[--color-accent] outline-none min-h-[44px]"
+            placeholder={t("okxManual.placeholder.secret_key")}
+            value={secretKey}
+            onInput={(e) => setSecretKey((e.target as HTMLInputElement).value)}
+            autoComplete="off"
+            spellcheck={false}
+            disabled={submitting || success}
+            required
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="okx-manual-passphrase"
+            class="block text-xs font-medium text-[--color-text-secondary] mb-1 flex items-center justify-between"
+          >
+            <span>{t("okxManual.field.passphrase")}</span>
+            <button
+              type="button"
+              class="text-[10px] text-[--color-accent-bright] hover:underline"
+              onClick={() => setShowPassphrase(!showPassphrase)}
+              aria-pressed={showPassphrase}
+            >
+              {showPassphrase ? t("okxManual.hide") : t("okxManual.show")}
+            </button>
+          </label>
+          <input
+            id="okx-manual-passphrase"
+            type={showPassphrase ? "text" : "password"}
+            class="w-full px-3 py-2.5 text-sm font-mono rounded border border-[--color-border] bg-[--color-bg-card] focus:border-[--color-accent] outline-none min-h-[44px]"
+            placeholder={t("okxManual.placeholder.passphrase")}
+            value={passphrase}
+            onInput={(e) => setPassphrase((e.target as HTMLInputElement).value)}
+            autoComplete="off"
+            spellcheck={false}
+            disabled={submitting || success}
+            required
+          />
+        </div>
+      </div>
+
+      {error && (
+        <p
+          class="text-xs text-[--color-down] mt-3"
+          role="alert"
+          aria-live="assertive"
+        >
+          {error}
+        </p>
+      )}
+
+      {success && (
+        <p
+          class="text-xs text-[--color-up] mt-3"
+          role="status"
+          aria-live="polite"
+        >
+          {t("okxManual.success")}
+        </p>
+      )}
+
+      <button
+        type="submit"
+        class="btn btn-primary btn-md w-full mt-4 min-h-[44px]"
+        disabled={submitting || success}
+        aria-label={
+          submitting ? t("okxManual.submitting") : t("okxManual.submit")
+        }
+      >
+        {submitting
+          ? t("okxManual.submitting")
+          : success
+            ? t("okxManual.success")
+            : t("okxManual.submit")}
+      </button>
+
+      <p class="text-[10px] text-[--color-text-muted] mt-3 leading-relaxed">
+        {t("okxManual.disclaimer")}
+      </p>
+    </form>
+  );
+}

--- a/src/config/exchanges.ts
+++ b/src/config/exchanges.ts
@@ -100,3 +100,11 @@ export const EXCHANGES: ExchangeFeeConfig[] = [
  */
 export const OKX = getExchange("okx");
 export const OKX_DISCOUNT_PCT: number = OKX.futuresDiscountPct;
+
+/**
+ * PRUVIQ DigitalOcean droplet IP — used as the recommended IP whitelist value
+ * shown to users when they create an OKX API key for the manual-paste auth
+ * flow. SSoT: never hardcode this string in components — import from here so
+ * a future IP change is a one-file edit.
+ */
+export const PRUVIQ_BACKEND_IP = "167.172.81.145";

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -2150,6 +2150,33 @@ export const en = {
   "simV2.empty.loading": "Running simulation…",
   "simV2.empty.pick_first": "Pick a preset above to see results.",
   "simV2.empty.error": "Couldn't run that simulation. Try another preset.",
+  "okxManual.heading": "Connect via OKX API Key",
+  "okxManual.subtitle":
+    "Paste your OKX API credentials. We validate them with OKX before saving.",
+  "okxManual.field.api_key": "API Key",
+  "okxManual.field.secret_key": "Secret Key",
+  "okxManual.field.passphrase": "Passphrase",
+  "okxManual.placeholder.api_key": "Paste your OKX API key",
+  "okxManual.placeholder.secret_key": "Paste your OKX secret key",
+  "okxManual.placeholder.passphrase": "Paste your OKX passphrase",
+  "okxManual.perms.required":
+    "Required permissions: Read + Trade. Do NOT enable Withdraw.",
+  "okxManual.ip.recommend":
+    "For maximum safety, restrict your API key to PRUVIQ's server IP:",
+  "okxManual.ip.warning":
+    "An API key without IP whitelist still works but is less secure.",
+  "okxManual.submit": "Validate & Connect",
+  "okxManual.submitting": "Validating with OKX…",
+  "okxManual.success": "Connected — redirecting to autotrading…",
+  "okxManual.error.invalid_credentials":
+    "OKX rejected the credentials. Check API key, secret, and passphrase.",
+  "okxManual.error.network": "Couldn't reach the server. Try again.",
+  "okxManual.error.missing_field": "All three fields are required.",
+  "okxManual.disclaimer":
+    "We never share your keys. They are encrypted at rest (Fernet/AES-128). You can disconnect anytime.",
+  "okxManual.help.docs": "OKX → API → Create New Key",
+  "okxManual.show": "Show",
+  "okxManual.hide": "Hide",
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -2106,4 +2106,31 @@ export const ko: Record<TranslationKey, string> = {
   "simV2.empty.loading": "시뮬레이션 실행 중…",
   "simV2.empty.pick_first": "위 프리셋 선택 시 결과가 표시됩니다.",
   "simV2.empty.error": "시뮬레이션 실패. 다른 프리셋 시도.",
+  "okxManual.heading": "OKX API 키로 연결",
+  "okxManual.subtitle":
+    "OKX API 키 정보를 붙여넣으세요. 저장 전에 OKX 에서 직접 검증합니다.",
+  "okxManual.field.api_key": "API 키",
+  "okxManual.field.secret_key": "시크릿 키",
+  "okxManual.field.passphrase": "Passphrase",
+  "okxManual.placeholder.api_key": "OKX API 키 붙여넣기",
+  "okxManual.placeholder.secret_key": "OKX 시크릿 키 붙여넣기",
+  "okxManual.placeholder.passphrase": "OKX passphrase 붙여넣기",
+  "okxManual.perms.required":
+    "필수 권한: Read + Trade. 출금(Withdraw) 권한은 절대 부여하지 마세요.",
+  "okxManual.ip.recommend":
+    "최대 안전을 위해 API 키를 PRUVIQ 서버 IP 로 제한하세요:",
+  "okxManual.ip.warning":
+    "IP 화이트리스트 없이도 작동하지만 보안이 낮아집니다.",
+  "okxManual.submit": "검증 후 연결",
+  "okxManual.submitting": "OKX 에서 검증 중…",
+  "okxManual.success": "연결 완료 — 자동매매 페이지로 이동합니다…",
+  "okxManual.error.invalid_credentials":
+    "OKX 가 인증을 거부했습니다. API 키 / 시크릿 / passphrase 를 확인하세요.",
+  "okxManual.error.network": "서버에 연결하지 못했습니다. 다시 시도하세요.",
+  "okxManual.error.missing_field": "세 항목 모두 필수입니다.",
+  "okxManual.disclaimer":
+    "키를 외부에 공유하지 않습니다. Fernet/AES-128 암호화 저장, 언제든 연결 해제 가능합니다.",
+  "okxManual.help.docs": "OKX → API → 새 키 만들기",
+  "okxManual.show": "보기",
+  "okxManual.hide": "숨김",
 };

--- a/src/pages/fees.astro
+++ b/src/pages/fees.astro
@@ -197,7 +197,7 @@ const t = useTranslations('en');
             Sign up on OKX &rarr;
           </a>
           <div class="mt-3">
-            <OKXConnectButton client:visible lang="en" size="sm" />
+            <OKXConnectButton client:visible lang="en" size="sm" variant="cta-only" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Frontend half of the OKX manual API key paste flow (backend in #1369)
- New `OKXManualPasteForm` component — 3-field form posting to `POST /auth/okx/manual-connect`
- `OKXConnectButton` flag split: `AUTOTRADE_OAUTH_COMING_SOON` (still true) + `AUTOTRADE_MANUAL_ENABLED` (false in this PR — form is hidden in production)
- `variant="cta-only"` prop added so `/fees` keeps the "Coming Soon" pill regardless of the manual flag (marketing surface)
- 19 i18n keys × 2 locales (en + ko) under `okxManual.*` namespace
- `PRUVIQ_BACKEND_IP="167.172.81.145"` SSoT constant added to `exchanges.ts` so the IP whitelist guidance string is single-sourced

## Why now / why hidden

Owner audit 2026-04-25 confirmed the OAuth Broker (Fast API) wait was a self-imposed bottleneck — every successful OKX automation product (3Commas, Cryptohopper, BitsGap, Altrady, WunderTrading) ships manual paste as the first-class path. Backend ships in #1369; this PR builds the UI but holds it behind `AUTOTRADE_MANUAL_ENABLED=false` so production stays unchanged until owner Day-3 dogfood (Mon 4-27) confirms end-to-end correctness against the live backend via direct `curl`.

A separate 1-line PR flips the flag to `true` after 24-48h owner-stable.

## Test plan

- [x] `npm run build` → 1192 pages, 0 errors
- [x] `bash scripts/qa-redirects.sh` → PASS
- [x] `grep` verification: split flags present, `OKXManualPasteForm` import wired, `variant="cta-only"` on `/fees`
- [ ] Post-deploy smoke: `https://pruviq.com/dashboard` shows existing "Coming Soon" pill (form hidden — flag=false)
- [ ] Owner local override: temporarily set `AUTOTRADE_MANUAL_ENABLED=true` in `npm run dev` to inspect form UX before flipping in prod
- [ ] Day-3 dogfood: `curl -X POST https://api.pruviq.com/auth/okx/manual-connect ...` against live backend with owner's own OKX API key, then dust trade with `tag` attribution check

## Safety

- Zero behavioral change in production: form is unreachable until the flag flips
- `/fees` marketing page explicitly opted out of any future flip via `variant="cta-only"`
- 44px min-height touch targets, `aria-describedby`, `role="alert"`, `aria-live="assertive"` on errors
- `AbortSignal.timeout(15000)` on the validate fetch — no hung requests
- Backend already validates and surfaces OKX-side error messages so users see "Invalid Sign" / "Invalid passphrase" rather than a generic black-box error
- Field-level error mapping: `missing_field`, `invalid_credentials`, `malformed_field` each get a localized message

## Files

- `src/components/OKXConnectButton.tsx` — flag split + form import + variant prop + conditional render
- `src/components/OKXManualPasteForm.tsx` — NEW
- `src/config/exchanges.ts` — `PRUVIQ_BACKEND_IP` constant
- `src/i18n/en.ts` + `src/i18n/ko.ts` — 19 keys each
- `src/pages/fees.astro` — `variant="cta-only"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)