### PR TITLE
perf(img): decoding=async on lazy referral imgs (Sprint 3.1)

### DIFF
--- a/src/pages/fees.astro
+++ b/src/pages/fees.astro
@@ -290,11 +290,11 @@ const t = useTranslations('en');
 
       <div class="grid md:grid-cols-2 gap-6 mb-6">
         <div class="text-center">
-          <img src="/images/binance-signup-rewards.png" alt="Binance signup page showing PRUVIQ referral rewards: up to 19% trade rebates and up to $600 new user bonus" class="rounded-lg border border-[--color-border] w-full" loading="lazy" width="1151" height="722" />
+          <img src="/images/binance-signup-rewards.png" alt="Binance signup page showing PRUVIQ referral rewards: up to 19% trade rebates and up to $600 new user bonus" class="rounded-lg border border-[--color-border] w-full" loading="lazy" decoding="async" width="1151" height="722" />
           <p class="text-[--color-text-muted] text-xs mt-2">What you see when signing up via PRUVIQ</p>
         </div>
         <div class="text-center">
-          <img src="/images/binance-referral-proof.png" alt="PRUVIQ Binance referral dashboard showing 1% platform, 19% spot and 9% futures commission to users" class="rounded-lg border border-[--color-border] w-full" loading="lazy" width="1255" height="248" />
+          <img src="/images/binance-referral-proof.png" alt="PRUVIQ Binance referral dashboard showing 1% platform, 19% spot and 9% futures commission to users" class="rounded-lg border border-[--color-border] w-full" loading="lazy" decoding="async" width="1255" height="248" />
           <p class="text-[--color-text-muted] text-xs mt-2">{t('fees.referral.proof.imageCaption')}</p>
         </div>
       </div>

--- a/src/pages/ko/fees.astro
+++ b/src/pages/ko/fees.astro
@@ -274,11 +274,11 @@ const t = useTranslations('ko');
 
       <div class="grid md:grid-cols-2 gap-6 mb-6">
         <div class="text-center">
-          <img src="/images/binance-signup-rewards.png" alt="바이낸스 가입 페이지 — PRUVIQ 레퍼럴 혜택: 최대 19% 거래 리베이트 + 최대 $600 신규 보너스" class="rounded-lg border border-[--color-border] w-full" loading="lazy" width="1151" height="722" />
+          <img src="/images/binance-signup-rewards.png" alt="바이낸스 가입 페이지 — PRUVIQ 레퍼럴 혜택: 최대 19% 거래 리베이트 + 최대 $600 신규 보너스" class="rounded-lg border border-[--color-border] w-full" loading="lazy" decoding="async" width="1151" height="722" />
           <p class="text-[--color-text-muted] text-xs mt-2">PRUVIQ를 통해 가입하면 보이는 화면</p>
         </div>
         <div class="text-center">
-          <img src="/images/binance-referral-proof.png" alt="PRUVIQ 바이낸스 레퍼럴 대시보드 — 1% 플랫폼, 19% 현물 + 9% 선물 수수료 사용자 환급" class="rounded-lg border border-[--color-border] w-full" loading="lazy" width="1255" height="248" />
+          <img src="/images/binance-referral-proof.png" alt="PRUVIQ 바이낸스 레퍼럴 대시보드 — 1% 플랫폼, 19% 현물 + 9% 선물 수수료 사용자 환급" class="rounded-lg border border-[--color-border] w-full" loading="lazy" decoding="async" width="1255" height="248" />
           <p class="text-[--color-text-muted] text-xs mt-2">{t('fees.referral.proof.imageCaption')}</p>
         </div>
       </div>


### PR DESCRIPTION
## Why
Sprint 3.1 micro-perf. Lazy 로드되는 referral 증빙 이미지 4개에 decoding=\"async\" 누락 — off-main-thread 디코딩 hint 추가로 paint 차단 해소.

## What
4개 \`<img>\`에 \`decoding=\"async\"\` 1 attr 추가:
- \`src/pages/fees.astro:293\` binance-signup-rewards
- \`src/pages/fees.astro:297\` binance-referral-proof
- \`src/pages/ko/fees.astro:277\` (KO mirror)
- \`src/pages/ko/fees.astro:281\` (KO mirror)

## Out of scope
Eager + fetchpriority=\"high\" hero 이미지 (simulator-preview / BrowserFrame)는 LCP critical path에 있어 decoding=async가 LCP에 마이너스 영향 가능 — 별 결정.

## Risk audit
- visual baseline diff: 0 (rendered pixels 동일, decoding strategy hint만)
- LCP/CLS: 0 (lazy 이미지는 viewport 진입 시점 로드)
- a11y: 무관
- semantic markup: 무관

**잔여 위험: 0**

## Build
1196 pages, 61s, 0 errors.

## 6원칙
- 일관: en/ko mirror
- 무결: 빌드 산출물 동일 (attr 추가만)
- 책임: Sprint 3.1 polish
- 근거: HTML spec decoding=async standard