### PR TITLE
fix(api-docs): coin count example 235 → 238 (실측 SSoT)

### DIFF
--- a/src/pages/api.astro
+++ b/src/pages/api.astro
@@ -94,7 +94,7 @@ const API_BASE = 'https://api.pruviq.com';
           response={`{
   "status": "ok",
   "version": "0.3.0",
-  "coins_loaded": 235,
+  "coins_loaded": 238,
   "uptime_seconds": 415785.5
 }`}
         />
@@ -205,7 +205,7 @@ const API_BASE = 'https://api.pruviq.com';
     "date_from": "2023-12-30",
     "date_to": "2026-04-03"
   },
-  ... // 235 coins total (OKX USDT-SWAP live)
+  ... // 238 coins total (OKX USDT-SWAP live)
 ]`}
         />
 

--- a/src/pages/ko/api.astro
+++ b/src/pages/ko/api.astro
@@ -81,7 +81,7 @@ const API_BASE = 'https://api.pruviq.com';
           response={`{
   "status": "ok",
   "version": "0.3.0",
-  "coins_loaded": 235,
+  "coins_loaded": 238,
   "uptime_seconds": 415785.5
 }`}
         />
@@ -192,7 +192,7 @@ const API_BASE = 'https://api.pruviq.com';
     "date_from": "2023-12-30",
     "date_to": "2026-04-03"
   },
-  ... // 235개 코인 (OKX USDT-SWAP 라이브)
+  ... // 238개 코인 (OKX USDT-SWAP 라이브)
 ]`}
         />
 


### PR DESCRIPTION
## 근거

`GET /health` 실측 응답 `coins_loaded=238` (project_pruviq.md SSoT 부합). api.astro / ko/api.astro의 example response가 옛 235를 보여주고 있어 개발자 오용 가능성.

## 변경 (4 line, 2 file)

- `coins_loaded` example: 235 → 238 (EN/KO 각 1)
- `// 235 coins total` 주석: 238 (EN/KO 각 1)

## 평가 약점 #3 부분 fix

frontend-design 평가의 'i18n 235+ coins 18건' = 실제 grep **0건** (이미 240+로 통일). api.astro 4건만 235 잔존 → 238로 정렬.

## 결과

| 위치 | 값 | 의미 |
|------|------|------|
| i18n 42건 | 240+ | 마케팅 라운드 |
| api.astro 4건 (변경 후) | 238 | 실측 API response |
| changelog 2건 | 238 | 역사 evidence |

3 위치 모두 의도된 값 — SSoT 일관 회복.

## 6원칙

| 원칙 | 매핑 |
|------|------|
| 3 일관 | 실측/마케팅/역사 명확 분리 |
| 6 근거 | grep 정량 + curl 실측 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)