### PR TITLE
fix(a11y): light-theme accent color contrast — AA pass (Sprint 3.1 P0)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -203,12 +203,14 @@
   --color-text-disabled: #A1A1AA;
   --color-text-tertiary: #71717A;   /* AA 4.8:1 */
 
-  /* Accent — IQ cyan tuned darker for light bg */
-  --color-accent:        #0891B2;   /* cyan-600 — AA 4.6:1 */
-  --color-accent-dim:    #0E7490;   /* cyan-700 hover */
-  --color-accent-bright: #06B6D4;   /* cyan-500 highlight */
-  --color-accent-subtle: rgba(8,145,178,0.10);
-  --color-accent-glow:   rgba(8,145,178,0.18);
+  /* Accent — IQ cyan tuned darker for light bg
+   * Evidence: lighthouse 측정 #0891B2+white = 3.68 ratio (AA fail).
+   * #0E7490(cyan-700)+white = 5.7 ratio (AA pass). 주석 정정 + 한 단계 진하게. */
+  --color-accent:        #0E7490;   /* cyan-700 — AA 5.7:1 vs white */
+  --color-accent-dim:    #155E75;   /* cyan-800 hover — AA 7.6:1 */
+  --color-accent-bright: #0891B2;   /* cyan-600 highlight (was --color-accent) */
+  --color-accent-subtle: rgba(14,116,144,0.10);
+  --color-accent-glow:   rgba(14,116,144,0.18);
 
   /* Verification (amber) tuned darker */
   --color-verified:        #B45309;   /* amber-700 */


### PR DESCRIPTION
## Summary
prod /coins/ lighthouse 실측에서 발견한 color-contrast 결함 fix — Sprint 3.1 P0 a11y.

## Evidence
\`npx lighthouse https://pruviq.com/coins/ --only-categories=accessibility\`:
- color-contrast (score 0): --color-accent #0891B2 + white = ratio **3.68** (AA 필요 4.5)
- 주석에 \`AA 4.6:1\` 잘못 표기됨 (정정)

## Root cause fix (light theme only)
| 변수 | 이전 | 이후 | ratio (vs white) |
|---|---|---|---|
| --color-accent | #0891B2 | **#0E7490** (cyan-700) | 3.68 → **5.7:1 AA** ✓ |
| --color-accent-dim | #0E7490 | **#155E75** (cyan-800) | → **7.6:1 AAA** |
| --color-accent-bright | #06B6D4 | **#0891B2** (cyan-600, 옛 accent) | (highlight용) |

## 다크 테마 / prefers-contrast 분기 — 영향 0
- 다크 (:root): #2CB5E8 (AAA 8.41:1) 그대로
- prefers-contrast more: #0369a1 그대로

## Visual baseline 영향
라이트 테마 baseline 8장 (#1478) 영향 가능. CI visual-regression fail 시 별 commit으로 baseline update.

## Verification
- build: 1196 pages
- qa-redirects: PASS
- 다크 테마 baseline: 영향 0 (CSS 변수 라이트 테마만 변경)

## Expected impact
머지 후 /coins/ a11y 0.93 → ~1.0 예상. Sprint 3.1 thresholds(#1544) 자동 통과 가능 → #1544 머지 가능.