### PR TITLE
feat(okx): trailing TP design spike — place_trailing_stop + 4 mock tests

### DIFF
--- a/backend/okx/client.py
+++ b/backend/okx/client.py
@@ -271,6 +271,88 @@ class OKXClient:
         logger.warning("← place-algo algoId=%s", algo_id)
         return result
 
+    async def place_trailing_stop(
+        self,
+        inst_id: str,
+        side: str,
+        sz: str,
+        callback_ratio: str | None = None,
+        callback_spread: str | None = None,
+        active_px: str | None = None,
+        td_mode: str = "isolated",
+        cl_ord_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Place an OKX trailing-stop algo order (ordType=move_order_stop).
+
+        Phase 2.0 spike helper. Decisions encoded:
+          1. Use OKX-managed trailing (move_order_stop) — OKX watches mark
+             price and fires automatically when callback condition met. No
+             app-side polling loop needed (cadence question resolved at
+             API boundary).
+          2. Trailing is placed as a *separate* algo order (different
+             algoId from the conditional SL). This lets us keep a
+             fixed downside SL while letting the upside trail.
+          3. Idempotency via algoClOrdId (OKX rejects duplicate with
+             code 51020) — caller passes a deterministic hash of the
+             source signal.
+          4. State persistence: caller stores algoId; on restart, query
+             /api/v5/trade/orders-algo-pending (helper below) to verify
+             the trailing is still armed and re-place if OKX dropped it.
+
+        Exactly one of callback_ratio (decimal % e.g. "0.01" for 1%)
+        or callback_spread (absolute price units) must be provided —
+        OKX rejects the request if both or neither are set.
+        """
+        if (callback_ratio is None) == (callback_spread is None):
+            raise ValueError(
+                "place_trailing_stop: exactly one of callback_ratio or "
+                "callback_spread is required"
+            )
+        body: dict[str, Any] = {
+            "instId": inst_id,
+            "tdMode": td_mode,
+            "side": side,
+            "ordType": "move_order_stop",
+            "sz": sz,
+            "tag": self.broker_code,
+        }
+        if callback_ratio is not None:
+            body["callbackRatio"] = callback_ratio
+        if callback_spread is not None:
+            body["callbackSpread"] = callback_spread
+        if active_px is not None:
+            body["activePx"] = active_px
+        if cl_ord_id:
+            body["algoClOrdId"] = cl_ord_id
+        logger.warning(
+            "→ place-trailing instId=%s side=%s sz=%s ratio=%s spread=%s active=%s",
+            inst_id, side, sz, callback_ratio, callback_spread, active_px,
+        )
+        result = await self._post("/api/v5/trade/order-algo", body)
+        algo_data = result.get("data", [{}])
+        algo_id = algo_data[0].get("algoId", "?") if algo_data else "?"
+        logger.warning("← place-trailing algoId=%s", algo_id)
+        return result
+
+    async def get_algo_orders_pending(
+        self, algo_id: str | None = None, inst_id: str | None = None
+    ) -> list[dict[str, Any]]:
+        """Query active (not yet triggered) algo orders.
+
+        Phase 2.0 spike helper for restart-recovery: after a backend
+        restart the trailing-stop algoId persisted in our DB may or may
+        not still be armed on OKX (e.g. user manually cancelled, OKX
+        purged after position close). Caller cross-checks before
+        deciding to re-arm.
+        """
+        params: dict[str, str] = {"ordType": "move_order_stop"}
+        if algo_id:
+            params["algoId"] = algo_id
+        if inst_id:
+            params["instId"] = inst_id
+        result = await self._get("/api/v5/trade/orders-algo-pending", params)
+        return result.get("data", [])
+
     async def cancel_order(self, inst_id: str, ord_id: str) -> dict[str, Any]:
         logger.warning("→ cancel-order instId=%s ordId=%s", inst_id, ord_id)
         result = await self._post("/api/v5/trade/cancel-order", {

--- a/backend/tests/test_okx_trailing_spike.py
+++ b/backend/tests/test_okx_trailing_spike.py
@@ -1,0 +1,191 @@
+"""Phase 2.0 trailing-TP design spike — 4 prototype tests answering the
+spike questions from the autotrading redesign plan.
+
+Spike questions (all answered at the OKX API boundary, code-as-decision):
+
+  1. OKX trailing API decision: place_algo_order (callback) vs amend_algos.
+     → Answer: separate `move_order_stop` algo order. Conditional SL/TP
+       cannot be morphed in-place into a trailing stop, so a second algo
+       (different algoId) is the correct shape. OKX manages the trailing
+       internally — no app-side polling loop required.
+
+  2. State persistence: how to recover trailing arm/disarm after restart.
+     → Answer: store algoId on place; on restart, query
+       /api/v5/trade/orders-algo-pending filtered by algoId. If present →
+       still armed. If missing → either triggered/cancelled by OKX or
+       cleared by user — fall back to the regular reconciler path.
+
+  3. Polling cadence: simulator uses 4h candle close, real trade?
+     → Answer: OKX move_order_stop uses live mark/last/index price (per
+       triggerPxType). No tick polling needed from us. Cadence question
+       collapses at the API boundary.
+
+  4. Idempotency: amend retry pattern with clOrdId.
+     → Answer: algoClOrdId on POST. OKX rejects duplicate algoClOrdId
+       with code 51020 (same code used for regular order clOrdId). Caller
+       uses deterministic hash of (signal_id, "trail") to make retries
+       safe.
+
+Tests are mocked — they verify the request shape we send to OKX.
+Production-ready hardening (real testnet calls, error handling, schema
+validation) lives in Phase 2.1.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """Build an OKXClient with broker code stubbed and HTTP mocked."""
+    monkeypatch.setenv("OKX_BROKER_CODE_API", "TEST_BROKER")
+    monkeypatch.setenv("OKX_DEMO_MODE", "false")
+    import importlib
+
+    import okx.config as config
+
+    importlib.reload(config)
+    import okx.client as client_mod
+
+    importlib.reload(client_mod)
+
+    c = client_mod.OKXClient(
+        api_key="ak", secret_key="sk", passphrase="pp"
+    )
+    return c
+
+
+@pytest.mark.anyio
+async def test_q1_trailing_stop_uses_move_order_stop_algo_type(client, monkeypatch):
+    """Q1: We send ordType=move_order_stop, NOT conditional. callbackRatio
+    sits in the body; broker tag is included for commission tracking."""
+    captured: dict = {}
+
+    async def fake_post(path, body):
+        captured["path"] = path
+        captured["body"] = body
+        return {"code": "0", "data": [{"algoId": "11111"}]}
+
+    monkeypatch.setattr(client, "_post", fake_post)
+    result = await client.place_trailing_stop(
+        inst_id="BTC-USDT-SWAP",
+        side="sell",
+        sz="2",
+        callback_ratio="0.01",
+        active_px="100000",
+    )
+    assert captured["path"] == "/api/v5/trade/order-algo"
+    body = captured["body"]
+    assert body["ordType"] == "move_order_stop"
+    assert body["instId"] == "BTC-USDT-SWAP"
+    assert body["side"] == "sell"
+    assert body["sz"] == "2"
+    assert body["callbackRatio"] == "0.01"
+    assert body["activePx"] == "100000"
+    assert body["tag"] == "TEST_BROKER"
+    assert "callbackSpread" not in body
+    assert result["data"][0]["algoId"] == "11111"
+
+
+@pytest.mark.anyio
+async def test_q2_restart_recovery_via_algos_pending_query(client, monkeypatch):
+    """Q2: After restart, app stored algoId. Query orders-algo-pending
+    filtered by ordType=move_order_stop + algoId. If returned list is
+    non-empty → still armed."""
+    captured: dict = {}
+
+    async def fake_get(path, params=None):
+        captured["path"] = path
+        captured["params"] = params or {}
+        return {
+            "code": "0",
+            "data": [
+                {
+                    "algoId": "11111",
+                    "instId": "BTC-USDT-SWAP",
+                    "ordType": "move_order_stop",
+                    "state": "live",
+                }
+            ],
+        }
+
+    monkeypatch.setattr(client, "_get", fake_get)
+    pending = await client.get_algo_orders_pending(
+        algo_id="11111", inst_id="BTC-USDT-SWAP"
+    )
+    assert captured["path"] == "/api/v5/trade/orders-algo-pending"
+    # ordType is hard-coded to move_order_stop so this helper only
+    # surfaces trailing — keeps the recovery path narrow.
+    assert captured["params"]["ordType"] == "move_order_stop"
+    assert captured["params"]["algoId"] == "11111"
+    assert captured["params"]["instId"] == "BTC-USDT-SWAP"
+    assert len(pending) == 1
+    assert pending[0]["state"] == "live"
+
+
+@pytest.mark.anyio
+async def test_q3_callback_ratio_xor_spread_enforced(client, monkeypatch):
+    """Q3 part 1: We don't poll — OKX manages trailing. The spike helper
+    enforces callback_ratio XOR callback_spread (OKX requires exactly
+    one). Both-or-neither must raise before any HTTP call."""
+    posted = False
+
+    async def fake_post(path, body):
+        nonlocal posted
+        posted = True
+        return {"code": "0", "data": [{"algoId": "x"}]}
+
+    monkeypatch.setattr(client, "_post", fake_post)
+
+    # Neither → reject.
+    with pytest.raises(ValueError, match="exactly one"):
+        await client.place_trailing_stop(
+            inst_id="BTC-USDT-SWAP", side="sell", sz="2"
+        )
+    # Both → reject.
+    with pytest.raises(ValueError, match="exactly one"):
+        await client.place_trailing_stop(
+            inst_id="BTC-USDT-SWAP",
+            side="sell",
+            sz="2",
+            callback_ratio="0.01",
+            callback_spread="50",
+        )
+    assert not posted, "POST must not fire when caller mis-specifies callback"
+
+
+@pytest.mark.anyio
+async def test_q4_idempotency_via_algo_cl_ord_id(client, monkeypatch):
+    """Q4: algoClOrdId is sent verbatim. OKX rejects duplicates with code
+    51020 — caller's responsibility to derive a deterministic hash."""
+    captured: dict = {}
+
+    async def fake_post(path, body):
+        captured["body"] = body
+        return {"code": "0", "data": [{"algoId": "22222"}]}
+
+    monkeypatch.setattr(client, "_post", fake_post)
+    await client.place_trailing_stop(
+        inst_id="ETH-USDT-SWAP",
+        side="buy",
+        sz="3",
+        callback_spread="5",
+        cl_ord_id="signal12345trail",
+    )
+    assert captured["body"]["algoClOrdId"] == "signal12345trail"
+    # Without cl_ord_id, the field must be absent (OKX treats empty
+    # strings as still-an-attempted-id, which would block legitimate
+    # retries).
+    captured.clear()
+    await client.place_trailing_stop(
+        inst_id="ETH-USDT-SWAP",
+        side="buy",
+        sz="3",
+        callback_spread="5",
+    )
+    assert "algoClOrdId" not in captured["body"]


### PR DESCRIPTION
## Phase 2.0 — autotrading redesign plan

Design-spike PR. Resolves the four open trailing-TP questions from the plan at the OKX API boundary, using **code as the binding artifact** (no separate spec doc per owner STOP LIST).

### Spike answers

| # | Question | Resolution |
|---|----------|------------|
| Q1 | trailing API shape — separate algo or amend conditional? | Separate `move_order_stop` algo order. Conditional SL/TP can't be morphed in-place into a trailing stop. |
| Q2 | state persistence after restart? | Store `algoId` on place; query `/api/v5/trade/orders-algo-pending` filtered by `ordType=move_order_stop` + `algoId`. helper added. |
| Q3 | polling cadence (sim 4h candle vs real)? | None. OKX uses live mark/last/index price per `triggerPxType`. No app-side tick loop required. |
| Q4 | idempotency? | `algoClOrdId` on POST. OKX rejects duplicates with code 51020. Caller passes a deterministic hash of `(signal_id, "trail")`. |

### What's in this PR

- `backend/okx/client.py` — two new helpers:
  - `place_trailing_stop(callback_ratio | callback_spread, active_px, cl_ord_id, ...)` — XOR enforcement on callback type, broker tag included, idempotency wired.
  - `get_algo_orders_pending(algo_id, inst_id)` — narrowed to `ordType=move_order_stop` so the recovery path can't accidentally surface unrelated algos.
- `backend/tests/test_okx_trailing_spike.py` — 4 tests, one per spike question. Mock-based (verify request shape we send to OKX).

### What's deliberately NOT here

Per the redesign plan Phase 2.0 vs 2.1 split:
- No real OKX testnet calls (Phase 2.1 — production-ready hardening)
- No \`auto_executor.py:452-455\` integration (Phase 2.1)
- No state schema migration (\`pruviq_okx.db\`) — caller stores \`algoId\` in existing column shape until Phase 2.1 decides if a new column is warranted.
- No \`strategy_loader.py\` schema extension (activate_pct, callback_pct) — Phase 2.1.

Keeping the spike's blast radius zero so Phase 2.1 can land cleanly without untangling experimental scaffolding.

### Local verification

\`\`\`
cd backend && uv run --with pytest --with anyio --with pydantic --with httpx --with cryptography --with fastapi --python 3.12 python -m pytest tests/test_okx_trailing_spike.py -v
\`\`\`

Result: 4 passed in 0.10s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)