### PR TITLE
fix(a11y): /strategies/ 11 buttons 44px touch (Sprint 3.1 WCAG AA 2.5.5)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -990,6 +990,17 @@ button:focus-visible,
   outline-offset: 2px;
   border-radius: 2px;
 }
+
+/* ─── WCAG AA 2.5.5 — Touch target ≥ 44px (Sprint 3.1)
+ * Filter/sort 버튼군 (font: text-xs, padding: py-2.5 = 36px) 일괄 보강.
+ * 인라인 텍스트가 아닌 명시적 컨트롤은 모두 44px 보장. */
+button[data-filter-group],
+button[data-sort-value] {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
 /* Form inputs: override Tailwind outline-none to ensure keyboard focus ring */
 input:focus-visible,
 select:focus-visible,


### PR DESCRIPTION
## Summary
PR #1510 e2e 가드가 발견한 14 element 중 **11건 일괄 fix** — Sprint 3.1 WCAG AA 2.5.5.

## Evidence
\`#1510\` Playwright run log:
- \`/strategies/\`: 11 interactive elements below 44px hit area
- 11개 모두 \`button[data-filter-group]\` (status/direction) + \`button[data-sort-value]\` 패턴
- text-xs (12px) + px-3 py-2.5 (10+10) = **36px tall** (44 미달)

## Root cause fix
글로벌 CSS selector 1개로 11 element 일괄 보강:
\`\`\`css
button[data-filter-group],
button[data-sort-value] {
  min-height: 44px;
  display: inline-flex;
  align-items: center;
  justify-content: center;
}
\`\`\`

각 페이지 inline class 수정 불필요 (DRY).

## Verification
- build: 1196 pages
- qa-redirects: PASS
- 회귀 위험: 낮음 (visual baseline /strategies/ 페이지 height 8px 정도 증가, threshold 초과 시 baseline update 별 commit)

## 잔여 (별 PR)
- \`/\`: 1 element (#1510 PR이 hero CTA 일부 처리, 미해결 1건 남음)
- \`/simulate/\`: 2 elements
- 패턴 다름 → 별 PR로

## Expected impact
머지 후 #1510 e2e 11/14 통과. /strategies/ 가드 SUCCESS. #1510 close vs 잔여 3건 fix 후 #1510 머지 결정.