### PR TITLE
feat(motion): /strategies grid stagger — 80ms cascade entrance

### DIFF
--- a/src/pages/ko/strategies/index.astro
+++ b/src/pages/ko/strategies/index.astro
@@ -224,7 +224,7 @@ const presetDirColors: Record<string, string> = { long: '--color-accent', short:
             </div>
           );
           const cards = (
-            <div class="space-y-4">
+            <div class="space-y-4 reveal-child">
         {strategyGroups[statusKey].map((strategy) => (
           <div class={`flex flex-col h-full block card-enterprise p-6 card-hover group ${strategy.data.status === 'verified' ? 'strategy-card-verified' : ''}`}
                data-status={strategy.data.status}

--- a/src/pages/strategies/index.astro
+++ b/src/pages/strategies/index.astro
@@ -242,7 +242,7 @@ const presetDirColors: Record<string, string> = { long: '--color-accent', short:
             </div>
           );
           const cards = (
-            <div class="space-y-4">
+            <div class="space-y-4 reveal-child">
         {strategyGroups[statusKey].map((strategy) => (
           <div class={`flex flex-col h-full block card-enterprise p-6 card-hover shadow-[var(--shadow-sm)] group ${strategy.data.status === 'verified' ? 'strategy-card-verified shadow-[var(--shadow-lg)]' : ''}`}
                data-status={strategy.data.status}


### PR DESCRIPTION
## Summary
Add `reveal-child` to the strategy-card grid container on /strategies (EN + KO). Each card fades up with the existing 80ms-staggered `nth-child` delays from global.css line 727-745, up to 12 cards (remainder shows together).

## Why now
/strategies index is the second-most visited page after /. Without entrance choreography it lands flat; with the cascade, the verified/killed/shelved status separation becomes a narrative as the eye follows the staggered reveal.

## Filter compatibility
The filter UI at `ko/strategies/index.astro` line 456 uses `querySelector('.space-y-4')` — adding `reveal-child` doesn't break that selector since class-list match still hits. Filter behavior preserved.

## Accessibility
- `prefers-reduced-motion: reduce` honored automatically (global.css line 752-756) — all cards visible immediately
- `<noscript>` fallback (Layout.astro line 458) keeps content visible without JS

## Build
- 1192 pages, qa-redirects: PASS

## Test plan
- [x] `npm run build` 0 errors
- [x] `qa-redirects` PASS
- [ ] /strategies: cards fade up sequentially in 80ms cascade
- [ ] /ko/strategies: same cascade
- [ ] Status filter (verified/killed/shelved) still works
- [ ] reduced-motion: all cards immediate