### PR TITLE
refactor(migration): Card primitive — CommandPalette panel (B-3)

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -4,6 +4,7 @@
  * Keyboard navigation: ↑↓ to move, Enter to select, Esc to close.
  */
 import { useState, useEffect, useRef, useCallback } from "preact/hooks";
+import Card from "./ui/Card";
 
 interface SearchItem {
   label: string;
@@ -293,7 +294,12 @@ export default function CommandPalette({ lang = "en" }: Props) {
       <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" />
 
       {/* Palette */}
-      <div class="relative w-full max-w-lg mx-4 rounded-xl border border-[--color-border] bg-[--color-bg-card] shadow-2xl overflow-hidden">
+      <Card
+        variant="default"
+        padding="none"
+        radius="lg"
+        class="relative w-full max-w-lg mx-4 shadow-2xl overflow-hidden"
+      >
         {/* Search input */}
         <div class="flex items-center gap-3 px-4 py-3 border-b border-[--color-border]">
           <svg
@@ -390,7 +396,7 @@ export default function CommandPalette({ lang = "en" }: Props) {
           <span>↵ open</span>
           <span>esc close</span>
         </div>
-      </div>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Continuing Migration B (Card primitive #1420). One more inline-card site:

**CommandPalette.tsx** — the cmd-K palette panel.
- Before: `<div class="rounded-xl border bg-card shadow-2xl overflow-hidden">`
- After: `<Card variant=default padding=none radius=lg class="shadow-2xl overflow-hidden">`

Kept shadow-2xl in `class` since Card's `elevated` variant uses shadow-md (smaller). The container parent retains `role=dialog`/`aria-modal` — Card is for the inner panel only.

## Cumulative B series
- B-1 #1448: HotStrategies + TopStrategyWidget (3 sites)
- B-2 #1450: ExchangeCTA + SimulatorPage + OKXConnectCTA (4 sites)
- **B-3 (this PR): CommandPalette (1 site)**
- **Total: 8 inline cards consolidated → primitive**

## Build
- 1192 pages, qa-redirects: PASS

## Test plan
- [x] `npm run build`
- [x] `qa-redirects` PASS
- [ ] Cmd-K opens palette, panel visually unchanged
- [ ] esc + ↑↓ + ↵ keyboard nav still works