### PR TITLE
fix(layout): header logo overlap on EN desktop (P0 — all 14 pages)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -482,9 +482,9 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <header>
     <!-- shadow-nav handles visual separation — no border-b needed -->
     <nav class="fixed top-0 w-full z-50 bg-[--color-bg-surface]/90 backdrop-blur-xl" role="navigation" aria-label="Main" style="box-shadow: var(--shadow-nav);">
-      <div class="w-full px-6 lg:px-28 h-14 grid grid-cols-[auto_1fr_auto] items-center">
-        <!-- 1열: Logo (좌측) -->
-        <a href={lang === 'ko' ? '/ko/' : '/'} class="flex items-center gap-2">
+      <div class="w-full px-6 lg:px-28 h-14 grid grid-cols-[max-content_1fr_max-content] items-center">
+        <!-- 1열: Logo (좌측) — max-content로 sizing해서 wordmark가 column 2(가운데 nav)로 bleed 안 함 (2026-04-28 P0 fix) -->
+        <a href={lang === 'ko' ? '/ko/' : '/'} class="flex items-center gap-2 min-w-max">
           <img src="/favicon.svg" alt="PRUVIQ" width="32" height="32" class="w-8 h-8" loading="eager" />
           <span class="font-mono font-bold text-2xl tracking-wider"><span class="text-[--color-text]">PRUV</span><span class="text-[var(--color-accent)]">IQ</span></span>
         </a>


### PR DESCRIPTION
## P0 Defect (QA 2026-04-27)

EN 데스크톱 14개 페이지에서 PRUVIQ 워드마크가 첫 nav item과 시각적 겹침.

## Root cause

`grid-cols-[auto_1fr_auto]` → auto 컬럼 min-content(102px) sizing → wordmark span(94px) overflow:visible로 column 2 (x=214) 32px bleed.

## Fix

`auto` → `max-content` + logo anchor `min-w-max` (이중 안전).

## Test plan

- [ ] CI Visual Regression: 14 EN 페이지 baseline 갱신 (logo wordmark가 nav 안 침범 확인)
- [ ] /ko/* 5 페이지 변화 0 (이전부터 OK)
- [ ] 모바일 변화 0 (hamburger 영향 없음)

QA evidence: `/tmp/pruviq-qa-20260427/shots/_header-overlap.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)