### PR TITLE
ci(data-deploy): drop paths filter + git diff gate (silent drop fix)

### DIFF
--- a/.github/workflows/data-deploy.yml
+++ b/.github/workflows/data-deploy.yml
@@ -10,30 +10,22 @@ name: "Data Deploy: build + wrangler deploy on public/data/** or src/** push"
 # Cloudflare API token + account ID are already stored as repo secrets.
 
 on:
+  # NO `paths:` filter. GitHub silently drops push events when the
+  # squash-merged HEAD only touches files that pass the filter on PR but
+  # not the resulting squash commit, or when the workflow registry stalls
+  # on a stale SHA. Same class of failure that hit deploy-backend.yml
+  # 2026-04-16~17 (8h frontend stall) and this workflow 2026-04-24 and
+  # again 2026-04-30. Pattern verified in deploy-backend.yml: trigger on
+  # every push to main, then short-circuit inside the job with a
+  # `git diff` gate so unrelated pushes still terminate in <1 minute.
   push:
     branches: [main]
-    paths:
-      - "public/data/**"
-      - "src/**"
-      - "astro.config.mjs"
-      - "wrangler.toml"
-      - "package.json"
-      - "package-lock.json"
   schedule:
-    # Drift detector — same pattern as deploy-backend.yml. The push event
-    # can be silently dropped by GitHub when the workflow registry gets
-    # stuck on a stale SHA. This happened 2026-04-16~17 (deploy-backend)
-    # and again 2026-04-24 00:15~15:22 UTC on this workflow: 10 frontend
-    # PRs merged but none auto-deployed until someone ran
-    # `gh workflow run data-deploy.yml` manually.
-    #
-    # 2026-04-26: bumped from */30 to 0 */6 (every 6h). After PR #1408
-    # the data path is push-driven (refresh_static.sh now commits+pushes
-    # public/data/** instead of calling wrangler), so the push trigger
-    # above already covers data refreshes. The schedule is purely a
-    # safety net for the registry-stuck class of bug, which is rare.
-    # Cuts CI runner cost ~12× without sacrificing detection.
-    - cron: "0 */6 * * *"
+    # Drift detector — primary deploy trigger is push above; this is a
+    # safety net for the registry-stuck class of bug. 1h cadence balances
+    # detection latency against runner cost (PUBLIC repo, ubuntu-latest
+    # has no minute cap, so 1h is virtually free).
+    - cron: "0 * * * *"
   workflow_dispatch: {}
 
 concurrency:
@@ -48,9 +40,29 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 2
+
+      - name: Skip if no deploy-relevant change
+        # Replaces the removed `paths:` filter. On push events, compare
+        # HEAD against its parent and bail if nothing under the deploy
+        # surface changed. Schedule and workflow_dispatch always proceed
+        # (drift detector / manual override).
+        id: gate
+        if: github.event_name == 'push'
+        run: |
+          set -euo pipefail
+          changed=$(git diff --name-only HEAD~1 HEAD | grep -E '^(public/data/|src/|astro\.config\.mjs|wrangler\.toml|package(-lock)?\.json)' || true)
+          if [ -z "$changed" ]; then
+            echo "no deploy-relevant files changed; skipping deploy"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "deploy-relevant changes:"
+            echo "$changed"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Sanity-check Cloudflare secrets present
+        if: steps.gate.outputs.skip != 'true'
         env:
           CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CF_ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -65,23 +77,28 @@ jobs:
           echo "secrets OK"
 
       - uses: actions/setup-node@v4
+        if: steps.gate.outputs.skip != 'true'
         with:
           node-version: "22"
           cache: npm
 
       - name: Install dependencies
+        if: steps.gate.outputs.skip != 'true'
         run: npm ci --prefer-offline
 
       - name: Build Astro site
+        if: steps.gate.outputs.skip != 'true'
         run: npm run build 2>&1 | tail -20
 
       - name: Deploy to Cloudflare Workers
+        if: steps.gate.outputs.skip != 'true'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: npx wrangler deploy 2>&1 | tail -10
 
       - name: Post-deploy smoke — production endpoint
+        if: steps.gate.outputs.skip != 'true'
         run: |
           sleep 10
           status=$(curl -sf -m 10 -o /dev/null -w "%{http_code}" https://pruviq.com/)


### PR DESCRIPTION
## Why
2026-04-30 09:28 KST PR #1584 머지 시 `data-deploy.yml`이 다시 silent drop됨. 4-24 사고와 동일 class. 매번 `gh workflow run data-deploy.yml` 수동 호출로 우회 중.

**Root cause** (advisor + code-reviewer 검증):
GitHub은 push event를 다음 경우 silent drop함:
1. squash-merged HEAD가 `paths:` 필터를 만족 못 할 때 (squash 결과 commit이 PR diff와 다름)
2. workflow registry가 stale SHA에 stuck됐을 때

`deploy-backend.yml`은 이 fix를 4-19 적용 후 안정 — `paths:` 제거 + 내부 `git diff` 게이트 패턴.

## What
1. **Remove `paths:` filter** from `on.push.branches`
2. **fetch-depth: 1 → 2** (parent commit 필요)
3. **New gate step** — push event에 한해 `git diff HEAD~1 HEAD` 결과로 deploy-relevant 변경 없으면 즉시 종료. schedule / workflow_dispatch는 그대로 진행 (drift detector / manual override).
4. **Cron 6h → 1h** — PUBLIC repo + ubuntu-latest 무한 minutes, drift detection latency 6×

## Side effects (advisor 확인)
- ❌ Mac Mini self-hosted runner 사용 안 함 (이미 ubuntu-latest)
- ❌ 다른 6개 paths-filter workflow는 건드리지 않음 (advisor: scope freeze)
- ❌ `pull_request: closed` 트리거 추가 안 함 (advisor block: actions/checkout@v6은 refs/pull/N/merge default → git diff HEAD~1 잘못 비교)
- ✅ 모든 deploy step에 `if: steps.gate.outputs.skip != 'true'` 추가하여 무관 push는 1분 이내 종료

## Test plan
- [ ] CI 통과 (이 PR 자체 머지 시 다음 push event 정상 trigger 확인)
- [ ] 머지 후 다음 ko 디자인 PR 머지 시 manual workflow_run 없이 자동 deploy
- [ ] schedule cron 1h tick에 정상 build+deploy 확인
- [ ] deploy-relevant 아닌 push (예: `docs/`만 변경)는 gate에서 즉시 종료 (<1분)

## 5원칙
- **뿌리**: silent drop의 근본 원인(paths-filter + squash) 제거
- **원론**: deploy-backend.yml 검증된 패턴 차용 (일관)
- **무결**: 미배포 PR class 영구 차단
- **책임**: drift detection 6h → 1h
- **근거**: deploy-backend.yml line 12-14, 4-30 09:28 manual workflow run 사고