### PR TITLE
chore(lhci): tighten best-practices 0.55→0.72 (Sprint 3.1, market/ TradingView cap)

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -29,7 +29,7 @@
       "assertions": {
         "categories:performance": ["error", { "minScore": 0.70 }],
         "categories:accessibility": ["error", { "minScore": 0.95 }],
-        "categories:best-practices": ["error", { "minScore": 0.55 }],
+        "categories:best-practices": ["error", { "minScore": 0.80 }],
         "categories:seo": ["error", { "minScore": 0.98 }],
         "largest-contentful-paint": ["error", { "maxNumericValue": 3000 }],
         "cumulative-layout-shift": ["error", { "maxNumericValue": 0.05 }],

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -29,7 +29,7 @@
       "assertions": {
         "categories:performance": ["error", { "minScore": 0.70 }],
         "categories:accessibility": ["error", { "minScore": 0.95 }],
-        "categories:best-practices": ["error", { "minScore": 0.80 }],
+        "categories:best-practices": ["error", { "minScore": 0.72 }],
         "categories:seo": ["error", { "minScore": 0.98 }],
         "largest-contentful-paint": ["error", { "maxNumericValue": 3000 }],
         "cumulative-layout-shift": ["error", { "maxNumericValue": 0.05 }],


### PR DESCRIPTION
## Summary

- best-practices 임계값 0.55 → 0.72 (0.80 시도 → LHCI 실패 → 0.72로 재보정)
- root cause 분석 후 현실적 ceiling 반영

## Evidence (CI 실측, run #25207036934)

| URL | BP |
|-----|----|
| pruviq.com/ | 100 |
| pruviq.com/ko/ | 100 |
| pruviq.com/simulate/ | 95 |
| pruviq.com/market/ | **73** (ceiling) |
| pruviq.com/coins/ | 95 |

## Root cause: /market/ BP = 73

- TradingView iframe third-party APIs 잔류 (deprecated APIs + 3rd-party cookies)
- `MarketDashboard.tsx:335` IntersectionObserver로 eager load 차단 → 59→73 개선됨
- TradingView embed 유지 시 73이 실질적 ceiling
- 0.80 → LHCI FAIL 확인 (3 identical runs: 0.73, 0.73, 0.73)

## Threshold 선택

- 0.72 = 실측 73 - 마진 0.01 (가장 낮은 페이지 /market/ 기준)
- 향후 TradingView 교체 시 0.90+ 인상 가능

## Sprint 3.1 threshold 현황 (이 PR 후)

| Metric | Before | After | Status |
|--------|--------|-------|--------|
| performance | 0.70 | 0.70 | 🔜 보류 |
| a11y | — | 0.95 | ✅ #1544 |
| best-practices | **0.55** | **0.72** | ✅ 이 PR |
| seo | — | 0.98 | ✅ #1544 |
| CLS | — | 0.05 | ✅ #1545 |
| TBT | — | 200 | ✅ #1545 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)