### PR TITLE
fix(refresh_static): auto-recover to main when feature branch is safely idle

### DIFF
--- a/backend/scripts/refresh_static.sh
+++ b/backend/scripts/refresh_static.sh
@@ -76,15 +76,52 @@ if ! crontab -l 2>/dev/null | grep -qF "refresh_static.sh"; then
     send_alert "WARN" "Cron entry was missing — auto-installed"
 fi
 
-# Only proceed if already on main. Never hijack a developer's feature branch
-# (previous behavior: `git stash + git checkout main` mid-session wiped WIP and
-# caused merge conflicts with the dev's commits — see 2026-04-18 audit incident).
-# Dev work stays intact; cron simply skips this cycle and alerts owner.
+# Auto-recovery from feature branch when safely idle.
+#
+# History:
+#   2026-04-18: blunt `git stash + git checkout main` mid-session wiped WIP
+#               and caused merge conflicts with the dev's commits → reverted
+#               to skip-only behavior with an alert.
+#   2026-04-25→26: skip-only behavior caused 18 alerts + 6h data staleness
+#               after a session ended on feature branch with all work pushed.
+#               Owner directive: alerts can flood (owner reads them) but
+#               recovery MUST be automatic when safe.
+#
+# This implementation re-enables auto main-checkout, but only when ALL three
+# conditions hold (any one missing = skip + WARN as before):
+#   1. uncommitted changes == 0 (working tree clean → no WIP to lose)
+#   2. local HEAD == origin/<branch> (every commit pushed → no commit to lose)
+#   3. last commit > 1h ago (active dev session would commit more often)
+# A push'd, clean, idle branch is exactly the post-PR-merge state where the
+# 2026-04-25 incident occurred.
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
 if [[ "$CURRENT_BRANCH" != "main" ]]; then
-    log "Not on main (on $CURRENT_BRANCH) — skipping this cron cycle (dev session active)"
-    send_alert "WARN" "refresh_static cron skipped: repo on branch '$CURRENT_BRANCH' (dev session). Will retry in 20min. If persistent, check Mac Mini git state."
-    exit 0
+    UNCOMMITTED=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+    LAST_COMMIT_TS=$(git log -1 --format=%ct 2>/dev/null || echo 0)
+    NOW_TS=$(date +%s)
+    IDLE_SEC=$(( NOW_TS - LAST_COMMIT_TS ))
+    LOCAL_HEAD=$(git rev-parse HEAD 2>/dev/null || echo "")
+    REMOTE_HEAD=$(git rev-parse "origin/$CURRENT_BRANCH" 2>/dev/null || echo "no-remote")
+    PUSHED=false
+    if [[ -n "$LOCAL_HEAD" && "$LOCAL_HEAD" == "$REMOTE_HEAD" ]]; then
+        PUSHED=true
+    fi
+
+    if [[ "$UNCOMMITTED" == "0" && "$PUSHED" == "true" && "$IDLE_SEC" -gt 3600 ]]; then
+        log "Feature branch '$CURRENT_BRANCH' safe-to-recover (clean=true, pushed=true, idle=${IDLE_SEC}s) — auto checkout main"
+        if git checkout main 2>&1 | while read l; do log "  $l"; done; then
+            send_alert "INFO" "refresh_static auto-recovered to main from '$CURRENT_BRANCH' (idle $((IDLE_SEC/60))min, all commits pushed). Your branch is preserved — \`git checkout $CURRENT_BRANCH\` to resume."
+        else
+            log "git checkout main failed during auto-recovery — skipping"
+            send_alert "ERROR" "refresh_static auto-recovery FAILED: git checkout main errored on '$CURRENT_BRANCH'. Manual intervention needed."
+            exit 1
+        fi
+    else
+        REASON="uncommitted=$UNCOMMITTED, pushed=$PUSHED, idle_min=$((IDLE_SEC/60))"
+        log "Not on main (on $CURRENT_BRANCH) — skip cycle (recovery blocked: $REASON)"
+        send_alert "WARN" "refresh_static cron skipped: branch '$CURRENT_BRANCH' ($REASON). Auto-recovery requires uncommitted=0 + pushed + idle>60min. Will retry in 20min."
+        exit 0
+    fi
 fi
 
 # Pull latest on main (no --autostash needed — we just confirmed clean branch state).


### PR DESCRIPTION
## Summary

어제 (2026-04-25 → 26) 사고 직접 fix — feature 브랜치에 모든 작업 push된 상태로 idle하면 cron이 자동으로 main으로 복귀해서 데이터 갱신 cycle 진행. 18번 skip 알림 + 6h stale 사고 재발 방지.

## Owner directive (2026-04-26)

> 알림은 도배 가능 — 내가 확인할 거니까 OK. 나머지 복구 가능한 부분은 자동 복구해야지.

## History

| 시점 | 상태 |
|---|---|
| **2026-04-18** | 단순 `git stash + git checkout main` 이 mid-session WIP wipeout → 너무 위험해서 skip-only로 전환 |
| **2026-04-25 → 26** | skip-only가 18번 알림 도배 + 6h 데이터 stale → 너무 보수적이라 사고 |
| **이 PR (2026-04-26)** | 안전 조건 명확히 만족 시에만 자동 main 복귀 |

## 안전 조건 (3 AND)

자동 main checkout 발생 조건:
1. **uncommitted == 0** — working tree clean (WIP loss 0%)
2. **local HEAD == origin/<branch>** — 모든 commit이 push됨 (commit loss 0%)
3. **last commit > 1h ago** — active dev session이면 1h 안에 commit 계속 함

세 조건 중 하나라도 안 맞으면 기존대로 skip + WARN 알림.

## 어제 사고 시뮬레이션

- branch: `feat/okx-oauth-experimental-variants`
- uncommitted: 0 (PR #1379 모든 변경 머지됨) ✓
- pushed: true (origin/feat/okx-oauth-experimental-variants 동일) ✓
- idle: 22:53 마지막 commit → 24:00 cron tick = **67분 > 60min 임계값** ✓
- → 24:00 시점 자동 main 복귀 + cycle 진행 = **stale 0h, 알림 1번 (INFO)**

## 알림

- 성공 시: `INFO: refresh_static auto-recovered to main from 'X' (idle 67min, all commits pushed). Your branch is preserved — git checkout X to resume.`
- 안전 조건 안 맞으면 기존 WARN 그대로

## Tests

- [x] `bash -n` syntax OK
- [x] Dry-run on 현재 active branch → SKIP (correct, working actively)
- [x] Dry-run on 어제 사고 시나리오 (uncommitted=0, pushed, idle 90min+) → AUTO-RECOVER
- [ ] 머지 후 다음 cron tick에서 정상 동작 (현재 main이라 즉시 cycle 진행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)