### PR TITLE
fix(ko): hero h1 mobile size 축소 — 5줄 wrap 결함 (사용자 4-30 핀포인트)

### DIFF
--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -37,7 +37,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
         <div>
           <HeroBadge stat={`${coinsAnalyzed}+`} label="코인 · 2년 데이터 · 실제 수수료" cta="무료 체험 →" />
           <p class="font-mono text-[--color-accent] text-sm tracking-wider mb-5 opacity-90">검증하고. 실행하고. 결정하고.</p>
-          <h1 class="text-5xl md:text-6xl lg:text-7xl font-extrabold tracking-[-0.02em] leading-[1.15] text-balance">
+          <h1 class="text-[1.875rem] sm:text-4xl md:text-6xl lg:text-7xl font-extrabold tracking-[-0.02em] leading-[1.15] text-balance">
             대부분의 백테스트는 거짓말입니다.<br/><span class="gradient-text-shimmer">우리는 증거를 공개합니다.</span>
           </h1>
           <p class="mt-10 text-xl md:text-2xl text-[--color-text-secondary] leading-relaxed max-w-xl">


### PR DESCRIPTION
## Summary
사용자 실측 피드백 (4-30): /ko/ 모바일에서 hero h1이 5줄 wrap → mobile size 축소.

## Evidence
사용자 핀포인트: "글자가 너무 크고 메인 텍스트 5줄"
- 영문 typography size (\`text-5xl\` 48px)를 한국어에 그대로 적용
- mobile 375px viewport 기준 줄당 7~8자만 들어감
- "대부분의 백테스트는 거짓말입니다." (15자) + br + "우리는 증거를 공개합니다." (12자) → **5줄 wrap**

## Fix (ko/index.astro h1만)
\`\`\`
text-5xl → text-[1.875rem] (30px, mobile)
md:text-6xl → text-4xl (sm: 640px+, 36px)
md:text-6xl 그대로 (md: 768px+)
lg:text-7xl 그대로 (lg: 1024px+)
\`\`\`

## 기대
- mobile: 5줄 → 3줄
- desktop: 영향 0 (md/lg 동일)

영문 페이지 (\`index.astro\`) 영향 0 — ko만 한국어 친화.

## Verification
- build: 1196 pages
- qa-redirects: PASS
- 회귀 위험: 0