### PR TITLE
fix(manifest): coin count 240 → 238 (SSoT 정렬)

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "name": "PRUVIQ — Crypto Strategy Verification",
   "short_name": "PRUVIQ",
   "id": "/",
-  "description": "Free crypto strategy backtester. Verify strategies on 240 OKX coins, share verified results, never trust unverified backtests again.",
+  "description": "Free crypto strategy backtester. Verify strategies on 238 OKX coins, share verified results, never trust unverified backtests again.",
   "start_url": "/",
   "scope": "/",
   "display": "standalone",


### PR DESCRIPTION
## Summary
\`public/manifest.json\` description의 \"240 OKX coins\" → \"238\" (실측 SSoT 정렬). PR #1518 후속.

## Evidence
- \`https://api.pruviq.com/health\` coins_loaded = **238** (4-29 실측)
- PR #1518: api docs example 235→238 정렬
- manifest.json description은 PWA install 시 사용자에게 표시 → 정확한 수치 신뢰도

## Verification
- JSON valid (\`jq .\` 통과)
- 회귀 위험: 0 (1줄, 텍스트만)