### PR TITLE
feat(flags): SSoT autotrading visibility flag (Phase 3b)

### DIFF
--- a/.github/workflows/data-deploy.yml
+++ b/.github/workflows/data-deploy.yml
@@ -88,6 +88,14 @@ jobs:
 
       - name: Build Astro site
         if: steps.gate.outputs.skip != 'true'
+        env:
+          # Phase 3b SSoT for autotrading visibility. Astro reads PUBLIC_*
+          # env vars at build time and exposes them via import.meta.env.
+          # 'false' (current) keeps every gated CTA in coming-soon mode.
+          # Phase 4 production rollout = single edit to 'true' here, then
+          # this workflow rebuilds + deploys, propagating the flag to
+          # every client bundle in one shot.
+          PUBLIC_AUTOTRADE_LIVE: 'false'
         run: npm run build 2>&1 | tail -20
 
       - name: Deploy to Cloudflare Workers

--- a/src/components/OKXConnectButton.tsx
+++ b/src/components/OKXConnectButton.tsx
@@ -51,8 +51,10 @@ const labels = {
   },
 };
 
-// 2026-04-23: feature flag. Flip to false once OKX integration is live.
-const AUTOTRADE_COMING_SOON = true;
+// Phase 3b: AUTOTRADE_COMING_SOON is now SSoT-derived from
+// src/config/feature-flags.ts (env-driven via PUBLIC_AUTOTRADE_LIVE).
+// Flip to live by setting PUBLIC_AUTOTRADE_LIVE='true' in data-deploy.yml.
+import { AUTOTRADE_COMING_SOON } from "../config/feature-flags";
 
 const sizeClasses = {
   sm: "btn-sm text-sm",

--- a/src/components/simulator/v1/MobileStickyCTA.tsx
+++ b/src/components/simulator/v1/MobileStickyCTA.tsx
@@ -9,6 +9,7 @@
 // - Honors reduced-motion: fades rather than slides.
 
 import { useEffect, useState } from "preact/hooks";
+import { AUTOTRADE_COMING_SOON } from "../../../config/feature-flags";
 import {
   getLocalizedPath,
   useTranslations,
@@ -24,8 +25,9 @@ interface Props {
 // 2026-04-23: auto-trading on hold. Sticky CTA now hides entirely —
 // instead of a confusing "Connect OKX → Coming Soon" sticky nag on
 // every scroll, we simply remove it. The bottom OKXConnectCTA still
-// announces the feature once. Flip AUTOTRADE_COMING_SOON to re-enable.
-const AUTOTRADE_COMING_SOON = true;
+// announces the feature once.
+// Phase 3b: AUTOTRADE_COMING_SOON SSoT-imported (env-driven via
+// PUBLIC_AUTOTRADE_LIVE in data-deploy.yml).
 
 export default function MobileStickyCTA({ lang, presetId }: Props) {
   const t = useTranslations(lang);

--- a/src/components/simulator/v1/OKXConnectCTA.tsx
+++ b/src/components/simulator/v1/OKXConnectCTA.tsx
@@ -1,7 +1,8 @@
 // Bottom CTA block — 2026-04-23: auto-trading on hold. Render as an
 // informational "Coming Soon" panel instead of an active conversion CTA.
-// Feature flip at AUTOTRADE_COMING_SOON below.
+// Phase 3b: feature flag SSoT-imported from src/config/feature-flags.
 
+import { AUTOTRADE_COMING_SOON } from "../../../config/feature-flags";
 import {
   getLocalizedPath,
   useTranslations,
@@ -14,9 +15,6 @@ interface Props {
   lang: Lang;
   presetId: string | null;
 }
-
-// Flip to false once OKX integration is live.
-const AUTOTRADE_COMING_SOON = true;
 
 export default function OKXConnectCTA({ lang, presetId }: Props) {
   const t = useTranslations(lang);

--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -1,0 +1,25 @@
+/**
+ * SSoT for runtime feature flags.
+ *
+ * Phase 3b of the autotrading redesign plan: prior to this file,
+ * `AUTOTRADE_COMING_SOON = true` was duplicated across 4 components
+ * (OKXConnectButton, dashboard.astro, OKXConnectCTA, MobileStickyCTA).
+ * Flipping the gate at Phase 4 production rollout therefore meant
+ * editing 4 files in lockstep — drift-prone.
+ *
+ * AUTOTRADE_LIVE is the canonical signal, env-driven so the rollout PR
+ * is a single workflow YAML change (data-deploy.yml `PUBLIC_AUTOTRADE_LIVE`
+ * env value flip from 'false' → 'true'). AUTOTRADE_COMING_SOON is exported
+ * as the inverted convenience to keep call-site JSX/logic unchanged from
+ * the pre-Phase 3b code — no inversion bugs introduced as a side effect
+ * of the refactor.
+ *
+ * Default (env unset) = false, which preserves the current
+ * coming-soon behaviour. Phase 4 sets PUBLIC_AUTOTRADE_LIVE='true' in the
+ * Astro build env to flip everything in one step.
+ */
+
+export const AUTOTRADE_LIVE: boolean =
+  import.meta.env.PUBLIC_AUTOTRADE_LIVE === "true";
+
+export const AUTOTRADE_COMING_SOON: boolean = !AUTOTRADE_LIVE;

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -2,15 +2,16 @@
 // Phase 7 un-hide (2026-04-17) — see src/pages/autotrading/index.astro header.
 // 2026-04-23: Auto-trading on hold. Dashboard surfaces a Coming Soon state
 // and hides the live connection widgets so users can't trigger broken
-// flows. Flip AUTOTRADE_COMING_SOON below to restore the active dashboard.
+// flows.
+// Phase 3b: AUTOTRADE_COMING_SOON SSoT-imported from src/config/feature-flags
+// (env-driven via PUBLIC_AUTOTRADE_LIVE). Phase 4 flip = single YAML change.
 import Layout from '../layouts/Layout.astro';
 import OKXConnectButton from '../components/OKXConnectButton';
 import AutoTradingStatus from '../components/AutoTradingStatus';
 import TradingSettings from '../components/TradingSettings';
 import LivePositions from '../components/LivePositions';
 import LiveTradeHistory from '../components/LiveTradeHistory';
-
-const AUTOTRADE_COMING_SOON = true;
+import { AUTOTRADE_COMING_SOON } from '../config/feature-flags';
 ---
 
 <Layout title="Dashboard — PRUVIQ" description="Auto-trading dashboard (coming soon). Simulations remain fully free.">


### PR DESCRIPTION
## Phase 3b — autotrading redesign plan

### Why

`AUTOTRADE_COMING_SOON = true` was duplicated across 4 components (OKXConnectButton, dashboard.astro, simulator OKXConnectCTA, simulator MobileStickyCTA) — each redeclaring the same flag in its own scope. Phase 4 production rollout would have required 4 lockstep edits with no compiler safety coupling them. Drift-prone.

### What

- New `src/config/feature-flags.ts` — canonical export site.
  - `AUTOTRADE_LIVE` — read from `import.meta.env.PUBLIC_AUTOTRADE_LIVE === 'true'`
  - `AUTOTRADE_COMING_SOON = !AUTOTRADE_LIVE` — convenience inverse so existing call-site JSX/predicates are unchanged. Refactor adds zero inversion bugs.
- 4 components now `import { AUTOTRADE_COMING_SOON } from "...config/feature-flags"` instead of re-declaring it.
- `.github/workflows/data-deploy.yml` build step gets explicit `PUBLIC_AUTOTRADE_LIVE: 'false'` env. Phase 4 rollout = edit one YAML line.

### Behavior preserved

Default env unset = `AUTOTRADE_LIVE === false` = `AUTOTRADE_COMING_SOON === true` = current coming-soon UI everywhere. Zero behavior change in this PR.

### Verification

```
build: 1196 pages, 0 errors
grep -rn "^const AUTOTRADE_COMING_SOON\|^export const AUTOTRADE" src/
  → only src/config/feature-flags.ts (single definition site)
```

### Phase 4 rollout preview (not in this PR)

Single line change in `.github/workflows/data-deploy.yml`:
```diff
-          PUBLIC_AUTOTRADE_LIVE: 'false'
+          PUBLIC_AUTOTRADE_LIVE: 'true'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)