### PR TITLE
ci(automerge): explicit data-deploy dispatch after merge (silent-drop workaround)

### DIFF
--- a/.github/workflows/automerge-on-label.yml
+++ b/.github/workflows/automerge-on-label.yml
@@ -25,6 +25,11 @@ permissions:
   contents: write
   pull-requests: write
   checks: read
+  # 2026-04-30: explicit data-deploy dispatch on successful merge — workaround
+  # for GitHub push-event silent drops observed on #1594, #1599 even after the
+  # paths-filter removal in #1586. Only `actions: write` is needed for
+  # workflow_dispatch via github.rest.actions.createWorkflowDispatch.
+  actions: write
 
 concurrency:
   # Per-SHA queue — different PRs don't cancel each other
@@ -202,6 +207,7 @@ jobs:
             }
 
             // All checks green + up-to-date with main — merge.
+            let mergeSucceeded = false;
             try {
               await github.rest.pulls.merge({
                 owner: context.repo.owner,
@@ -210,9 +216,41 @@ jobs:
                 merge_method: 'squash',
               });
               core.info(`Successfully merged PR #${prNumber}`);
+              mergeSucceeded = true;
             } catch (err) {
               // Merge can still fail in race conditions (concurrent push to main
               // between BEHIND check above and merge call). Next check_suite
               // completion or cron tick retries.
               core.warning(`Merge attempt for PR #${prNumber} did not succeed: ${err.message}`);
+            }
+
+            // 2026-04-30: explicit data-deploy dispatch after successful merge.
+            // Workaround (NOT root-cause fix) for GitHub push-event silent
+            // drops observed on #1594 and #1599 even after the paths-filter
+            // removal in #1586. The actual root cause is unknown GitHub
+            // workflow registry behavior. The 1h cron drift detector in
+            // data-deploy.yml remains the second backstop — this dispatch is
+            // the first, deterministic trigger.
+            //
+            // GITHUB_TOKEN is permitted to call workflow_dispatch (recursive
+            // workflow restriction does NOT apply to dispatch events).
+            //
+            // Concurrency in data-deploy.yml (group: data-deploy,
+            // cancel-in-progress: false) serializes any double-trigger that
+            // happens when push event ALSO fires. Cost on PUBLIC repo: zero.
+            //
+            // Failure here MUST NOT bubble — merge already succeeded and is
+            // irreversible. Log warning and rely on push event / 1h cron.
+            if (mergeSucceeded) {
+              try {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: 'data-deploy.yml',
+                  ref: 'main',
+                });
+                core.info(`Dispatched data-deploy.yml on main for PR #${prNumber}`);
+              } catch (err) {
+                core.warning(`data-deploy dispatch failed (push event or 1h cron will backstop): ${err.message}`);
+              }
             }


### PR DESCRIPTION
## Why
오늘 실측: paths-filter 제거(#1586) 이후에도 #1594, #1599 머지에서 silent drop 재발. matter manual \`gh workflow run\` dispatch로 매번 우회. 1h cron drift detector도 24h 중 3회만 발화 (~12.5% schedule 신뢰성, GitHub Actions 알려진 한계).

## What
**Workaround**, not root-cause fix (root cause = GitHub workflow registry 내부 동작 unknown). automerge 성공 직후 data-deploy.yml \`createWorkflowDispatch\` 명시 트리거.

\`\`\`diff
+permissions:
+  actions: write    # workflow_dispatch 호출용

# attempt-merge step 끝:
+if (mergeSucceeded) {
+  try {
+    await github.rest.actions.createWorkflowDispatch({
+      owner, repo, workflow_id: 'data-deploy.yml', ref: 'main',
+    });
+  } catch (err) {
+    core.warning(\`dispatch failed: \${err.message}\`);  // push event/1h cron이 backstop
+  }
+}
\`\`\`

## advisor cross-check 반영
1. ✓ try/catch wrapping (merge는 이미 final이라 dispatch 실패가 run을 fail로 만들지 않게)
2. ✓ GITHUB_TOKEN은 workflow_dispatch 호출 가능 (recursive 제한 면제)
3. ✓ 정직한 framing — \"workaround\" 명시 (#1586 \"victory before measuring\" 실수 반복 안 함)
4. ✓ double-deploy 수용 (concurrency lock으로 직렬, PUBLIC repo runner free)

## Risk audit (사이드 이펙트 0)
- 룰 7: wrangler deploy는 여전히 data-deploy.yml 1곳 ✓
- 권한 확장: \`actions:write\` 1줄 (workflow_dispatch 표준 권한) ✓
- workflow_dispatch는 GitHub recursive-workflow 제한에서 명시 면제 ✓
- data-deploy.yml \`concurrency: data-deploy + cancel-in-progress: false\`가 push + dispatch 동시 트리거 시 직렬화 (race 0) ✓
- merge 실패 시 mergeSucceeded gate로 dispatch 미호출 ✓
- dispatch 실패 시 push event / 1h cron backstop ✓

**잔여 위험: 0**

## Test plan (다음 3 머지)
- [ ] \`gh run list --workflow=data-deploy.yml --json event\` → 머지마다 workflow_dispatch event 표시
- [ ] \`measure-deploy-latency.sh\` phase2 (push→workflow) 일관 ~5초
- [ ] silent drop 0회

## 기대 효과
- silent drop 시나리오: 사라짐 (manual dispatch 불필요)
- happy path: 머지→즉시 dispatch → phase2 ~5초
- 평균 머지→live 추가 단축 3-5분

## 6원칙
- 뿌리: silent drop root cause는 GitHub 내부 동작 unknown — 정직하게 \"workaround\" 명시
- 원론: cron 빈도↑는 schedule 12.5% 발화율로 회피 불가
- 일관: 룰 7 유지
- 무결: concurrency race 0
- 책임: dispatch 실패 격리
- 근거: 오늘 #1594/#1599 silent drop 실측