### PR TITLE
perf(hero): preload simulator-preview.webp (Sprint 3.1 /ko/ LCP fix)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -21,6 +21,10 @@ interface Props {
   canonicalOverride?: string;
   noAlternate?: boolean;
   skipArticleLD?: boolean;
+  /** Hero LCP candidate image — emit `<link rel="preload" as="image">` with
+   * `fetchpriority=high` for pages where this image is the LCP element.
+   * Sprint 3.1 — /ko/ LCP 2812ms fix (lhci 측정 기준). */
+  heroImagePreload?: string;
 }
 
 const lang = getLangFromUrl(Astro.url);
@@ -33,7 +37,7 @@ const cfToken = import.meta.env.PUBLIC_CF_ANALYTICS_TOKEN;
 const buildTime = new Date().toISOString();
 const currentYear = new Date().getFullYear();
 
-const { title, description = t('meta.home_desc'), type = 'website', date, updatedDate, category, keywords: customKeywords, canonicalOverride, noAlternate = false, skipArticleLD = false } = Astro.props;
+const { title, description = t('meta.home_desc'), type = 'website', date, updatedDate, category, keywords: customKeywords, canonicalOverride, noAlternate = false, skipArticleLD = false, heroImagePreload } = Astro.props;
 const lastModified = updatedDate || date || buildTime;
 const ogImage = new URL(Astro.props.ogImage || '/og-image.jpg', Astro.site || 'https://pruviq.com').href;
 // Only emit webp variant for the default static og-image.jpg (which has a
@@ -191,6 +195,9 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <meta name="application-name" content="PRUVIQ" />
     <link rel="preload" href="/fonts/geist.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="/fonts/geist-mono.woff2" as="font" type="font/woff2" crossorigin />
+    {heroImagePreload && (
+      <link rel="preload" href={heroImagePreload} as="image" fetchpriority="high" />
+    )}
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96.png" />
     <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48.png" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -26,7 +26,7 @@ const tradingDays = (stats.trading_days ?? 0).toLocaleString('en-US');
 const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1) + 'M';
 ---
 
-<Layout title={t('meta.home_title')} description={t('meta.index_desc')} ogImage="/og/home.png">
+<Layout title={t('meta.home_title')} description={t('meta.index_desc')} ogImage="/og/home.png" heroImagePreload="/images/simulator-preview.webp">
 
   <!-- HERO — 50/50 layout: text left, live demo right -->
   <section id="hero-section" class="relative overflow-hidden hero-bg-depth section-glow-green">

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -26,7 +26,7 @@ const tradingDays = (stats.trading_days ?? 0).toLocaleString('ko-KR');
 const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1) + 'M';
 ---
 
-<Layout title={t('meta.home_title')} description={t('meta.index_desc')} ogImage="/og/home.png">
+<Layout title={t('meta.home_title')} description={t('meta.index_desc')} ogImage="/og/home.png" heroImagePreload="/images/simulator-preview.webp">
 
   <!-- HERO — 50/50 layout: text left, live demo right -->
   <section id="hero-section" class="relative overflow-hidden hero-bg-depth section-glow-green">


### PR DESCRIPTION
## Summary
\`/ko/\` LCP 2812ms (lhci 실측) 미달 fix — Sprint 3.1 LCP 2500ms 인상 준비.

## Evidence
PR #1545 lhci report:
- / : LCP 1316ms (good)
- **/ko/ : LCP 2812ms** (>2500ms 미달 — Sprint 3.1 thresholds 인상 blocker)
- /simulate/, /market/, /coins/ : 800-1000ms (good)

## Root cause fix
Layout.astro에 옵셔널 prop \`heroImagePreload\`:
- 페이지가 LCP candidate 이미지 명시 → head에 \`<link rel=\"preload\" as=\"image\" fetchpriority=\"high\">\` 발행
- 모든 페이지 무차별 preload 안 함 (안전 기본값)

## Changes
- \`src/layouts/Layout.astro\` — Props 추가 + head emit
- \`src/pages/index.astro\` — \`heroImagePreload=\"/images/simulator-preview.webp\"\`
- \`src/pages/ko/index.astro\` — 동일

## Verification
- build: 1196 pages
- qa-redirects: PASS
- dist 확인: \`<link rel=\"preload\" href=\"/images/simulator-preview.webp\" as=\"image\" fetchpriority=\"high\">\` 두 페이지 모두 출력
- 회귀 위험: 0 (Layout prop 옵셔널, 다른 페이지 영향 0, visual baseline 영향 0)

## Expected impact
- /ko/ LCP 2812ms → ~2400ms 예상 (preload + fetchpriority high)
- 영문 home LCP 1316ms도 추가 개선 가능
- 후속 PR로 LCP 3000 → 2500ms threshold 인상 가능