### PR TITLE
fix(layout): bottom-cta IIFE references undefined `shown` (unblocks queue)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -837,9 +837,15 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
         if (!bar) return;
         if (localStorage.getItem('visited-simulator') || localStorage.getItem('bottom-cta-dismissed')) return;
         var cookieNotice = document.getElementById('cookie-notice');
+        /* Track local shown state — was previously referenced from
+           the sibling sticky-cta IIFE (`shown`) which is a different
+           closure scope, throwing "shown is not defined" on /market
+           when the IntersectionObserver callback fires. */
+        var shown = false;
         function tryShow() {
           if (cookieNotice && cookieNotice.style.display !== 'none' && window.innerWidth < 640) return;
           bar.style.transform = 'translateY(0)';
+          shown = true;
         }
         setTimeout(tryShow, 1500);
         /* Hide near footer */


### PR DESCRIPTION
## Summary
**Pre-existing bug surfaced by Playwright E2E flakes.** Every PR's `"data-render: /market/ should have no component-crashing JS errors"` test fails intermittently with `["shown is not defined"]`. **This flake is the load-bearing reason the merge queue has been stuck for ~1.5 hours** — PRs are CI-green when the IntersectionObserver callback doesn't fire the broken branch, CI-red when it does.

## Root cause
`Layout.astro` has two sticky-bar IIFEs:
1. **sticky-cta IIFE** — declares `var shown = false;` locally (line 796)
2. **bottom-cta IIFE** — references `shown` on line 851 **without declaring it locally**

Each IIFE is a separate closure scope so the bottom-cta cannot see the sticky-cta's `shown`. When the bottom-cta IntersectionObserver fires the `else if (shown)` branch (footer NOT in view), JS throws `ReferenceError: shown is not defined`.

The branch only fires when the user scrolls so footer goes from intersecting → not intersecting. This is timing-sensitive in tests, hence the flake.

## Fix
Track `shown` locally in the bottom-cta IIFE. Set to `true` inside `tryShow()` so the IntersectionObserver "scrolled past footer → show again" branch reads the right state.

```diff
+ /* Track local shown state */
+ var shown = false;
  function tryShow() {
    if (cookieNotice && cookieNotice.style.display !== 'none' && window.innerWidth < 640) return;
    bar.style.transform = 'translateY(0)';
+   shown = true;
  }
```

## Why this unblocks the queue
Every pending PR's CI runs this same Playwright test (data-render). The flake hits randomly across PRs:
- #1441 (service worker) currently shows the failure
- Other "BEHIND" PRs occasionally hit it
- `mergeStateStatus = UNKNOWN` for several PRs is correlated with the flake

After this fix lands, the test becomes deterministic → CI passes consistently → automerge picks up the queue.

## Test plan
- [x] `npm run build` → 1192 pages, 0 errors
- [x] `bash scripts/qa-redirects.sh` → PASS
- [ ] CI auto-runs — should pass deterministically (no `shown is not defined`)
- [ ] After merge, watch the queue: previously-flaky PRs should start merging within minutes

## Diff size
+6 lines, -0 lines. Surgical fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)