### PR TITLE
chore(infra): cut data-deploy cron 12× + bump api-watchdog timeout 3×

### DIFF
--- a/.github/workflows/data-deploy.yml
+++ b/.github/workflows/data-deploy.yml
@@ -27,11 +27,13 @@ on:
     # PRs merged but none auto-deployed until someone ran
     # `gh workflow run data-deploy.yml` manually.
     #
-    # A */30 cron guarantees worst-case staleness of 30 min. The build is
-    # idempotent (wrangler deploy is a no-op if nothing changed on CF's
-    # side) so running against an unchanged main costs ~2 min of runner
-    # time and no user impact.
-    - cron: "*/30 * * * *"
+    # 2026-04-26: bumped from */30 to 0 */6 (every 6h). After PR #1408
+    # the data path is push-driven (refresh_static.sh now commits+pushes
+    # public/data/** instead of calling wrangler), so the push trigger
+    # above already covers data refreshes. The schedule is purely a
+    # safety net for the registry-stuck class of bug, which is rare.
+    # Cuts CI runner cost ~12× without sacrificing detection.
+    - cron: "0 */6 * * *"
   workflow_dispatch: {}
 
 concurrency:

--- a/backend/deploy/systemd/bin/api-watchdog.sh
+++ b/backend/deploy/systemd/bin/api-watchdog.sh
@@ -39,7 +39,12 @@ last_restart=${last_restart:-0}
 now=$(date +%s)
 
 # Probe /health. curl exit 0 only when HTTP 2xx and non-empty body.
-if curl -sf -m 5 "$HEALTH_URL" >/dev/null 2>&1; then
+# Timeout 15s (was 5s) — 2026-04-26 10:23 KST false-positive: API was
+# serving heavy /simulate traffic; /health queued behind big requests
+# and timed out at 5s, so 3 consecutive watchdog probes failed and
+# force-restarted a perfectly healthy API. 15s is still well under the
+# 60s probe interval and just lets /health drain the queue.
+if curl -sf -m 15 "$HEALTH_URL" >/dev/null 2>&1; then
     if [ "$fail_count" -gt 0 ]; then
         echo "recovery: reset fail_count from $fail_count to 0"
     fi


### PR DESCRIPTION
## Why

Two post-incident hardenings batched as one small PR.

### 1. \`data-deploy.yml\` schedule: \`*/30 * * * *\` → \`0 */6 * * *\`

After #1408, data refreshes flow through git push (refresh_static.sh now commits+pushes \`public/data/**\` instead of calling wrangler). The workflow's push trigger already covers every refresh; the \`schedule\` cron is purely a registry-stuck safety net (cf. 2026-04-16~17 where push events were silently dropped by GitHub). Hourly-grade granularity is overkill for that scenario — every 6h still bounds detection within a half-day.

Effect: ~12× fewer ubuntu-latest runner cycles for this workflow. No user-facing impact (push trigger handles real data changes immediately).

### 2. \`api-watchdog.sh\` probe timeout: \`-m 5\` → \`-m 15\`

2026-04-26 10:23 KST false-positive: pruviq-api was serving heavy \`/simulate\` traffic; the watchdog's \`curl /health\` request queued behind big request bodies and timed out at 5s. Three consecutive timeouts → forced restart of a perfectly healthy API.

15s is still well under the 60s probe interval, so it doesn't weaken real hang detection (genuine hangs > 15s still trigger). Just stops the watchdog from misjudging busy-but-healthy as dead.

## Test plan

- [x] YAML validates (\`python3 -c "import yaml; yaml.safe_load(...)"\`)
- [x] Bash syntax (\`bash -n\`)
- [ ] After merge: backend deploy auto-fires (paths-filter doesn't match, so this PR doesn't redeploy backend; api-watchdog.sh stays as is on DO until next backend deploy via \`backend/**\`). Acceptable — the change is a one-character edit that takes effect on next \`backend/\` push, and meanwhile the false-positive is rare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)