### PR TITLE
feat(verify): post-merge /events telemetry health check

### DIFF
--- a/scripts/post-merge-verify.sh
+++ b/scripts/post-merge-verify.sh
@@ -180,6 +180,36 @@ check_url "$BASE/ko/" "검증"
 check_optional "$BASE/" "class=\"reveal"
 
 echo ""
+echo "── /events telemetry endpoint (P1 fix verification, 2026-04-28) ──"
+# Valid event → 204 (Cloudflare Pages Advanced Mode bypasses functions/, so
+# routing must live in public/_worker.js).
+EVENTS_VALID_CODE=$(curl -sL -o /dev/null -w "%{http_code}" --max-time 10 \
+  -X POST "$BASE/events" \
+  -H "Content-Type: application/json" \
+  -d '{"type":"sim.view","ts":1}' || echo "000")
+if [ "$EVENTS_VALID_CODE" = "204" ]; then
+  echo "${GREEN}✓${RESET} POST $BASE/events {sim.view} → 204"
+  PASS=$((PASS + 1))
+else
+  echo "${RED}✗${RESET} POST $BASE/events {sim.view} → HTTP $EVENTS_VALID_CODE (expected 204) — telemetry funnel dropping data"
+  FAIL=$((FAIL + 1))
+  FAILED_URLS+=("POST /events sim.view (HTTP $EVENTS_VALID_CODE)")
+fi
+# Invalid event type → 400 (closed event set)
+EVENTS_INVALID_CODE=$(curl -sL -o /dev/null -w "%{http_code}" --max-time 10 \
+  -X POST "$BASE/events" \
+  -H "Content-Type: application/json" \
+  -d '{"type":"bogus.unknown"}' || echo "000")
+if [ "$EVENTS_INVALID_CODE" = "400" ]; then
+  echo "${GREEN}✓${RESET} POST $BASE/events {bogus.unknown} → 400 (closed event set enforced)"
+  PASS=$((PASS + 1))
+else
+  echo "${YELLOW}△${RESET} POST $BASE/events {bogus.unknown} → HTTP $EVENTS_INVALID_CODE (expected 400)"
+  FAIL=$((FAIL + 1))
+  FAILED_URLS+=("POST /events bogus (HTTP $EVENTS_INVALID_CODE)")
+fi
+
+echo ""
 echo "=== Result: ${GREEN}${PASS} pass${RESET} · ${RED}${FAIL} fail${RESET} ==="
 
 if [ "$FAIL" -gt 0 ]; then


### PR DESCRIPTION
## Background

PR #1509 (/events 405 fix)와 페어. post-merge-verify.sh가 머지 후 텔레메트리 흐름이 진짜 작동하는지 자동 검증 → silent regression 영구 차단.

## 추가 검증

| 테스트 | 기대 |
|--------|------|
| POST /events {sim.view} | **204** (정상 수집) |
| POST /events {bogus.unknown} | **400** (closed event set 강제) |

## Silent fail 차단

이번 4-26~28 사고처럼 'functions/ → dead code' 회귀가 또 일어나도 post-merge-verify가 머지 직후 즉시 감지 → 텔레그램 알림.

## 5원칙

| 원칙 | 매핑 |
|------|------|
| 4 무결 | silent regression 자동 차단 |
| 5 책임 | telemetry 흐름 audit 가능 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)