### PR TITLE
polish(ko): hero p max-width lg → xl (Sprint 4.4-B 2차)

### DIFF
--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -40,7 +40,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
           <h1 class="text-5xl md:text-6xl lg:text-7xl font-extrabold tracking-[-0.02em] leading-[1.15] text-balance">
             대부분의 백테스트는 거짓말입니다.<br/><span class="gradient-text-shimmer">우리는 증거를 공개합니다.</span>
           </h1>
-          <p class="mt-10 text-xl md:text-2xl text-[--color-text-secondary] leading-relaxed max-w-lg">
+          <p class="mt-10 text-xl md:text-2xl text-[--color-text-secondary] leading-relaxed max-w-xl">
             <strong class="text-[--color-text]">{coinsAnalyzed}개 이상의 코인</strong>에서 실제 수수료를 포함한 전략 검증. 실패를 확인하고, 살아남은 전략만 남기세요. 코딩 불필요. 가입 불필요.
           </p>
           <!-- Differentiator — front and center -->


### PR DESCRIPTION
## Summary
한국어 hero p 줄당 글자수 확장 — Sprint 4.4-B 2차.

## Evidence
- 영문 hero p \`max-w-lg\` (32rem ≈ 512px) — 영문 ~52~60자/줄 적정
- 한국어 동일 max-width — 한국어 ~28~32자/줄 (글자 폭 1.2~1.4x로 줄당 글자수 ↓)
- "쓸데없는 줄바꿈" (사용자 4-30 피드백) 핵심 원인

## Fix
\`src/pages/ko/index.astro:43\`:
- \`max-w-lg\` (512px) → \`max-w-xl\` (576px)
- 영문 페이지 (\`src/pages/index.astro\`) 영향 0

## Verification
- build: 1196 pages
- qa-redirects: PASS
- 회귀 위험: 0 (1라인, ko/index.astro만)
- visual baseline: ko-home 2장 (threshold 0.02 안 들어올 가능성)

## Sprint 4.4-B 후속
- 다른 ko 페이지 (simulate, strategies, learn 등) hero typography 동일 패턴 적용
- :lang(ko) 글로벌 패턴화