### PR TITLE
feat(theme): wire T key global shortcut to theme toggle (W5-3.1)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -742,7 +742,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <script is:inline>
       /* Theme toggle (PR-4 of light-mode rollout).
          FOUC-prevention head script (PR-5) sets data-theme before paint;
-         this handler only owns user clicks + icon swap. */
+         this handler owns user clicks + T key shortcut + icon swap. */
       (function() {
         var btn = document.getElementById('theme-toggle');
         if (!btn) return;
@@ -756,8 +756,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
             moon.classList.toggle('hidden', !isLight);
           }
         }
-        syncIcon();
-        btn.addEventListener('click', function() {
+        function toggle() {
           var isLight = document.documentElement.getAttribute('data-theme') === 'light';
           if (isLight) {
             document.documentElement.removeAttribute('data-theme');
@@ -767,6 +766,24 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
             try { localStorage.setItem('pruviq-theme', 'light'); } catch (_) {}
           }
           syncIcon();
+        }
+        syncIcon();
+        btn.addEventListener('click', toggle);
+        /* W5-3.1: T key global shortcut. Promised by KeyboardShortcuts
+           overlay (? key), now wired. Ignored when typing in inputs,
+           textareas, or contenteditable to avoid hijacking text entry.
+           Modifier keys (Cmd/Ctrl/Alt/Shift) are excluded so it doesn't
+           collide with browser shortcuts (e.g., Cmd+T for new tab). */
+        document.addEventListener('keydown', function(e) {
+          if (e.key !== 't' && e.key !== 'T') return;
+          if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
+          var t = e.target;
+          if (!t) return;
+          var tag = t.tagName;
+          if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+          if (t.isContentEditable) return;
+          e.preventDefault();
+          toggle();
         });
       })();
     </script>


### PR DESCRIPTION
## Summary
Closes a small open promise: KeyboardShortcuts overlay (#1431) catalogs **"T → toggle theme"** but the key wasn't actually wired. This PR wires it.

## Implementation
- Refactor existing click handler into shared `toggle()` function — single source of truth for the swap + localStorage persistence
- Add document-level `keydown` listener for `t` / `T`
- **Skip when modifier keys are held** (`Cmd/Ctrl/Alt/Shift`) — avoids collision with browser shortcuts like `Cmd+T` (new tab)
- **Skip when target is `INPUT` / `TEXTAREA` / `SELECT` / `contentEditable`** — avoids hijacking text entry
- `preventDefault()` so the keystroke doesn't propagate further

Inline script in Layout.astro (no new file) — stays consistent with the existing FOUC-prevention pattern (theme bootstrap is also inline).

## Verification
| Scenario | Behavior |
|---|---|
| `T` on body / button / link | Theme toggles |
| `T` inside `<input>` / `<textarea>` | Types literal "t" (no toggle) |
| `Cmd+T` | Opens new browser tab (no toggle, no preventDefault) |
| `Shift+T` | Types capital T (no toggle) |
| Click toggle button | Toggles (unchanged) |

## Test plan
- [x] `npm run build` → 1192 pages, 0 errors
- [x] `bash scripts/qa-redirects.sh` → PASS
- [ ] Manual: press T on /, /simulate, /strategies — theme flips; type t in CommandPalette search input — types literal t
- [ ] CI auto-runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)