### PR TITLE
feat(autotrade): production rollout — Phase 4 flag flip

### DIFF
--- a/.github/workflows/data-deploy.yml
+++ b/.github/workflows/data-deploy.yml
@@ -91,11 +91,13 @@ jobs:
         env:
           # Phase 3b SSoT for autotrading visibility. Astro reads PUBLIC_*
           # env vars at build time and exposes them via import.meta.env.
-          # 'false' (current) keeps every gated CTA in coming-soon mode.
-          # Phase 4 production rollout = single edit to 'true' here, then
-          # this workflow rebuilds + deploys, propagating the flag to
-          # every client bundle in one shot.
-          PUBLIC_AUTOTRADE_LIVE: 'false'
+          # Phase 4 rollout (2026-05-01): flipped 'false' → 'true' after
+          # Phase 0/2.0/2.1/2.2/3a/3b code work merged.
+          # post-rollout 안전망: scripts/dry-run-monitor.sh가 7일 parity smoke
+          # daily 운영. drift 발견 시 즉시 'true' → 'false' revert PR.
+          # 자동 rollback 트리거: OAuth 5xx > 5% 15min, DO CPU > 80% 5min,
+          # smoke FAIL 1건이라도.
+          PUBLIC_AUTOTRADE_LIVE: 'true'
         run: npm run build 2>&1 | tail -20
 
       - name: Deploy to Cloudflare Workers


### PR DESCRIPTION
## Phase 4 — autotrading production rollout

Single-line flip of `PUBLIC_AUTOTRADE_LIVE` SSoT (introduced in #1613). All prerequisite code work merged in main.

### Prerequisite chain (이미 완료)

| Phase | PR | 효과 |
|-------|-----|------|
| 0 | #1601 #1602 #1603 | dispatch hook + broker 분리 + harness fix |
| 2.0 | #1609 | trailing TP helper + 4 mock 테스트 |
| 2.1 | #1611 | trailing wireup + `/execute/dry-run` + 5 통합 테스트 |
| 3a | #1612 | KO 페이지 EN parity |
| 3b | #1613 | `PUBLIC_AUTOTRADE_LIVE` SSoT |
| 2.2 | #1614 | `scripts/dry-run-monitor.sh` parity smoke |

### What this PR does

`data-deploy.yml:100` build-time env: `'false'` → `'true'`

→ Astro build: `AUTOTRADE_LIVE = true` → `AUTOTRADE_COMING_SOON = false`
→ `OKXConnectButton`: active connect 모드 (not Coming Soon)
→ users complete OAuth, dashboard widgets activate, `/execute/order` 라이브

### Reversed verification model (owner directive 2026-05-01)

| 기존 plan | 본 PR (정정) |
|-----------|-------------|
| Phase 2.2 7일 dry-run **AFTER** code merge / **BEFORE** Phase 4 | Phase 2.2 7일 dry-run **AFTER** Phase 4 (post-rollout 안전망) |

`dry-run-monitor.sh`는 cron 등록 후 daily 실행 → drift 즉시 Telegram alert.

### Pre-rollout 체크리스트 (2026-05-01 실측)

| 항목 | 결과 |
|------|------|
| /execute/dry-run live | ✅ HTTP 422 (schema check, Phase 2.1 deploy 확인) |
| /admin/halt kill switch | ✅ HTTP 403 (auth) |
| /trust/merkle/{date} | ✅ HTTP 400 (date format) |
| DO 5 active services | ✅ pruviq-api/staging/cloudflared + alloy + litestream |
| DO 자원 | ✅ load 0.00, mem 2.0G/3.8G, disk 29% |
| 8 systemd timers | ✅ api-watchdog/monitor/staleness-watch/등 |
| /auth/okx/start p95 | ⚠️ 0.99s (목표 <500ms 초과 — 동시처리 시 지연 위험) |
| pnl_sync 24h 로그 | ⚠️ 0건 (자동매매 비활성이라 자연 — post-rollout 검증) |

### Auto-rollback (30min 관측 기간)

| 트리거 | 액션 |
|--------|------|
| OAuth 5xx > 5% (15min cumulative) | revert PR (1줄 flip back) → automerge |
| DO CPU > 80% sustained 5min | 동상 |
| smoke FAIL 1건 | 동상 |
| visible 회귀 알림 (Telegram) | 동상 |

Revert는 `false`로 1줄 되돌림 = 2분 내 prod 활성화 → coming-soon 복귀.

### Build verification

```
PUBLIC_AUTOTRADE_LIVE=true npm run build → 1196 pages, 0 errors
grep "Coming Soon" dist/dashboard/index.html → 0 matches (active mode 확인)
grep "OAuth" dist/dashboard/index.html → 1 match
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)