### PR TITLE
fix(qa): coin_count SSoT align 238 → 240 (Smoke FAIL fix)

### DIFF
--- a/tests/harness/qa-rules.json
+++ b/tests/harness/qa-rules.json
@@ -8,10 +8,10 @@
     "api_base_url": "https://api.pruviq.com"
   },
   "coin_count": {
-    "current": 238,
+    "current": 240,
     "stale_value": 549,
     "min_acceptable": 220,
-    "description": "현재 코인 수. 새 코인 추가 시 여기만 수정."
+    "description": "현재 코인 수. site-stats.json.coins_analyzed 와 일치. 새 코인 추가 시 두 곳 같이 수정 (또는 site-stats를 SSoT로 일원화 — 별도 리팩토링)."
   },
   "data_sources": {
     "expected": "CoinGecko",


### PR DESCRIPTION
## Summary

Smoke 가 deploy마다 FAIL — Telegram에 알림 도배 + 어제 23:56 이후 6시간 자동 recovery 없음. 근본 원인은 `qa-rules.json` SSoT 가 prod 와 1년 가까이 어긋나 있던 것.

## Root cause (4중 SSoT drift)

| SSoT | Value | Note |
|---|---|---|
| `qa-rules.json.coin_count.current` | **238** ← 이것만 변경 | 테스트가 home HTML에서 `/238/` 검색 |
| `site-stats.json.coins_analyzed` | 240 | 실제 home 페이지 텍스트 ("240+ coins") |
| `/health.coins_loaded` | 238 | 백엔드 OHLCV CSV 카운트 |
| coverage stats | 235 | 백테스트 가능 코인 (frontend 노출 — "235+ Coins") |

= home 페이지에 "238" 이 한 번도 등장한 적 없는데 smoke 가 그걸 기대해서 매번 FAIL. 어제 PR #1379 머지 후 23:56 알림이 그렇게 시작.

## Fix

`tests/harness/qa-rules.json`:
- `coin_count.current`: 238 → 240 (home 텍스트 + site-stats 와 일치)
- description 업데이트 — site-stats.json 과 alignment 의존 명시

## Out of scope (별도 task)

진짜 SSoT 일원화 (4개 → 1개) 는 frontend 컴포넌트 레벨 리팩토링 필요. 이번 PR은 1-byte fix 로 Smoke 알림 도배 즉시 차단만.

## Test plan

- [x] grep verify `"current": 240`
- [ ] 머지 후 다음 deploy 의 prod-smoke step pass 확인 (Smoke FAIL Telegram 알림 0건)

🤖 Generated with [Claude Code](https://claude.com/claude-code)