### PR TITLE
feat(ui): Reveal + Stagger motion primitives (W1-2)

### DIFF
--- a/src/components/ui/Reveal.tsx
+++ b/src/components/ui/Reveal.tsx
@@ -1,0 +1,78 @@
+/**
+ * Reveal.tsx — Single-child fade + translateY entrance.
+ *
+ * Wraps existing global `.reveal` CSS (src/styles/global.css line 706-715).
+ * Two modes:
+ *   1. auto (default) — animates on viewport entry via IntersectionObserver
+ *   2. trigger — animates when the `trigger` prop becomes truthy
+ *      (use for orchestrated reveals after API responses)
+ *
+ * `prefers-reduced-motion: reduce` is honored by the global CSS rule
+ * (line 753-757) — children stay visible without transition.
+ */
+import { useEffect, useRef, useState, type ComponentChildren } from "preact";
+
+interface RevealProps {
+  children: ComponentChildren;
+  /** When provided, animates only after this becomes truthy. */
+  trigger?: boolean;
+  /** Delay in ms before adding `.visible` (default 0) */
+  delay?: number;
+  /** Tailwind/utility classes to merge onto the wrapper */
+  class?: string;
+  /** Wrapper element type (default `div`) */
+  as?: "div" | "section" | "article" | "li" | "span";
+}
+
+export default function Reveal({
+  children,
+  trigger,
+  delay = 0,
+  class: className = "",
+  as = "div",
+}: RevealProps) {
+  const ref = useRef<HTMLElement>(null);
+  const [visible, setVisible] = useState(false);
+  const isManual = trigger !== undefined;
+
+  // Manual trigger mode — flip on prop change
+  useEffect(() => {
+    if (!isManual) return;
+    if (!trigger) {
+      setVisible(false);
+      return;
+    }
+    const t = setTimeout(() => setVisible(true), delay);
+    return () => clearTimeout(t);
+  }, [trigger, delay, isManual]);
+
+  // Auto mode — IntersectionObserver
+  useEffect(() => {
+    if (isManual) return;
+    const el = ref.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setTimeout(() => setVisible(true), delay);
+            observer.unobserve(entry.target);
+          }
+        }
+      },
+      { threshold: 0.1, rootMargin: "0px 0px -40px 0px" },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [delay, isManual]);
+
+  const Tag = as as keyof JSX.IntrinsicElements;
+  return (
+    <Tag
+      ref={ref as never}
+      class={`reveal ${visible ? "visible" : ""} ${className}`.trim()}
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/src/components/ui/Stagger.tsx
+++ b/src/components/ui/Stagger.tsx
@@ -1,0 +1,77 @@
+/**
+ * Stagger.tsx — Multi-child staggered fade + translateY entrance.
+ *
+ * Wraps existing global `.reveal-child` CSS (src/styles/global.css line 727-745).
+ * Each direct child gets a `transition-delay` of (80ms × index) up to 12 children.
+ *
+ * Mode:
+ *   - auto (default)    : animates on viewport entry
+ *   - trigger={bool}    : animates when prop becomes truthy (use for result reveal)
+ *
+ * `prefers-reduced-motion: reduce` is honored by the global CSS rule
+ * (line 753-757) — all children stay visible with no transition.
+ */
+import { useEffect, useRef, useState, type ComponentChildren } from "preact";
+
+interface StaggerProps {
+  children: ComponentChildren;
+  /** When provided, animates only after this becomes truthy. */
+  trigger?: boolean;
+  /** Initial delay before stagger sequence starts (default 0) */
+  delay?: number;
+  /** Tailwind/utility classes to merge onto the wrapper */
+  class?: string;
+  /** Wrapper element type (default `div`) */
+  as?: "div" | "section" | "ul" | "ol";
+}
+
+export default function Stagger({
+  children,
+  trigger,
+  delay = 0,
+  class: className = "",
+  as = "div",
+}: StaggerProps) {
+  const ref = useRef<HTMLElement>(null);
+  const [visible, setVisible] = useState(false);
+  const isManual = trigger !== undefined;
+
+  useEffect(() => {
+    if (!isManual) return;
+    if (!trigger) {
+      setVisible(false);
+      return;
+    }
+    const t = setTimeout(() => setVisible(true), delay);
+    return () => clearTimeout(t);
+  }, [trigger, delay, isManual]);
+
+  useEffect(() => {
+    if (isManual) return;
+    const el = ref.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setTimeout(() => setVisible(true), delay);
+            observer.unobserve(entry.target);
+          }
+        }
+      },
+      { threshold: 0.1, rootMargin: "0px 0px -40px 0px" },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [delay, isManual]);
+
+  const Tag = as as keyof JSX.IntrinsicElements;
+  return (
+    <Tag
+      ref={ref as never}
+      class={`reveal-child ${visible ? "visible" : ""} ${className}`.trim()}
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,9 @@
+/**
+ * UI primitives barrel export.
+ *
+ * Motion primitives (W1-2) — viewport-entry or trigger-based reveals
+ * built on top of the global `.reveal` / `.reveal-child` CSS classes.
+ */
+export { default as CountUp } from "./CountUp";
+export { default as Reveal } from "./Reveal";
+export { default as Stagger } from "./Stagger";


### PR DESCRIPTION
## Summary
- Two Preact components wrapping existing global `.reveal` / `.reveal-child` CSS (already wired in `src/styles/global.css` line 706-757 + reduced-motion at line 753-757)
- `<Reveal>` — single-child fade + translateY entrance
- `<Stagger>` — multi-child auto-staggered entrance (80ms × index, up to 12 children)
- Two trigger modes: `auto` (IntersectionObserver, default) or `trigger={bool}` (flip on prop change — for orchestrated reveals after API responses)
- Barrel `src/components/ui/index.ts` exposes existing `CountUp` + new primitives

## Why
Foundation for W2-2 result reveal choreography (chart → count-up → verified badge → share-CTA stagger when /simulate response arrives). The CSS infrastructure is already in place — these wrappers just make it ergonomic to trigger from React state and provide the manual-trigger mode the global Layout.astro IntersectionObserver doesn't support.

## Scope (intentionally small)
| File | Purpose |
|---|---|
| `src/components/ui/Reveal.tsx` | single child wrapper, ~75 lines |
| `src/components/ui/Stagger.tsx` | multi-child wrapper, ~70 lines |
| `src/components/ui/index.ts` | barrel — exports CountUp + Reveal + Stagger |

## Test plan
- [x] `npm run build` → 1192 pages, 0 errors
- [x] `bash scripts/qa-redirects.sh` → PASS
- [x] No new CSS — fully reuses already-tested `.reveal` / `.reveal-child` classes
- [ ] Visual regression auto-runs (no surface-level changes — components not yet consumed)
- [ ] First consumer in W2-2 PR

## Not in this PR
- `<SlideIn>` directional variant — defer until concrete use case (current `.reveal-child` translateY covers result-panel scenario)
- Result reveal choreography itself — separate PR W2-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)