### PR TITLE
feat(i18n): KO idiomatic trade-count — formatLocalizedCount helper

### DIFF
--- a/src/components/PerformanceDashboard.tsx
+++ b/src/components/PerformanceDashboard.tsx
@@ -11,6 +11,7 @@ import {
   signColor,
   getCssVar,
   formatPF,
+  formatLocalizedCount,
 } from "../utils/format";
 import type { IChartApi, AreaData, Time } from "lightweight-charts";
 
@@ -424,7 +425,7 @@ export default function PerformanceDashboard({
       <div class="grid grid-cols-2 md:grid-cols-5 gap-3 mb-6">
         <MetricCard
           label={t.trades}
-          value={s.total_trades.toLocaleString()}
+          value={formatLocalizedCount(s.total_trades, lang)}
           color="var(--color-text)"
         />
         <MetricCard

--- a/src/components/ResultsCard.tsx
+++ b/src/components/ResultsCard.tsx
@@ -1,5 +1,10 @@
 import { useState } from "preact/hooks";
-import { winRateColor, profitFactorColor, signColor } from "../utils/format";
+import {
+  winRateColor,
+  profitFactorColor,
+  signColor,
+  formatLocalizedCount,
+} from "../utils/format";
 import { COLORS } from "./simulator-types";
 import Term from "./ui/Term";
 import CollapsibleSection from "./ui/CollapsibleSection";
@@ -660,7 +665,7 @@ export default function ResultsCard({
       {/* ── Always visible: Trade summary (compact) ── */}
       <div class="flex items-center justify-between font-mono text-xs text-[--color-text-muted] mb-1">
         <span>
-          {data.total_trades.toLocaleString()} {t.trades}
+          {formatLocalizedCount(data.total_trades, lang)} {t.trades}
         </span>
         {data.avg_bars_held != null && data.avg_bars_held > 0 && (
           <span class="text-[10px]">

--- a/src/components/TopStrategyWidget.tsx
+++ b/src/components/TopStrategyWidget.tsx
@@ -5,6 +5,7 @@
  */
 import { useState, useEffect } from "preact/hooks";
 import { API_BASE_URL } from "../config/api";
+import { formatLocalizedCount } from "../utils/format";
 
 interface RankingEntry {
   rank: number;
@@ -217,7 +218,7 @@ export function TopStrategyWidget({ lang = "en" }: { lang?: Lang }) {
               {t.trades}
             </p>
             <p class="font-mono text-lg font-bold text-[--color-text]">
-              {top.total_trades.toLocaleString()}
+              {formatLocalizedCount(top.total_trades, lang)}
             </p>
           </div>
         </div>

--- a/src/components/simulator/v1/ResultsPanel.tsx
+++ b/src/components/simulator/v1/ResultsPanel.tsx
@@ -16,6 +16,7 @@ import { API_BASE_URL } from "../../../config/api";
 import type { SimConfig } from "../../../hooks/useSimConfig";
 import { useTranslations, type Lang } from "../../../i18n/index";
 import { emit } from "../../../lib/events";
+import { formatLocalizedCount } from "../../../utils/format";
 
 interface Props {
   config: SimConfig;
@@ -127,8 +128,8 @@ function buildVerdict(
       tone: "good",
       text:
         lang === "ko"
-          ? `견고한 수익 곡선 — PF ${d.profit_factor.toFixed(2)}, ${d.total_trades.toLocaleString()}건 표본.`
-          : `Solid profit curve — PF ${d.profit_factor.toFixed(2)} across ${d.total_trades.toLocaleString()} trades.`,
+          ? `견고한 수익 곡선 — PF ${d.profit_factor.toFixed(2)}, ${formatLocalizedCount(d.total_trades, "ko")}건 표본.`
+          : `Solid profit curve — PF ${d.profit_factor.toFixed(2)} across ${formatLocalizedCount(d.total_trades, "en")} trades.`,
     };
   }
   return {
@@ -334,7 +335,7 @@ export default function ResultsPanel({ config, lang }: Props) {
           <span>
             {lang === "ko" ? "거래" : "Trades"}:{" "}
             <span class="text-(--color-text) tabular-nums">
-              {d.total_trades.toLocaleString()}
+              {formatLocalizedCount(d.total_trades, lang)}
             </span>
           </span>
           <span>
@@ -371,7 +372,8 @@ export default function ResultsPanel({ config, lang }: Props) {
 function verdictTone(tone: "good" | "bad" | "neutral"): string {
   if (tone === "good")
     return "border-(--color-up)/30 bg-(--color-up)/10 text-(--color-up)";
-  if (tone === "bad") return "border-(--color-down)/30 bg-(--color-down)/10 text-(--color-down)";
+  if (tone === "bad")
+    return "border-(--color-down)/30 bg-(--color-down)/10 text-(--color-down)";
   return "border-(--color-verified)/20 bg-(--color-verified-subtle) text-(--color-verified)";
 }
 
@@ -470,14 +472,18 @@ function SkeletonFrame({
 function MetricGridSkeleton({ shimmer }: { shimmer?: boolean }) {
   const base =
     "h-10 rounded " +
-    (shimmer ? "animate-pulse bg-(--color-bg-elevated)" : "bg-(--color-bg-elevated)/60");
+    (shimmer
+      ? "animate-pulse bg-(--color-bg-elevated)"
+      : "bg-(--color-bg-elevated)/60");
   return (
     <div class="grid grid-cols-2 gap-4 md:grid-cols-4">
       {[0, 1, 2, 3].map((i) => (
         <div key={i}>
           <div
             class={`mb-2 h-3 w-16 rounded ${
-              shimmer ? "animate-pulse bg-(--color-bg-elevated)" : "bg-(--color-bg-elevated)/60"
+              shimmer
+                ? "animate-pulse bg-(--color-bg-elevated)"
+                : "bg-(--color-bg-elevated)/60"
             }`}
           />
           <div class={base} />

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -210,3 +210,20 @@ export function formatKoNum(
   }
   return `${sign}${parts.join(" ")}`;
 }
+
+/**
+ * formatLocalizedCount — lang-aware integer formatter for trade counts /
+ * activity numbers / sample sizes. Always lossless (no compact mode here —
+ * call `formatKoNum(n, { compact: true })` directly when you need that).
+ *
+ *   formatLocalizedCount(12_345, "en") → "12,345"
+ *   formatLocalizedCount(12_345, "ko") → "1만 2,345"
+ *
+ * Single source for "render this integer for this user". Use this instead
+ * of `n.toLocaleString()` whenever the surrounding component already knows
+ * the lang prop, so KO readers see the idiom without per-site branching.
+ */
+export function formatLocalizedCount(n: number, lang: "en" | "ko"): string {
+  if (lang === "ko") return formatKoNum(n);
+  return n.toLocaleString("en-US");
+}

--- a/tests/unit/formatKoNum.test.ts
+++ b/tests/unit/formatKoNum.test.ts
@@ -2,7 +2,7 @@
  * formatKoNum.test.ts — contract test for Korean idiomatic number formatting.
  */
 import { describe, expect, test } from "vitest";
-import { formatKoNum } from "../../src/utils/format";
+import { formatKoNum, formatLocalizedCount } from "../../src/utils/format";
 
 describe("formatKoNum (verbose)", () => {
   test("zero → '0'", () => {
@@ -82,5 +82,38 @@ describe("formatKoNum (compact)", () => {
   test("compact preserves negative sign", () => {
     expect(formatKoNum(-1_234_567_890, { compact: true })).toBe("-12억");
     expect(formatKoNum(-12_345, { compact: true })).toBe("-1.2만");
+  });
+});
+
+describe("formatLocalizedCount", () => {
+  test("EN — falls back to en-US locale grouping", () => {
+    expect(formatLocalizedCount(0, "en")).toBe("0");
+    expect(formatLocalizedCount(123, "en")).toBe("123");
+    expect(formatLocalizedCount(1_234, "en")).toBe("1,234");
+    expect(formatLocalizedCount(12_345, "en")).toBe("12,345");
+    expect(formatLocalizedCount(1_234_567, "en")).toBe("1,234,567");
+  });
+
+  test("KO — uses 만/억 idioms (matches formatKoNum verbose)", () => {
+    expect(formatLocalizedCount(0, "ko")).toBe("0");
+    expect(formatLocalizedCount(123, "ko")).toBe("123");
+    expect(formatLocalizedCount(12_345, "ko")).toBe("1만 2,345");
+    expect(formatLocalizedCount(1_234_567, "ko")).toBe("123만 4,567");
+    expect(formatLocalizedCount(123_456_789, "ko")).toBe("1억 2,345만 6,789");
+  });
+
+  test("EN and KO diverge above 만 threshold (10,000)", () => {
+    // Below threshold: EN/KO identical (no 만 idiom kicks in)
+    expect(formatLocalizedCount(9_999, "en")).toBe("9,999");
+    expect(formatLocalizedCount(9_999, "ko")).toBe("9,999");
+
+    // At threshold: KO inserts 만, EN sticks with comma grouping
+    expect(formatLocalizedCount(10_000, "en")).toBe("10,000");
+    expect(formatLocalizedCount(10_000, "ko")).toBe("1만");
+  });
+
+  test("negative numbers preserve sign in both locales", () => {
+    expect(formatLocalizedCount(-12_345, "en")).toBe("-12,345");
+    expect(formatLocalizedCount(-12_345, "ko")).toBe("-1만 2,345");
   });
 });


### PR DESCRIPTION
## Summary
Apply `formatKoNum` (#1430 W1-h) to user-facing trade-count displays via a new lang-aware helper `formatLocalizedCount(n, lang)` in `utils/format.ts`. Single source for "render this integer for this user".

## Why
KO readers parse "1만 2,345" much faster than "12,345" — Korean numerals natively break at 만 (10,000) and 억 (10⁸), not thousands. The `formatKoNum` primitive existed but had no consumers — this PR closes that gap on the high-value trade-count surface.

## Examples (12,345 trades)
- **EN**: `12,345 trades`
- **KO**: `1만 2,345 trades` (idiomatic)

## Consumers wired
1. **PerformanceDashboard.tsx** — KPI grid trade count
2. **simulator/v1/ResultsPanel.tsx** — verdict text (PF strong) + footer row
3. **TopStrategyWidget.tsx** — homepage hero live data card
4. **ResultsCard.tsx** — main simulator result

All 4 already had `lang` prop in scope — no new plumbing.

## Helper design
- Lossless (full precision always)
- For abbreviated forms (1.2만 / 12억) call `formatKoNum(n, { compact: true })` directly — those hit different visual contexts (badge / chip / hero stat)

## Build
- 1192 pages, qa-redirects: PASS

## Test plan
- [x] `npm run build` 0 errors
- [x] `qa-redirects` PASS
- [ ] /ko/performance: KPI shows "1만 2,345" form for 5-digit trades
- [ ] /ko/simulate result panel: verdict + footer use idiom
- [ ] /ko home: TopStrategyWidget trade count idiomatic
- [ ] EN paths unaffected (still toLocaleString output)