### PR TITLE
polish(html): scroll-padding-top for sticky nav anchor scroll

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -531,6 +531,8 @@
 html {
   scroll-behavior: smooth;
   overflow-x: hidden;
+  /* sticky nav (h-14 = 56px) 위 여유. anchor link scroll 시 nav 가림 방지. */
+  scroll-padding-top: 5rem;
 }
 
 body {


### PR DESCRIPTION
## Summary
anchor link 클릭 시 sticky nav 가림 방지 — UX micro polish.

## Root cause
- Layout.astro nav: \`h-14\` (56px) sticky
- 기존: anchor scroll 시 target heading이 nav 뒤에 숨음 (UX 결함)
- 사용자 직접 스크롤 다시 위로 올려야 보임

## Fix
\`global.css html\`에 \`scroll-padding-top: 5rem\` (80px, nav 56px + 여유 24px) 추가.
anchor link scroll 시 target이 nav 아래에 자연스럽게 위치.

## Verification
- 영향: 모든 페이지 anchor scroll
- visual baseline: 0 (idle 상태 영향 없음)
- 회귀 위험: 0
- build: 1196 pages, qa-redirects: PASS