### PR TITLE
feat(motion): homepage section reveal — fade-up entrance on scroll

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -112,7 +112,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- HOW IT WORKS -->
   <hr class="section-divider" />
-  <section class="max-w-7xl mx-auto px-6 py-24 md:py-32 section-elevated">
+  <section class="reveal max-w-7xl mx-auto px-6 py-24 md:py-32 section-elevated">
     <p class="font-mono text-[--color-accent] text-sm tracking-wider text-center mb-4">HOW IT WORKS</p>
     <h2 class="text-3xl md:text-4xl lg:text-5xl font-extrabold text-center mb-5">Three Steps to Verified Results</h2>
     <p class="text-[--color-text-secondary] text-center text-xl mb-14 max-w-xl mx-auto">From strategy idea to data-backed decision.</p>
@@ -153,7 +153,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- HOW AUTOTRADING WORKS -->
   <hr class="section-divider" />
-  <section class="max-w-7xl mx-auto px-6 py-24 md:py-32 section-elevated" aria-labelledby="autotrading-heading">
+  <section class="reveal max-w-7xl mx-auto px-6 py-24 md:py-32 section-elevated" aria-labelledby="autotrading-heading">
     <p class="font-mono text-[--color-accent] text-sm tracking-wider text-center mb-4">AUTOTRADING</p>
     <h2 id="autotrading-heading" class="text-3xl md:text-4xl lg:text-5xl font-extrabold text-center mb-5">From Verified Strategy to Running Bot</h2>
     <p class="text-[--color-text-secondary] text-center text-xl mb-14 max-w-xl mx-auto">Backtested. Verified. Executing 24/7 on OKX.</p>
@@ -174,7 +174,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- COMPARISON TABLE -->
   <hr class="section-divider" />
-  <section class="py-24 md:py-32 section-accent-glow">
+  <section class="reveal py-24 md:py-32 section-accent-glow">
     <div class="max-w-4xl mx-auto px-6">
       <p class="font-mono text-[--color-accent] text-sm mb-3 tracking-wider text-center">{t('compare.section_tag')}</p>
       <h2 class="text-3xl md:text-4xl lg:text-5xl font-extrabold text-center mb-16">{t('compare.section_title')}</h2>
@@ -210,7 +210,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- WHY PRUVIQ (Merged Problem + Evidence) -->
   <hr class="section-divider" />
-  <section class="py-24 md:py-32 section-warm-glow" aria-labelledby="why-heading">
+  <section class="reveal py-24 md:py-32 section-warm-glow" aria-labelledby="why-heading">
     <div class="max-w-7xl mx-auto px-6">
       <p class="font-mono text-[--color-down] text-sm mb-3 tracking-wider">{t('problem.tag')}</p>
       <h2 id="why-heading" class="text-3xl md:text-4xl font-bold mb-5">{t('problem.title')}</h2>
@@ -257,7 +257,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- FEATURES & TRUST (Merged) -->
   <hr class="section-divider" />
-  <section class="py-24 md:py-32 section-elevated" aria-labelledby="features-heading">
+  <section class="reveal py-24 md:py-32 section-elevated" aria-labelledby="features-heading">
     <div class="max-w-7xl mx-auto px-6">
       <p class="font-mono text-[--color-accent] text-sm mb-3 tracking-wider">{t('features.tag')}</p>
       <h2 id="features-heading" class="text-3xl md:text-4xl font-bold mb-14">{t('features.title')}</h2>
@@ -342,7 +342,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- FAQ (visible section matching JSON-LD) -->
   <hr class="section-divider" />
-  <section class="py-24 md:py-32 section-accent-glow" aria-labelledby="faq-heading">
+  <section class="reveal py-24 md:py-32 section-accent-glow" aria-labelledby="faq-heading">
     <div class="max-w-7xl mx-auto px-6">
       <p class="font-mono text-[--color-accent] text-sm mb-3 tracking-wider">FAQ</p>
       <h2 id="faq-heading" class="text-3xl md:text-4xl font-bold mb-14">{t('faq.title')}</h2>
@@ -368,7 +368,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- CTA -->
   <hr class="section-divider" />
-  <section class="relative pt-24 pb-20 md:pt-32 md:pb-28 overflow-hidden section-glow-cyan" aria-labelledby="cta-heading">
+  <section class="reveal relative pt-24 pb-20 md:pt-32 md:pb-28 overflow-hidden section-glow-cyan" aria-labelledby="cta-heading">
     <!-- Background glow orb -->
     <div class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[400px] rounded-full bg-[--color-accent]/[0.06] blur-[120px] pointer-events-none" aria-hidden="true"></div>
     <div class="relative max-w-7xl mx-auto px-6 text-center">

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -112,7 +112,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- HOW IT WORKS -->
   <hr class="section-divider" />
-  <section class="max-w-7xl mx-auto px-6 py-24 md:py-32 section-elevated">
+  <section class="reveal max-w-7xl mx-auto px-6 py-24 md:py-32 section-elevated">
     <p class="font-mono text-[--color-accent] text-sm tracking-wider text-center mb-4">{t('how.tag')}</p>
     <h2 class="text-3xl md:text-4xl lg:text-5xl font-extrabold text-center mb-5">작동 방식</h2>
     <p class="text-[--color-text-secondary] text-center text-xl mb-20 max-w-xl mx-auto">전략 아이디어에서 검증된 결과까지 3단계.</p>
@@ -150,7 +150,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- HOW AUTOTRADING WORKS -->
   <hr class="section-divider" />
-  <section class="max-w-7xl mx-auto px-6 py-24 md:py-32 section-elevated" aria-labelledby="autotrading-ko-heading">
+  <section class="reveal max-w-7xl mx-auto px-6 py-24 md:py-32 section-elevated" aria-labelledby="autotrading-ko-heading">
     <p class="font-mono text-[--color-accent] text-sm tracking-wider text-center mb-4">자동매매</p>
     <h2 id="autotrading-ko-heading" class="text-3xl md:text-4xl lg:text-5xl font-extrabold text-center mb-5">검증된 전략에서 실행 봇까지</h2>
     <p class="text-[--color-text-secondary] text-center text-xl mb-14 max-w-xl mx-auto">백테스트 완료. 검증됨. OKX에서 24시간 실행.</p>
@@ -171,7 +171,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- COMPARISON TABLE -->
   <hr class="section-divider" />
-  <section class="py-24 md:py-32 section-accent-glow">
+  <section class="reveal py-24 md:py-32 section-accent-glow">
     <div class="max-w-4xl mx-auto px-6">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider text-center">{t('compare.section_tag')}</p>
       <h2 class="text-3xl md:text-4xl lg:text-5xl font-extrabold text-center mb-16">{t('compare.section_title')}</h2>
@@ -207,7 +207,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- WHY PRUVIQ (Merged Problem + Evidence) -->
   <hr class="section-divider" />
-  <section class="py-24 md:py-32 section-warm-glow" aria-labelledby="why-heading-ko">
+  <section class="reveal py-24 md:py-32 section-warm-glow" aria-labelledby="why-heading-ko">
     <div class="max-w-7xl mx-auto px-6">
       <p class="font-mono text-[--color-down] text-sm mb-2 tracking-wider">{t('problem.tag')}</p>
       <h2 id="why-heading-ko" class="text-3xl md:text-4xl font-bold mb-4">{t('problem.title')}</h2>
@@ -254,7 +254,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- FEATURES & TRUST (Merged) -->
   <hr class="section-divider" />
-  <section class="py-24 md:py-32 section-elevated" aria-labelledby="features-heading-ko">
+  <section class="reveal py-24 md:py-32 section-elevated" aria-labelledby="features-heading-ko">
     <div class="max-w-7xl mx-auto px-6">
       <p class="font-mono text-[--color-accent] text-sm mb-2 tracking-wider">{t('features.tag')}</p>
       <h2 id="features-heading-ko" class="text-3xl md:text-4xl font-bold mb-14">{t('features.title')}</h2>
@@ -340,7 +340,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- FAQ (visible section matching JSON-LD) -->
   <hr class="section-divider" />
-  <section class="py-24 md:py-32 section-accent-glow" aria-labelledby="faq-heading-ko">
+  <section class="reveal py-24 md:py-32 section-accent-glow" aria-labelledby="faq-heading-ko">
     <div class="max-w-7xl mx-auto px-6">
       <p class="font-mono text-[--color-accent] text-sm mb-3 tracking-wider">FAQ</p>
       <h2 id="faq-heading-ko" class="text-3xl md:text-4xl font-bold mb-14">{t('faq.title')}</h2>
@@ -366,7 +366,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
   <!-- CTA -->
   <hr class="section-divider" />
-  <section class="relative pt-32 pb-28 md:pt-44 md:pb-36 overflow-hidden section-glow-cyan" aria-labelledby="cta-heading-ko">
+  <section class="reveal relative pt-32 pb-28 md:pt-44 md:pb-36 overflow-hidden section-glow-cyan" aria-labelledby="cta-heading-ko">
     <!-- Background glow orb -->
     <div class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[400px] rounded-full bg-[--color-accent]/[0.06] blur-[120px] pointer-events-none" aria-hidden="true"></div>
     <div class="relative max-w-7xl mx-auto px-6 text-center">


### PR DESCRIPTION
## Summary
Adds the existing `.reveal` class to all 7 homepage sections after hero (EN + KO mirror). On scroll, each section fades up via the global `IntersectionObserver` in Layout.astro, using the same CSS already proven on /fees, /about, /trust (~100 existing reveal sites).

## Why
The homepage was the only major page without scroll-driven entrance — the rest of the site already uses `.reveal` consistently. This closes the gap and gives first-time visitors the same polish on the landing page.

Hero is intentionally untouched — owns its own `hero-enter` animation and is above-fold for LCP.

## Sections (EN + KO each)
1. HOW IT WORKS
2. HOW AUTOTRADING WORKS
3. COMPARISON TABLE
4. WHY PRUVIQ
5. FEATURES & TRUST
6. FAQ
7. CTA

## Accessibility
- `prefers-reduced-motion: reduce` honored automatically (global.css line 752-756)
- `<noscript>` fallback (Layout.astro line 458) keeps content visible without JS

## Visual regression safety
All home `toHaveScreenshot` tests use `clip: { y: 0, height: 600 }` (hero only). Hero has no `.reveal`, so existing baselines stay valid. fullPage screenshots in visual-snapshot.spec.ts are PR-artifact uploads, not stored baselines.

## Build
- 1192 pages, qa-redirects: PASS

## Test plan
- [x] `npm run build` 0 errors
- [x] `qa-redirects` PASS
- [ ] Scroll homepage: each section fades up as it enters viewport
- [ ] reduced-motion: no animation, immediate visible
- [ ] EN + KO render
- [ ] Lighthouse home score unchanged