### PR TITLE
refactor(ko): home H1 token-pure — inline-style 제거 + EN 사이즈 일관 (Sprint 1.5)

### DIFF
--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -37,7 +37,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
         <div>
           <HeroBadge stat={`${coinsAnalyzed}+`} label="코인 · 2년 데이터 · 88 전략 검증" cta="무료 체험 →" />
           <p class="font-mono text-[--color-accent] text-sm tracking-wider mb-5 opacity-90">검증하고. 실행하고. 수익내고.</p>
-          <h1 class="text-[1.7rem] sm:text-4xl md:text-5xl lg:text-5xl font-extrabold tracking-[-0.04em]" style="line-height:1.1">
+          <h1 class="text-5xl md:text-6xl lg:text-7xl font-extrabold tracking-[-0.04em] leading-[1.1] text-balance">
             대부분의 백테스트는 거짓말입니다.<br/><span class="gradient-text-shimmer">우리는 증거를 공개합니다.</span>
           </h1>
           <p class="mt-10 text-xl md:text-2xl text-[--color-text-secondary] leading-relaxed max-w-lg">


### PR DESCRIPTION
## 디자인 평가 약점 #5 (P1)

KO 홈 H1만 `style="line-height:1.1"` inline + `text-[1.7rem]` (27.2px) — 디자인 토큰 SSoT 위반 + 모바일 H1 작음 (EN 5xl=48px).

## 변경 1 line

`src/pages/ko/index.astro:40`:
`text-[1.7rem] sm:text-4xl md:text-5xl lg:text-5xl ... style="line-height:1.1"` →
`text-5xl md:text-6xl lg:text-7xl ... leading-[1.1] text-balance` (EN 패턴 동일, leading만 KO 글리프 1.1)

## 효과

- 모바일 27px → 48px (페르소나 2 한국 트레이더 +0.5pt)
- inline style 0 (디자인 토큰 SSoT 회복)
- EN/KO H1 시각 일관

🤖 Generated with [Claude Code](https://claude.com/claude-code)