### PR TITLE
fix(harness): skip PF/WR thresholds for low_sample entries (false-positive smoke alert)

### DIFF
--- a/tests/harness/run-golden.ts
+++ b/tests/harness/run-golden.ts
@@ -300,9 +300,26 @@ async function runCase(c: GoldenCase): Promise<number> {
       ...(Array.isArray(d["worst3"]) ? d["worst3"] : []),
     ] as Record<string, unknown>[];
     for (const entry of entries) {
+      // Backend marks `low_sample: true` on entries with too few trades
+      // (e.g. BB Squeeze 6H short with 2 trades over 30d). Such entries
+      // emit *sentinel* values by design — PF=99.99 (no losses → ÷0 cap),
+      // win_rate=100 (2/2 wins). These are mathematically valid for the
+      // sample and the UI already shows a warning state via the same flag.
+      // Per-entry PF/WR range checks here are tuned for normal-sample
+      // entries; applying them to low_sample entries would be false-
+      // positive (Telegram smoke alerts on sentinel values, not regressions).
+      // total_trades and other fields remain enforced — those are useful
+      // even for low_sample entries (e.g. catching total_trades=0).
+      const isLowSample = entry["low_sample"] === true;
       for (const [field, range] of Object.entries(perEntry)) {
         const val = entry[field];
         if (typeof val !== "number") continue;
+        if (
+          isLowSample &&
+          (field === "win_rate" || field === "profit_factor")
+        ) {
+          continue;
+        }
         if (range.min !== undefined && val < range.min) {
           failures += fail(
             `entry ${JSON.stringify(entry["name_en"])} ${field} = ${val} < ${range.min}`,


### PR DESCRIPTION
## Why
2026-04-30 17:43 Telegram \"Deploy Smoke FAIL\" alert on c49340f7 (#1601):
\`\`\`
❌ entry \"BB Squeeze 6H\" win_rate = 100 > 95
❌ entry \"BB Squeeze 6H\" profit_factor = 99.99 > 20
\`\`\`

#1601은 \`.github/workflows/automerge-on-label.yml\` 1 파일만 변경 — 시뮬레이션/데이터 코드 미변경. 회귀 인과 0.

## Root cause (백엔드 직접 검증)
\`\`\`bash
$ curl https://api.pruviq.com/rankings/daily?period=30d&group=top50
{
  \"name_en\":\"BB Squeeze 6H\",\"strategy\":\"bb-squeeze-short\",
  \"win_rate\":100.0,\"profit_factor\":99.99,
  \"total_return\":0.03,\"total_trades\":2,\"max_drawdown\":0.0,
  \"low_sample\":true,\"streak\":3
}
\`\`\`
- \`total_trades=2\` → 둘 다 승리 → \`win_rate=100\` (수학적 정상)
- \`profit_factor=99.99\` = sentinel (손실 0건일 때 백엔드 cap 값)
- 백엔드가 이미 \`low_sample=true\` 플래그로 \"샘플 부족\" 표시 (UI도 같은 플래그로 경고 상태 렌더링: \`tests/e2e/i18n-language.spec.ts:199\`)

Golden harness가 \`low_sample\` 플래그를 미체크 → PF/WR threshold 무조건 적용 → false-positive smoke alert.

## What
\`tests/harness/run-golden.ts:302-316\` 범위 체크에서 \`low_sample=true\` 항목은 \`win_rate\` + \`profit_factor\` threshold skip. 다른 필드(total_trades 등)는 enforce 유지 — low_sample이라도 \`total_trades=0\` 같은 진짜 회귀는 잡아야 함.

## Test
\`\`\`
$ BASE_URL=https://api.pruviq.com npx tsx tests/harness/run-golden.ts
5/5 cases passed, 0 total failures
Per-entry range checks passed (6 entries)  ← BB Squeeze 6H 포함
\`\`\`

## Risk
- 정상 sample 항목 threshold 그대로 (PF<20, WR<95) ✓
- low_sample 항목도 total_trades 등 다른 필드는 enforce ✓
- 회귀 검출 능력: total_trades=0 / 잘못된 schema 등 진짜 회귀는 그대로 검출 ✓

**잔여 위험: 0**

## 6원칙
- 뿌리: 백엔드 직접 호출로 root cause = harness gap (코드 회귀 X)
- 일관: e2e \`i18n-language.spec.ts:199\`의 low_sample UI 처리 패턴 정합
- 무결: 회귀 검출 능력 보존
- 책임: telegram alert 신뢰도 회복
- 근거: API 응답 JSON + e2e spec 코드 라인 인용