### PR TITLE
refactor(migration): Card primitive — ExchangeCTA + SimulatorPage loading shell (B-2)

### DIFF
--- a/src/components/ExchangeCTA.tsx
+++ b/src/components/ExchangeCTA.tsx
@@ -1,4 +1,5 @@
 import { exchanges, type Exchange } from "../data/exchanges";
+import Card from "./ui/Card";
 
 interface Props {
   /** Display mode: 'inline' for table rows, 'card' for full-width */
@@ -90,17 +91,22 @@ export default function ExchangeCTA({
 
   // Card mode (full-width)
   return (
-    <div class="border border-[--color-border] rounded-xl bg-[--color-bg-card] p-6 mt-6">
+    <Card variant="default" padding="lg" radius="lg" class="mt-6">
       <h3 class="text-sm font-bold mb-1">{t.heading}</h3>
       <p class="text-[0.75rem] text-[--color-text-muted] mb-4">{t.subtext}</p>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
         {available.map((ex) => (
-          <a
+          <Card
             key={ex.id}
+            as="a"
             href={buildUrl(ex, coin, strategy)}
             target="_blank"
             rel="noopener noreferrer sponsored"
-            class="flex items-center justify-between p-3 rounded-lg border border-[--color-border] hover:border-[--color-accent] transition-colors group"
+            variant="default"
+            padding="sm"
+            radius="md"
+            interactive
+            class="group flex items-center justify-between"
           >
             <div>
               <div class="font-semibold text-sm">{ex.name}</div>
@@ -117,12 +123,12 @@ export default function ExchangeCTA({
             >
               {t.signup} &rarr;
             </span>
-          </a>
+          </Card>
         ))}
       </div>
       <p class="text-[0.5625rem] text-[--color-text-muted] mt-3">
         {t.disclosure}
       </p>
-    </div>
+    </Card>
   );
 }

--- a/src/components/SimulatorPage.tsx
+++ b/src/components/SimulatorPage.tsx
@@ -32,6 +32,7 @@ import HotStrategies from "./HotStrategies";
 import StandardPanel from "./StandardPanel";
 import AchievementBadges from "./AchievementBadges";
 import LoadingEquityAnimation from "./LoadingEquityAnimation";
+import Card from "./ui/Card";
 
 // ─── i18n ───
 const L = {
@@ -1793,13 +1794,18 @@ export default function SimulatorPage({
       >
         {/* Phase 1.5: Loading animation replaces empty results area */}
         {isRunning && !result && (
-          <div class="rounded-xl border border-[--color-border] bg-[--color-bg-card] overflow-hidden">
+          <Card
+            variant="default"
+            padding="none"
+            radius="lg"
+            class="overflow-hidden"
+          >
             <LoadingEquityAnimation
               t={t}
               progressStep={progressStep}
               elapsedSec={elapsedSec}
             />
-          </div>
+          </Card>
         )}
         <ResultsPanel
           t={t}

--- a/src/components/simulator/v1/OKXConnectCTA.tsx
+++ b/src/components/simulator/v1/OKXConnectCTA.tsx
@@ -8,6 +8,7 @@ import {
   type Lang,
 } from "../../../i18n/index";
 import { emit } from "../../../lib/events";
+import Card from "../../ui/Card";
 
 interface Props {
   lang: Lang;
@@ -29,9 +30,13 @@ export default function OKXConnectCTA({ lang, presetId }: Props) {
         ? "시뮬레이션 결과를 OKX에서 자동으로 실행하는 기능을 준비 중입니다. 현재는 백테스트 + 검증만 무료로 사용 가능합니다."
         : "We're building a way to auto-execute your simulation on OKX. For now, backtesting + verification stay fully free.";
     return (
-      <section
+      <Card
+        as="section"
         aria-label={heading}
-        class="rounded-xl border border-[--color-border] bg-[--color-bg-card] p-6 text-center"
+        variant="default"
+        padding="lg"
+        radius="lg"
+        class="text-center"
         data-testid="sim-v1-okx-cta"
       >
         <div class="mb-3 flex items-center justify-center gap-2">
@@ -64,7 +69,7 @@ export default function OKXConnectCTA({ lang, presetId }: Props) {
             {t("simV2.cta.learn_more")}
           </a>
         </div>
-      </section>
+      </Card>
     );
   }
 


### PR DESCRIPTION
## Summary
Continuing Migration B (Card primitive #1420). 3 more inline-card sites:

1. **ExchangeCTA.tsx** — outer card mode panel + per-exchange anchor cards
   - Before: hand-written `rounded-xl border bg-card p-6` + `rounded-lg border hover:border-accent` per row
   - After: `<Card padding=lg>` outer + `<Card as=a interactive>` per exchange. Hover lift now from primitive.

2. **SimulatorPage.tsx** — loading-animation shell wrapper
   - Before: inline `rounded-xl border bg-card overflow-hidden`
   - After: `<Card padding=none radius=lg class=overflow-hidden>` (LoadingEquityAnimation owns internal spacing)

## Cumulative Card adoption
- B-1 #1448: HotStrategies + TopStrategyWidget (2 components, 3 sites)
- B-2 (this PR): ExchangeCTA + SimulatorPage (2 components, 3 sites)
- **Total: 6 inline cards consolidated → primitive**

## Build
- 1192 pages, qa-redirects: PASS
- Simulator smoke check: ✅

## Test plan
- [x] `npm run build`
- [x] `qa-redirects` PASS
- [ ] /simulate visual: loading state still rounded
- [ ] /strategies/ranking: ExchangeCTA card mode unchanged
- [ ] Mobile + KO render