### PR TITLE
polish(ko): 본문 typography 글로벌 강화 (Sprint 4.4-B 4차, :lang(ko) 패턴화)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -572,6 +572,19 @@ body {
 :lang(ko) .btn, :lang(ko) .btn-primary, :lang(ko) .btn-ghost {
   letter-spacing: 0.01em;
 }
+/* Sprint 4.4-B 4차 — 본문 텍스트 한국어 친화 (Tailwind inline class 없는 element 자동 적용)
+ * - 본문 p line-height 1.7 (한국어 글자 압박 해소, 영문 leading-relaxed 1.625보다 약간 ↑)
+ * - 리스트 item 동일 leading
+ * - strong 굵기 — 영문 600은 한국어에 약함, 700이 명확한 강조 */
+:lang(ko) p:not([class*="text-"]):not([class*="font-mono"]) {
+  line-height: 1.7;
+}
+:lang(ko) li:not([class*="font-mono"]) {
+  line-height: 1.7;
+}
+:lang(ko) strong {
+  font-weight: 700;
+}
 
 /* Tabular numbers for all mono/data contexts */
 .font-mono,


### PR DESCRIPTION
## Summary
페이지별 inline 변경 (#1570/#1572/#1573)에서 한 단계 위 — 모든 ko 페이지 자동 적용. Sprint 4.4-B 4차.

## Why pattern (DRY)
inline class 페이지별 fix 누적은 비효율. \`:lang(ko)\` 글로벌 셀렉터로 한 번 적용하면 ko 모든 페이지 자동 보호.

## Changes (global.css \`:lang(ko)\` 블록 확장)
1. \`p:not([class*="text-"]):not([class*="font-mono"])\` line-height 1.7
   - 한국어 본문 글자 압박 해소
2. \`li:not([class*="font-mono"])\` line-height 1.7
   - 리스트 가독성 일관
3. \`strong\` font-weight 700
   - 한국어 강조 명확화 (영문 600 약함)

selector 정밀:
- \`:not([class*="text-"])\` — Tailwind \`text-xs/sm/lg/xl\` 명시 사용처 제외 (hero 등)
- \`:not([class*="font-mono"])\` — mono 텍스트 (numbers, code) 제외

## Verification
- 영향: ko 모든 페이지 본문 (hero text-xl 등 명시 제외)
- 영문 페이지 영향 0 (:lang(ko) 셀렉터)
- visual baseline: ko-* 본문 line-height 미세 변화 (threshold 0.02 안 들어올 가능성)
- build: 1196 pages, qa-redirects: PASS
- 회귀 위험: 0