### PR TITLE
refactor(visual): feature card 4색 → accent 1색 통일 (Sprint 2.B)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -273,24 +273,24 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
           <p class="text-[--color-text-muted] text-sm leading-relaxed">{t('features.card1_desc')}</p>
         </a>
         <a href="/strategies" class="card-premium p-6 block group">
-          <div class="w-14 h-14 rounded-2xl bg-[--color-up]/15 flex items-center justify-center mb-5">
-            <svg class="w-7 h-7 text-[--color-up]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z"/></svg>
+          <div class="w-14 h-14 rounded-2xl bg-[--color-accent]/15 flex items-center justify-center mb-5">
+            <svg class="w-7 h-7 text-[--color-accent]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z"/></svg>
           </div>
           <p class="font-mono text-[--color-accent] text-xs font-bold mb-2 tracking-wider">{t('features.card2_tag')}</p>
           <h3 class="font-bold text-lg mb-2 group-hover:text-[--color-accent] transition-colors">{t('features.card2_title')}</h3>
           <p class="text-[--color-text-muted] text-sm leading-relaxed">{t('features.card2_desc')}</p>
         </a>
         <a href="/fees" class="card-premium p-6 block group">
-          <div class="w-14 h-14 rounded-2xl bg-[--color-verified]/15 flex items-center justify-center mb-5">
-            <svg class="w-7 h-7 text-[--color-verified]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818l.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+          <div class="w-14 h-14 rounded-2xl bg-[--color-accent]/15 flex items-center justify-center mb-5">
+            <svg class="w-7 h-7 text-[--color-accent]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818l.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
           </div>
           <p class="font-mono text-[--color-accent] text-xs font-bold mb-2 tracking-wider">{t('features.card3_tag')}</p>
           <h3 class="font-bold text-lg mb-2 group-hover:text-[--color-accent] transition-colors">{t('features.card3_title')}</h3>
           <p class="text-[--color-text-muted] text-sm leading-relaxed">{t('features.card3_desc')}</p>
         </a>
         <a href="/learn" class="card-premium card-accent-gradient p-6 block group">
-          <div class="w-14 h-14 rounded-2xl bg-[--color-purple]/15 flex items-center justify-center mb-5">
-            <svg class="w-7 h-7 text-[--color-purple]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M4.26 10.147a60.436 60.436 0 00-.491 6.347A48.627 48.627 0 0112 20.904a48.627 48.627 0 018.232-4.41 60.46 60.46 0 00-.491-6.347m-15.482 0a50.57 50.57 0 00-2.658-.813A59.905 59.905 0 0112 3.493a59.902 59.902 0 0110.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.697 50.697 0 0112 13.489a50.702 50.702 0 017.74-3.342"/></svg>
+          <div class="w-14 h-14 rounded-2xl bg-[--color-accent]/15 flex items-center justify-center mb-5">
+            <svg class="w-7 h-7 text-[--color-accent]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M4.26 10.147a60.436 60.436 0 00-.491 6.347A48.627 48.627 0 0112 20.904a48.627 48.627 0 018.232-4.41 60.46 60.46 0 00-.491-6.347m-15.482 0a50.57 50.57 0 00-2.658-.813A59.905 59.905 0 0112 3.493a59.902 59.902 0 0110.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.697 50.697 0 0112 13.489a50.702 50.702 0 017.74-3.342"/></svg>
           </div>
           <p class="font-mono text-[--color-accent] text-xs font-bold mb-2 tracking-wider">{t('features.learn_tag')}</p>
           <h3 class="font-bold text-lg mb-2 group-hover:text-[--color-accent] transition-colors">{t('features.learn_title')}</h3>

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -270,24 +270,24 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
           <p class="text-[--color-text-muted] text-sm leading-relaxed">{t('features.card1_desc')}</p>
         </a>
         <a href="/ko/strategies" class="card-premium p-6 block group">
-          <div class="w-14 h-14 rounded-2xl bg-[--color-up]/10 flex items-center justify-center mb-4">
-            <svg class="w-6 h-6 text-[--color-up]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z"/></svg>
+          <div class="w-14 h-14 rounded-2xl bg-[--color-accent]/10 flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-[--color-accent]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z"/></svg>
           </div>
           <p class="font-mono text-[--color-accent] text-xs font-bold mb-2 tracking-wider">{t('features.card2_tag')}</p>
           <h3 class="font-bold text-lg mb-2 group-hover:text-[--color-accent] transition-colors">{t('features.card2_title')}</h3>
           <p class="text-[--color-text-muted] text-sm leading-relaxed">{t('features.card2_desc')}</p>
         </a>
         <a href="/ko/fees" class="card-premium p-6 block group">
-          <div class="w-14 h-14 rounded-2xl bg-[--color-verified]/10 flex items-center justify-center mb-4">
-            <svg class="w-6 h-6 text-[--color-verified]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818l.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+          <div class="w-14 h-14 rounded-2xl bg-[--color-accent]/10 flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-[--color-accent]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818l.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
           </div>
           <p class="font-mono text-[--color-accent] text-xs font-bold mb-2 tracking-wider">{t('features.card3_tag')}</p>
           <h3 class="font-bold text-lg mb-2 group-hover:text-[--color-accent] transition-colors">{t('features.card3_title')}</h3>
           <p class="text-[--color-text-muted] text-sm leading-relaxed">{t('features.card3_desc')}</p>
         </a>
         <a href="/ko/learn" class="card-premium card-accent-gradient p-6 block group">
-          <div class="w-14 h-14 rounded-2xl bg-[--color-purple]/10 flex items-center justify-center mb-4">
-            <svg class="w-6 h-6 text-[--color-purple]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M4.26 10.147a60.436 60.436 0 00-.491 6.347A48.627 48.627 0 0112 20.904a48.627 48.627 0 018.232-4.41 60.46 60.46 0 00-.491-6.347m-15.482 0a50.57 50.57 0 00-2.658-.813A59.905 59.905 0 0112 3.493a59.902 59.902 0 0110.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.697 50.697 0 0112 13.489a50.702 50.702 0 017.74-3.342"/></svg>
+          <div class="w-14 h-14 rounded-2xl bg-[--color-accent]/10 flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-[--color-accent]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M4.26 10.147a60.436 60.436 0 00-.491 6.347A48.627 48.627 0 0112 20.904a48.627 48.627 0 018.232-4.41 60.46 60.46 0 00-.491-6.347m-15.482 0a50.57 50.57 0 00-2.658-.813A59.905 59.905 0 0112 3.493a59.902 59.902 0 0110.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.697 50.697 0 0112 13.489a50.702 50.702 0 017.74-3.342"/></svg>
           </div>
           <p class="font-mono text-[--color-accent] text-xs font-bold mb-2 tracking-wider">{t('features.learn_tag')}</p>
           <h3 class="font-bold text-lg mb-2 group-hover:text-[--color-accent] transition-colors">{t('features.learn_title')}</h3>


### PR DESCRIPTION
## 디자인 평가 약점 #8 (P2)

home feature card 4종 4색 → Linear/Vercel 1~2색 패턴 부합 위해 통일.

## 변경 (EN + KO, 4 line each)

| Card | Color before | Color after |
|------|-------------|-------------|
| /simulate | accent | accent ✓ |
| /strategies | up (green) | **accent** |
| /fees | verified (amber) | **accent** |
| /learn | purple | **accent** |

## 의미 색 보존 (변경 0)

- verified (amber) — TrustGapPanel + 검증 amber 박스
- up/down — 데이터 시각화 (수익/손실)
- purple — TopStrategyWidget 배지

## ⚠️ Visual regression baseline

컬러 변경이 threshold 0.02 초과 가능. 머지 시 fail → 별 commit으로 baseline 갱신:
```
npx playwright test --update-snapshots tests/e2e/visual-regression.spec.ts
git add tests/e2e/visual-regression.spec.ts-snapshots/
git commit -m "test: update visual baselines (feature card color)"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)