### PR TITLE
feat(monitor): Phase 2.2 dry-run parity smoke script

### DIFF
--- a/scripts/dry-run-monitor.sh
+++ b/scripts/dry-run-monitor.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Phase 2.2 — daily parity smoke for the trailing TP wire-up.
+#
+# Runs the integration tests that pin the simulator↔OKX request-shape
+# parity. Two tests cover the regression surface:
+#
+#   T1: test_t1_trailing_signal_places_two_algo_legs
+#       — trailing strategy emits SL conditional + move_order_stop.
+#         callbackRatio == str(trail_pct/100) (the single seam between
+#         simulator decimal-form and OKX decimal-string).
+#
+#   T5: test_t5_dry_run_endpoint_emits_no_okx_post
+#       — /execute/dry-run produces the three request bodies with zero
+#         POSTs. Trailing payload's callbackRatio matches the expected
+#         decimal-string. Fixed-path branch returns null trailing payload.
+#
+# Drift in *either* test means a refactor or dependency bump silently
+# changed how a real auto-trade signal would map to OKX. Phase 4
+# production rollout pre-condition: 7 consecutive days of OK from this
+# script (advisor parity-correctness scope; result-equivalence is
+# unmeasurable since simulator uses 4h candle high/low and OKX live ticks).
+#
+# Cron entry suggestion (Mac Mini or DO):
+#   0 0 * * *  /Users/jepo/pruviq/scripts/dry-run-monitor.sh >> /var/log/pruviq-dry-run-monitor.log 2>&1
+#
+# Telegram alert on FAIL — uses TELEGRAM_TOKEN + TELEGRAM_CHAT_ID env.
+# Quietly OK on PASS so cron logs stay readable.
+
+set -euo pipefail
+
+REPO_ROOT="${PRUVIQ_REPO_ROOT:-$HOME/pruviq}"
+LOG_FILE="${PHASE22_MONITOR_LOG:-/tmp/phase22-monitor.log}"
+
+# Telegram alert is optional — script still fails (exit 1) if env vars
+# are missing, so cron emails the operator. The notify_telegram helper
+# is a best-effort layer on top.
+notify_telegram() {
+    local msg="$1"
+    if [ -z "${TELEGRAM_TOKEN:-}" ] || [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
+        return 0
+    fi
+    curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_TOKEN}/sendMessage" \
+        -d "chat_id=${TELEGRAM_CHAT_ID}" \
+        -d "text=${msg}" \
+        -d "disable_web_page_preview=true" \
+        > /dev/null 2>&1 || true
+}
+
+cd "$REPO_ROOT/backend"
+
+# uv ephemeral env keeps the runtime hermetic — pinning Python 3.12
+# avoids local interpreter drift dependening on which Mac/DO host runs
+# the cron. Only the deps the tests actually need are pulled in.
+if uv run \
+    --with pytest \
+    --with anyio \
+    --with pydantic \
+    --with httpx \
+    --with cryptography \
+    --with fastapi \
+    --python 3.12 \
+    python -m pytest \
+        tests/test_auto_executor.py::test_t1_trailing_signal_places_two_algo_legs \
+        tests/test_auto_executor.py::test_t5_dry_run_endpoint_emits_no_okx_post \
+        -v \
+    > "$LOG_FILE" 2>&1
+then
+    echo "OK: Phase 2.2 dry-run parity verified at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    exit 0
+else
+    msg="🚨 PRUVIQ Phase 2.2 dry-run parity DRIFT at $(date -u +%Y-%m-%dT%H:%M:%SZ) — log: ${LOG_FILE} on $(hostname)"
+    notify_telegram "$msg"
+    echo "$msg" >&2
+    echo "--- Last 30 lines of test output ---"
+    tail -30 "$LOG_FILE"
+    exit 1
+fi


### PR DESCRIPTION
## Phase 2.2 — autotrading redesign plan

### Why

Phase 2.1 (#1611) wired trailing TP into the live trade path with 5 integration tests pinning the request-shape parity. Phase 2.2 is the **operational** half: daily smoke that re-runs the parity tests so a future refactor / dependency bump can't silently break the simulator↔OKX mapping before we flip Phase 4.

### What

`scripts/dry-run-monitor.sh` — runs T1 + T5 from `test_auto_executor.py` via uv ephemeral env (Python 3.12 hermetic, no host interpreter drift).

| Test | Pins |
|------|------|
| T1 | trailing path emits SL conditional + `move_order_stop` legs; `callbackRatio == str(trail_pct/100)` |
| T5 | `/execute/dry-run` emits 3 request bodies with 0 POSTs; trailing/fixed branches both verified |

### Parity scope (advisor #1 from Phase 2.1)

This monitor checks **API params-correctness**, not result equivalence. Simulator uses 4h candle high/low (engine_fast.py:1376) and OKX uses live tick price — they can never match on PF/MDD/win-rate. The parity we *can* pin: the parameter mapping seam (`callbackRatio = trail_pct/100`), side direction, sz computation, SL leg coexistence. That's what these tests assert and what this script re-runs daily.

### Cron entry suggestion

```
0 0 * * *  /Users/jepo/pruviq/scripts/dry-run-monitor.sh >> /var/log/pruviq-dry-run-monitor.log 2>&1
```

(Schedule placement is operator's call — Mac Mini cron or DO systemd timer both work. Phase 4 entry condition: 7 consecutive days of `OK` output.)

### Out of scope

- Phase 4 production env flip (`PUBLIC_AUTOTRADE_LIVE`) — depends on 7-day green window from this script
- Real continuous dry-run execution against the prod OKX read endpoints — separate operational task; the test mocks OKX so the script doesn't burn API rate limit
- Conditional SL/TP algoId persistence (pre-existing bug, separate PR per Phase 2.1 plan D2)

### Verification

```
PRUVIQ_REPO_ROOT=/path/to/pruviq scripts/dry-run-monitor.sh
→ OK: Phase 2.2 dry-run parity verified at 2026-05-01T01:22:08Z
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)