### PR TITLE
feat(okx-oauth): experimental variant endpoint for silent-drop A/B test

### DIFF
--- a/backend/okx/config.py
+++ b/backend/okx/config.py
@@ -67,6 +67,17 @@ OKX_OAUTH_PKCE_ENABLED = (
     os.environ.get("OKX_OAUTH_PKCE_ENABLED", "true").lower() == "true"
 )
 
+# ── Experimental OAuth debug endpoint toggle ──
+# Activates GET /auth/okx/start-experimental?variant=X for testing parameter
+# combinations against OKX silent-drop. Default false → 404 in prod. Owner
+# enables temporarily via DO .env + systemctl restart pruviq-api when
+# debugging, disables when done. Variants: baseline, read_only_trade,
+# no_channel, no_access_type, add_domain, add_platform,
+# read_only_trade_no_channel, no_pkce.
+OKX_OAUTH_EXPERIMENTAL_ENABLED = (
+    os.environ.get("OKX_OAUTH_EXPERIMENTAL_ENABLED", "false").lower() == "true"
+)
+
 # ── Database path (SQLite) ──
 OKX_DB_PATH = os.environ.get("OKX_DB_PATH", "")
 

--- a/backend/okx/oauth.py
+++ b/backend/okx/oauth.py
@@ -175,6 +175,84 @@ def generate_auth_url(redirect_after: str = "", lang: str = "en") -> str:
     return f"{OKX_OAUTH_AUTHORIZE}?{urlencode(params)}"
 
 
+# Variants for OAuth silent-drop debugging. Baseline = current production.
+# Each variant flips ONE parameter so we can isolate which mutation lifts
+# the /account/users redirect. Browser-tested by owner.
+EXPERIMENTAL_VARIANTS = (
+    "baseline",
+    "read_only_trade",
+    "no_channel",
+    "no_access_type",
+    "add_domain",
+    "add_platform",
+    "read_only_trade_no_channel",
+    "no_pkce",
+)
+
+
+def generate_auth_url_experimental(
+    variant: str,
+    redirect_after: str = "",
+    lang: str = "en",
+) -> str:
+    """Generate authorize URL with parameter variants for silent-drop debug.
+
+    Variants applied AFTER baseline assembly:
+      baseline                    : current production (fast_api + PKCE + channelId)
+      read_only_trade             : scope=read_only,trade (PKCE on)
+      no_channel                  : remove channelId
+      no_access_type              : remove access_type
+      add_domain                  : add domain=okx.com
+      add_platform                : add platform=web
+      read_only_trade_no_channel  : combine read_only,trade + no channelId
+      no_pkce                     : strip PKCE params
+    """
+    from urllib.parse import urlencode
+
+    if variant not in EXPERIMENTAL_VARIANTS:
+        raise ValueError(f"unknown variant: {variant!r}")
+
+    redirect_after = _validate_redirect(redirect_after)
+    state = secrets.token_urlsafe(32)
+    code_verifier = ""
+
+    params: dict[str, str] = {
+        "client_id": OKX_CLIENT_ID,
+        "response_type": "code",
+        "access_type": "offline",
+        "redirect_uri": OKX_REDIRECT_URI,
+        "scope": "fast_api",
+        "state": state,
+    }
+    if OKX_OAUTH_PKCE_ENABLED:
+        code_verifier, code_challenge = _gen_pkce_pair()
+        params["code_challenge"] = code_challenge
+        params["code_challenge_method"] = "S256"
+    if OKX_BROKER_CODE:
+        params["channelId"] = OKX_BROKER_CODE
+
+    if variant == "read_only_trade":
+        params["scope"] = "read_only,trade"
+    elif variant == "no_channel":
+        params.pop("channelId", None)
+    elif variant == "no_access_type":
+        params.pop("access_type", None)
+    elif variant == "add_domain":
+        params["domain"] = "okx.com"
+    elif variant == "add_platform":
+        params["platform"] = "web"
+    elif variant == "read_only_trade_no_channel":
+        params["scope"] = "read_only,trade"
+        params.pop("channelId", None)
+    elif variant == "no_pkce":
+        params.pop("code_challenge", None)
+        params.pop("code_challenge_method", None)
+        code_verifier = ""
+
+    save_csrf_state(state, redirect_after or "", lang, code_verifier)
+    return f"{OKX_OAUTH_AUTHORIZE}?{urlencode(params)}"
+
+
 async def _create_user_apikey(access_token: str) -> dict:
     """
     Step 4 of Fast API flow: use one-time access_token to create API key for user.

--- a/backend/okx/router.py
+++ b/backend/okx/router.py
@@ -21,7 +21,13 @@ from typing import Optional
 from fastapi import APIRouter, Header, HTTPException, Query, Request, Response
 from fastapi.responses import RedirectResponse
 
-from .config import COOKIE_DOMAIN, FRONTEND_URL, OKX_CLIENT_ID, OKX_MANUAL_PASTE_ENABLED
+from .config import (
+    COOKIE_DOMAIN,
+    FRONTEND_URL,
+    OKX_CLIENT_ID,
+    OKX_MANUAL_PASTE_ENABLED,
+    OKX_OAUTH_EXPERIMENTAL_ENABLED,
+)
 
 ADMIN_KEY = os.environ.get("ADMIN_API_KEY", "")
 
@@ -34,6 +40,7 @@ from .oauth import (
     disconnect,
     exchange_code,
     generate_auth_url,
+    generate_auth_url_experimental,
     generate_oauth_params,
     get_api_credentials,
     is_authenticated,
@@ -98,6 +105,32 @@ async def oauth_start(
     if not OKX_CLIENT_ID:
         raise HTTPException(503, "OKX Broker not configured")
     url = generate_auth_url(redirect_after=redirect, lang=lang)
+    return RedirectResponse(url=url, status_code=302)
+
+
+@router.api_route("/auth/okx/start-experimental", methods=["GET", "HEAD"])
+async def oauth_start_experimental(
+    variant: str = Query("baseline", description="Param variant for silent-drop debugging"),
+    redirect: str = Query("", description="Post-OAuth redirect URL"),
+    lang: str = Query("en", description="Language for redirect"),
+):
+    """Experimental OAuth start — flips ONE parameter vs baseline so the
+    owner can A/B test which mutation lifts the /account/users silent drop.
+    Activates only when OKX_OAUTH_EXPERIMENTAL_ENABLED=true on DO. Returns
+    404 in normal prod state.
+
+    Variants: baseline, read_only_trade, no_channel, no_access_type,
+    add_domain, add_platform, read_only_trade_no_channel, no_pkce.
+    """
+    if not OKX_OAUTH_EXPERIMENTAL_ENABLED:
+        raise HTTPException(404, "experimental_disabled")
+    if not OKX_CLIENT_ID:
+        raise HTTPException(503, "OKX Broker not configured")
+    try:
+        url = generate_auth_url_experimental(variant, redirect_after=redirect, lang=lang)
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+    logger.warning("oauth-experimental: variant=%s", variant)
     return RedirectResponse(url=url, status_code=302)
 
 

--- a/backend/tests/test_okx_oauth_experimental.py
+++ b/backend/tests/test_okx_oauth_experimental.py
@@ -1,0 +1,127 @@
+"""
+OKX OAuth experimental-variant endpoint regression guard.
+
+Owner uses this endpoint to A/B test parameter combinations against the
+silent /account/users redirect. Each variant flips ONE parameter from
+baseline so we isolate which mutation lifts the drop. Tests assert each
+variant produces the expected URL shape so a future refactor can't
+silently break a debugging path.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+BACKEND = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND))
+
+OAUTH_PY = BACKEND / "okx" / "oauth.py"
+
+
+def test_experimental_variants_constant_lists_all_eight():
+    """The variant set is the contract between backend and the owner's
+    browser test plan. Adding/removing without updating the plan = drift."""
+    src = OAUTH_PY.read_text(encoding="utf-8")
+    expected = {
+        "baseline",
+        "read_only_trade",
+        "no_channel",
+        "no_access_type",
+        "add_domain",
+        "add_platform",
+        "read_only_trade_no_channel",
+        "no_pkce",
+    }
+    for v in expected:
+        assert f'"{v}"' in src, f"variant {v!r} missing from EXPERIMENTAL_VARIANTS"
+
+
+def test_experimental_endpoint_gated_by_env(monkeypatch):
+    """Endpoint must 404 when OKX_OAUTH_EXPERIMENTAL_ENABLED=false (default).
+    Returning the URL by accident in prod = experiment leak / OAuth
+    re-route. Source-level guard since we can't reliably hit FastAPI here."""
+    router_py = (BACKEND / "okx" / "router.py").read_text(encoding="utf-8")
+    # The experimental handler must reference the env flag and raise 404.
+    handler_block = re.search(
+        r"async def oauth_start_experimental.*?(?=\n@router\.|\Z)",
+        router_py,
+        re.S,
+    )
+    assert handler_block, "oauth_start_experimental handler not found"
+    body = handler_block.group(0)
+    assert "OKX_OAUTH_EXPERIMENTAL_ENABLED" in body, (
+        "experimental handler must check OKX_OAUTH_EXPERIMENTAL_ENABLED"
+    )
+    assert "HTTPException(404" in body, (
+        "disabled experimental endpoint must return 404 (matches normal "
+        "fastapi behavior of unknown route — no leak via 503/error message)"
+    )
+
+
+def test_read_only_trade_variant_produces_expected_scope(monkeypatch):
+    """read_only_trade variant must set scope=read_only,trade and KEEP
+    PKCE + channelId so we can isolate the scope flip alone."""
+    monkeypatch.setenv("OKX_CLIENT_ID", "test-client")
+    monkeypatch.setenv("OKX_REDIRECT_URI", "https://api.example/callback")
+    monkeypatch.setenv("OKX_BROKER_CODE", "BROKER123")
+    monkeypatch.setenv("OKX_OAUTH_PKCE_ENABLED", "true")
+
+    import importlib
+    import okx.config as config_mod
+    import okx.oauth as oauth_mod
+    importlib.reload(config_mod)
+    importlib.reload(oauth_mod)
+
+    monkeypatch.setattr(oauth_mod, "save_csrf_state", lambda *a, **k: None)
+
+    url = oauth_mod.generate_auth_url_experimental(
+        "read_only_trade", redirect_after="", lang="en"
+    )
+    qs = parse_qs(urlparse(url).query)
+
+    assert qs["scope"] == ["read_only,trade"]
+    assert qs["channelId"] == ["BROKER123"]
+    assert "code_challenge" in qs
+    assert qs["code_challenge_method"] == ["S256"]
+
+
+def test_no_channel_variant_drops_channel_id(monkeypatch):
+    """no_channel variant removes channelId — isolates whether broker code
+    presence is the silent-drop trigger when scope=fast_api."""
+    monkeypatch.setenv("OKX_CLIENT_ID", "test-client")
+    monkeypatch.setenv("OKX_REDIRECT_URI", "https://api.example/callback")
+    monkeypatch.setenv("OKX_BROKER_CODE", "BROKER123")
+    monkeypatch.setenv("OKX_OAUTH_PKCE_ENABLED", "true")
+
+    import importlib
+    import okx.config as config_mod
+    import okx.oauth as oauth_mod
+    importlib.reload(config_mod)
+    importlib.reload(oauth_mod)
+
+    monkeypatch.setattr(oauth_mod, "save_csrf_state", lambda *a, **k: None)
+
+    url = oauth_mod.generate_auth_url_experimental("no_channel")
+    qs = parse_qs(urlparse(url).query)
+    assert "channelId" not in qs
+    assert qs["scope"] == ["fast_api"]
+
+
+def test_unknown_variant_raises_value_error(monkeypatch):
+    """Unknown variant must raise ValueError so the endpoint returns 400
+    instead of silently producing a malformed URL."""
+    monkeypatch.setenv("OKX_CLIENT_ID", "test-client")
+    monkeypatch.setenv("OKX_REDIRECT_URI", "https://api.example/callback")
+
+    import importlib
+    import okx.config as config_mod
+    import okx.oauth as oauth_mod
+    importlib.reload(config_mod)
+    importlib.reload(oauth_mod)
+
+    import pytest
+    with pytest.raises(ValueError) as exc_info:
+        oauth_mod.generate_auth_url_experimental("nonexistent_variant")
+    assert "nonexistent_variant" in str(exc_info.value)


### PR DESCRIPTION
## Summary

GET `/auth/okx/start-experimental?variant=X` — debugging-only endpoint that flips ONE OAuth parameter from baseline so we can isolate which mutation lifts the OKX `/account/users` silent drop.

Console audit (2026-04-25) confirmed every registered field on OKX broker portal matches our backend byte-for-byte (redirect_uri, IP whitelist, app name, logo, broker code, OAuth broker mode, Active + Lvl 2 verified). Every doc-grounded fix already shipped (#1375 PKCE + IP binding). Next move = parameter-level A/B test.

## Variants (8)

| Variant | What it flips | Hypothesis |
|---|---|---|
| `baseline` | (none — control) | sanity check |
| `read_only_trade` | scope → read_only,trade (PKCE on) | scope was the trigger; PKCE wasn't enough alone |
| `no_channel` | drop `channelId` | broker code presence triggers silent drop |
| `no_access_type` | drop `access_type=offline` | `offline` flag incompatible with current OAuth app |
| `add_domain` | + `domain=okx.com` | OKX SDK sends a domain param we miss |
| `add_platform` | + `platform=web` | OKX SDK sends platform we miss |
| `read_only_trade_no_channel` | combine top-2 | two-fix combo |
| `no_pkce` | strip PKCE | rule out a new regression from #1375 |

## Safety

- New env `OKX_OAUTH_EXPERIMENTAL_ENABLED` (default `false`) — endpoint returns 404 in normal prod
- Production `/auth/okx/start` handler **untouched**
- Each variant emits `logger.warning("oauth-experimental: variant=%s")` for journalctl traceability
- Unknown variant → 400 (not 500)

## Owner test plan (after merge + deploy)

1. SSH DO: append `OKX_OAUTH_EXPERIMENTAL_ENABLED=true` to `/opt/pruviq/shared/.env` + `systemctl restart pruviq-api`
2. Browser, while logged into OKX, hit each URL in turn (or just the high-value ones):
   - `https://api.pruviq.com/auth/okx/start-experimental?variant=read_only_trade`
   - `https://api.pruviq.com/auth/okx/start-experimental?variant=no_channel`
   - `https://api.pruviq.com/auth/okx/start-experimental?variant=read_only_trade_no_channel`
   - `https://api.pruviq.com/auth/okx/start-experimental?variant=add_domain`
   - `https://api.pruviq.com/auth/okx/start-experimental?variant=add_platform`
   - `https://api.pruviq.com/auth/okx/start-experimental?variant=no_access_type`
   - `https://api.pruviq.com/auth/okx/start-experimental?variant=no_pkce`
3. For each, note final URL — `/account/users` (still drop) vs `/account/oauth/authorize?...` (consent page!) vs callback success
4. After done: remove env line + restart → endpoint returns 404 again

## Test plan (CI)

- [x] `pytest tests/test_okx_oauth_experimental.py -v` — 5 pass
- [x] Full OAuth regression (PKCE, scope, security, exchange) — 21 pass
- [ ] Post-deploy: `curl https://api.pruviq.com/auth/okx/start-experimental?variant=read_only_trade -I` → expect `404 experimental_disabled` until env flipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)