### PR TITLE
chore(deps): remove 3 unused deps (Sprint 3.4 — bundle diet)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,6 @@
         "@astrojs/sitemap": "^3.7.2",
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource-variable/geist-mono": "^5.2.7",
-        "@fontsource/inter": "^5.2.8",
-        "@fontsource/jetbrains-mono": "^5.2.8",
         "@resvg/resvg-js": "^2.6.2",
         "@tailwindcss/vite": "^4.2.4",
         "astro": "^5.17.1",
@@ -23,7 +21,6 @@
         "tailwindcss": "^4.1.18"
       },
       "devDependencies": {
-        "@anthropic-ai/sdk": "^0.91.1",
         "@axe-core/playwright": "^4.11.2",
         "@playwright/test": "^1.50.0",
         "@testing-library/jest-dom": "^6.9.1",
@@ -41,27 +38,6 @@
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.11",
@@ -1189,24 +1165,6 @@
       "version": "5.2.7",
       "resolved": "https://registry.npmjs.org/@fontsource-variable/geist-mono/-/geist-mono-5.2.7.tgz",
       "integrity": "sha512-ZKlZ5sjtalb2TwXKs400mAGDlt/+2ENLNySPx0wTz3bP3mWARCsUW+rpxzZc7e05d2qGch70pItt3K4qttbIYA==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
-      }
-    },
-    "node_modules/@fontsource/inter": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
-      "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
-      }
-    },
-    "node_modules/@fontsource/jetbrains-mono": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
-      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
@@ -6097,20 +6055,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -9104,13 +9048,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/tsconfck": {
       "version": "3.1.6",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
     "@astrojs/sitemap": "^3.7.2",
     "@fontsource-variable/geist": "^5.2.8",
     "@fontsource-variable/geist-mono": "^5.2.7",
-    "@fontsource/inter": "^5.2.8",
-    "@fontsource/jetbrains-mono": "^5.2.8",
     "@resvg/resvg-js": "^2.6.2",
     "@tailwindcss/vite": "^4.2.4",
     "astro": "^5.17.1",
@@ -29,7 +27,6 @@
     "tailwindcss": "^4.1.18"
   },
   "devDependencies": {
-    "@anthropic-ai/sdk": "^0.91.1",
     "@axe-core/playwright": "^4.11.2",
     "@playwright/test": "^1.50.0",
     "@testing-library/jest-dom": "^6.9.1",


### PR DESCRIPTION
## Sprint 3.4 — 번들 다이어트

사용 0 검증된 3 deps 제거 — 디자인 평가 9.4→9.7 진입 작업.

## 제거 (grep 검증)

| dep | 사유 |
|-----|------|
| @fontsource/inter | grep 0 imports. `public/fonts/inter.woff2` 직접 파일 사용 |
| @fontsource/jetbrains-mono | grep 0 imports. `global.css:44` 직접 woff2 import |
| @anthropic-ai/sdk | grep 0 imports (주석 1건만) |

## 남은 fontsource (사용 검증됨)

- @fontsource-variable/geist
- @fontsource-variable/geist-mono

## 영향

- node_modules 크기 ↓
- npm install 시간 단축
- 보안 surface 감소
- frontend bundle 영향 0 (모두 dev/font, runtime 미포함)

## 6원칙

| 원칙 | 매핑 |
|------|------|
| 4 무결 | dead dep 청산 |
| 6 근거 | grep 정량 검증 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)