### PR TITLE
feat(motion): result reveal choreography + Reveal/Stagger import fix (W2-2)

### DIFF
--- a/src/components/simulator/v1/ResultsPanel.tsx
+++ b/src/components/simulator/v1/ResultsPanel.tsx
@@ -16,6 +16,7 @@ import { API_BASE_URL } from "../../../config/api";
 import type { SimConfig } from "../../../hooks/useSimConfig";
 import { useTranslations, type Lang } from "../../../i18n/index";
 import { emit } from "../../../lib/events";
+import Reveal from "../../ui/Reveal";
 
 interface Props {
   config: SimConfig;
@@ -267,10 +268,19 @@ export default function ResultsPanel({ config, lang }: Props) {
   const d = state.data;
   const returnPositive = d.total_return_pct >= 0;
   const verdict = buildVerdict(d, lang);
+  // W2-2 reveal choreography: trigger fires when results land. The
+  // wrapper also carries `.reveal-child`, so when `.visible` is added
+  // its direct children fade up using the 80ms-staggered nth-child
+  // delays from global.css (line 727-745). Visual narrative is metric
+  // grid → verdict → footer-row (numbers first, interpretation second,
+  // actions last). `prefers-reduced-motion: reduce` is honored
+  // automatically (global.css line 752-756). data-testid passes through
+  // Reveal's rest spread so existing E2E selectors keep working.
   return (
-    <div
+    <Reveal
+      trigger={state.kind === "ok"}
+      class="reveal-child rounded-xl border border-(--color-border) bg-(--color-bg-card)/60 p-5 shadow-sm"
       data-testid="sim-v1-results-ok"
-      class="rounded-xl border border-(--color-border) bg-(--color-bg-card)/60 p-5 shadow-sm"
     >
       <div class="grid grid-cols-2 gap-4 md:grid-cols-4">
         <Metric
@@ -364,14 +374,15 @@ export default function ResultsPanel({ config, lang }: Props) {
           {lang === "ko" ? "CSV 다운로드" : "Download CSV"} ↓
         </button>
       </div>
-    </div>
+    </Reveal>
   );
 }
 
 function verdictTone(tone: "good" | "bad" | "neutral"): string {
   if (tone === "good")
     return "border-(--color-up)/30 bg-(--color-up)/10 text-(--color-up)";
-  if (tone === "bad") return "border-(--color-down)/30 bg-(--color-down)/10 text-(--color-down)";
+  if (tone === "bad")
+    return "border-(--color-down)/30 bg-(--color-down)/10 text-(--color-down)";
   return "border-(--color-verified)/20 bg-(--color-verified-subtle) text-(--color-verified)";
 }
 
@@ -470,14 +481,18 @@ function SkeletonFrame({
 function MetricGridSkeleton({ shimmer }: { shimmer?: boolean }) {
   const base =
     "h-10 rounded " +
-    (shimmer ? "animate-pulse bg-(--color-bg-elevated)" : "bg-(--color-bg-elevated)/60");
+    (shimmer
+      ? "animate-pulse bg-(--color-bg-elevated)"
+      : "bg-(--color-bg-elevated)/60");
   return (
     <div class="grid grid-cols-2 gap-4 md:grid-cols-4">
       {[0, 1, 2, 3].map((i) => (
         <div key={i}>
           <div
             class={`mb-2 h-3 w-16 rounded ${
-              shimmer ? "animate-pulse bg-(--color-bg-elevated)" : "bg-(--color-bg-elevated)/60"
+              shimmer
+                ? "animate-pulse bg-(--color-bg-elevated)"
+                : "bg-(--color-bg-elevated)/60"
             }`}
           />
           <div class={base} />

--- a/src/components/ui/Reveal.tsx
+++ b/src/components/ui/Reveal.tsx
@@ -10,7 +10,8 @@
  * `prefers-reduced-motion: reduce` is honored by the global CSS rule
  * (line 753-757) — children stay visible without transition.
  */
-import { useEffect, useRef, useState, type ComponentChildren } from "preact";
+import type { ComponentChildren, JSX } from "preact";
+import { useEffect, useRef, useState } from "preact/hooks";
 
 interface RevealProps {
   children: ComponentChildren;
@@ -22,6 +23,12 @@ interface RevealProps {
   class?: string;
   /** Wrapper element type (default `div`) */
   as?: "div" | "section" | "article" | "li" | "span";
+  /** Pass-through ARIA / data attributes for testing + a11y. */
+  "data-testid"?: string;
+  "aria-label"?: string;
+  "aria-live"?: JSX.HTMLAttributes["aria-live"];
+  role?: string;
+  id?: string;
 }
 
 export default function Reveal({
@@ -30,6 +37,7 @@ export default function Reveal({
   delay = 0,
   class: className = "",
   as = "div",
+  ...rest
 }: RevealProps) {
   const ref = useRef<HTMLElement>(null);
   const [visible, setVisible] = useState(false);
@@ -71,6 +79,7 @@ export default function Reveal({
     <Tag
       ref={ref as never}
       class={`reveal ${visible ? "visible" : ""} ${className}`.trim()}
+      {...rest}
     >
       {children}
     </Tag>

--- a/src/components/ui/Stagger.tsx
+++ b/src/components/ui/Stagger.tsx
@@ -11,7 +11,7 @@
  * `prefers-reduced-motion: reduce` is honored by the global CSS rule
  * (line 753-757) — all children stay visible with no transition.
  */
-import type { ComponentChildren } from "preact";
+import type { ComponentChildren, JSX } from "preact";
 import { useEffect, useRef, useState } from "preact/hooks";
 
 interface StaggerProps {
@@ -24,6 +24,12 @@ interface StaggerProps {
   class?: string;
   /** Wrapper element type (default `div`) */
   as?: "div" | "section" | "ul" | "ol";
+  /** Pass-through ARIA / data attributes (parity with Reveal). */
+  "data-testid"?: string;
+  "aria-label"?: string;
+  "aria-live"?: JSX.HTMLAttributes["aria-live"];
+  role?: string;
+  id?: string;
 }
 
 export default function Stagger({
@@ -32,6 +38,7 @@ export default function Stagger({
   delay = 0,
   class: className = "",
   as = "div",
+  ...rest
 }: StaggerProps) {
   const ref = useRef<HTMLElement>(null);
   const [visible, setVisible] = useState(false);
@@ -71,6 +78,7 @@ export default function Stagger({
     <Tag
       ref={ref as never}
       class={`reveal-child ${visible ? "visible" : ""} ${className}`.trim()}
+      {...rest}
     >
       {children}
     </Tag>

--- a/src/components/ui/Stagger.tsx
+++ b/src/components/ui/Stagger.tsx
@@ -11,7 +11,8 @@
  * `prefers-reduced-motion: reduce` is honored by the global CSS rule
  * (line 753-757) — all children stay visible with no transition.
  */
-import { useEffect, useRef, useState, type ComponentChildren } from "preact";
+import type { ComponentChildren } from "preact";
+import { useEffect, useRef, useState } from "preact/hooks";
 
 interface StaggerProps {
   children: ComponentChildren;

--- a/tests/unit/Reveal.test.tsx
+++ b/tests/unit/Reveal.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Reveal.test.tsx — contract test for W1-2 / W2-2.
+ *
+ * Covers the manual `trigger` mode + the typed pass-through props that
+ * W2-2 added (data-testid, aria-label, aria-live, role, id). The `as`
+ * polymorphic prop is also exercised so consumers know they can wrap
+ * <section> / <article> / <li> / <span> without losing semantics.
+ *
+ * IntersectionObserver auto-mode isn't tested here — happy-dom doesn't
+ * polyfill IO and the existing global Layout.astro observer covers
+ * that path in E2E.
+ */
+import { describe, expect, test, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/preact";
+import Reveal from "../../src/components/ui/Reveal";
+
+afterEach(cleanup);
+
+describe("Reveal primitive — manual trigger mode", () => {
+  test("default tag is <div> with .reveal class", () => {
+    const { container } = render(
+      <Reveal trigger={false}>
+        <span>child</span>
+      </Reveal>,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.tagName.toLowerCase()).toBe("div");
+    expect(root.className).toContain("reveal");
+  });
+
+  test("trigger=false renders without .visible (initial fade-out state)", () => {
+    const { container } = render(
+      <Reveal trigger={false}>
+        <span>child</span>
+      </Reveal>,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).not.toContain("visible");
+  });
+
+  test("merges custom class with .reveal", () => {
+    const { container } = render(
+      <Reveal trigger={false} class="my-extra reveal-child">
+        <span>child</span>
+      </Reveal>,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toContain("reveal");
+    expect(root.className).toContain("my-extra");
+    expect(root.className).toContain("reveal-child");
+  });
+
+  test("data-testid passes through to wrapper element", () => {
+    const { container } = render(
+      <Reveal trigger={false} data-testid="my-reveal">
+        <span>child</span>
+      </Reveal>,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.getAttribute("data-testid")).toBe("my-reveal");
+  });
+
+  test("aria-label, aria-live, role, id pass through", () => {
+    const { container } = render(
+      <Reveal
+        trigger={false}
+        aria-label="results"
+        aria-live="polite"
+        role="status"
+        id="results-region"
+      >
+        <span>child</span>
+      </Reveal>,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.getAttribute("aria-label")).toBe("results");
+    expect(root.getAttribute("aria-live")).toBe("polite");
+    expect(root.getAttribute("role")).toBe("status");
+    expect(root.getAttribute("id")).toBe("results-region");
+  });
+
+  test("as='section' renders <section> while keeping reveal class", () => {
+    const { container } = render(
+      <Reveal trigger={false} as="section" data-testid="sect">
+        <span>child</span>
+      </Reveal>,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.tagName.toLowerCase()).toBe("section");
+    expect(root.className).toContain("reveal");
+    expect(root.getAttribute("data-testid")).toBe("sect");
+  });
+
+  test("renders children content", () => {
+    const { container } = render(
+      <Reveal trigger={false}>
+        <span data-testid="payload">hello</span>
+      </Reveal>,
+    );
+    const payload = container.querySelector(
+      "[data-testid='payload']",
+    ) as HTMLElement;
+    expect(payload).toBeTruthy();
+    expect(payload.textContent).toBe("hello");
+  });
+});

--- a/tests/unit/Stagger.test.tsx
+++ b/tests/unit/Stagger.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Stagger.test.tsx — contract test for W1-2 / W2-2.
+ *
+ * Mirror of Reveal.test.tsx since Stagger has the same manual `trigger`
+ * mode + the same typed pass-through props. The 80ms cascade itself is
+ * pure CSS (.reveal-child > * { transition-delay: nth-child × 80ms })
+ * and is verified at the page level by visual regression / E2E.
+ */
+import { describe, expect, test, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/preact";
+import Stagger from "../../src/components/ui/Stagger";
+
+afterEach(cleanup);
+
+describe("Stagger primitive — manual trigger mode", () => {
+  test("default tag is <div> with .reveal-child class", () => {
+    const { container } = render(
+      <Stagger trigger={false}>
+        <span>a</span>
+        <span>b</span>
+      </Stagger>,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.tagName.toLowerCase()).toBe("div");
+    expect(root.className).toContain("reveal-child");
+  });
+
+  test("trigger=false renders without .visible (initial fade-out)", () => {
+    const { container } = render(
+      <Stagger trigger={false}>
+        <span>a</span>
+      </Stagger>,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).not.toContain("visible");
+  });
+
+  test("merges custom class with .reveal-child", () => {
+    const { container } = render(
+      <Stagger trigger={false} class="grid grid-cols-3">
+        <span>a</span>
+      </Stagger>,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toContain("reveal-child");
+    expect(root.className).toContain("grid");
+    expect(root.className).toContain("grid-cols-3");
+  });
+
+  test("data-testid passes through to wrapper", () => {
+    const { container } = render(
+      <Stagger trigger={false} data-testid="my-stagger">
+        <span>a</span>
+      </Stagger>,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.getAttribute("data-testid")).toBe("my-stagger");
+  });
+
+  test("aria-label, aria-live, role, id pass through", () => {
+    const { container } = render(
+      <Stagger
+        trigger={false}
+        aria-label="card grid"
+        aria-live="polite"
+        role="list"
+        id="stagger-region"
+      >
+        <span>a</span>
+      </Stagger>,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.getAttribute("aria-label")).toBe("card grid");
+    expect(root.getAttribute("aria-live")).toBe("polite");
+    expect(root.getAttribute("role")).toBe("list");
+    expect(root.getAttribute("id")).toBe("stagger-region");
+  });
+
+  test("as='ul' renders <ul> while keeping reveal-child class", () => {
+    const { container } = render(
+      <Stagger trigger={false} as="ul" data-testid="lst">
+        <li>a</li>
+        <li>b</li>
+      </Stagger>,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.tagName.toLowerCase()).toBe("ul");
+    expect(root.className).toContain("reveal-child");
+    expect(root.getAttribute("data-testid")).toBe("lst");
+  });
+
+  test("renders all children", () => {
+    const { container } = render(
+      <Stagger trigger={false}>
+        <span data-testid="c1">A</span>
+        <span data-testid="c2">B</span>
+        <span data-testid="c3">C</span>
+      </Stagger>,
+    );
+    expect(container.querySelector("[data-testid='c1']")?.textContent).toBe(
+      "A",
+    );
+    expect(container.querySelector("[data-testid='c2']")?.textContent).toBe(
+      "B",
+    );
+    expect(container.querySelector("[data-testid='c3']")?.textContent).toBe(
+      "C",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
W2-2 result reveal choreography. When `/simulate` returns results, the panel
fades up and its 4 metric tiles + verdict badge + footer row stagger in via
the existing `.reveal-child` 80ms cascade CSS.

Order = visual narrative: **metrics → verdict → actions** (numbers first,
interpretation second, share/CSV last).

`prefers-reduced-motion: reduce` honored automatically (global.css line 752-756).

## Root-cause fix bundled

Found a latent bug in `Reveal.tsx` + `Stagger.tsx` (#1411 W1-2): both imported
`useEffect`, `useRef`, `useState` from `"preact"`. Preact exports those hooks
from `"preact/hooks"`. Dev mode was lenient; production rollup trips on it
the moment a downstream importer triggers a fresh bind. Fixed in same PR
since W2-2 was the trigger that surfaced it.

```ts
// before
import { useEffect, useRef, useState, type ComponentChildren } from "preact";

// after
import type { ComponentChildren } from "preact";
import { useEffect, useRef, useState } from "preact/hooks";
```

Reveal also gained typed pass-through for the attributes this primitive
actually needs (`data-testid`, `aria-label`, `aria-live`, `role`, `id`).
Spread is intentionally narrow — TypeScript still catches typos.

## Files
- `~` `src/components/ui/Reveal.tsx` — fix import + typed rest spread
- `~` `src/components/ui/Stagger.tsx` — fix import (same bug)
- `~` `src/components/simulator/v1/ResultsPanel.tsx` — wrap OK branch in
  `<Reveal trigger={state.kind === "ok"} class="reveal-child ...">`

## Build
- 1192 pages, qa-redirects: PASS
- Simulator smoke check: ✅

## Test plan
- [x] `npm run build` 0 errors
- [x] `qa-redirects` PASS
- [ ] /simulate result panel: 4 metrics fade up sequentially after API return
- [ ] Re-run sim → metrics fade in again
- [ ] reduced-motion: no animation, immediate visible
- [ ] EN + KO render