### PR TITLE
fix(ci): schedule safety net for automerge stale trigger (#1379, #1393)

### DIFF
--- a/.github/workflows/automerge-on-label.yml
+++ b/.github/workflows/automerge-on-label.yml
@@ -5,6 +5,13 @@ on:
     types: [labeled]
   check_suite:
     types: [completed]   # fires on every check completion — no hardcoded workflow list needed
+  # 2026-04-26: schedule safety net. check_suite events are unreliable —
+  # GitHub sometimes does not fire check_suite.completed for the LAST workflow
+  # in a fan-out (observed in PR #1379 and #1393: all checks SUCCESS, mergeable
+  # CLEAN, but attempt-merge never re-triggered after Playwright finished).
+  # Cron catches these stale cases within 10 minutes.
+  schedule:
+    - cron: '*/10 * * * *'
   workflow_dispatch: {}
 
 permissions:
@@ -61,7 +68,12 @@ jobs:
               }
               pr = candidate;
 
-            } else if (context.eventName === 'workflow_dispatch') {
+            } else if (context.eventName === 'workflow_dispatch' || context.eventName === 'schedule') {
+              // schedule + workflow_dispatch share the same logic: paginate
+              // every open PR with the automerge label. Fan-out: when several
+              // PRs are simultaneously waiting, schedule processes the FIRST
+              // one each tick — subsequent ticks pick up the next ones, so
+              // a backlog of N stale PRs clears within N*10 minutes.
               const openPRs = await github.paginate(github.rest.pulls.list, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -72,7 +84,7 @@ jobs:
                 p.labels.some(l => l.name === labelName)
               );
               if (!candidate) {
-                core.info('No open PRs with automerge label found');
+                core.info(`No open PRs with automerge label found (event=${context.eventName})`);
                 return;
               }
               pr = candidate;


### PR DESCRIPTION
## Summary

자동 머지 인프라가 어제+오늘 같은 패턴으로 2번 stale — 모든 check SUCCESS인데 attempt-merge workflow 가 마지막 check 완료 시 다시 trigger 안 함. 매번 수동 \`gh pr merge\` 필요. 이번 PR은 그 stale 케이스를 자동 복구.

## Observed twice in 18 hours

| PR | Symptom |
|---|---|
| #1379 (어제 14:00) | 13 checks SUCCESS + CLEAN + automerge label → 30분+ stale → 수동 머지 |
| #1393 (오늘 06:00) | 동일 패턴, Playwright IN_PROGRESS 중에 마지막 attempt-merge fire → exit → 그 후 trigger 0 |

## Root cause

GitHub Actions \`check_suite.completed\` 이벤트가 fan-out의 LAST workflow에 대해 **불안정하게 fire**. 특히 Playwright처럼 느린 workflow가 다른 fast checks 끝난 후에 끝날 때, attempt-merge 가 fast checks 시점에 fire → \`allCompleted=false\` → exit. Playwright 완료 후 다시 fire 안 됨.

## Fix

\`automerge-on-label.yml\`:
- \`schedule: '*/10 * * * *'\` trigger 추가 (safety net)
- \`schedule\` 이벤트를 \`workflow_dispatch\` 와 동일 핸들러로 처리: open PR 순회 + automerge label 찾아 머지 시도
- 어떤 stale PR도 10분 내 자동 회복

## Cost

- GitHub Actions 추가 호출: 매 10분 1회 (144회/일)
- candidate PR 없을 때 ~5초 실행 후 종료
- free-tier 무관 + stale 발생 시 가치 큼

## Why not other approach

- MIN_CHECK_RUNS 증가? — 이건 under-counting 방어. 우리 문제는 events not firing (반대)
- branch protection 강화? — 이미 강화됨. 문제는 stale, not security
- schedule 이 정확한 답

## Test plan

- [x] YAML parse OK (\`python3 -c "import yaml; yaml.safe_load(...)"\`)
- [x] 변경 line 검증 (grep schedule + cron)
- [ ] 머지 후 다음 stale PR 케이스 발생 시 10분 내 자동 회복 관찰

🤖 Generated with [Claude Code](https://claude.com/claude-code)