### PR TITLE
feat(i18n): formatKoNum — Korean idiomatic number formatting (W1-h)

### DIFF
--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -139,3 +139,74 @@ export function getCssVar(name: string): string {
     .getPropertyValue(name)
     .trim();
 }
+
+/**
+ * formatKoNum — Korean idiomatic number formatting.
+ *
+ * Korean numerals break at 만 (10,000) and 억 (10^8), not at thousands.
+ * `toLocaleString("ko-KR")` only inserts commas (Western grouping) — it
+ * doesn't compose the 만 / 억 idioms that feel native to Korean readers.
+ *
+ * Default (verbose) mode preserves precision but reads natively:
+ *   formatKoNum(123)          → "123"
+ *   formatKoNum(1_234)        → "1,234"
+ *   formatKoNum(12_345)       → "1만 2,345"
+ *   formatKoNum(1_234_567)    → "123만 4,567"
+ *   formatKoNum(12_345_678)   → "1,234만 5,678"
+ *   formatKoNum(123_456_789)  → "1억 2,345만 6,789"
+ *   formatKoNum(-12_345)      → "-1만 2,345"
+ *
+ * Compact mode rounds to one significant fraction:
+ *   formatKoNum(12_345,        { compact: true }) → "1.2만"
+ *   formatKoNum(1_234_567,     { compact: true }) → "123만"
+ *   formatKoNum(12_345_678,    { compact: true }) → "1,234만"
+ *   formatKoNum(123_456_789,   { compact: true }) → "1.2억"
+ *   formatKoNum(1_234_567_890, { compact: true }) → "12억"
+ *
+ * Use this in any user-facing numeric copy targeting Korean readers
+ * (KO `:lang(ko)` text, /ko/* pages, or trader-facing dollar/USDT amounts
+ * where a parallel KRW idiom feels more grounded).
+ */
+const EOK = 100_000_000;
+const MAN = 10_000;
+
+export function formatKoNum(
+  n: number,
+  opts: { compact?: boolean } = {},
+): string {
+  if (!Number.isFinite(n)) return String(n);
+  if (n === 0) return "0";
+  const sign = n < 0 ? "-" : "";
+  const v = Math.abs(n);
+
+  if (opts.compact) {
+    // Compact: round to 1 fraction. Drop fraction if >= 10 of the unit.
+    if (v >= EOK) {
+      const eok = v / EOK;
+      const formatted =
+        eok >= 10 ? Math.round(eok).toLocaleString("en-US") : eok.toFixed(1);
+      return `${sign}${formatted}억`;
+    }
+    if (v >= MAN) {
+      const man = v / MAN;
+      const formatted =
+        man >= 10 ? Math.round(man).toLocaleString("en-US") : man.toFixed(1);
+      return `${sign}${formatted}만`;
+    }
+    return `${sign}${Math.round(v).toLocaleString("en-US")}`;
+  }
+
+  // Verbose: preserve full precision, compose 억 / 만 / 단위 segments.
+  const eok = Math.floor(v / EOK);
+  const remAfterEok = v - eok * EOK;
+  const man = Math.floor(remAfterEok / MAN);
+  const ones = remAfterEok - man * MAN;
+
+  const parts: string[] = [];
+  if (eok > 0) parts.push(`${eok.toLocaleString("en-US")}억`);
+  if (man > 0) parts.push(`${man.toLocaleString("en-US")}만`);
+  if (ones > 0 || (eok === 0 && man === 0)) {
+    parts.push(ones.toLocaleString("en-US"));
+  }
+  return `${sign}${parts.join(" ")}`;
+}

--- a/tests/unit/formatKoNum.test.ts
+++ b/tests/unit/formatKoNum.test.ts
@@ -1,0 +1,86 @@
+/**
+ * formatKoNum.test.ts — contract test for Korean idiomatic number formatting.
+ */
+import { describe, expect, test } from "vitest";
+import { formatKoNum } from "../../src/utils/format";
+
+describe("formatKoNum (verbose)", () => {
+  test("zero → '0'", () => {
+    expect(formatKoNum(0)).toBe("0");
+  });
+
+  test("under 1만 → comma-grouped only", () => {
+    expect(formatKoNum(1)).toBe("1");
+    expect(formatKoNum(123)).toBe("123");
+    expect(formatKoNum(1234)).toBe("1,234");
+    expect(formatKoNum(9_999)).toBe("9,999");
+  });
+
+  test("1만 ~ 1억 — composes 만 segment + remainder", () => {
+    expect(formatKoNum(10_000)).toBe("1만");
+    expect(formatKoNum(12_345)).toBe("1만 2,345");
+    expect(formatKoNum(100_000)).toBe("10만");
+    expect(formatKoNum(1_234_567)).toBe("123만 4,567");
+    expect(formatKoNum(12_345_678)).toBe("1,234만 5,678");
+    expect(formatKoNum(99_999_999)).toBe("9,999만 9,999");
+  });
+
+  test("1억+ — composes 억 + 만 + remainder", () => {
+    expect(formatKoNum(100_000_000)).toBe("1억");
+    expect(formatKoNum(123_456_789)).toBe("1억 2,345만 6,789");
+    expect(formatKoNum(1_234_567_890)).toBe("12억 3,456만 7,890");
+  });
+
+  test("억 with no 만 segment skips 만 part", () => {
+    expect(formatKoNum(100_000_000)).toBe("1억");
+    expect(formatKoNum(100_000_500)).toBe("1억 500");
+  });
+
+  test("억 with no 단위 ones segment skips ones part", () => {
+    expect(formatKoNum(100_010_000)).toBe("1억 1만");
+  });
+
+  test("negative numbers preserve sign with 만/억 idioms", () => {
+    expect(formatKoNum(-12_345)).toBe("-1만 2,345");
+    expect(formatKoNum(-100_000_000)).toBe("-1억");
+  });
+
+  test("non-finite inputs are passed through as string", () => {
+    expect(formatKoNum(NaN)).toBe("NaN");
+    expect(formatKoNum(Infinity)).toBe("Infinity");
+  });
+});
+
+describe("formatKoNum (compact)", () => {
+  test("under 1만 → no suffix", () => {
+    expect(formatKoNum(0, { compact: true })).toBe("0");
+    expect(formatKoNum(123, { compact: true })).toBe("123");
+    expect(formatKoNum(9_999, { compact: true })).toBe("9,999");
+  });
+
+  test("1만 ~ 10만 → 1 fraction digit", () => {
+    expect(formatKoNum(12_345, { compact: true })).toBe("1.2만");
+    expect(formatKoNum(56_700, { compact: true })).toBe("5.7만");
+  });
+
+  test("10만+ → integer rounding", () => {
+    expect(formatKoNum(123_456, { compact: true })).toBe("12만");
+    expect(formatKoNum(1_234_567, { compact: true })).toBe("123만");
+    expect(formatKoNum(12_345_678, { compact: true })).toBe("1,235만");
+  });
+
+  test("1억 ~ 10억 → 1 fraction digit", () => {
+    expect(formatKoNum(123_456_789, { compact: true })).toBe("1.2억");
+    expect(formatKoNum(567_000_000, { compact: true })).toBe("5.7억");
+  });
+
+  test("10억+ → integer rounding", () => {
+    expect(formatKoNum(1_234_567_890, { compact: true })).toBe("12억");
+    expect(formatKoNum(12_345_678_901, { compact: true })).toBe("123억");
+  });
+
+  test("compact preserves negative sign", () => {
+    expect(formatKoNum(-1_234_567_890, { compact: true })).toBe("-12억");
+    expect(formatKoNum(-12_345, { compact: true })).toBe("-1.2만");
+  });
+});


### PR DESCRIPTION
## Summary
Korean numerals break at 만 (10,000) and 억 (10⁸), not at thousands. `toLocaleString("ko-KR")` only inserts Western-style commas — it doesn't compose the 만/억 idioms that feel native to Korean readers. `formatKoNum` fills that gap.

## Two modes
**Verbose** (default) — preserves precision, composes segments:
```
formatKoNum(123)         → "123"
formatKoNum(1_234)       → "1,234"
formatKoNum(12_345)      → "1만 2,345"
formatKoNum(1_234_567)   → "123만 4,567"
formatKoNum(12_345_678)  → "1,234만 5,678"
formatKoNum(123_456_789) → "1억 2,345만 6,789"
formatKoNum(-12_345)     → "-1만 2,345"
```

**Compact** — rounds to 1 fraction digit (or integer when ≥ 10 of the unit):
```
formatKoNum(12_345,        { compact: true }) → "1.2만"
formatKoNum(1_234_567,     { compact: true }) → "123만"
formatKoNum(12_345_678,    { compact: true }) → "1,235만"
formatKoNum(123_456_789,   { compact: true }) → "1.2억"
formatKoNum(1_234_567_890, { compact: true }) → "12억"
```

## Why
- Korean retail traders read "12억" much more fluently than "1.2 billion" or "1,234,567,890"
- Hero stats, trade counts, dollar amounts, coin counts — all feel more grounded with native idiom
- Pairs with future `formatKrw()` for KRW currency display

## Edge cases
| Input | Output |
|---|---|
| `0` | `"0"` |
| Negative | sign preserved before number (`"-1만 2,345"`) |
| `NaN` / `Infinity` | string passthrough (caller decides UX) |
| 1억 with no 만 segment | `"1억 500"` (skips zero 만 part) |
| 1억 with no ones segment | `"1억 1만"` (skips zero ones part) |

## Test coverage (14 tests)
- zero / sub-1만 / 1만-1억 boundary / 1억+ composition
- gap handling: 억 with no 만, 억 with no ones
- negative sign + 만/억 idioms
- non-finite passthrough
- compact: sub-1만 / 1만-10만 (1 fraction) / 10만+ (integer) / 1억-10억 (1 fraction) / 10억+ (integer)
- compact preserves negative sign

## Where this gets used (follow-up PRs)
- `/ko/*` user-facing numeric copy (current balance, total return, candle counts)
- Hero stats showing "12억 코인 분석" vs "1.2 billion candles processed"
- Live trade dollar amounts in KO pages

## Test plan
- [x] `npm run build` → 1192 pages, 0 errors
- [x] `bash scripts/qa-redirects.sh` → PASS
- [x] `npx vitest run tests/unit/formatKoNum.test.ts` → 14/14 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)