### PR TITLE
polish(focus): keyboard focus soft accent ring (Sprint 4.1)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -830,10 +830,13 @@ details .faq-body > div {
 /* ─── Fade in ─── */
 .fade-in { animation: fadeIn 0.3s var(--ease-default); }
 
-/* ─── Keyboard focus (WCAG AA) ─── */
+/* ─── Keyboard focus (WCAG AA + Sprint 4.1 micro polish) ─── */
 :focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
+  /* soft accent glow ring (Linear/Vercel pattern) */
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-accent) 18%, transparent);
+  transition: box-shadow var(--duration-fast) var(--ease-smooth);
 }
 a:focus-visible,
 button:focus-visible,
@@ -844,6 +847,7 @@ textarea:focus-visible,
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
   border-radius: 2px;
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-accent) 18%, transparent);
 }
 #mobile-menu a:focus:not(:focus-visible) {
   outline: none;


### PR DESCRIPTION
## Summary
키보드 \`:focus-visible\` 시 outline에 부드러운 accent glow ring 추가 — Sprint 4.1 마이크로 인터랙션.

## Why
기존: outline 2px solid accent만 (기능적이지만 거친 feel).
Linear/Vercel 패턴: outline + soft halo (box-shadow ring) 조합으로 키보드 focus 명확 + 시각적 부드러움.

## Changes
\`global.css\` \`:focus-visible\`:
- \`box-shadow: 0 0 0 4px color-mix(accent 18%, transparent)\` — 옅은 4px halo
- \`transition: box-shadow fast\` — 부드러운 진입

## Verification
- 영향: 모든 a/button/input/select/textarea/[tabindex] (focus 시)
- visual baseline: 0 (focus 시에만)
- prefers-reduced-motion: transition 자동 비활성 (#1525)
- build: 1196 pages, qa-redirects: PASS
- 회귀 위험: 0