### PR TITLE
refactor(theme): tokenize TrustGapPanel chart + BOTH-button borders (W0)

### DIFF
--- a/src/components/BuilderPanel.tsx
+++ b/src/components/BuilderPanel.tsx
@@ -384,7 +384,7 @@ export default function BuilderPanel(props: Props) {
                       ? {
                           background:
                             "linear-gradient(90deg, rgba(239,68,68,0.15), rgba(0,255,136,0.15))",
-                          borderColor: "#888",
+                          borderColor: "var(--color-border-hover)",
                           color: "#fff",
                         }
                       : undefined

--- a/src/components/StandardPanel.tsx
+++ b/src/components/StandardPanel.tsx
@@ -226,7 +226,7 @@ export default function StandardPanel({
                       ? {
                           background:
                             "linear-gradient(90deg, rgba(239,68,68,0.15), rgba(0,255,136,0.15))",
-                          borderColor: "#888",
+                          borderColor: "var(--color-border-hover)",
                           color: "#fff",
                         }
                       : {

--- a/src/components/simulator/v1/TrustGapPanel.tsx
+++ b/src/components/simulator/v1/TrustGapPanel.tsx
@@ -395,10 +395,15 @@ function EquitySparkline({
   const zeroY = toY(0);
   const finalE = equities[equities.length - 1] ?? 0;
   const finalPositive = finalE >= 0;
-  const strokeColor = finalPositive ? "#10b981" : "#f43f5e";
-  // 2026-04-22 fix: fillColor hex previously had a typo (#f4365622) that
-  // didn't match the stroke hue. Same base hue + 22 alpha for the fill.
-  const fillColor = finalPositive ? "#10b98122" : "#f43f5e22";
+  const strokeStyle = {
+    stroke: `var(${finalPositive ? "--color-up" : "--color-down"})`,
+  };
+  const dotFillStyle = {
+    fill: `var(${finalPositive ? "--color-up" : "--color-down"})`,
+  };
+  const areaFillStyle = {
+    fill: `var(${finalPositive ? "--color-up-fill" : "--color-down-fill"})`,
+  };
 
   const path = equities
     .map(
@@ -437,15 +442,15 @@ function EquitySparkline({
           y1={zeroY}
           x2={W}
           y2={zeroY}
-          stroke="#52525b"
+          style={{ stroke: "var(--color-text-tertiary)" }}
           stroke-width="0.5"
           stroke-dasharray="2 3"
         />
-        <path d={areaPath} fill={fillColor} />
+        <path d={areaPath} style={areaFillStyle} />
         <path
           d={path}
           fill="none"
-          stroke={strokeColor}
+          style={strokeStyle}
           stroke-width="1.5"
           stroke-linejoin="round"
         />
@@ -454,8 +459,7 @@ function EquitySparkline({
           cx={(equities.length - 1) * xStep}
           cy={toY(finalE)}
           r={2.5}
-          fill={strokeColor}
-          stroke="#09090b"
+          style={{ ...dotFillStyle, stroke: "var(--color-bg)" }}
           stroke-width="1"
         />
       </svg>
@@ -463,7 +467,9 @@ function EquitySparkline({
         <span>
           {daily[0]?.date?.slice(5)} → {daily[daily.length - 1]?.date?.slice(5)}
         </span>
-        <span class={finalPositive ? "text-(--color-up)" : "text-(--color-down)"}>
+        <span
+          class={finalPositive ? "text-(--color-up)" : "text-(--color-down)"}
+        >
           {finalPositive ? "+" : ""}
           {finalPct.toFixed(1)}%
         </span>


### PR DESCRIPTION
## Summary
- TrustGapPanel.tsx (BT-vs-LV equity sparkline) chart hex literals → CSS tokens — adapts to light theme without changing dark-mode appearance
- BuilderPanel.tsx + StandardPanel.tsx: BOTH-direction button borderColor `#888` → `var(--color-border-hover)`
- Token mapping uses already-calibrated `:root` + `[data-theme="light"]` definitions (WCAG AA in both modes)

## Scope (deliberately narrow)
| File | Change |
|---|---|
| `simulator/v1/TrustGapPanel.tsx` | stroke `#10b981/#f43f5e` → `var(--color-up/down)`, area fill `#10b98122/#f43f5e22` → `var(--color-up-fill/down-fill)`, zero line `#52525b` → `var(--color-text-tertiary)`, dot outline `#09090b` → `var(--color-bg)` |
| `BuilderPanel.tsx` | BOTH-button `borderColor: "#888"` → `var(--color-border-hover)` |
| `StandardPanel.tsx` | same |

## Deliberately NOT migrated
- `simulator-types.ts` `COLORS` palette — owner decision 2026-04-25 (separate semantic from site `--color-accent`, WCAG AA pre-calibrated 5.7/5.25/4.86 contrast)
- `color: "#fff"` on accent buttons — universally readable in both themes
- `LoadingEquityAnimation` hex fallbacks — `getCssVar` default pattern (correct)
- `"#F7931A80"` in ResultsPanel — Bitcoin brand color

## Test plan
- [x] `npm run build` → 1192 pages, 0 errors
- [x] `bash scripts/qa-redirects.sh` → PASS
- [x] grep verification: no `#888` / `#10b981` / `#f43f5e` / `#52525b` / `#09090b` literals remain in the 3 changed files
- [ ] CI light-mode-axe + light-mode-visual specs (auto-runs)
- [ ] Visual regression (auto-runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)