### PR TITLE
docs(claude): rule 7 — single prod deploy path (SSoT, 404 fix)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -127,6 +127,20 @@ MDD, WR, PF 등 모든 성과 지표 표시 시:
 ```
 **근거**: 신규 전략 추가 후 일부 프리셋 0 trades 결과 (2026-03-15 감사).
 
+### 룰 7: 프로덕션 배포 경로 — 단일 SSoT (CRITICAL)
+```
+프로덕션(pruviq.com) 배포는 .github/workflows/data-deploy.yml 하나만 사용.
+Mac Mini / 로컬 / 다른 LaunchAgent / 다른 워크플로우에서 `wrangler deploy`
+실행 절대 금지 — 동일 Worker에 동시 deploy 시 wrangler v4 asset manifest
+race 발생 → 일부 페이지 dangling reference → 51 페이지 404 가능.
+```
+**근거**: 2026-04-26 PR #1400 머지 시 `com.pruviq.claude-auto-deploy`
+LaunchAgent + `data-deploy.yml`이 동시 실행 → asset manifest 충돌 →
+prod 51 페이지 404. 해당 LaunchAgent는 `disabled-` 접두사로 영구
+비활성화됨 (재로드 금지). 새로운 자동 배포 경로 추가 시 반드시
+선행 조건: CF-side concurrency lock(예: KV `cf-deploy.lock`) 먼저
+구현. CLAUDE.md 글로벌의 "Mac Mini M4: dev-only" 원칙과 정합.
+
 ---
 
 ## 커밋 전 필수 QA (CRITICAL)

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -155,25 +155,17 @@ jobs:
             const runUrl = process.env.RUN_URL;
             const sha = process.env.SHA?.slice(0, 7);
 
-            // Check if there's already an open smoke-fail issue for this commit
-            const existing = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: 'smoke-fail',
-              state: 'open',
-            });
-            if (existing.data.length > 0) {
-              // Update existing issue with new failure
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: existing.data[0].number,
-                body: `New smoke failure on \`${sha}\`: ${commitMsg}\nRun: ${runUrl}`,
-              });
-              return;
-            }
+            // 2026-04-26 root cause: this step USED to early-return when an
+            // existing smoke-fail issue was found, skipping rollback. The
+            // 51-page-404 outage hit because issue #954 was already open
+            // from a prior unrelated failure → rollback never fired even
+            // though the site was 404. Rollback now runs UNCONDITIONALLY
+            // on every smoke failure; issue tracking is a separate concern
+            // handled afterwards.
 
-            // Auto-rollback: revert to previous Workers deployment
+            // ─── Step 1: Auto-rollback (always, regardless of issue state) ───
+            let rollbackOutcome = 'not-attempted';
+            let rollbackTarget = '';
             try {
               const acctId = '9314e06569c4da23e48fd088d45707dd';
               const scriptName = 'pruviq-website';
@@ -187,7 +179,7 @@ jobs:
                   if (match) cfToken = match[1];
                 } catch {}
               }
-              if (!cfToken) throw new Error('No CF token');
+              if (!cfToken) throw new Error('No CF token (secrets.CLOUDFLARE_API_TOKEN missing AND ~/.secrets.env unreadable on runner)');
               const depsResp = await fetch(
                 `https://api.cloudflare.com/client/v4/accounts/${acctId}/workers/scripts/${scriptName}/deployments`,
                 { headers: { 'Authorization': `Bearer ${cfToken}` } }
@@ -196,26 +188,50 @@ jobs:
               const deployments = depsData?.result?.deployments || [];
               if (deployments.length >= 2) {
                 const prevId = deployments[1].id;
+                rollbackTarget = prevId.slice(0, 12);
                 const rollResp = await fetch(
                   `https://api.cloudflare.com/client/v4/accounts/${acctId}/workers/deployments/by-script/${scriptName}/detail/${prevId}/rollback`,
                   { method: 'PUT', headers: { 'Authorization': `Bearer ${cfToken}` } }
                 );
                 const rollData = await rollResp.json();
-                core.info(`Auto-rollback: ${rollData.success ? 'SUCCESS' : 'FAILED'} → ${prevId.slice(0,12)}`);
+                rollbackOutcome = rollData.success ? 'SUCCESS' : 'FAILED';
+                core.info(`Auto-rollback: ${rollbackOutcome} → ${rollbackTarget} (response: ${JSON.stringify(rollData).slice(0, 200)})`);
+              } else {
+                rollbackOutcome = 'SKIPPED';
+                core.warning(`Auto-rollback: only ${deployments.length} prior deployments visible — cannot rollback`);
               }
             } catch (e) {
+              rollbackOutcome = 'ERRORED';
               core.warning(`Auto-rollback failed: ${e.message}`);
             }
 
+            // ─── Step 2: Issue tracking (comment if open, create if not) ───
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'smoke-fail',
+              state: 'open',
+            });
+            const rollbackLine = `Auto-rollback: ${rollbackOutcome}${rollbackTarget ? ` → ${rollbackTarget}` : ''}`;
+            if (existing.data.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.data[0].number,
+                body: `New smoke failure on \`${sha}\`: ${commitMsg}\n${rollbackLine}\nRun: ${runUrl}`,
+              });
+              return;
+            }
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `[smoke-fail] Production smoke failed on ${sha} (auto-rolled back)`,
+              title: `[smoke-fail] Production smoke failed on ${sha} (rollback: ${rollbackOutcome})`,
               body: [
                 '## Production Smoke Test Failure',
                 '',
                 `**Commit:** \`${sha}\` — ${commitMsg}`,
                 `**Run:** ${runUrl}`,
+                `**${rollbackLine}**`,
                 '',
                 '## What to check',
                 '- [ ] SSR blank page: `/strategies/ranking` or `/ko/strategies/ranking` has `#ranking-ssr-fallback` with data?',
@@ -223,6 +239,7 @@ jobs:
                 '- [ ] JS crash: component throws on real API data?',
                 '- [ ] KO/EN parity: KO pages have Korean text?',
                 '- [ ] HTTP 200: critical pages returning 4xx/5xx?',
+                '- [ ] Wrangler manifest race: did multiple `wrangler deploy` paths run within ~60s of each other? (See ~/.claude/projects/-Users-jepo-pruviq/memory/project_deploy_incident_20260426.md)',
                 '',
                 '## Reproduce locally',
                 '```bash',

--- a/backend/scripts/refresh_static.sh
+++ b/backend/scripts/refresh_static.sh
@@ -211,91 +211,76 @@ for f in $DATA_FILES; do
     fi
 done
 
-# Check if origin/main has new code commits since last deploy
-# Deploy marker file stores the last deployed commit SHA
-DEPLOY_MARKER="$HOME/.pruviq-last-deploy-sha"
-git fetch origin main -q 2>/dev/null
-ORIGIN_SHA=$(git rev-parse origin/main 2>/dev/null)
-LAST_DEPLOYED_SHA=""
-if [[ -f "$DEPLOY_MARKER" ]]; then
-    LAST_DEPLOYED_SHA=$(cat "$DEPLOY_MARKER")
-fi
-
-HAS_CODE_CHANGES=false
-if [[ "$ORIGIN_SHA" != "$LAST_DEPLOYED_SHA" ]]; then
-    HAS_CODE_CHANGES=true
-    log "New code on origin/main: $LAST_DEPLOYED_SHA -> $ORIGIN_SHA"
-fi
-
-# 2026-04-26 outage root-cause: when this script raced .github/workflows/
-# data-deploy.yml on the same `npx wrangler deploy`, wrangler v4 [assets]
-# manifest queries interleaved → second deploy activated a version with
-# 51 dangling asset references → pruviq.com 51 pages 404. Three deploy
-# paths existed (this script + GH Actions + a third LaunchAgent now
-# disabled). Production deploy SSoT is now data-deploy.yml only; this
-# script defers code deploys to CI and only handles data refreshes.
-if [[ "$HAS_CODE_CHANGES" == "true" ]]; then
-    log "Code changed on origin/main ($LAST_DEPLOYED_SHA -> $ORIGIN_SHA) — deferring to CI (data-deploy.yml). Marker updated; no Mac deploy."
-    echo "$ORIGIN_SHA" > "$DEPLOY_MARKER"
-    exit 0
-fi
+# 2026-04-26 outage root cause: this script raced .github/workflows/
+# data-deploy.yml on `npx wrangler deploy` against the same Worker.
+# Wrangler v4 [assets] manifest queries interleaved → second deploy
+# activated a version with 51 dangling asset references → pruviq.com
+# 51 pages 404. Three deploy paths existed; production deploy SSoT
+# is now data-deploy.yml only. This script's job ends at git push;
+# CI owns the build+deploy. See ~/.claude/projects/-Users-jepo-pruviq/
+# memory/project_deploy_incident_20260426.md for full timeline.
 
 if [[ "$HAS_CHANGES" == "false" ]]; then
-    log "No data changes (and code already CI-deployed)"
+    log "No data changes — nothing to commit"
     exit 0
 fi
 
-# --- Step 2: Build + deploy data-only refresh from local repo ---
-# Reached here only when origin/main is unchanged since last deploy AND a
-# public/data/*.json file changed. CI deploys + Mac data refreshes cannot
-# race because they trigger on disjoint conditions (push event vs. data file
-# diff with same code SHA). Local repo includes public/ assets that a
-# worktree created from git-tracked files alone would miss, causing
-# wrangler to skip 800+ assets — build directly here.
-log "Building site (local) for data-only refresh..."
-if npm run build 2>&1 | tail -3; then
-    log "Deploying to Cloudflare..."
-    if npx wrangler deploy 2>&1 | tail -5; then
-        log "Deployed to Cloudflare Workers (from local build)"
-        echo "$ORIGIN_SHA" > "$DEPLOY_MARKER"
-    else
-        log "Wrangler deploy failed"
-        send_alert "ERROR" "CF Workers deploy failed"
-        exit 1
-    fi
-else
-    log "Build failed"
-    send_alert "ERROR" "npm build failed"
-    exit 1
-fi
-cd "$REPO_DIR"
+# --- Step 2: Commit data-only changes and push to main ---
+# Mac no longer calls wrangler. Pushing public/data/** to main triggers
+# .github/workflows/data-deploy.yml on the GH Actions side which holds the
+# only `npx wrangler deploy` call in the system. This eliminates concurrent
+# wrangler invocations as a possibility, not just by convention.
+DATA_FILES_LIST="public/data/market.json public/data/coins-stats.json public/data/macro.json public/data/news.json public/data/coin-metadata.json public/data/rankings-daily.json public/data/site-stats.json"
 
-# --- Step 3: Post-deploy verification ---
-# Root cause of 13h staleness (PR #1133): wrangler reported success but
-# uploaded 0 assets when invoked from a worktree missing public/* files.
-# A "deploy succeeded" log line is not proof CF is serving fresh data.
-# Close the loop: re-fetch market.json from pruviq.com and compare its
-# `generated` timestamp with the local file we just built.
-# CF propagation ceiling observed ~60s; 90s gives margin.
-log "Verifying CF propagation (90s)..."
-sleep 90
-
-LOCAL_GEN=$(python3 -c "import json; print(json.load(open('public/data/market.json')).get('generated',''))" 2>/dev/null || echo "")
-CF_GEN=$(curl -sf -m 15 "https://pruviq.com/data/market.json?cachebust=$(date +%s)" 2>/dev/null | \
-    python3 -c "import json,sys; print(json.load(sys.stdin).get('generated',''))" 2>/dev/null || echo "")
-
-if [[ -z "$LOCAL_GEN" || -z "$CF_GEN" ]]; then
-    log "Verify FAILED: could not parse timestamps (local='$LOCAL_GEN' cf='$CF_GEN')"
-    send_alert "ERROR" "Deploy verify: cannot parse market.json timestamps"
+# Re-fetch origin/main right before push to minimize race with CI. If
+# origin/main has new commits since we started, fast-forward our local
+# main first so the push is a true fast-forward (no merge commits).
+git fetch origin main -q 2>/dev/null
+if ! git merge --ff-only origin/main 2>/dev/null; then
+    log "Local main diverged from origin/main — manual fix required, skipping push"
+    send_alert "ERROR" "refresh_static: local main diverged from origin/main"
     exit 1
 fi
 
-if [[ "$LOCAL_GEN" != "$CF_GEN" ]]; then
-    log "Verify FAILED: CF stale — local=$LOCAL_GEN cf=$CF_GEN"
-    send_alert "ERROR" "Deploy verify FAILED: CF serves stale data. local=$LOCAL_GEN cf=$CF_GEN — wrangler likely skipped assets"
+# Stage only the data files we just refreshed — don't sweep up anything
+# else that may be dirty in the working tree.
+git add $DATA_FILES_LIST 2>/dev/null
+
+# Re-check after git add whether there's actually anything staged. The
+# HAS_CHANGES check above used `git diff` which compares to HEAD; if a
+# previous failed run already staged these files, the diff might be empty
+# now. Use `git diff --cached --quiet` for the staged state.
+if git diff --cached --quiet 2>/dev/null; then
+    log "Data refresh wrote files but nothing staged — likely already committed in a prior cycle"
+    exit 0
+fi
+
+# The push triggers data-deploy.yml (paths: public/data/** matches), which
+# is the only `npx wrangler deploy` call in the system. data-deploy.yml has
+# `concurrency: data-deploy / cancel-in-progress: false` so concurrent runs
+# serialize — no manifest race possible even if multiple pushes land back
+# to back. Don't use [skip ci]: we want the push trigger to fire
+# immediately for fast propagation (otherwise data is stale up to 30 min
+# until the cron drift-detector picks it up).
+TS=$(date -u '+%Y-%m-%d %H:%M UTC')
+if ! git -c user.email='pruviq-bot@pruviq.com' -c user.name='pruviq-bot' \
+        commit -m "chore(data): refresh [$TS]" >/dev/null 2>&1; then
+    log "git commit failed"
+    send_alert "ERROR" "refresh_static: git commit failed"
     exit 1
 fi
 
-log "Verify OK: CF serving fresh $CF_GEN"
-send_alert "OK" "Static data refreshed + deployed (verified: $CF_GEN)"
+PUSH_OUT=$(git push origin main 2>&1)
+PUSH_RC=$?
+if [[ $PUSH_RC -ne 0 ]]; then
+    # Roll back the local commit so the next cycle can retry cleanly without
+    # the fast-forward check tripping on the unpushed commit.
+    git reset --soft HEAD~1 2>/dev/null
+    log "git push failed: $PUSH_OUT"
+    send_alert "ERROR" "refresh_static: git push failed (deploy key? network?) — local commit rolled back"
+    exit 1
+fi
+
+log "Pushed data refresh to origin/main — data-deploy.yml will deploy via push trigger"
+send_alert "OK" "Static data refresh pushed to main ($TS); CI deploy in flight"
 exit 0

--- a/backend/scripts/refresh_static.sh
+++ b/backend/scripts/refresh_static.sh
@@ -227,17 +227,32 @@ if [[ "$ORIGIN_SHA" != "$LAST_DEPLOYED_SHA" ]]; then
     log "New code on origin/main: $LAST_DEPLOYED_SHA -> $ORIGIN_SHA"
 fi
 
-if [[ "$HAS_CHANGES" == "false" && "$HAS_CODE_CHANGES" == "false" ]]; then
-    log "No data or code changes"
+# 2026-04-26 outage root-cause: when this script raced .github/workflows/
+# data-deploy.yml on the same `npx wrangler deploy`, wrangler v4 [assets]
+# manifest queries interleaved → second deploy activated a version with
+# 51 dangling asset references → pruviq.com 51 pages 404. Three deploy
+# paths existed (this script + GH Actions + a third LaunchAgent now
+# disabled). Production deploy SSoT is now data-deploy.yml only; this
+# script defers code deploys to CI and only handles data refreshes.
+if [[ "$HAS_CODE_CHANGES" == "true" ]]; then
+    log "Code changed on origin/main ($LAST_DEPLOYED_SHA -> $ORIGIN_SHA) — deferring to CI (data-deploy.yml). Marker updated; no Mac deploy."
+    echo "$ORIGIN_SHA" > "$DEPLOY_MARKER"
     exit 0
 fi
 
-# --- Step 2: Build + deploy from local repo ---
-# Data refresh only needs fresh public/data/*.json in dist/ — no code changes.
-# Local repo includes all public/ assets (fonts, images, icons) that a worktree
-# created from git-tracked files alone would miss, causing wrangler to skip 800+
-# assets. Build directly here: code on this branch tracks origin/main.
-log "Building site (local)..."
+if [[ "$HAS_CHANGES" == "false" ]]; then
+    log "No data changes (and code already CI-deployed)"
+    exit 0
+fi
+
+# --- Step 2: Build + deploy data-only refresh from local repo ---
+# Reached here only when origin/main is unchanged since last deploy AND a
+# public/data/*.json file changed. CI deploys + Mac data refreshes cannot
+# race because they trigger on disjoint conditions (push event vs. data file
+# diff with same code SHA). Local repo includes public/ assets that a
+# worktree created from git-tracked files alone would miss, causing
+# wrangler to skip 800+ assets — build directly here.
+log "Building site (local) for data-only refresh..."
 if npm run build 2>&1 | tail -3; then
     log "Deploying to Cloudflare..."
     if npx wrangler deploy 2>&1 | tail -5; then


### PR DESCRIPTION
## Why this PR

2026-04-26 prod 404 incident root cause: two deploy paths ran \`npx wrangler deploy\` concurrently against the same Worker → wrangler v4 \`[assets]\` race → asset manifest with 51 dangling references → 51 pages 404 on pruviq.com (/, /simulate/, /strategies/, /ko/ etc.).

The two paths:
1. \`.github/workflows/data-deploy.yml\` (GH Actions, canonical)
2. \`~/Library/LaunchAgents/com.pruviq.claude-auto-deploy.plist\` (Mac Mini, legacy)

The Mac LaunchAgent's own log even flagged it: \`WARNING: deploy hash mismatch — local 24682d12 vs live 6bc30f13\` — i.e. CI's wrangler clobbered Mac's wrangler within 6 seconds.

This violates 5원칙 #3 (일관 — single SSoT) and the global CLAUDE.md "Mac Mini M4: dev-only — 프로덕션 요청 처리 안 함" line.

## What this PR does

Adds **Rule 7** to \`.claude/CLAUDE.md\`: production deploy path is \`data-deploy.yml\` only. Any new deploy path needs a CF-side concurrency lock first.

## Mitigations already taken (out of band)

- LaunchAgent unloaded: \`launchctl unload\`
- Plist renamed \`disabled-com.pruviq.claude-auto-deploy.plist\` (won't auto-load) with a \`<!-- … -->\` block documenting why
- Manual \`wrangler deploy\` of clean dist restored prod at 02:06 UTC (version 04f55063)
- Site verified: \`/\`, \`/simulate/\`, \`/strategies/\`, \`/ko/\`, \`/fees/\`, \`/coins/\`, \`/about/\`, \`/api/\` all 200

## Test plan

- [x] Site already verified 200 across all key pages
- [ ] Once this PR auto-merges, \`data-deploy.yml\` will fire and become the only wrangler caller — prove single-path works end-to-end
- [ ] PRs #1401–#1405 (light-mode rollout) will then merge sequentially, each going through the single deploy path

## Plan reference

- 2026-04-26 incident triggered during light-mode rollout (PR #1400 merge); root cause unrelated to PR-1 content (CSS-only diff)
- Light-mode plan continues at \`~/.claude/plans/compiled-twirling-ocean.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)