### PR TITLE
refactor(migration): RankingCard sparkline → EquitySparkline primitive

### DIFF
--- a/src/components/RankingCard.tsx
+++ b/src/components/RankingCard.tsx
@@ -86,10 +86,10 @@ function Sparkline({
   data[steps] = totalReturn;
 
   return (
-    <div class="opacity-60">
+    <div class="opacity-60 w-16" aria-hidden="true">
       <EquitySparkline
         data={data}
-        ariaLabel=""
+        ariaLabel="Synthetic equity sparkline"
         width={64}
         height={20}
         showEndpoint={false}

--- a/src/components/RankingCard.tsx
+++ b/src/components/RankingCard.tsx
@@ -1,6 +1,7 @@
 import { h } from "preact";
 import { buildSimulatorUrl } from "../config/simulation-context";
 import { getStrategyDescription } from "../config/strategy-descriptions";
+import EquitySparkline from "./ui/EquitySparkline";
 
 export interface RankingEntry {
   rank: number;
@@ -49,6 +50,12 @@ const cardLabels = {
  * Synthetic sparkline — generates a plausible equity curve from total_return.
  * Uses strategy name as a simple hash seed so the same card always renders
  * the same curve (no flickering on re-render). Visual hint only, not real data.
+ *
+ * 2026-04-26: rendering migrated to EquitySparkline primitive (#1423) for
+ * a single visual signature across the site. Synthetic data generation is
+ * unchanged. Animation disabled (16+ cards on /strategies/ranking — would
+ * thrash); endpoint dot disabled (too noisy at 64×20 thumbnail size); zero
+ * baseline disabled (preserves the original minimal aesthetic).
  */
 function Sparkline({
   totalReturn,
@@ -78,31 +85,18 @@ function Sparkline({
   // Ensure final point = totalReturn
   data[steps] = totalReturn;
 
-  const min = Math.min(...data);
-  const max = Math.max(...data);
-  const range = max - min || 1;
-  const w = 64;
-  const hh = 20;
-  const points = data
-    .map(
-      (v, i) =>
-        `${(i / (data.length - 1)) * w},${hh - ((v - min) / range) * hh}`,
-    )
-    .join(" ");
-
-  const strokeColor = totalReturn >= 0 ? "var(--color-up)" : "var(--color-red)";
-
   return (
-    <svg width={w} height={hh} class="opacity-60" aria-hidden="true" role="img">
-      <polyline
-        points={points}
-        fill="none"
-        stroke={strokeColor}
-        stroke-width="1.5"
-        stroke-linejoin="round"
-        stroke-linecap="round"
+    <div class="opacity-60">
+      <EquitySparkline
+        data={data}
+        ariaLabel=""
+        width={64}
+        height={20}
+        showEndpoint={false}
+        showZero={false}
+        animate={false}
       />
-    </svg>
+    </div>
   );
 }
 

--- a/src/components/RankingCard.tsx
+++ b/src/components/RankingCard.tsx
@@ -89,7 +89,7 @@ function Sparkline({
     <div class="opacity-60 w-16" aria-hidden="true">
       <EquitySparkline
         data={data}
-        ariaLabel="Synthetic equity sparkline"
+        ariaLabel=""
         width={64}
         height={20}
         showEndpoint={false}


### PR DESCRIPTION
## Summary
Replace inline polyline rendering in RankingCard's synthetic sparkline with the EquitySparkline primitive (#1423). Synthetic data generation is unchanged (same hash-seeded curve, same 16 steps, same end-equals-totalReturn pin) — only the SVG rendering swaps.

## Why
Unifies the equity-curve visual signature across the site. RankingCard, TrustGapPanel (#1449 in queue), and any future consumer all render the same gradient stroke. Single source of truth for sparkline visuals.

## Per-card flag tuning (preserves thumbnail aesthetic)
- `showEndpoint={false}` — 64×20 too small for endpoint dot
- `showZero={false}` — zero baseline noisy at thumbnail scale
- `animate={false}` — 16+ cards on /strategies/ranking, no animation thrash

`opacity-60` wrapper preserved (existing depth cue against card border).

## Cumulative EquitySparkline adoption
- Primitive merged: #1423 (W2-1)
- Consumer 1: TrustGapPanel via #1449 (in queue)
- **Consumer 2 (this PR): RankingCard**

Net change: -23 lines / +17 lines = **6 lines saved per card render path**

## Build
- 1192 pages, qa-redirects: PASS

## Test plan
- [x] `npm run build` 0 errors
- [x] `qa-redirects` PASS
- [ ] /strategies/ranking: 12+ ranking cards render with subtle gradient stroke
- [ ] Both LONG (green) and SHORT (red) curves visible
- [ ] No animation hitch on page load (animate=false)