### PR TITLE
polish(ko): about + autotrading h1 tracking 한국어 친화 (Sprint 4.4-B 3차)

### DIFF
--- a/src/pages/ko/about.astro
+++ b/src/pages/ko/about.astro
@@ -33,7 +33,7 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
     </div>
     <div class="relative max-w-4xl mx-auto px-6 text-center">
       <p class="font-mono text-[--color-accent] text-sm mb-3 tracking-wider">{t('about.tag')}</p>
-      <h1 class="text-4xl md:text-6xl font-bold tracking-[-0.04em] leading-[1.08] mb-6">{t('about.title')}</h1>
+      <h1 class="text-4xl md:text-6xl font-bold tracking-[-0.02em] leading-[1.18] mb-6">{t('about.title')}</h1>
       <p class="text-[--color-text-muted] text-lg md:text-xl max-w-2xl mx-auto leading-relaxed">
         {t('about.mission')}
       </p>

--- a/src/pages/ko/autotrading/index.astro
+++ b/src/pages/ko/autotrading/index.astro
@@ -19,7 +19,7 @@ import Layout from '../../../layouts/Layout.astro';
         <span class="font-mono text-xs font-bold tracking-widest text-[--color-accent] uppercase">곧 출시 · OKX OAuth 승인 대기</span>
       </div>
 
-      <h1 class="text-5xl md:text-6xl lg:text-7xl font-extrabold tracking-[-0.04em] leading-[1.05] text-balance mb-8">
+      <h1 class="text-5xl md:text-6xl lg:text-7xl font-extrabold tracking-[-0.02em] leading-[1.15] text-balance mb-8">
         검증된 전략,<br/>
         <span class="gradient-text-shimmer">준비되면 배포</span>
       </h1>


### PR DESCRIPTION
## Summary
#1570 (ko home h1 한국어 typography 분리) 패턴을 다른 ko 랜딩 페이지로 일관 확장.

## Changes
- \`src/pages/ko/about.astro:36\` — \`tracking-[-0.04em]\` → \`tracking-[-0.02em]\`, leading 1.08 → 1.18
- \`src/pages/ko/autotrading/index.astro:22\` — \`tracking-[-0.04em]\` → \`tracking-[-0.02em]\`, leading 1.05 → 1.15

## Why
한국어 글자 폭이 영문 1.2~1.4배 → 영문 권장 자간 -0.04em이 한국어에 너무 좁음.
일관 적용으로 ko home + about + autotrading 디자인 톤 통일.

## Verification
- 영문 페이지 (about.astro, autotrading/index.astro) 영향 0
- build: 1196 pages
- qa-redirects: PASS
- 회귀 위험: 0