### PR TITLE
fix(a11y): coin row tr aria-label — /coins/ a11y 0.93 회복 (Sprint 3.1)

### DIFF
--- a/src/components/CoinListTable.tsx
+++ b/src/components/CoinListTable.tsx
@@ -602,6 +602,7 @@ export default function CoinListTable({ lang = "en" }: { lang?: "en" | "ko" }) {
                   key={coin.symbol}
                   tabIndex={0}
                   role="link"
+                  aria-label={`${coin.name} (${coin.symbol.replace("USDT", "")}) — view detail`}
                   onClick={(e: MouseEvent) => {
                     if (!(e.target as HTMLElement).closest("a"))
                       window.location.href = coinUrl;


### PR DESCRIPTION
## Summary
prod /coins/ lighthouse 실측 진단 → a11y 0.93 미달 원인 정확 식별 + 1차 fix.

## Evidence (직접 측정)
\`npx lighthouse https://pruviq.com/coins/ --only-categories=accessibility\` 실행 결과:
- **aria-command-name** (score 0): \`<tr role=\"link\">\` 49건 모두 accessible name 없음 ← 이 PR 처리
- **color-contrast** (score 0): \`--color-accent #0891b2\` ratio 3.68 (필요 4.5) ← 별 PR

## Changes
\`src/components/CoinListTable.tsx:605\` — \`<tr role=\"link\">\`에 aria-label 추가:
\`\`\`tsx
aria-label={\`\${coin.name} (\${coin.symbol.replace(\"USDT\", \"\")}) — view detail\`}
\`\`\`

screen reader가 \"Bitcoin (BTC) — view detail\" 식으로 row를 명확히 읽음.

## Why scope split
color-contrast는 \`--color-accent\` 토큰 변경 → 사이트 전체 accent UI 영향 → visual baseline 다 깨짐 → 사용자 시각 검수 필수. 별 PR.

## Verification
- build: 1196 pages
- qa-redirects: PASS
- 회귀 위험: 0 (aria-label 추가만, visual 영향 0, layout 영향 0)

## Expected impact
머지 후 /coins/ a11y 0.93 → 0.97 예상 (color-contrast 0.03 미달 잔존, 별 PR 후 1.0)