### PR TITLE
refactor(migration): Card primitive — HotStrategies + TopStrategyWidget (Migration B-1)

### DIFF
--- a/src/components/HotStrategies.tsx
+++ b/src/components/HotStrategies.tsx
@@ -7,6 +7,7 @@
 import { useState, useEffect } from "preact/hooks";
 import { API_BASE_URL as API_URL } from "../config/api";
 import { buildSimulatorUrl } from "../config/simulation-context";
+import Card from "./ui/Card";
 
 interface HotStrategy {
   strategy_id: string;
@@ -73,10 +74,15 @@ export default function HotStrategies({ lang = "en" }: { lang?: string }) {
           });
 
           return (
-            <a
+            <Card
               key={s.strategy_id + s.direction}
+              as="a"
               href={url}
-              class="block rounded-md border border-[--color-border] bg-[--color-bg-card] p-3 hover:border-[--color-warning]/40 transition-colors"
+              variant="default"
+              radius="sm"
+              padding="sm"
+              interactive
+              class="hover:border-[--color-warning]/40 no-underline"
             >
               <div class="flex items-center justify-between mb-1">
                 <span class="text-xs font-medium text-[--color-text]">
@@ -107,7 +113,7 @@ export default function HotStrategies({ lang = "en" }: { lang?: string }) {
                 <span>WR {s.win_rate.toFixed(0)}%</span>
                 <span>{s.total_trades}T</span>
               </div>
-            </a>
+            </Card>
           );
         })}
       </div>

--- a/src/components/TopStrategyWidget.tsx
+++ b/src/components/TopStrategyWidget.tsx
@@ -5,6 +5,7 @@
  */
 import { useState, useEffect } from "preact/hooks";
 import { API_BASE_URL } from "../config/api";
+import Card from "./ui/Card";
 
 interface RankingEntry {
   rank: number;
@@ -89,9 +90,10 @@ export function TopStrategyWidget({ lang = "en" }: { lang?: Lang }) {
 
   if (loading) {
     return (
-      <div
-        class="rounded-xl p-5 border border-[--color-border] bg-[--color-bg-card]"
-        style="box-shadow: var(--shadow-card);"
+      <Card
+        radius="lg"
+        padding="md"
+        class="shadow-[var(--shadow-card)]"
         aria-busy="true"
         aria-label={t.loading}
       >
@@ -115,7 +117,7 @@ export function TopStrategyWidget({ lang = "en" }: { lang?: Lang }) {
             </div>
           ))}
         </div>
-      </div>
+      </Card>
     );
   }
 
@@ -127,9 +129,10 @@ export function TopStrategyWidget({ lang = "en" }: { lang?: Lang }) {
   const name = lang === "ko" ? top.name_ko : top.name_en;
 
   return (
-    <div
-      class="rounded-xl border border-[--color-border-accent] bg-[--color-bg-card] overflow-hidden"
-      style="box-shadow: var(--shadow-accent-glow);"
+    <Card
+      radius="lg"
+      padding="none"
+      class="border-[--color-border-accent] overflow-hidden shadow-[var(--shadow-accent-glow)]"
     >
       {/* Header bar */}
       <div class="flex items-center justify-between px-5 py-3 border-b border-[--color-border] bg-[--color-bg]">
@@ -246,6 +249,6 @@ export function TopStrategyWidget({ lang = "en" }: { lang?: Lang }) {
           {t.disclaimer}
         </p>
       </div>
-    </div>
+    </Card>
   );
 }


### PR DESCRIPTION
## Summary
First batch of Migration B (Card primitive 30+ sites). Card primitive (#1420) already on main; these 2 components consume it directly.

## Changes
| File | Before | After |
|---|---|---|
| `HotStrategies.tsx` | inline `<a class="block rounded-md border bg-card p-3 hover:border-warning/40">` | `<Card as="a" href={url} variant="default" radius="sm" padding="sm" interactive>` polymorphic anchor |
| `TopStrategyWidget.tsx` | 2× inline `rounded-xl border bg-card` divs (loading skeleton + main widget) | 2× `<Card>` with custom shadow/border merge |

## Net effect
- Same visual output (no regression)
- Single token-enforced surface
- Future hover/focus/lift behavior changes propagate automatically
- Net diff: +20 / -11 lines

## Test plan
- [x] `npm run build` → 1192 pages, 0 errors
- [x] `bash scripts/qa-redirects.sh` → PASS
- [ ] Manual: /simulate (HotStrategies render), homepage (TopStrategyWidget loading + loaded states)
- [ ] CI auto-runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)