### PR TITLE
refactor(migration): Card primitive — LearnProgress + PerformanceDashboard (B-4)

### DIFF
--- a/src/components/LearnProgress.tsx
+++ b/src/components/LearnProgress.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "preact/hooks";
+import Card from "./ui/Card";
 
 interface Props {
   postIds: string[];
@@ -46,7 +47,12 @@ export default function LearnProgress({ postIds, lang = "en" }: Props) {
   if (total === 0) return null;
 
   return (
-    <div class="mb-8 p-4 rounded-xl bg-[--color-bg-card] border border-[--color-border] shadow-[var(--shadow-sm)]">
+    <Card
+      variant="default"
+      padding="md"
+      radius="lg"
+      class="mb-8 shadow-[var(--shadow-sm)]"
+    >
       <div class="flex items-center justify-between mb-2">
         <span class="font-mono text-xs text-[--color-text-muted] uppercase tracking-wider">
           {t.progress}
@@ -68,7 +74,7 @@ export default function LearnProgress({ postIds, lang = "en" }: Props) {
           }}
         />
       </div>
-    </div>
+    </Card>
   );
 }
 

--- a/src/components/PerformanceDashboard.tsx
+++ b/src/components/PerformanceDashboard.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "preact/hooks";
 import { COINS_ANALYZED } from "../config/site-stats";
+import Card from "./ui/Card";
 import {
   formatPrice,
   formatUsd,
@@ -148,7 +149,12 @@ function MetricCard({
   color: string;
 }) {
   return (
-    <div class="p-3 md:p-4 rounded-lg bg-[--color-bg-card] border border-[--color-border] text-center min-w-0">
+    <Card
+      variant="default"
+      padding="none"
+      radius="md"
+      class="p-3 md:p-4 text-center min-w-0"
+    >
       <div class="font-mono text-[0.6875rem] text-[--color-text-muted] uppercase tracking-wider mb-1.5 whitespace-nowrap overflow-hidden text-ellipsis">
         {label}
       </div>
@@ -158,7 +164,7 @@ function MetricCard({
       >
         {value}
       </div>
-    </div>
+    </Card>
   );
 }
 
@@ -166,13 +172,16 @@ function SkeletonMetrics() {
   return (
     <div class="grid grid-cols-2 md:grid-cols-5 gap-3 mb-6">
       {Array.from({ length: 5 }, (_, i) => (
-        <div
+        <Card
           key={i}
-          class="p-3 md:p-4 rounded-lg bg-[--color-bg-card] border border-[--color-border] text-center"
+          variant="default"
+          padding="none"
+          radius="md"
+          class="p-3 md:p-4 text-center"
         >
           <div class="skeleton h-2.5 w-16 mx-auto mb-3" />
           <div class="skeleton h-5 w-20 mx-auto" />
-        </div>
+        </Card>
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
Two more inline-card sites adopt Card primitive (#1420):

1. **LearnProgress.tsx** — /learn page reading-progress panel
   - `<Card padding=md radius=lg class="mb-8 shadow-sm">` (1 site)

2. **PerformanceDashboard.tsx** — stat tile + 5x skeleton loader
   - `<Card padding=none class="p-3 md:p-4 ...">` (custom padding kept for responsive breakpoint)
   - 6 sites in this file (1 stat tile component + 5 skeleton loop)

## Cumulative Card adoption
| PR | Sites | Files |
|----|-------|-------|
| #1448 (B-1) | 3 | HotStrategies, TopStrategyWidget |
| #1450 (B-2) | 4 | ExchangeCTA, SimulatorPage, OKXConnectCTA |
| #1451 (B-3) | 1 | CommandPalette |
| **this** (B-4) | 2 | LearnProgress, PerformanceDashboard |
| **Total** | **10** | **8 components** |

## Build
- 1192 pages, qa-redirects: PASS

## Test plan
- [x] `npm run build`
- [x] `qa-redirects` PASS
- [ ] /learn: progress card unchanged
- [ ] /performance: 5 stat tiles + skeleton loader unchanged