### PR TITLE
perf(img): footer logo decoding=async (Sprint 3.1)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -689,7 +689,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
         <div class="flex flex-col md:flex-row gap-10 mb-10">
           <div class="md:w-1/3">
             <span class="flex items-center gap-1.5">
-              <img src="/favicon.svg" alt="PRUVIQ" width="24" height="24" class="w-6 h-6" loading="lazy" />
+              <img src="/favicon.svg" alt="PRUVIQ" width="24" height="24" class="w-6 h-6" loading="lazy" decoding="async" />
               <span class="font-mono font-bold text-lg tracking-wider"><span class="text-[--color-text]">PRUV</span><span class="text-[var(--color-accent)]">IQ</span></span>
             </span>
             <p class="text-[--color-text-muted] text-sm mt-2">{t('footer.tagline')}</p>


### PR DESCRIPTION
## Why
#1593 패턴 확장. Footer logo (loading="lazy") 에 `decoding="async"` 1 attr 누락.

## What
`Layout.astro:692` footer logo img에 1 attr 추가.

## Out of scope
Header logo (line 505)는 loading="eager" LCP path. 이미 favicon.svg라 decode 비용 미미하지만 별 결정.

## Risk
- visual baseline diff 0
- 빌드 1196 pages 0 errors
- **잔여 위험: 0**