### PR TITLE
fix(a11y): WCAG AA 44px touch targets — hit area + e2e guard (P2)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -203,7 +203,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       </div>
 
       <div class="text-center mt-8">
-        <a href="/compare" class="btn btn-ghost btn-sm font-mono">See full comparison →</a>
+        <a href="/compare" class="btn btn-ghost btn-md font-mono">See full comparison →</a>
       </div>
     </div>
   </section>

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -200,7 +200,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       </div>
 
       <div class="text-center mt-6">
-        <a href="/ko/compare" class="btn btn-ghost btn-sm font-mono">전체 비교 보기 →</a>
+        <a href="/ko/compare" class="btn btn-ghost btn-md font-mono">전체 비교 보기 →</a>
       </div>
     </div>
   </section>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1238,6 +1238,15 @@ textarea:focus-visible {
   font-size: 0.8125rem;
   border-radius: var(--radius-sm);
   min-height: 36px;
+  position: relative;
+}
+/* WCAG AA 44px touch target — visual size 36px 유지하되 가상 클릭 영역
+   확장으로 a11y 표준 충족. 2026-04-28 P2 fix (QA Sweep). */
+.btn-sm::after {
+  content: "";
+  position: absolute;
+  inset: -4px 0;
+  pointer-events: auto;
 }
 
 /* ─── Ghost button — higher contrast ─── */

--- a/tests/e2e/a11y-touch-targets.spec.ts
+++ b/tests/e2e/a11y-touch-targets.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * WCAG AA 2.5.5 — Target Size (Enhanced) — interactive controls 44×44 CSS px.
+ *
+ * 2026-04-28 P2 (QA Sweep): 홈 "See full comparison →" 31px tall 발견 → fix.
+ * 회귀 자동 차단을 위해 모든 주요 페이지의 인터랙티브 요소(.btn*, a[role=button],
+ * button:not([type=hidden])) 시각 또는 가상 hit area가 44px 이상인지 검증.
+ *
+ * 예외 (WCAG AA spacing exception):
+ * - 인라인 텍스트 흐름 안의 link (text-flow inline)
+ * - 다른 일반 컨트롤이 영향받지 않게 충분한 spacing 확보된 경우
+ *
+ * Hit area 측정: 가상 요소(::before/::after) 포함하기 위해 elementHandle.boundingBox()
+ * 가 아닌 getComputedStyle 기반 측정 + offsetHeight + virtual ::after inset 합산.
+ */
+
+const PAGES = [
+  "/",
+  "/simulate/",
+  "/strategies/",
+  "/coins/",
+  "/fees",
+  "/about",
+  "/learn",
+  "/compare",
+];
+
+const MIN_TOUCH_PX = 44;
+
+async function measureHitArea(page: any, selector: string) {
+  return await page.$$eval(
+    selector,
+    (els: HTMLElement[], minPx: number) => {
+      const failures: { tag: string; text: string; w: number; h: number }[] =
+        [];
+      for (const el of els) {
+        // 인라인 link (block formatting context 안 inline)는 spacing exception
+        const cs = getComputedStyle(el);
+        if (cs.display === "inline" && el.tagName === "A") continue;
+        // 가상 hit area 포함 (::after inset)
+        const rect = el.getBoundingClientRect();
+        let extraTop = 0,
+          extraBottom = 0,
+          extraLeft = 0,
+          extraRight = 0;
+        try {
+          const after = getComputedStyle(el, "::after");
+          if (after && after.content && after.content !== "none") {
+            extraTop = -parseFloat(after.top || "0") || 0;
+            extraBottom = -parseFloat(after.bottom || "0") || 0;
+            extraLeft = -parseFloat(after.left || "0") || 0;
+            extraRight = -parseFloat(after.right || "0") || 0;
+          }
+        } catch {
+          /* ignore */
+        }
+        const effW =
+          rect.width + Math.max(0, extraLeft) + Math.max(0, extraRight);
+        const effH =
+          rect.height + Math.max(0, extraTop) + Math.max(0, extraBottom);
+        if (effW < minPx || effH < minPx) {
+          failures.push({
+            tag:
+              el.tagName.toLowerCase() +
+              (el.className ? "." + String(el.className).split(/\s+/)[0] : ""),
+            text: (el.textContent || "").trim().slice(0, 40),
+            w: Math.round(effW),
+            h: Math.round(effH),
+          });
+        }
+      }
+      return failures;
+    },
+    MIN_TOUCH_PX,
+  );
+}
+
+for (const path of PAGES) {
+  test(`a11y touch targets — ${path} buttons/CTAs ≥ 44px`, async ({ page }) => {
+    await page.goto(path, { waitUntil: "domcontentloaded" });
+    await page.waitForTimeout(800); // hydration
+
+    const selector =
+      '.btn, a[role="button"], button:not([type="hidden"]):not([aria-hidden="true"])';
+    const fails = await measureHitArea(page, selector);
+
+    // Filter: hidden/0-size elements (display:none, dropdown content) 제외
+    const visible = fails.filter((f) => f.w > 0 && f.h > 0);
+
+    if (visible.length > 0) {
+      const msg = visible
+        .slice(0, 5)
+        .map((f) => `  - ${f.tag} "${f.text}" → ${f.w}×${f.h}px`)
+        .join("\n");
+      throw new Error(
+        `${path}: ${visible.length} interactive elements below ${MIN_TOUCH_PX}px hit area:\n${msg}`,
+      );
+    }
+    expect(visible.length).toBe(0);
+  });
+}


### PR DESCRIPTION
## P2 Defect (QA 2026-04-27)

홈 'See full comparison →' CTA 31px tall (WCAG AA 44px 미만).

## 원론 fix (3-layer)

| Layer | 변경 | 효과 |
|-------|------|------|
| 1. 글로벌 .btn-sm | `::after` 가상요소 hit area +8px 확장 | 시각 36px 유지, 터치 44px 충족 (18 인스턴스 적용) |
| 2. 홈 직접 fix | btn-sm → btn-md | 시각도 44px (이중 안전) |
| 3. e2e 가드 | tests/e2e/a11y-touch-targets.spec.ts 신규 | 8개 페이지 회귀 자동 차단 |

## 페르소나 영향

- **모바일** (iPhone 13 등): 손가락 터치 정확도 ↑
- **접근성**: WCAG AA 2.5.5 Target Size 명시 준수

## Test plan

- [ ] 신규 e2e `a11y-touch-targets.spec.ts` 8 페이지 통과
- [ ] 시각 디자인 회귀 0 (홈만 btn-md로 변경)
- [ ] Visual regression baseline 갱신 1건 (홈)

## Followup (별 PR)

전체 페이지 a11y 종합 sweep — 홈 외 13 페이지 추가 검사 (이번엔 8 페이지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)