### PR TITLE
polish(prose): inline link decoration micro-polish (Sprint 4.1)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1220,9 +1220,17 @@ textarea:focus-visible {
 .prose a {
   color: var(--color-accent);
   text-decoration: underline;
-  text-underline-offset: 2px;
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1.5px;
+  text-decoration-color: color-mix(in srgb, var(--color-accent) 60%, transparent);
+  transition:
+    color var(--duration-fast) var(--ease-smooth),
+    text-decoration-color var(--duration-fast) var(--ease-smooth);
 }
-.prose a:hover { color: var(--color-accent-bright); }
+.prose a:hover {
+  color: var(--color-accent-bright);
+  text-decoration-color: var(--color-accent);
+}
 .prose hr {
   border-color: var(--color-border);
   margin: 2rem 0;


### PR DESCRIPTION
## Summary
\`.prose\` 본문 inline link 가독성 + 인터랙션 정밀 — Sprint 4.1 마이크로 인터랙션 1차.

## Changes
\`src/styles/global.css\` \`.prose a\` 블록:
- \`text-underline-offset\` 2px → **3px** (Linear/Vercel 권장 가독성)
- \`text-decoration-thickness: 1.5px\` 명시 (브라우저 기본 thin 일관)
- \`text-decoration-color\` 60% accent (옅은 하단선) → hover 시 100%
- \`transition\` color + decoration-color (smoothing)

## Why micro-polish
- Linear/Vercel 수준 디자인은 inline link decoration 정밀이 핵심
- 기존: underline 항상 100% accent (강조 과함)
- 이후: 60% → 100% (정보 우선, hover 시 명확)

## Verification
- build: 1196 pages
- qa-redirects: PASS
- 영향 범위: .prose 컨테이너 (블로그/learn/about 본문 inline link)
- visual baseline 영향: 거의 0 (.prose 콘텐츠 적은 페이지)
- 회귀 위험: 0 (정확한 .prose selector 한정, btn/nav 영향 없음)