### PR TITLE
feat(okx-oauth): PKCE flow + API-key IP binding (doc-grounded weakness fixes)

### DIFF
--- a/backend/okx/config.py
+++ b/backend/okx/config.py
@@ -50,6 +50,23 @@ OKX_MANUAL_PASTE_ENABLED = (
     os.environ.get("OKX_MANUAL_PASTE_ENABLED", "true").lower() == "true"
 )
 
+# ── OKX OAuth-issued API key IP binding ──
+# OKX docs (OKX_API_SPECS.md §1, L66-67): keys with trade perm + no IP
+# binding expire after 14 days of inactivity. Without this our owner's
+# OAuth-issued API key dies silently every 2 weeks if no trade fires.
+# Comma-separated, max 20 IPs per OKX broker docs.
+OKX_API_KEY_IP = os.environ.get("OKX_API_KEY_IP", "167.172.81.145")
+
+# ── PKCE flow toggle ──
+# OKX broker docs say OAuth 2.0 supports authorization code mode AND PKCE
+# mode. Sending code_challenge + code_challenge_method=S256 on authorize
+# and code_verifier on token-exchange. Hypothesis H for the consent-page
+# silent-drop: newer OAuth apps may require PKCE. Toggle ON by default
+# (extra params are typically ignored if PKCE not enforced — safe to ship).
+OKX_OAUTH_PKCE_ENABLED = (
+    os.environ.get("OKX_OAUTH_PKCE_ENABLED", "true").lower() == "true"
+)
+
 # ── Database path (SQLite) ──
 OKX_DB_PATH = os.environ.get("OKX_DB_PATH", "")
 

--- a/backend/okx/oauth.py
+++ b/backend/okx/oauth.py
@@ -10,9 +10,22 @@ Flow:
 scope="fast_api" — REQUIRED for OKX Broker OAuth (OKX_API_SPECS.md §1).
 scope="read_only,trade" silently routes user to /account/users (OKX drop). Do NOT use.
 (Earlier comment had this reversed — corrected 2026-04-19 after /users drop confirmed live.)
+
+PKCE (2026-04-25):
+  Per OKX broker docs, OAuth 2.0 supports authorization code mode AND PKCE
+  mode. We send code_challenge + code_challenge_method=S256 on /authorize and
+  the matching code_verifier on token exchange. PKCE params are typically
+  ignored if a provider doesn't enforce them, so leaving the toggle on is
+  safe even when not strictly required. Toggle: OKX_OAUTH_PKCE_ENABLED.
+
+API key IP binding (2026-04-25):
+  OKX docs (§1, L66-67): keys with trade perm + no IP binding expire after
+  14 days inactivity. We now pass `ip` on POST /api/v5/users/oauth/apikey.
 """
 from __future__ import annotations
 
+import base64
+import hashlib
 import logging
 import secrets
 import string
@@ -21,12 +34,14 @@ import time
 import httpx
 
 from .config import (
+    OKX_API_KEY_IP,
     OKX_BASE_URL,
     OKX_BROKER_CODE,
     OKX_CLIENT_ID,
     OKX_CLIENT_SECRET,
     OKX_DEMO_MODE,
     OKX_OAUTH_AUTHORIZE,
+    OKX_OAUTH_PKCE_ENABLED,
     OKX_OAUTH_TOKEN,
     OKX_REDIRECT_URI,
 )
@@ -46,6 +61,19 @@ def _gen_passphrase() -> str:
     chars = string.ascii_letters + string.digits + "!@#$%"
     rand = "".join(secrets.choice(chars) for _ in range(12))
     return f"Pr1!{rand}"  # guaranteed: upper(P), lower(r), digit(1), special(!)
+
+
+def _gen_pkce_pair() -> tuple[str, str]:
+    """Generate (code_verifier, code_challenge) per RFC 7636.
+
+    code_verifier: 43-128 char URL-safe base64 of 32 random bytes (no padding).
+    code_challenge: base64url(SHA256(code_verifier)) (no padding) when
+    code_challenge_method=S256.
+    """
+    code_verifier = secrets.token_urlsafe(32)  # 43 chars URL-safe, no `=`
+    digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
+    code_challenge = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+    return code_verifier, code_challenge
 
 
 def _validate_redirect(url: str) -> str:
@@ -104,7 +132,7 @@ def generate_oauth_params(redirect_after: str = "", lang: str = "en") -> dict:
     """Generate OAuth params for frontend authorize URL."""
     redirect_after = _validate_redirect(redirect_after)
     state = secrets.token_urlsafe(32)
-    save_csrf_state(state, redirect_after or "", lang)
+    code_verifier = ""
     params = {
         "state": state,
         "client_id": OKX_CLIENT_ID,
@@ -113,8 +141,13 @@ def generate_oauth_params(redirect_after: str = "", lang: str = "en") -> dict:
         "scope": "fast_api",
         "redirect_uri": OKX_REDIRECT_URI,
     }
+    if OKX_OAUTH_PKCE_ENABLED:
+        code_verifier, code_challenge = _gen_pkce_pair()
+        params["code_challenge"] = code_challenge
+        params["code_challenge_method"] = "S256"
     if OKX_BROKER_CODE:
         params["channelId"] = OKX_BROKER_CODE
+    save_csrf_state(state, redirect_after or "", lang, code_verifier)
     return params
 
 
@@ -123,7 +156,7 @@ def generate_auth_url(redirect_after: str = "", lang: str = "en") -> str:
     from urllib.parse import urlencode
     redirect_after = _validate_redirect(redirect_after)
     state = secrets.token_urlsafe(32)
-    save_csrf_state(state, redirect_after or "", lang)
+    code_verifier = ""
     params = {
         "client_id": OKX_CLIENT_ID,
         "response_type": "code",
@@ -132,8 +165,13 @@ def generate_auth_url(redirect_after: str = "", lang: str = "en") -> str:
         "scope": "fast_api",
         "state": state,
     }
+    if OKX_OAUTH_PKCE_ENABLED:
+        code_verifier, code_challenge = _gen_pkce_pair()
+        params["code_challenge"] = code_challenge
+        params["code_challenge_method"] = "S256"
     if OKX_BROKER_CODE:
         params["channelId"] = OKX_BROKER_CODE
+    save_csrf_state(state, redirect_after or "", lang, code_verifier)
     return f"{OKX_OAUTH_AUTHORIZE}?{urlencode(params)}"
 
 
@@ -156,7 +194,15 @@ async def _create_user_apikey(access_token: str) -> dict:
         "passphrase": passphrase,
         "perm": "read_only,trade",
     }
-    logger.warning("→ POST /api/v5/users/oauth/apikey demo=%s", OKX_DEMO_MODE)
+    # IP binding: keys with trade perm + no IP expire after 14d inactivity
+    # (OKX_API_SPECS.md §1, L66-67). Always pass our backend IP so OAuth-issued
+    # keys persist across cold periods.
+    if OKX_API_KEY_IP:
+        body["ip"] = OKX_API_KEY_IP
+    logger.warning(
+        "→ POST /api/v5/users/oauth/apikey demo=%s ip_bound=%s",
+        OKX_DEMO_MODE, bool(OKX_API_KEY_IP),
+    )
     async with httpx.AsyncClient() as client:
         resp = await client.post(
             f"{OKX_BASE_URL}/api/v5/users/oauth/apikey",
@@ -193,7 +239,7 @@ async def exchange_code(code: str, state: str, domain: str = "") -> tuple[str, s
     csrf_result = validate_csrf_state(state)
     if csrf_result is None:
         raise ValueError("Invalid or expired CSRF state")
-    redirect_url, lang = csrf_result
+    redirect_url, lang, code_verifier = csrf_result
 
     data = {
         "client_id": OKX_CLIENT_ID,
@@ -202,6 +248,10 @@ async def exchange_code(code: str, state: str, domain: str = "") -> tuple[str, s
         "grant_type": "authorization_code",
         "redirect_uri": OKX_REDIRECT_URI,
     }
+    # PKCE: pass code_verifier on token exchange so OKX can verify
+    # SHA256(verifier) == code_challenge sent on /authorize.
+    if code_verifier:
+        data["code_verifier"] = code_verifier
     # CodeQL py/clear-text-logging-sensitive-data: false positive. `OKX_OAUTH_TOKEN`
     # is the public endpoint URL (`https://www.okx.com/api/v5/users/oauth/...`),
     # not a token/secret. The `data` dict below is NEVER logged — only the URL

--- a/backend/okx/storage.py
+++ b/backend/okx/storage.py
@@ -91,9 +91,20 @@ def _get_conn() -> sqlite3.Connection:
             state      TEXT PRIMARY KEY,
             redirect_url TEXT NOT NULL DEFAULT '',
             lang       TEXT NOT NULL DEFAULT 'en',
-            created_at REAL NOT NULL
+            created_at REAL NOT NULL,
+            code_verifier TEXT NOT NULL DEFAULT ''
         )
     """)
+    # Migration for pre-PKCE schemas (column added 2026-04-25). SQLite has no
+    # `IF NOT EXISTS` for ADD COLUMN — catch the duplicate-column error and
+    # let any other OperationalError bubble up.
+    try:
+        conn.execute(
+            "ALTER TABLE okx_csrf_states ADD COLUMN code_verifier TEXT NOT NULL DEFAULT ''"
+        )
+    except sqlite3.OperationalError as e:
+        if "duplicate column" not in str(e).lower():
+            raise
     return conn
 
 
@@ -156,7 +167,12 @@ def delete_session(session_id: str) -> None:
 CSRF_TTL = 1800  # 30 minutes
 
 
-def save_csrf_state(state: str, redirect_url: str, lang: str = "en") -> None:
+def save_csrf_state(
+    state: str,
+    redirect_url: str,
+    lang: str = "en",
+    code_verifier: str = "",
+) -> None:
     with _get_conn() as conn:
         # Cleanup expired states on write
         conn.execute(
@@ -164,17 +180,23 @@ def save_csrf_state(state: str, redirect_url: str, lang: str = "en") -> None:
             (time.time() - CSRF_TTL,),
         )
         conn.execute(
-            "INSERT INTO okx_csrf_states (state, redirect_url, lang, created_at) "
-            "VALUES (?, ?, ?, ?)",
-            (state, redirect_url, lang, time.time()),
+            "INSERT INTO okx_csrf_states "
+            "(state, redirect_url, lang, created_at, code_verifier) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (state, redirect_url, lang, time.time(), code_verifier),
         )
 
 
-def validate_csrf_state(state: str) -> tuple[str, str] | None:
-    """Validate and consume CSRF state. Returns (redirect_url, lang) or None."""
+def validate_csrf_state(state: str) -> tuple[str, str, str] | None:
+    """Validate and consume CSRF state.
+
+    Returns (redirect_url, lang, code_verifier) or None.
+    code_verifier is "" for non-PKCE legacy rows.
+    """
     with _get_conn() as conn:
         row = conn.execute(
-            "SELECT redirect_url, lang, created_at FROM okx_csrf_states WHERE state = ?",
+            "SELECT redirect_url, lang, created_at, code_verifier "
+            "FROM okx_csrf_states WHERE state = ?",
             (state,),
         ).fetchone()
         if not row:
@@ -184,4 +206,4 @@ def validate_csrf_state(state: str) -> tuple[str, str] | None:
         # Check expiry
         if time.time() - row[2] > CSRF_TTL:
             return None
-        return row[0], row[1]
+        return row[0], row[1], row[3]

--- a/backend/tests/test_emergency_close_and_oauth_flow.py
+++ b/backend/tests/test_emergency_close_and_oauth_flow.py
@@ -212,7 +212,7 @@ async def test_exchange_code_token_missing_raises():
     client_cm.__aexit__ = AsyncMock(return_value=False)
     with patch(
         "okx.oauth.validate_csrf_state",
-        return_value=("https://pruviq.com/dashboard", "en"),
+        return_value=("https://pruviq.com/dashboard", "en", ""),
     ), patch("okx.oauth.httpx.AsyncClient", return_value=client_cm):
         with pytest.raises(ValueError, match="OKX token error"):
             await exchange_code("expired-code", "ok-state", "")
@@ -232,7 +232,7 @@ async def test_exchange_code_5xx_raises_httpx_error():
     client_cm.__aexit__ = AsyncMock(return_value=False)
     with patch(
         "okx.oauth.validate_csrf_state",
-        return_value=("https://pruviq.com/dashboard", "en"),
+        return_value=("https://pruviq.com/dashboard", "en", ""),
     ), patch("okx.oauth.httpx.AsyncClient", return_value=client_cm):
         with pytest.raises(httpx.HTTPStatusError):
             await exchange_code("any-code", "ok-state", "")
@@ -274,7 +274,7 @@ async def test_exchange_code_happy_path_saves_session():
 
     with patch(
         "okx.oauth.validate_csrf_state",
-        return_value=("https://pruviq.com/dashboard", "en"),
+        return_value=("https://pruviq.com/dashboard", "en", ""),
     ), patch("okx.oauth.save_session") as mock_save, patch(
         "okx.oauth.httpx.AsyncClient", return_value=client_cm
     ):
@@ -312,7 +312,7 @@ async def test_exchange_code_apikey_failure_raises():
 
     with patch(
         "okx.oauth.validate_csrf_state",
-        return_value=("https://pruviq.com/dashboard", "en"),
+        return_value=("https://pruviq.com/dashboard", "en", ""),
     ), patch("okx.oauth.httpx.AsyncClient", return_value=client_cm):
         with pytest.raises(ValueError, match="OKX API key creation failed"):
             await exchange_code("ok-code", "ok-state", "")

--- a/backend/tests/test_okx_manual_auth.py
+++ b/backend/tests/test_okx_manual_auth.py
@@ -66,11 +66,14 @@ async def test_validate_and_store_happy_path(monkeypatch):
         os.environ["OKX_ENCRYPTION_KEY"] = (
             "ZmDfcTF7_60GrrY167zsiPd67pEvs0aGOv2oasOM1Pg="
         )
-        # Reload modules to pick up env.
+        # Reload modules to pick up env. config first so storage/manual_auth
+        # re-capture OKX_ENCRYPTION_KEY etc. (other tests reload config too).
         import importlib
+        import okx.config as config_mod
         import okx.storage as storage
         import okx.manual_auth as manual_auth
         import okx.client as client_mod
+        importlib.reload(config_mod)
         importlib.reload(storage)
         importlib.reload(manual_auth)
 
@@ -114,9 +117,11 @@ async def test_validate_and_store_rejects_invalid_credentials(monkeypatch):
             "ZmDfcTF7_60GrrY167zsiPd67pEvs0aGOv2oasOM1Pg="
         )
         import importlib
+        import okx.config as config_mod
         import okx.storage as storage
         import okx.manual_auth as manual_auth
         import okx.client as client_mod
+        importlib.reload(config_mod)
         importlib.reload(storage)
         importlib.reload(manual_auth)
 

--- a/backend/tests/test_okx_oauth_pkce.py
+++ b/backend/tests/test_okx_oauth_pkce.py
@@ -1,0 +1,161 @@
+"""
+OKX OAuth PKCE flow regression guards (added 2026-04-25).
+
+Why this exists:
+  OKX broker docs explicitly state OAuth 2.0 supports both authorization-code
+  mode AND PKCE mode. PR #1159 spent 6 hours debugging the consent-page silent
+  drop and verified every "value-level" parameter (client_id, secret, IP,
+  channelId, redirect_uri) — but never tried adding `code_challenge` to the
+  authorize request. Hypothesis H: newer OAuth apps registered with OKX may
+  require PKCE, and our authorize URL silently drops without it.
+
+These tests don't prove PKCE fixes the silent-drop (that needs a live browser
+test on prod). They prove our code:
+  1. Generates a valid RFC 7636 PKCE pair when the toggle is on
+  2. Emits code_challenge + code_challenge_method=S256 on /authorize params
+  3. Persists the verifier with the CSRF state and reads it back
+  4. Includes code_verifier on token exchange
+  5. Passes the IP whitelist on the API key creation body (#1, prevents 14d
+     inactivity expiry — separate concern but verified together)
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+BACKEND = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND))
+
+OAUTH_PY = BACKEND / "okx" / "oauth.py"
+
+
+def test_oauth_source_implements_pkce_helpers():
+    """Source-level guard: oauth.py must define _gen_pkce_pair and route
+    code_challenge through to authorize params + code_verifier through to
+    token exchange."""
+    src = OAUTH_PY.read_text(encoding="utf-8")
+    assert "_gen_pkce_pair" in src, (
+        "oauth.py must define _gen_pkce_pair() — RFC 7636 verifier+challenge "
+        "generator. Missing means PKCE flow not wired."
+    )
+    assert "code_challenge" in src and "code_challenge_method" in src, (
+        "oauth.py must emit code_challenge + code_challenge_method on the "
+        "authorize URL. Missing one of these = invalid PKCE flow."
+    )
+    assert '"S256"' in src, (
+        'oauth.py must use code_challenge_method="S256" — plain method is '
+        "deprecated and should not be used by new clients."
+    )
+    assert "code_verifier" in src, (
+        "oauth.py must pass code_verifier on token exchange so OKX can "
+        "verify SHA256(verifier) == challenge sent on /authorize."
+    )
+
+
+def test_pkce_pair_is_rfc7636_compliant():
+    """_gen_pkce_pair must produce: verifier 43-128 chars URL-safe; challenge
+    = base64url(SHA256(verifier)) with no padding. Mismatch = OKX 53010."""
+    import okx.oauth as oauth
+    verifier, challenge = oauth._gen_pkce_pair()
+
+    # RFC 7636 §4.1: verifier 43-128 chars from [A-Z][a-z][0-9]-._~
+    assert 43 <= len(verifier) <= 128, (
+        f"verifier len={len(verifier)} outside RFC 7636 [43, 128]"
+    )
+    assert re.match(r"^[A-Za-z0-9\-._~]+$", verifier), (
+        f"verifier contains non-URL-safe chars: {verifier!r}"
+    )
+
+    # Challenge = base64url(SHA256(verifier)), no padding
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    expected = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+    assert challenge == expected, (
+        f"challenge mismatch: got {challenge!r}, expected {expected!r} — "
+        f"OKX will reject with 53010 (parameter error) on token exchange"
+    )
+    assert "=" not in challenge, (
+        "challenge has padding — base64url for PKCE must strip `=` per RFC"
+    )
+
+
+def test_authorize_params_include_pkce_when_enabled(monkeypatch):
+    """generate_oauth_params must include code_challenge + method when
+    OKX_OAUTH_PKCE_ENABLED is true. Off => no PKCE keys at all (so legacy
+    OAuth flows aren't accidentally broken)."""
+    import importlib
+    import okx.oauth as oauth_mod
+    import okx.config as config_mod
+
+    # Force PKCE on, reload the module so the constant is re-read at top-level.
+    monkeypatch.setenv("OKX_OAUTH_PKCE_ENABLED", "true")
+    monkeypatch.setenv("OKX_CLIENT_ID", "test-client")
+    monkeypatch.setenv("OKX_REDIRECT_URI", "https://api.example/callback")
+    importlib.reload(config_mod)
+    importlib.reload(oauth_mod)
+
+    # save_csrf_state writes to SQLite — stub it out, we only inspect params
+    saved = []
+
+    def fake_save(state, redirect_url, lang, code_verifier=""):
+        saved.append((state, redirect_url, lang, code_verifier))
+
+    monkeypatch.setattr(oauth_mod, "save_csrf_state", fake_save)
+
+    params = oauth_mod.generate_oauth_params(redirect_after="", lang="en")
+    assert "code_challenge" in params, (
+        "PKCE on but code_challenge missing from authorize params"
+    )
+    assert params.get("code_challenge_method") == "S256"
+    assert params["code_challenge"] != ""
+    # Verifier must have been persisted with the CSRF state
+    assert len(saved) == 1
+    assert saved[0][3] != "", "code_verifier must be saved with CSRF state"
+
+    # Off path: no PKCE params should appear at all
+    monkeypatch.setenv("OKX_OAUTH_PKCE_ENABLED", "false")
+    importlib.reload(config_mod)
+    importlib.reload(oauth_mod)
+    saved.clear()
+    monkeypatch.setattr(oauth_mod, "save_csrf_state", fake_save)
+    params_off = oauth_mod.generate_oauth_params(redirect_after="", lang="en")
+    assert "code_challenge" not in params_off
+    assert "code_challenge_method" not in params_off
+    assert saved[0][3] == ""
+
+
+def test_apikey_body_includes_ip_binding():
+    """OKX docs: keys with trade perm + no IP expire after 14d inactivity.
+    _create_user_apikey must send `ip` field on POST .../oauth/apikey
+    whenever OKX_API_KEY_IP is configured (default: DO server IP)."""
+    src = OAUTH_PY.read_text(encoding="utf-8")
+    # The body assembly + ip injection live in _create_user_apikey.
+    # Look for the pattern: body["ip"] = OKX_API_KEY_IP (or similar).
+    has_ip_field = bool(
+        re.search(r'body\[\s*[\'"]ip[\'"]\s*\]\s*=\s*OKX_API_KEY_IP', src)
+    )
+    has_inline_ip = bool(re.search(r'"ip"\s*:\s*OKX_API_KEY_IP', src))
+    assert has_ip_field or has_inline_ip, (
+        "_create_user_apikey must pass `ip` to OKX. Without it OAuth-issued "
+        "keys with trade perm expire after 14d inactivity (OKX_API_SPECS.md "
+        "§1, L66-67)."
+    )
+    assert "OKX_API_KEY_IP" in src, (
+        "OKX_API_KEY_IP must be imported and referenced — SSoT for the IP."
+    )
+
+
+def test_validate_csrf_state_returns_three_tuple_shape():
+    """Source-level: storage.validate_csrf_state must return a 3-tuple
+    (redirect_url, lang, code_verifier). Any caller assuming 2-tuple breaks
+    silently — explicit check protects against accidental signature drift."""
+    storage_py = (BACKEND / "okx" / "storage.py").read_text(encoding="utf-8")
+    assert re.search(
+        r"def\s+validate_csrf_state\s*\([^)]*\)\s*->\s*tuple\[str,\s*str,\s*str\]\s*\|\s*None",
+        storage_py,
+    ), (
+        "validate_csrf_state must return tuple[str, str, str] | None — the "
+        "third slot is code_verifier for PKCE."
+    )


### PR DESCRIPTION
## Summary

Two doc-grounded weakness fixes for OKX OAuth — found by re-reading `OKX_API_SPECS.md` + OKX broker docs after the 2026-04-25 audit determined our prior OAuth diagnosis (PR #1159) had ruled out value-level parameters but never checked structural ones (PKCE, IP binding).

## Weakness #1 — API-key IP binding 🔴

- **Doc**: `OKX_API_SPECS.md §1, L66-67` — "keys without IP + trade perm expire after **14 days inactivity**"
- **Impact**: owner's OAuth-issued API key silently dies every 2 weeks if no trade fires; any quiet user account disconnects
- **Fix**: `_create_user_apikey` now passes `ip` on POST `/api/v5/users/oauth/apikey` body
- **Env**: `OKX_API_KEY_IP` (default `167.172.81.145` — DO server)

## Weakness #2 — PKCE flow 🔴

- **Doc**: OKX broker docs — "OAuth 2.0 provides authorization code mode **AND PKCE mode**"
- **Hypothesis**: PR #1159's 6h debug verified value-level params but never tried adding `code_challenge`. Newer OAuth apps may require PKCE; missing it = silent drop to `/account/users`
- **Fix**: 
  - `_gen_pkce_pair()` helper (RFC 7636 S256: 43-char URL-safe verifier + base64url(SHA256) challenge, no padding)
  - `generate_oauth_params()` + `generate_auth_url()` emit `code_challenge` + `code_challenge_method=S256` when toggle is on
  - `okx_csrf_states` table gains `code_verifier` TEXT column (with `ALTER TABLE` migration wrapped in try/except OperationalError for duplicate-column safety)
  - `validate_csrf_state` returns 3-tuple `(redirect_url, lang, code_verifier)`
  - `exchange_code` reads verifier back and passes it on token exchange
- **Env**: `OKX_OAUTH_PKCE_ENABLED` (default `true` — extra params typically ignored if not enforced; safe to ship)

## What this does NOT prove

PKCE may not be the consent-page silent-drop fix — that requires a live browser test on prod after deploy. This PR is a doc-grounded weakness fix worth shipping regardless.

After merge + deploy, owner can browser-test OAuth on prod; if consent page now appears for `scope=read_only,trade`, hypothesis H confirmed → 1-line follow-up flips scope. If consent page still drops, root cause is either #3 (`redirect_uri` byte-level mismatch — check OKX console) or #5 (Fast-API-only app category — needs OKX portal application change).

## Tests

- `test_okx_oauth_pkce.py` (NEW, 5 tests): source guard, RFC 7636 compliance, authorize params on/off, IP binding, signature drift
- `test_emergency_close_and_oauth_flow.py` (UPDATE): 4 mock return_values bumped to 3-tuple
- `test_okx_manual_auth.py` (UPDATE): added `config_mod` reload for test isolation
- **30/30 OAuth-related tests pass** locally

## Files

- `backend/okx/config.py` — `OKX_API_KEY_IP` + `OKX_OAUTH_PKCE_ENABLED` env
- `backend/okx/oauth.py` — `_gen_pkce_pair()` helper, PKCE wired through 4 functions, IP binding in `_create_user_apikey`
- `backend/okx/storage.py` — `code_verifier` column + 3-tuple signature
- `backend/tests/test_okx_oauth_pkce.py` — NEW
- `backend/tests/test_emergency_close_and_oauth_flow.py` — mock signature update
- `backend/tests/test_okx_manual_auth.py` — test isolation fix

## Test plan post-deploy

- [ ] `curl -s https://api.pruviq.com/auth/okx/init | jq` — verify `code_challenge` + `code_challenge_method=S256` present
- [ ] Browser: visit `/dashboard` → click Connect OKX → check if consent page now appears (or still drops to `/account/users`)
- [ ] If still drops: owner checks OKX console for app category (Fast API vs Standard OAuth)
- [ ] If consent appears: 1-line PR flips `scope=fast_api` → `scope=read_only,trade`

🤖 Generated with [Claude Code](https://claude.com/claude-code)