### PR TITLE
refactor(brand): slogan SSoT — Profit → Decide (replaces #1516)

### DIFF
--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -199,7 +199,7 @@ export const ko: Record<TranslationKey, string> = {
     "투자 조언이 아닙니다. 암호화폐 트레이딩은 상당한 손실 위험을 수반합니다. 과거 성과는 미래 결과를 보장하지 않습니다. PRUVIQ는 교육 및 연구 프로젝트입니다.",
 
   // Footer
-  "footer.tagline": "검증하고. 실행하고. 수익내고.",
+  "footer.tagline": "검증하고. 실행하고. 결정하고.",
   "footer.strategies": "전략",
   "footer.learn": "학습",
   "footer.fees": "수수료 절약",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -36,7 +36,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
         <!-- Left: Text + CTA -->
         <div>
           <HeroBadge stat={`${coinsAnalyzed}+`} label="coins · 2yr data · real fees" />
-          <p class="font-mono text-[--color-accent] text-sm tracking-wider mb-5 opacity-90">Verify. Execute. Profit.</p>
+          <p class="font-mono text-[--color-accent] text-sm tracking-wider mb-5 opacity-90">Verify. Execute. Decide.</p>
           <h1 class="text-5xl md:text-6xl lg:text-7xl font-extrabold tracking-[-0.04em] leading-[1.05] text-balance">
             Most Backtests Lie.<br/><span class="gradient-text-shimmer">Ours Come With Proof.</span>
           </h1>

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -36,7 +36,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
         <!-- Left: Text + CTA -->
         <div>
           <HeroBadge stat={`${coinsAnalyzed}+`} label="코인 · 2년 데이터 · 실제 수수료" cta="무료 체험 →" />
-          <p class="font-mono text-[--color-accent] text-sm tracking-wider mb-5 opacity-90">검증하고. 실행하고. 수익내고.</p>
+          <p class="font-mono text-[--color-accent] text-sm tracking-wider mb-5 opacity-90">검증하고. 실행하고. 결정하고.</p>
           <h1 class="text-5xl md:text-6xl lg:text-7xl font-extrabold tracking-[-0.04em] leading-[1.1] text-balance">
             대부분의 백테스트는 거짓말입니다.<br/><span class="gradient-text-shimmer">우리는 증거를 공개합니다.</span>
           </h1>


### PR DESCRIPTION
## Summary
브랜드 slogan을 "Verify. Execute. Profit." → "Verify. Execute. Decide."로 통일.

## Why this PR (replaces #1516)
원본 #1516은 4-26에 만들어진 후 #1436 (Kakao OG + Naver SEO) + #1519 (KO H1 token-pure) + 다른 7개 PR이 머지되면서 다음을 회귀시키는 상태가 됨:
- ❌ #1436의 og:image:secure_url, article:author, og:updated_time, author meta, og:image:alt 다국어 분기 — 모두 제거됨
- ❌ #1519의 ko/index.astro inline-style 제거 — inline-style 부활됨

→ #1516을 그대로 rebase 시 직전 2 머지 무효화 = 회귀 0 절대조건 위반.

## What changed
3 라인 텍스트 치환만:
- `src/pages/index.astro:39` — `Verify. Execute. Profit.` → `Verify. Execute. Decide.`
- `src/pages/ko/index.astro:39` — `수익내고.` → `결정하고.`
- `src/i18n/ko.ts:202` — footer.tagline `수익내고.` → `결정하고.`

`src/i18n/en.ts` footer.tagline은 PR #1520에서 이미 정렬됨.

## Verification
- `npm run build` → 1196 pages, 0 errors
- `bash scripts/qa-redirects.sh` → PASS, 충돌 0
- 직전 머지(#1436 SEO meta, #1519 KO H1) 보존 확인 — Layout.astro / og:* 미수정
- 회귀 위험: 0

## Test plan
- [x] build 1196 pages
- [x] qa-redirects PASS
- [ ] CI Playwright E2E
- [ ] visual-regression (텍스트 변경이라 baseline 영향 가능, threshold 0.02 이내 예상)
- [ ] axe a11y / lhci

## Follow-up (다른 PR로)
hero p 슬로건이 i18n key가 아닌 inline 하드코딩 — 추후 `t('hero.slogan')` 추출 PR 권장 (Sprint 4.4 KO native checker와 함께).

Closes #1516