### PR TITLE
perf(hero): fetchpriority=high for BrowserFrame img (Sprint 3.1 LCP hint)

### DIFF
--- a/src/components/ui/BrowserFrame.astro
+++ b/src/components/ui/BrowserFrame.astro
@@ -22,7 +22,7 @@ const { src, alt, url = 'pruviq.com/simulate' } = Astro.props;
   <slot>
     <picture>
       <source type="image/webp" srcset={src.replace(/\.png$/, '.webp')} />
-      <img {src} {alt} class="w-full block" loading="eager" />
+      <img {src} {alt} class="w-full block" loading="eager" fetchpriority="high" />
     </picture>
   </slot>
 </div>


### PR DESCRIPTION
## Summary
hero img(simulator-preview)에 fetchpriority=high browser hint 추가. Sprint 3.1 — Lighthouse 100 LCP 미세조정.

## Why
실측 lhci report (#1545):
- /ko/ LCP 2812ms (>2500 미달)
- 다른 페이지 LCP 800-1300 (good)

/ko/ LCP fix 가장 안전한 1차: BrowserFrame img에 fetchpriority=high. browser가 다른 리소스보다 먼저 fetch.

## Changes
- `src/components/ui/BrowserFrame.astro:25` — `<img>` attribute 1개 추가

## Why this scope
- preload `<link rel=preload>`는 페이지별 분기 필요 → Layout.astro 광범위 변경 → 회귀 위험
- fetchpriority는 attribute 1개, 모든 BrowserFrame 사용처 일괄 적용 (한 페이지 내 LCP 후보 1개라 안전)

## Verification
- 회귀 위험: 0 (img attribute 1개, baseline 영향 0, layout 영향 0)
- build: 1196 pages, qa-redirects: PASS
- 머지 후 lhci로 /ko/ LCP 변동 측정 가능

## Follow-up plan
- 효과 부족 시 Layout.astro에 페이지별 preload prop 추가 (큰 변경, 별 PR)