### PR TITLE
feat(motion): /trust page reveal — metrics cascade + platform health

### DIFF
--- a/src/pages/ko/trust.astro
+++ b/src/pages/ko/trust.astro
@@ -24,7 +24,7 @@ const t = useTranslations('ko');
       </p>
     </header>
 
-    <section id="metrics" class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-12">
+    <section id="metrics" class="reveal reveal-child grid grid-cols-1 md:grid-cols-2 gap-6 mb-12">
       <div class="card-enterprise rounded-2xl p-6">
         <p class="text-xs font-mono text-[--color-text-muted] uppercase mb-2">{t('trust.trades_24h')}</p>
         <p class="text-4xl font-extrabold" data-metric="trades_24h">—</p>
@@ -56,7 +56,7 @@ const t = useTranslations('ko');
       {t('trust.loading')}
     </p>
 
-    <section id="platform-health" class="mt-16 border-t border-[--color-border] pt-12">
+    <section id="platform-health" class="reveal mt-16 border-t border-[--color-border] pt-12">
       <header class="mb-6 text-center">
         <p class="font-mono text-[--color-accent] text-xs tracking-widest uppercase mb-3">{t('trust.platform_tag')}</p>
         <h2 class="text-2xl md:text-3xl font-bold mb-2">{t('trust.platform_heading')}</h2>

--- a/src/pages/trust.astro
+++ b/src/pages/trust.astro
@@ -21,7 +21,7 @@ const t = useTranslations('en');
       </p>
     </header>
 
-    <section id="metrics" class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-12">
+    <section id="metrics" class="reveal reveal-child grid grid-cols-1 md:grid-cols-2 gap-6 mb-12">
       <div class="card-enterprise rounded-2xl p-6">
         <p class="text-xs font-mono text-[--color-text-muted] uppercase mb-2">{t('trust.trades_24h')}</p>
         <p class="text-4xl font-extrabold" data-metric="trades_24h">—</p>
@@ -53,7 +53,7 @@ const t = useTranslations('en');
       {t('trust.loading')}
     </p>
 
-    <section id="platform-health" class="mt-16 border-t border-[--color-border] pt-12">
+    <section id="platform-health" class="reveal mt-16 border-t border-[--color-border] pt-12">
       <header class="mb-6 text-center">
         <p class="font-mono text-[--color-accent] text-xs tracking-widest uppercase mb-3">{t('trust.platform_tag')}</p>
         <h2 class="text-2xl md:text-3xl font-bold mb-2">{t('trust.platform_heading')}</h2>


### PR DESCRIPTION
## Summary
Add `reveal` + `reveal-child` to /trust and /ko/trust sections. The metrics grid staggers in (live trade volume / slippage / SL+TP adoption rate fade up sequentially), and the platform-health section fades up below the fold.

Pattern matches the homepage section reveal (#1455 in queue).

## Visual narrative
header → metrics cascade (proof) → platform health (transparency) — mirroring the page's actual rhetorical structure.

## Accessibility
- `prefers-reduced-motion: reduce` honored automatically
- `<noscript>` fallback keeps content visible
- No new ARIA attributes needed

## Build
- 1192 pages, qa-redirects: PASS

## Test plan
- [x] `npm run build` 0 errors
- [x] `qa-redirects` PASS
- [ ] /trust: 5 metric cards stagger up, platform health fades after scroll
- [ ] /ko/trust: same cascade
- [ ] reduced-motion: all immediate