### PR TITLE
feat(okx): trailing TP wire-up + dry-run endpoint (Phase 2.1)

### DIFF
--- a/backend/okx/auto_executor.py
+++ b/backend/okx/auto_executor.py
@@ -25,6 +25,7 @@ from typing import Optional
 
 from .client import OKXClient
 from .oauth import get_api_credentials, is_authenticated
+from . import storage
 from .orders import _pruviq_to_okx_inst_id, _calc_sl_tp_prices, _calc_contract_sz
 from .retry import retry_async
 from .settings import (
@@ -441,6 +442,12 @@ async def _try_execute(
     tp_pct = signal.get("tp_pct", 8)
     leverage = settings["leverage"]
     td_mode = settings.get("td_mode", "isolated")
+    # tp_source / trail_pct surface so the live-trade branch can route to
+    # OKX move_order_stop instead of conditional TP. Phase 2.1: replaces the
+    # pre-existing trail_pct → fixed TP downgrade. Defaults preserve legacy
+    # behaviour (tp_source falls through to follow_signal/custom_pct paths).
+    tp_source: str = "follow_signal"
+    trail_pct: Optional[float] = None
 
     # ── Strategy overrides (only apply fields the user explicitly detached
     #    from the signal defaults). ──
@@ -449,10 +456,14 @@ async def _try_execute(
             sl_pct = float(strategy.get("sl_pct", sl_pct))
         if strategy.get("tp_source") == "custom_pct":
             tp_pct = float(strategy.get("tp_pct", tp_pct))
+            tp_source = "custom_pct"
         elif strategy.get("tp_source") == "trailing":
-            # Trailing not supported in current execution path — fall back
-            # to trail_pct as a fixed TP until trailing stops are implemented.
-            tp_pct = float(strategy.get("trail_pct", tp_pct))
+            # Phase 2.1: trailing TP routed to OKX move_order_stop in the
+            # execute_from_simulation branch below (tp_source/trail_pct
+            # passed through SimToExecRequest). Pre-Phase 2.1 this branch
+            # downgraded trail_pct to a fixed TP — that fallback is gone.
+            tp_source = "trailing"
+            trail_pct = float(strategy.get("trail_pct", 3.0))
         if strategy.get("leverage_source") == "custom":
             leverage = int(strategy.get("leverage", leverage))
 
@@ -621,30 +632,90 @@ async def _try_execute(
             fill_price, signal["direction"], sl_pct, tp_pct, tick_sz=tick_sz,
         )
         close_side = "buy" if signal["direction"] == "short" else "sell"
+        # Phase 2.1: trailing strategies place SL conditional + separate
+        # move_order_stop. Non-trailing keeps the original SL+TP single-algo
+        # path. trail_algo_id is None when not used so result/persist
+        # branches are uniform.
+        use_trailing = tp_source == "trailing" and trail_pct
+        callback_ratio_str: Optional[str] = None
+        trail_algo_id: Optional[str] = None
+        trail_algo_raw: Optional[dict] = None
 
         try:
-            algo = await client.place_algo_order(
-                inst_id=inst_id,
-                side=close_side,
-                sz=sz,
-                sl_trigger_px=sl_price,
-                tp_trigger_px=tp_price,
-                td_mode=td_mode,
-            )
-            algo_id = (algo.get("data") or [{}])[0].get("algoId", "")
-            logger.warning("← SL/TP set: SL=%s TP=%s algoId=%s", sl_price, tp_price, algo_id)
+            if use_trailing:
+                from .orders import _trail_pct_to_callback_ratio  # local import to avoid cycle
+                algo = await client.place_algo_order(
+                    inst_id=inst_id,
+                    side=close_side,
+                    sz=sz,
+                    sl_trigger_px=sl_price,
+                    td_mode=td_mode,
+                )
+                algo_id = (algo.get("data") or [{}])[0].get("algoId", "")
+                logger.warning(
+                    "← SL set (trailing strategy): SL=%s algoId=%s", sl_price, algo_id,
+                )
+                callback_ratio_str = _trail_pct_to_callback_ratio(trail_pct)
+                trail_cl_ord_id = (
+                    f"{cl_ord_id}t" if cl_ord_id else None
+                )
+                trail_algo_raw = await client.place_trailing_stop(
+                    inst_id=inst_id,
+                    side=close_side,
+                    sz=sz,
+                    callback_ratio=callback_ratio_str,
+                    td_mode=td_mode,
+                    cl_ord_id=trail_cl_ord_id,
+                )
+                trail_algo_id = (
+                    (trail_algo_raw.get("data") or [{}])[0].get("algoId") or None
+                )
+                logger.warning(
+                    "← Trailing TP armed: callbackRatio=%s algoId=%s",
+                    callback_ratio_str, trail_algo_id,
+                )
+            else:
+                algo = await client.place_algo_order(
+                    inst_id=inst_id,
+                    side=close_side,
+                    sz=sz,
+                    sl_trigger_px=sl_price,
+                    tp_trigger_px=tp_price,
+                    td_mode=td_mode,
+                )
+                algo_id = (algo.get("data") or [{}])[0].get("algoId", "")
+                logger.warning("← SL/TP set: SL=%s TP=%s algoId=%s", sl_price, tp_price, algo_id)
         except Exception as algo_err:
             logger.error(
-                "CRITICAL: SL/TP failed after auto-order %s (%s) — closing: %s",
+                "CRITICAL: algo placement failed after auto-order %s (%s) — closing: %s",
                 ord_id, inst_id, algo_err,
             )
             await _emergency_close_with_retry(
                 client, inst_id, td_mode,
-                reason=f"SL/TP failed after auto-order (ordId={ord_id}): {algo_err}",
+                reason=f"Algo failed after auto-order (ordId={ord_id}): {algo_err}",
                 chat_id=chat_id, signal=signal,
             )
             update_signal_status(session_id, strategy_id, coin, dedup_time, "failed")
             return None
+
+    # Phase 2.1: persist the trailing algoId so close-detection can cancel
+    # the sibling and restart-recovery has a target to reconcile against.
+    # Failure non-fatal — same invariant as merkle audit further down.
+    if use_trailing and trail_algo_id:
+        try:
+            storage.insert_trailing_algo(
+                algo_id=trail_algo_id,
+                session_id=session_id,
+                inst_id=inst_id,
+                callback_ratio=callback_ratio_str or "",
+                ts_iso=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                signal_id=cl_ord_id,
+                parent_ord_id=ord_id,
+            )
+        except Exception as persist_err:
+            logger.warning(
+                "trailing algo persist failed (non-fatal): %s", persist_err
+            )
 
     result = {
         "session_id": session_id[:8],
@@ -654,9 +725,13 @@ async def _try_execute(
         "size": sz,
         "fill_price": fill_price,
         "sl": sl_price,
-        "tp": tp_price,
+        "tp": tp_price if not use_trailing else None,
+        "callback_ratio": callback_ratio_str,
         "order": order,
         "algo": algo,
+        "trailing_algo": trail_algo_raw,
+        "trailing_algo_id": trail_algo_id,
+        "tp_source": tp_source,
         "cl_ord_id": cl_ord_id,
         "timestamp": time.time(),
     }
@@ -700,7 +775,11 @@ async def _try_execute(
     if chat_id:
         asyncio.create_task(send_trade_executed(chat_id, signal, fill_price, sz, sl_price, tp_price))
 
-    # Fire-and-forget: sync actual realized PnL once position closes
-    asyncio.create_task(sync_realized_pnl(session_id, inst_id, trade_created_at))
+    # Fire-and-forget: sync actual realized PnL once position closes.
+    # Phase 2.1.4: passing ord_id so close detection also cancels the sibling
+    # trailing algo (no-op when the trade was non-trailing).
+    asyncio.create_task(
+        sync_realized_pnl(session_id, inst_id, trade_created_at, parent_ord_id=ord_id)
+    )
 
     return result

--- a/backend/okx/models.py
+++ b/backend/okx/models.py
@@ -3,7 +3,7 @@ OKX Broker Pydantic models — request/response schemas.
 """
 from __future__ import annotations
 
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -50,3 +50,17 @@ class SimToExecRequest(BaseModel):
     position_size_usdt: float = Field(..., ge=1, description="Position size in USDT")
     leverage: int = Field(1, ge=1, le=125)
     td_mode: str = Field("isolated", description="isolated or cross")
+    # Phase 2.1: trailing TP wire-up. Optional + default keeps every existing
+    # caller (Astro frontend, /execute/order, manual UI) on the conditional
+    # SL+TP path with no signature change. tp_source="trailing" + trail_pct
+    # routes through place_trailing_stop instead.
+    tp_source: Optional[Literal["follow_signal", "custom_pct", "trailing"]] = Field(
+        "follow_signal",
+        description="follow_signal=use signal's tp_pct; custom_pct=use user override; trailing=use trail_pct as OKX move_order_stop callbackRatio",
+    )
+    trail_pct: Optional[float] = Field(
+        None,
+        ge=0.01,
+        le=100.0,
+        description="Trailing distance %, only applied when tp_source='trailing'. Mapped to OKX callbackRatio as str(trail_pct/100) (e.g. 2.0 → '0.02').",
+    )

--- a/backend/okx/orders.py
+++ b/backend/okx/orders.py
@@ -9,6 +9,7 @@ import math
 from datetime import datetime, timezone
 from typing import Optional
 
+from . import storage
 from .client import OKXClient
 from .models import SimToExecRequest
 from .oauth import get_api_credentials
@@ -86,6 +87,22 @@ def _round_to_tick(price: float, tick_sz: float, *, round_down: bool) -> str:
     # Cap at 10 — OKX price precision ceiling.
     decimals = min(decimals, 10)
     return f"{snapped:.{decimals}f}"
+
+
+def _trail_pct_to_callback_ratio(trail_pct: float) -> str:
+    """Map PRUVIQ's percent-form trail_pct (e.g. 2.0 = 2%) to OKX
+    callbackRatio decimal-string (e.g. "0.02").
+
+    Parity anchor: simulator engine_fast.py:1372 uses decimal-form trailing_pct
+    in `best_price * (1 - trailing_pct)`. PRUVIQ's strategy schema stores
+    percent-form (strategies.py:88 `trail_pct REAL DEFAULT 3` = 3%).
+    OKX move_order_stop's callbackRatio is decimal-string per its API spec.
+
+    The /100 division happens here, in *one place only* — Phase 2.1 plan
+    advisor #1: params-correctness parity is the test target, and this
+    function is the single seam where the conversion lives.
+    """
+    return f"{trail_pct / 100:g}"
 
 
 def _calc_sl_tp_prices(
@@ -182,25 +199,66 @@ async def execute_from_simulation(
         ord_id = order.get("ordId", "")
         logger.warning("← Market order placed ordId=%s", ord_id)
 
-        # SL/TP algo order — if this fails, immediately close the naked position
+        # Algo legs — if any fail, immediately close the naked position.
+        # Branching on tp_source:
+        #   - "trailing" → conditional SL only + separate move_order_stop trailing TP
+        #   - else       → conditional SL+TP single algo (existing path)
         sl_price, tp_price = _calc_sl_tp_prices(
             current_price, req.direction, req.sl_pct, req.tp_pct, tick_sz=tick_sz,
         )
         close_side = "buy" if req.direction == "short" else "sell"
 
+        use_trailing = req.tp_source == "trailing" and req.trail_pct
+        callback_ratio: Optional[str] = None
+        trail_algo_id: Optional[str] = None
+
         try:
-            algo_result = await client.place_algo_order(
-                inst_id=inst_id,
-                side=close_side,
-                sz=sz,
-                sl_trigger_px=sl_price,
-                tp_trigger_px=tp_price,
-                td_mode=td_mode,
-            )
-            logger.warning("← SL/TP set: SL=%s TP=%s ordId=%s", sl_price, tp_price, ord_id)
+            if use_trailing:
+                # SL leg only — no TP on the conditional algo.
+                algo_result = await client.place_algo_order(
+                    inst_id=inst_id,
+                    side=close_side,
+                    sz=sz,
+                    sl_trigger_px=sl_price,
+                    td_mode=td_mode,
+                )
+                logger.warning("← SL set (trailing strategy): SL=%s ordId=%s", sl_price, ord_id)
+                # Trailing TP via OKX move_order_stop. Sim parity:
+                # engine_fast.py:1372 uses decimal-form trailing_pct (0.02);
+                # we convert PRUVIQ's percent-form trail_pct in one seam.
+                callback_ratio = _trail_pct_to_callback_ratio(req.trail_pct)
+                trail_cl_ord_id = (
+                    f"{cl_ord_id}t" if cl_ord_id else None
+                )  # OKX algoClOrdId limit ~32 chars; suffix narrows to keep len.
+                trail_result = await client.place_trailing_stop(
+                    inst_id=inst_id,
+                    side=close_side,
+                    sz=sz,
+                    callback_ratio=callback_ratio,
+                    td_mode=td_mode,
+                    cl_ord_id=trail_cl_ord_id,
+                )
+                trail_algo_data = trail_result.get("data", [{}])
+                trail_algo_id = (
+                    trail_algo_data[0].get("algoId") if trail_algo_data else None
+                )
+                logger.warning(
+                    "← Trailing TP armed: callbackRatio=%s algoId=%s",
+                    callback_ratio, trail_algo_id,
+                )
+            else:
+                algo_result = await client.place_algo_order(
+                    inst_id=inst_id,
+                    side=close_side,
+                    sz=sz,
+                    sl_trigger_px=sl_price,
+                    tp_trigger_px=tp_price,
+                    td_mode=td_mode,
+                )
+                logger.warning("← SL/TP set: SL=%s TP=%s ordId=%s", sl_price, tp_price, ord_id)
         except Exception as algo_err:
             logger.error(
-                "CRITICAL: SL/TP failed after order %s (%s) — closing naked position: %s",
+                "CRITICAL: algo placement failed after order %s (%s) — closing naked position: %s",
                 ord_id, inst_id, algo_err,
             )
             try:
@@ -209,8 +267,28 @@ async def execute_from_simulation(
             except Exception as close_err:
                 logger.error("EMERGENCY CLOSE FAILED for %s: %s", inst_id, close_err)
             raise ValueError(
-                f"SL/TP placement failed for {inst_id} (ordId={ord_id}), "
+                f"Algo placement failed for {inst_id} (ordId={ord_id}), "
                 f"position closed as safety measure. Error: {algo_err}"
+            )
+
+    # Persist the trailing algoId for close-detection sibling-cancel and
+    # restart-recovery. Outside the OKXClient ctx so the DB write doesn't
+    # contend with the OKX HTTP client's connection pool teardown.
+    # Failure here is non-fatal — same invariant the merkle audit honours.
+    if use_trailing and trail_algo_id:
+        try:
+            storage.insert_trailing_algo(
+                algo_id=trail_algo_id,
+                session_id=session_id,
+                inst_id=inst_id,
+                callback_ratio=callback_ratio or "",
+                ts_iso=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                signal_id=cl_ord_id,
+                parent_ord_id=ord_id,
+            )
+        except Exception as persist_err:
+            logger.warning(
+                "trailing algo persist failed (non-fatal): %s", persist_err
             )
 
     # Moat-2: Merkle audit leaf for the manual /execute/order path.
@@ -251,15 +329,153 @@ async def execute_from_simulation(
     return {
         "order": order,
         "algo": algo_result,
+        "trailing_algo_id": trail_algo_id,
         "details": {
             "inst_id": inst_id,
             "side": side,
             "size": sz,
             "entry_price": current_price,
             "sl_price": sl_price,
-            "tp_price": tp_price,
+            "tp_price": tp_price if not use_trailing else None,
+            "callback_ratio": callback_ratio,
             "leverage": req.leverage,
             "td_mode": td_mode,
             "strategy": req.strategy,
+            "tp_source": req.tp_source,
         },
     }
+
+
+async def build_dry_run_payload(
+    session_id: str,
+    req: SimToExecRequest,
+    current_price: Optional[float] = None,
+) -> dict:
+    """Phase 2.2 dry-run entrypoint. Computes the OKX request bodies that
+    `execute_from_simulation` *would* send for this signal — without firing
+    any POST. OKX read endpoints (mark price + instrument info) are still
+    called because tickSz/ctVal cannot be derived without them, and they're
+    cheap GETs.
+
+    Returns the three request bodies (`order_request`, `sl_algo_request`,
+    `trailing_algo_request`) and a `details` block mirroring the live path.
+    The Phase 2.2 monitor diffs these against the simulator ledger to flag
+    parity drift over a 7-day window.
+    """
+    creds = get_api_credentials(session_id)
+    inst_id = _pruviq_to_okx_inst_id(req.symbol)
+    side = "sell" if req.direction == "short" else "buy"
+    close_side = "buy" if req.direction == "short" else "sell"
+    td_mode = req.td_mode if req.td_mode in ("isolated", "cross") else "isolated"
+
+    async with OKXClient(**creds) as client:
+        if not current_price or current_price <= 0:
+            current_price = await client.get_mark_price(inst_id)
+        info = await client.get_instrument_info(inst_id)
+        tick_sz = info.get("tickSz", 0.01)
+        sz = await _calc_contract_sz(
+            client, inst_id, req.position_size_usdt, req.leverage, current_price,
+        )
+
+    sl_price, tp_price = _calc_sl_tp_prices(
+        current_price, req.direction, req.sl_pct, req.tp_pct, tick_sz=tick_sz,
+    )
+    use_trailing = req.tp_source == "trailing" and req.trail_pct
+    callback_ratio = (
+        _trail_pct_to_callback_ratio(req.trail_pct) if use_trailing else None
+    )
+
+    order_request = {
+        "instId": inst_id,
+        "tdMode": td_mode,
+        "side": side,
+        "ordType": "market",
+        "sz": sz,
+    }
+    if use_trailing:
+        sl_algo_request = {
+            "instId": inst_id,
+            "tdMode": td_mode,
+            "side": close_side,
+            "ordType": "conditional",
+            "sz": sz,
+            "slTriggerPx": sl_price,
+            "slOrdPx": "-1",
+        }
+        trailing_algo_request = {
+            "instId": inst_id,
+            "tdMode": td_mode,
+            "side": close_side,
+            "ordType": "move_order_stop",
+            "sz": sz,
+            "callbackRatio": callback_ratio,
+        }
+    else:
+        sl_algo_request = {
+            "instId": inst_id,
+            "tdMode": td_mode,
+            "side": close_side,
+            "ordType": "conditional",
+            "sz": sz,
+            "slTriggerPx": sl_price,
+            "slOrdPx": "-1",
+            "tpTriggerPx": tp_price,
+            "tpOrdPx": "-1",
+        }
+        trailing_algo_request = None
+
+    return {
+        "order_request": order_request,
+        "sl_algo_request": sl_algo_request,
+        "trailing_algo_request": trailing_algo_request,
+        "details": {
+            "inst_id": inst_id,
+            "side": side,
+            "size": sz,
+            "entry_price": current_price,
+            "sl_price": sl_price,
+            "tp_price": tp_price if not use_trailing else None,
+            "callback_ratio": callback_ratio,
+            "leverage": req.leverage,
+            "td_mode": td_mode,
+            "strategy": req.strategy,
+            "tp_source": req.tp_source,
+        },
+    }
+
+
+async def cancel_trailing_for_position(
+    session_id: str, parent_ord_id: str
+) -> dict:
+    """Phase 2.1.4: when a position closes (SL hit, manual close, OKX-managed
+    exit), cancel the sibling trailing algo so it doesn't leak as an orphan.
+
+    Looked-up via the entry order's ordId (parent_ord_id). If no trailing
+    was armed for this position (fixed SL+TP path), this is a no-op.
+
+    Failure to cancel is non-fatal here — reconciler.py sweeps orphan
+    positions on its next tick (Phase 2.2 monitor will surface algo orphans
+    similarly).
+    """
+    row = storage.find_trailing_by_parent(parent_ord_id)
+    if not row:
+        return {"cancelled": False, "reason": "no_trailing_for_position"}
+
+    creds = get_api_credentials(session_id)
+    async with OKXClient(**creds) as client:
+        try:
+            await client.cancel_algo_orders(
+                algo_ids=[row["algo_id"]], inst_id=row["inst_id"],
+            )
+            storage.update_trailing_state(row["algo_id"], "cancelled")
+            return {"cancelled": True, "algo_id": row["algo_id"]}
+        except Exception as cancel_err:
+            logger.warning(
+                "trailing cancel failed for algoId=%s (parent=%s): %s",
+                row["algo_id"], parent_ord_id, cancel_err,
+            )
+            return {
+                "cancelled": False,
+                "reason": "okx_cancel_error",
+                "error": str(cancel_err),
+            }

--- a/backend/okx/pnl_sync.py
+++ b/backend/okx/pnl_sync.py
@@ -23,6 +23,7 @@ import asyncio
 import json
 import logging
 import time
+from typing import Optional
 
 from .client import OKXClient
 from .oauth import get_api_credentials, is_authenticated
@@ -37,7 +38,12 @@ _RETRY_LOOKBACK_S = 7 * 24 * 3600  # only retry rows from last 7 days
 _RETRY_HISTORY_LIMIT = "50"
 
 
-async def sync_realized_pnl(session_id: str, inst_id: str, trade_created_at: float) -> None:
+async def sync_realized_pnl(
+    session_id: str,
+    inst_id: str,
+    trade_created_at: float,
+    parent_ord_id: Optional[str] = None,
+) -> None:
     """
     Poll positions-history to find actual realized PnL for a recently closed trade.
     Updates trade_log.pnl_usdt with the real value and sets pnl_synced=1 on success.
@@ -45,6 +51,14 @@ async def sync_realized_pnl(session_id: str, inst_id: str, trade_created_at: flo
     Called asynchronously after a trade is logged (fire-and-forget).
     Polls up to 3 times (at 30s, 60s, 120s); on failure leaves pnl_usdt untouched
     and sets pnl_synced=0 for the retry loop to pick up.
+
+    Phase 2.1.4: when `parent_ord_id` is supplied (auto_executor passes it
+    after the entry order's ordId is known), the close-detection path also
+    cancels any sibling trailing algo armed against this entry. SL hit →
+    position closes → trailing leg becomes orphan on OKX without an explicit
+    cancel; reconciler would catch it eventually, but explicit cancel here
+    keeps the user's algo-list clean and removes any window where a stale
+    trailing could fire on a re-opened position.
     """
     if not is_authenticated(session_id):
         return
@@ -79,6 +93,24 @@ async def sync_realized_pnl(session_id: str, inst_id: str, trade_created_at: flo
                     session_id[:8], inst_id, realized_pnl,
                 )
                 _update_trade_pnl(session_id, inst_id, trade_created_at, realized_pnl)
+                # Phase 2.1.4 sibling cancel — non-fatal so PnL update sticks
+                # regardless of whether the cancel succeeded.
+                if parent_ord_id:
+                    try:
+                        from .orders import cancel_trailing_for_position
+                        cancel_result = await cancel_trailing_for_position(
+                            session_id, parent_ord_id,
+                        )
+                        if cancel_result.get("cancelled"):
+                            logger.warning(
+                                "trailing sibling cancelled: parent=%s algoId=%s",
+                                parent_ord_id, cancel_result.get("algo_id"),
+                            )
+                    except Exception as cancel_err:
+                        logger.warning(
+                            "trailing sibling cancel raised (non-fatal): %s",
+                            cancel_err,
+                        )
                 return
 
         except Exception as e:

--- a/backend/okx/router.py
+++ b/backend/okx/router.py
@@ -45,7 +45,7 @@ from .oauth import (
     get_api_credentials,
     is_authenticated,
 )
-from .orders import execute_from_simulation
+from .orders import build_dry_run_payload, execute_from_simulation
 
 logger = logging.getLogger("okx_router")
 
@@ -349,6 +349,52 @@ def _pos_to_camel(p) -> dict:
         "mgnMode": p.mgn_mode,
         "posSide": p.pos_side,
     }
+
+
+@router.post("/execute/dry-run")
+async def execute_dry_run(
+    req: SimToExecRequest,
+    request: Request,
+    current_price: float = Query(
+        None, description="Current market price (auto-fetched from OKX mark if omitted)"
+    ),
+):
+    """Phase 2.2 dry-run entrypoint — emits the OKX request bodies that
+    /execute/order *would* send for this signal, without firing any POST.
+    OKX read endpoints (mark price + instrument info) are still hit because
+    tickSz / ctVal are needed to compute the bodies, and they're cheap GETs.
+
+    Use case: 7-day continuous parity check. The Phase 2.2 monitor calls
+    this once per simulator-emitted signal and diffs the resulting
+    `sl_algo_request` / `trailing_algo_request` against the simulator's
+    own ledger. Any drift in callbackRatio mapping, sz rounding, or SL
+    price snapping surfaces before Phase 4 production rollout.
+
+    Read-only on OKX side; same auth + position-size cap as /execute/order.
+    """
+    session_id = _get_session(request)
+    if not is_authenticated(session_id):
+        raise HTTPException(401, "Not connected to OKX. Connect first.")
+
+    # Same server-side position cap as live order path. Dry-run has no money
+    # at risk but enforcing the cap keeps "what /execute/order would have
+    # done" honest — a signal that would be 400-rejected live should also
+    # be rejected here.
+    from .settings import get_settings
+    _settings = get_settings(session_id)
+    _cap = float(_settings.get("max_per_trade_usdt", 200.0))
+    if req.position_size_usdt > _cap:
+        raise HTTPException(
+            400,
+            f"Position size ${req.position_size_usdt:.2f} exceeds max_per_trade_usdt cap ${_cap:.2f}.",
+        )
+
+    try:
+        return await build_dry_run_payload(session_id, req, current_price=current_price)
+    except ValueError as ve:
+        # _calc_contract_sz raises ValueError when notional too small — same
+        # 400-shape as live path so the monitor can compare apples to apples.
+        raise HTTPException(400, str(ve))
 
 
 @router.get("/execute/positions")

--- a/backend/okx/storage.py
+++ b/backend/okx/storage.py
@@ -105,6 +105,29 @@ def _get_conn() -> sqlite3.Connection:
     except sqlite3.OperationalError as e:
         if "duplicate column" not in str(e).lower():
             raise
+    # Phase 2.1: trailing-stop algo tracking. Mutable state separate from the
+    # immutable merkle audit leaf — leaf records the entry fill (one per
+    # position), this table records the trailing-leg lifecycle (arm → live →
+    # cancelled/triggered) so close detection can cancel the sibling and
+    # restart-recovery can reconcile against /api/v5/trade/orders-algo-pending.
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS okx_trailing_algos (
+            algo_id        TEXT PRIMARY KEY,
+            session_id     TEXT NOT NULL,
+            inst_id        TEXT NOT NULL,
+            signal_id      TEXT,
+            parent_ord_id  TEXT,
+            callback_ratio TEXT NOT NULL,
+            ts_iso         TEXT NOT NULL,
+            state          TEXT NOT NULL DEFAULT 'live'
+        )
+    """)
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_trailing_session ON okx_trailing_algos(session_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_trailing_parent ON okx_trailing_algos(parent_ord_id)"
+    )
     return conn
 
 
@@ -207,3 +230,101 @@ def validate_csrf_state(state: str) -> tuple[str, str, str] | None:
         if time.time() - row[2] > CSRF_TTL:
             return None
         return row[0], row[1], row[3]
+
+
+# ── Trailing-stop algo orders (Phase 2.1) ───────────────────
+
+
+def insert_trailing_algo(
+    *,
+    algo_id: str,
+    session_id: str,
+    inst_id: str,
+    callback_ratio: str,
+    ts_iso: str,
+    signal_id: str | None = None,
+    parent_ord_id: str | None = None,
+) -> None:
+    """Persist a freshly-armed trailing algo order so close-detection and
+    restart-recovery have something to reconcile against."""
+    with _get_conn() as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO okx_trailing_algos "
+            "(algo_id, session_id, inst_id, signal_id, parent_ord_id, "
+            " callback_ratio, ts_iso, state) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, 'live')",
+            (
+                algo_id, session_id, inst_id, signal_id, parent_ord_id,
+                callback_ratio, ts_iso,
+            ),
+        )
+
+
+def find_trailing_by_parent(parent_ord_id: str) -> dict | None:
+    """Return the trailing algo armed against a given entry order, if any.
+
+    Used by close-detection to cancel the sibling — when the entry order's
+    position closes (SL hit, manual close, OKX-managed exit), the trailing
+    leg becomes orphaned on OKX. We cancel it to keep the user's algo-list
+    clean and to avoid a stale algo firing if OKX delays its own cleanup.
+    """
+    with _get_conn() as conn:
+        row = conn.execute(
+            "SELECT algo_id, session_id, inst_id, signal_id, parent_ord_id, "
+            " callback_ratio, ts_iso, state "
+            "FROM okx_trailing_algos WHERE parent_ord_id = ? AND state = 'live'",
+            (parent_ord_id,),
+        ).fetchone()
+    if not row:
+        return None
+    return {
+        "algo_id": row[0],
+        "session_id": row[1],
+        "inst_id": row[2],
+        "signal_id": row[3],
+        "parent_ord_id": row[4],
+        "callback_ratio": row[5],
+        "ts_iso": row[6],
+        "state": row[7],
+    }
+
+
+def update_trailing_state(algo_id: str, state: str) -> None:
+    """Mark a trailing algo as cancelled / triggered. State is intentionally
+    a free-form string — caller passes the OKX state verbatim ('cancelled',
+    'effective', 'order_failed', etc.) so the audit trail keeps the original
+    OKX vocabulary rather than our re-interpreted one."""
+    with _get_conn() as conn:
+        conn.execute(
+            "UPDATE okx_trailing_algos SET state = ? WHERE algo_id = ?",
+            (state, algo_id),
+        )
+
+
+def list_live_trailing_algos(session_id: str | None = None) -> list[dict]:
+    """Return all currently-live trailing algos. Used by restart-recovery
+    to sweep against /api/v5/trade/orders-algo-pending — any live row whose
+    algoId is no longer pending on OKX has been cleared by OKX (triggered or
+    cancelled) and we update our state to match."""
+    with _get_conn() as conn:
+        if session_id:
+            rows = conn.execute(
+                "SELECT algo_id, session_id, inst_id, parent_ord_id, callback_ratio "
+                "FROM okx_trailing_algos WHERE state = 'live' AND session_id = ?",
+                (session_id,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT algo_id, session_id, inst_id, parent_ord_id, callback_ratio "
+                "FROM okx_trailing_algos WHERE state = 'live'"
+            ).fetchall()
+    return [
+        {
+            "algo_id": r[0],
+            "session_id": r[1],
+            "inst_id": r[2],
+            "parent_ord_id": r[3],
+            "callback_ratio": r[4],
+        }
+        for r in rows
+    ]

--- a/backend/tests/test_auto_executor.py
+++ b/backend/tests/test_auto_executor.py
@@ -1,0 +1,304 @@
+"""Phase 2.1 integration tests — trailing TP wire-up across orders.py +
+auto_executor.py + storage.py + dry-run endpoint helper.
+
+Five tests, each pinned to one Phase 2.1 sub-step from the plan:
+
+  T1 trailing places two algo legs           (orders.execute_from_simulation)
+  T2 fixed places one algo leg               (regression — no behaviour drift)
+  T3 algoId persists to okx_trailing_algos   (storage.insert_trailing_algo)
+  T4 close detection cancels sibling         (orders.cancel_trailing_for_position)
+  T5 dry-run helper emits zero POSTs         (orders.build_dry_run_payload)
+
+Mocking strategy mirrors test_okx_trailing_spike.py: monkeypatch the
+OKXClient HTTP plumbing (`_post`, `_get`) and any helpers that call out to
+external services. Tests are hermetic — temp DB via env override + module
+reload — so concurrent runs don't share state.
+
+The params-correctness parity check (advisor #1) lives in T1: callbackRatio
+is asserted to be exactly `str(trail_pct/100)`, which is the single seam
+between simulator decimal-form (engine_fast.py:1372) and OKX decimal-string.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+@pytest.fixture
+def temp_db(monkeypatch):
+    """Hermetic SQLite per test. Modules that read OKX_DB_PATH at import
+    time (storage) are reloaded so the path takes effect."""
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = str(Path(tmp) / "phase21.db")
+        monkeypatch.setenv("OKX_DB_PATH", db_path)
+        monkeypatch.setenv("OKX_BROKER_CODE_API", "TEST_BROKER")
+        monkeypatch.setenv("OKX_DEMO_MODE", "false")
+        # Reload anything that captured these env vars at import time.
+        import importlib
+
+        import okx.config as config
+
+        importlib.reload(config)
+        import okx.storage as storage
+
+        importlib.reload(storage)
+        # Touch the DB so schema CREATE IF NOT EXISTS fires.
+        storage._get_conn().close()
+        yield db_path
+
+
+@pytest.fixture
+def patched_okx(monkeypatch, temp_db):
+    """Patch every OKX side-effecting call so `execute_from_simulation` and
+    `build_dry_run_payload` run end-to-end without touching the network.
+
+    Returns a record dict that the test inspects to verify what *would* have
+    been sent. POST counts and the captured bodies live there.
+    """
+    import importlib
+
+    import okx.client as client_mod
+
+    importlib.reload(client_mod)
+    import okx.orders as orders_mod
+
+    importlib.reload(orders_mod)
+
+    rec: dict = {
+        "post_calls": [],   # list of (path, body)
+        "get_calls": [],    # list of (path, params)
+        "leverage_calls": 0,
+        "close_calls": 0,
+    }
+
+    # Stub credentials so OKXClient constructor succeeds in test.
+    monkeypatch.setattr(
+        orders_mod, "get_api_credentials",
+        lambda sid: {"api_key": "ak", "secret_key": "sk", "passphrase": "pp"},
+    )
+
+    # Patch OKXClient methods at the class level so any new instance gets
+    # the stubs (orders.py opens its own client inside the function).
+    async def fake_get_mark_price(self, inst_id):
+        rec["get_calls"].append(("mark_price", inst_id))
+        return 100000.0
+
+    async def fake_get_instrument_info(self, inst_id):
+        rec["get_calls"].append(("instrument_info", inst_id))
+        return {"ctVal": 0.01, "minSz": 1, "lotSz": 1, "tickSz": 0.1}
+
+    async def fake_set_leverage(self, **kwargs):
+        rec["leverage_calls"] += 1
+        return {"code": "0"}
+
+    async def fake_place_order(self, **kwargs):
+        body = {"path": "/api/v5/trade/order", **kwargs}
+        rec["post_calls"].append(("/api/v5/trade/order", body))
+        return {"ordId": "OID-MARKET-1", "code": "0"}
+
+    async def fake_place_algo_order(self, **kwargs):
+        # Mirror the body shape for assertion. ordType always "conditional"
+        # for this helper; trailing goes through place_trailing_stop.
+        body = {"path": "/api/v5/trade/order-algo", "ordType": "conditional", **kwargs}
+        rec["post_calls"].append(("/api/v5/trade/order-algo", body))
+        return {"code": "0", "data": [{"algoId": "ALGO-SL-1"}]}
+
+    async def fake_place_trailing_stop(self, **kwargs):
+        body = {
+            "path": "/api/v5/trade/order-algo",
+            "ordType": "move_order_stop",
+            **kwargs,
+        }
+        rec["post_calls"].append(("/api/v5/trade/order-algo", body))
+        return {"code": "0", "data": [{"algoId": "ALGO-TRAIL-1"}]}
+
+    async def fake_cancel_algo_orders(self, algo_ids, inst_id):
+        rec["post_calls"].append(
+            ("/api/v5/trade/cancel-algos", {"algo_ids": algo_ids, "inst_id": inst_id})
+        )
+        return {"code": "0"}
+
+    async def fake_close_position(self, inst_id, mgn_mode="isolated"):
+        rec["close_calls"] += 1
+        return {"code": "0"}
+
+    monkeypatch.setattr(client_mod.OKXClient, "get_mark_price", fake_get_mark_price)
+    monkeypatch.setattr(client_mod.OKXClient, "get_instrument_info", fake_get_instrument_info)
+    monkeypatch.setattr(client_mod.OKXClient, "set_leverage", fake_set_leverage)
+    monkeypatch.setattr(client_mod.OKXClient, "place_order", fake_place_order)
+    monkeypatch.setattr(client_mod.OKXClient, "place_algo_order", fake_place_algo_order)
+    monkeypatch.setattr(client_mod.OKXClient, "place_trailing_stop", fake_place_trailing_stop)
+    monkeypatch.setattr(client_mod.OKXClient, "cancel_algo_orders", fake_cancel_algo_orders)
+    monkeypatch.setattr(client_mod.OKXClient, "close_position", fake_close_position)
+
+    # OKXClient.__aenter__/__aexit__ default to the unpatched (real) impls,
+    # which only do `httpx.AsyncClient` lifecycle — safe with no requests.
+
+    # Also stub merkle so non-fatal try/except doesn't interfere with assertions.
+    import okx.merkle as merkle_mod
+
+    monkeypatch.setattr(merkle_mod, "record_order", lambda **kw: None)
+
+    return rec
+
+
+def _build_request(*, tp_source: str = "follow_signal", trail_pct=None,
+                    sl_pct: float = 5.0, tp_pct: float = 8.0):
+    from okx.models import SimToExecRequest
+
+    return SimToExecRequest(
+        strategy="bb-squeeze-short",
+        direction="long",
+        symbol="BTCUSDT",
+        sl_pct=sl_pct,
+        tp_pct=tp_pct,
+        position_size_usdt=1000.0,
+        leverage=5,
+        td_mode="isolated",
+        tp_source=tp_source,
+        trail_pct=trail_pct,
+    )
+
+
+@pytest.mark.anyio
+async def test_t1_trailing_signal_places_two_algo_legs(patched_okx):
+    """T1: tp_source='trailing' + trail_pct=2.0 produces SL conditional algo
+    + trailing move_order_stop algo. callbackRatio == '0.02' (the parity
+    seam between sim engine_fast.py:1372 decimal form and OKX decimal-string)."""
+    from okx.orders import execute_from_simulation
+
+    req = _build_request(tp_source="trailing", trail_pct=2.0, sl_pct=5.0)
+    result = await execute_from_simulation("sess-T1", req, current_price=100000.0)
+
+    algo_calls = [c for c in patched_okx["post_calls"] if c[0].endswith("/order-algo")]
+    assert len(algo_calls) == 2, (
+        f"trailing strategy must place SL conditional + trailing move_order_stop, "
+        f"got {len(algo_calls)}: {algo_calls}"
+    )
+
+    sl_body = next(c[1] for c in algo_calls if c[1].get("ordType") == "conditional")
+    trail_body = next(c[1] for c in algo_calls if c[1].get("ordType") == "move_order_stop")
+
+    # SL leg: trigger present, TP absent (trailing replaces TP).
+    assert sl_body.get("sl_trigger_px"), "SL trigger missing"
+    assert sl_body.get("tp_trigger_px") is None, (
+        "trailing strategies must omit conditional TP (trailing replaces it)"
+    )
+    # Trailing leg: callbackRatio is the parity anchor.
+    assert trail_body.get("callback_ratio") == "0.02", (
+        f"callbackRatio must equal trail_pct/100 (engine_fast.py:1372 parity); "
+        f"got {trail_body.get('callback_ratio')}"
+    )
+    # Both algoIds surfaced into the result for the caller / audit.
+    assert result.get("trailing_algo_id") == "ALGO-TRAIL-1"
+    assert result["details"]["callback_ratio"] == "0.02"
+    assert result["details"]["tp_source"] == "trailing"
+
+
+@pytest.mark.anyio
+async def test_t2_fixed_signal_places_one_algo_leg_only(patched_okx):
+    """T2 regression: tp_source='custom_pct' (or default) places exactly one
+    conditional SL+TP algo. No trailing POST. Phase 2.1's strategy_overrides
+    rewrite must not break the legacy fixed path."""
+    from okx.orders import execute_from_simulation
+
+    req = _build_request(tp_source="custom_pct", trail_pct=None, sl_pct=5.0, tp_pct=8.0)
+    await execute_from_simulation("sess-T2", req, current_price=100000.0)
+
+    algo_calls = [c for c in patched_okx["post_calls"] if c[0].endswith("/order-algo")]
+    assert len(algo_calls) == 1, (
+        f"fixed strategy must place exactly one conditional algo, "
+        f"got {len(algo_calls)}: {algo_calls}"
+    )
+    sl_body = algo_calls[0][1]
+    assert sl_body.get("ordType") == "conditional"
+    assert sl_body.get("sl_trigger_px"), "SL still required on fixed path"
+    assert sl_body.get("tp_trigger_px"), "TP still required on fixed path"
+
+
+@pytest.mark.anyio
+async def test_t3_trailing_algo_id_persists_to_db(patched_okx):
+    """T3: a successful trailing arm inserts a row into okx_trailing_algos
+    with the algoId, parent_ord_id, callback_ratio. Phase 2.1.4 close-cancel
+    queries this table by parent_ord_id."""
+    from okx import storage
+    from okx.orders import execute_from_simulation
+
+    req = _build_request(tp_source="trailing", trail_pct=2.0, sl_pct=5.0)
+    await execute_from_simulation(
+        "sess-T3", req, current_price=100000.0, cl_ord_id="signalT3"
+    )
+
+    rows = storage.list_live_trailing_algos(session_id="sess-T3")
+    assert len(rows) == 1, f"expected 1 trailing row for sess-T3, got {len(rows)}"
+    row = rows[0]
+    assert row["algo_id"] == "ALGO-TRAIL-1"
+    assert row["inst_id"] == "BTC-USDT-SWAP"
+    assert row["parent_ord_id"] == "OID-MARKET-1"
+    assert row["callback_ratio"] == "0.02"
+
+
+@pytest.mark.anyio
+async def test_t4_close_detection_cancels_sibling_trailing(patched_okx):
+    """T4: when a trailing algo is armed and the close-detection path
+    invokes cancel_trailing_for_position, OKX cancel-algos POST fires once
+    with the right algoId, and the DB state flips to 'cancelled'."""
+    from okx import storage
+    from okx.orders import cancel_trailing_for_position, execute_from_simulation
+
+    # Seed a trailing position.
+    req = _build_request(tp_source="trailing", trail_pct=2.0, sl_pct=5.0)
+    await execute_from_simulation(
+        "sess-T4", req, current_price=100000.0, cl_ord_id="signalT4"
+    )
+    # Reset post_calls so we count only the cancel.
+    patched_okx["post_calls"].clear()
+
+    cancel_result = await cancel_trailing_for_position("sess-T4", "OID-MARKET-1")
+    assert cancel_result["cancelled"] is True
+    assert cancel_result["algo_id"] == "ALGO-TRAIL-1"
+
+    cancel_calls = [
+        c for c in patched_okx["post_calls"] if c[0].endswith("/cancel-algos")
+    ]
+    assert len(cancel_calls) == 1
+    assert cancel_calls[0][1]["algo_ids"] == ["ALGO-TRAIL-1"]
+    assert cancel_calls[0][1]["inst_id"] == "BTC-USDT-SWAP"
+
+    # DB state flipped → list_live no longer surfaces it.
+    live_after = storage.list_live_trailing_algos(session_id="sess-T4")
+    assert len(live_after) == 0, "cancelled trailing must not appear in live list"
+
+
+@pytest.mark.anyio
+async def test_t5_dry_run_endpoint_emits_no_okx_post(patched_okx):
+    """T5: build_dry_run_payload returns the three OKX request bodies
+    without firing any POST. OKX read GETs (mark price + instrument info)
+    are still allowed because tickSz/ctVal aren't derivable otherwise."""
+    from okx.orders import build_dry_run_payload
+
+    req = _build_request(tp_source="trailing", trail_pct=2.0, sl_pct=5.0)
+    payload = await build_dry_run_payload("sess-T5", req, current_price=100000.0)
+
+    posts = patched_okx["post_calls"]
+    assert posts == [], (
+        f"dry-run must emit ZERO POSTs (Phase 2.2 ledger goal), "
+        f"observed {len(posts)}: {[p[0] for p in posts]}"
+    )
+    # Three required keys present; trailing populated for trailing strategy.
+    assert payload["order_request"]["ordType"] == "market"
+    assert payload["sl_algo_request"]["ordType"] == "conditional"
+    assert payload["trailing_algo_request"]["ordType"] == "move_order_stop"
+    assert payload["trailing_algo_request"]["callbackRatio"] == "0.02"
+    # Fixed path branch: trailing_algo_request must be None, regression guard.
+    fixed_req = _build_request(tp_source="custom_pct", trail_pct=None)
+    fixed_payload = await build_dry_run_payload(
+        "sess-T5", fixed_req, current_price=100000.0,
+    )
+    assert fixed_payload["trailing_algo_request"] is None


### PR DESCRIPTION
## Phase 2.1 — autotrading redesign plan

Wires the Phase 2.0 spike helpers (`place_trailing_stop` + `get_algo_orders_pending`, merged in #1609) into the live trade path. Removes the `trail_pct → fixed TP` fallback at `auto_executor.py:452-455` so trailing strategies actually trail in production.

### Behaviour change is gated

Every existing caller that doesn't set `tp_source="trailing"` (Astro frontend, `/execute/order` without `trail_pct`, manual UI) takes the unchanged conditional SL+TP path. Regression pinned by integration test T2.

### Single-answer plan decisions

| # | Decision | Choice | Why |
|---|----------|--------|-----|
| D1 | sim↔live parity | API params-correctness | sim 4h candle high/low can't match live tick. T1 asserts `callbackRatio = trail_pct/100`. |
| D2 | algo_id persist scope | trailing leg only | conditional SL/TP algoId discard at L634 is a pre-existing bug, separate PR. |
| D3 | OCO leak | explicit cancel in close detection | `pnl_sync` hooks `cancel_trailing_for_position` on realized-PnL. Reconciler extension out of scope. |
| D4 | activePx default | omit (trail from place-time) | sim `engine_fast.py:1356-1360` parity. Delayed arming = different schema field, not this PR. |
| D5 | initial_sl_pct | production uses sl_pct only | accept divergence from sim. Min `SimToExecRequest` surface. |
| D6 | dry-run mode | new endpoint, OKX POST=0 | `POST /execute/dry-run`. Read GETs (mark price, instrument info) still happen because tickSz/ctVal can't be derived otherwise. |
| D7 | DB schema | `okx_trailing_algos` lightweight | separate from merkle audit (mutable state ≠ immutable leaf). |
| D8 | docs | 0 (code + PR description only) | owner STOP LIST. |

### Files

| File | Change |
|------|--------|
| `backend/okx/storage.py` | new table `okx_trailing_algos` + `insert_trailing_algo`, `find_trailing_by_parent`, `update_trailing_state`, `list_live_trailing_algos` |
| `backend/okx/models.py` | `SimToExecRequest` + `tp_source` Literal + `trail_pct` Optional |
| `backend/okx/orders.py` | `execute_from_simulation` trailing branch + `build_dry_run_payload` + `cancel_trailing_for_position` + `_trail_pct_to_callback_ratio` parity seam |
| `backend/okx/auto_executor.py` | strategy_overrides preserves `tp_source`/`trail_pct`, algo placement branches on `use_trailing`, trailing algoId persisted, `sync_realized_pnl` receives `parent_ord_id` |
| `backend/okx/pnl_sync.py` | `sync_realized_pnl` optional `parent_ord_id`; cancels sibling trailing on close detection |
| `backend/okx/router.py` | `POST /execute/dry-run` endpoint |
| `backend/tests/test_auto_executor.py` | 5 integration tests |

### Tests

| # | Test | Pins |
|---|------|------|
| T1 | `test_t1_trailing_signal_places_two_algo_legs` | trailing path emits SL conditional + trailing `move_order_stop` legs; `callbackRatio = trail_pct/100` parity |
| T2 | `test_t2_fixed_signal_places_one_algo_leg_only` | regression — fixed strategies still emit single conditional SL+TP |
| T3 | `test_t3_trailing_algo_id_persists_to_db` | `okx_trailing_algos` row inserted with parent_ord_id, callback_ratio |
| T4 | `test_t4_close_detection_cancels_sibling_trailing` | cancel-algos POST + DB state flip on close |
| T5 | `test_t5_dry_run_endpoint_emits_no_okx_post` | `build_dry_run_payload` produces 0 POSTs; trailing/fixed branches both verified |

### Verification

```
cd backend && uv run --with pytest --with anyio --with pydantic --with httpx --with cryptography --with fastapi --python 3.12 python -m pytest tests/test_auto_executor.py tests/test_okx_trailing_spike.py -v
```

Result: 9 passed (5 Phase 2.1 + 4 Phase 2.0 spike regression).

Broader OKX suite (idempotency, oauth pkce/scope/experimental, manual_auth, tick_and_age) → 39 passed total, 0 regression.

### Out of scope

- Phase 2.2: 7-day dry-run operation + monitor (uses this endpoint)
- Phase 3: KO unblock + flag SSoT
- Phase 4: production env flip
- Conditional SL/TP algoId persistence (pre-existing bug, separate PR)
- Reconciler orphan-algo sweep (separate PR if Phase 2.2 dry-run shows leak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)