### PR TITLE
polish(ko): hero h1 tracking 한국어 친화 (Sprint 4.4-B 1차)

### DIFF
--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -37,7 +37,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
         <div>
           <HeroBadge stat={`${coinsAnalyzed}+`} label="코인 · 2년 데이터 · 실제 수수료" cta="무료 체험 →" />
           <p class="font-mono text-[--color-accent] text-sm tracking-wider mb-5 opacity-90">검증하고. 실행하고. 결정하고.</p>
-          <h1 class="text-5xl md:text-6xl lg:text-7xl font-extrabold tracking-[-0.04em] leading-[1.1] text-balance">
+          <h1 class="text-5xl md:text-6xl lg:text-7xl font-extrabold tracking-[-0.02em] leading-[1.15] text-balance">
             대부분의 백테스트는 거짓말입니다.<br/><span class="gradient-text-shimmer">우리는 증거를 공개합니다.</span>
           </h1>
           <p class="mt-10 text-xl md:text-2xl text-[--color-text-secondary] leading-relaxed max-w-lg">


### PR DESCRIPTION
## Summary
사용자 피드백 (4-29) — 한국어/영문 typography 분리 부족으로 가독성 저하 → Sprint 4.4-B 한국어 레이아웃 분리 1차.

## Evidence
- 영문 hero h1 디자인 토큰: \`tracking-[-0.04em] leading-[1.05]\`
- 한국어 글자 폭 영문 1.2~1.4배 → 자간 -0.04em이 너무 좁음
- 영문 권장 자간을 한국어에 적용한 결과 가독성 ↓

## Root cause fix (ko/index.astro h1만)
- \`tracking-[-0.04em]\` → \`tracking-[-0.02em]\` (한국어 자간 친화)
- \`leading-[1.1]\` → \`leading-[1.15]\` (한국어 줄간격 더 여유)

영문 페이지 (\`index.astro\`) 영향 0 — 동일 토큰 유지.

## Why minimal
- 1 라인, 단일 파일
- visual baseline 영향: ko-home 2장 (threshold 0.02 안 들어올 가능성)
- 사용자 시각 검수 필요한 4.4-B 큰 작업의 가장 안전한 1차 step

## Sprint 4.4-B 후속 (별 PR)
- hero p / 다른 ko 페이지 큰 텍스트 동일 적용
- max-width 한국어 재계산 (글자 폭 1.2x)
- :lang(ko) 셀렉터 강화로 글로벌 패턴화

## Verification
- build: 1196 pages
- qa-redirects: PASS
- 회귀 위험: 0 (영문 페이지 무관, ko/index.astro 1라인만)

CI visual-regression 통과 시 자동 머지. fail 시 baseline update commit 추가 푸시.