### PR TITLE
fix(ci): automerge auto-update BEHIND PRs — drain stuck queue

### DIFF
--- a/.github/workflows/automerge-on-label.yml
+++ b/.github/workflows/automerge-on-label.yml
@@ -167,7 +167,34 @@ jobs:
               return;
             }
 
-            // All checks green — merge
+            // 2026-04-26: queue-drain root-cause fix.
+            // PRUVIQ ruleset has strict_required_status_checks_policy=true →
+            // PR must be up-to-date with main before merge. When the schedule
+            // cron picks up a BEHIND PR, the merge call below fails with 405
+            // "Base branch was modified" and the next cron retries the same
+            // stuck PR forever. Detect BEHIND state up front and trigger
+            // update-branch so the next cron tick can actually merge.
+            const prDetail = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            if (prDetail.data.mergeable_state === 'behind') {
+              core.info(`PR #${prNumber} is BEHIND main — triggering update-branch.`);
+              try {
+                await github.rest.pulls.updateBranch({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                });
+                core.info(`update-branch dispatched for PR #${prNumber}; checks will rerun, next cron tick will retry merge.`);
+              } catch (err) {
+                core.warning(`update-branch failed for PR #${prNumber}: ${err.message}`);
+              }
+              return;
+            }
+
+            // All checks green + up-to-date with main — merge.
             try {
               await github.rest.pulls.merge({
                 owner: context.repo.owner,
@@ -177,7 +204,8 @@ jobs:
               });
               core.info(`Successfully merged PR #${prNumber}`);
             } catch (err) {
-              // Merge can fail when PR is behind main (data refresh commits).
-              // Next check_suite completion will retry automatically.
+              // Merge can still fail in race conditions (concurrent push to main
+              // between BEHIND check above and merge call). Next check_suite
+              // completion or cron tick retries.
               core.warning(`Merge attempt for PR #${prNumber} did not succeed: ${err.message}`);
             }


### PR DESCRIPTION
## Root cause

PRUVIQ ruleset has `strict_required_status_checks_policy=true` — PRs must be up-to-date with main before merge. The cron-driven schedule mode of the automerge workflow picks the first matching open PR each tick, but when that PR is BEHIND main, the merge call fails with 405 \"Base branch was modified\" and the cron retries the SAME stuck PR forever, never advancing.

**Observed today**: 1 merge of #1448 left 30 BEHIND PRs queued. None auto-rebased over the next 60+ minutes — schedule kept hitting the first one and bouncing.

## Fix

Detect `mergeable_state === 'behind'` up front and dispatch `updateBranch()` instead of `merge()`. Branch update pushes a fresh SHA, checks rerun, and the next cron tick (or check_suite completion) retries the merge — now no longer BEHIND.

Mirrors GitHub's own \"auto-merge\" feature (which auto-updates behind PRs), but the schedule fan-out we depend on for backlog drain needs the explicit call since check_suite events are unreliable in fan-outs (per existing comment at line 7-12).

## Effect on the current 30-PR backlog

Each cron tick (10 min) will now either merge a CLEAN PR or trigger update-branch on a BEHIND PR. Within ~5 hours all stuck PRs converge. Without this fix, only 1 PR could ever advance per actual main commit.

## Risk
- update-branch failure is caught and logged; loop retries.
- Single-tick processing preserved (deliberately — avoids GitHub API rate spikes when 30+ PRs need rebasing simultaneously).

## Test plan
- [ ] Merge this PR. Within 10 min the schedule cron fires and starts updating BEHIND PRs.
- [ ] Watch /actions/workflows/automerge-on-label.yml runs — log lines should show \"PR #X is BEHIND main — triggering update-branch\".
- [ ] After 30-50 min, queue BEHIND count should drop as PRs cycle through update → checks rerun → merge.