### PR TITLE
feat(okx): admin/sessions endpoint + OAuth session logging

### DIFF
--- a/backend/okx/router.py
+++ b/backend/okx/router.py
@@ -723,6 +723,27 @@ async def reject_pending_signal(signal_id: str, request: Request):
     return {"signal": signal}
 
 
+# ── Admin: session overview ─────────────────────────────────
+
+@router.get("/admin/sessions")
+async def admin_sessions(request: Request):
+    """
+    Connected user count. Requires X-Admin-Key header.
+
+    Returns total OAuth sessions in DB and the most recent connect timestamp.
+    """
+    if not ADMIN_KEY:
+        raise HTTPException(503, "Admin endpoint disabled (ADMIN_API_KEY unset)")
+
+    import hmac
+    provided = request.headers.get("x-admin-key", "")
+    if not provided or not hmac.compare_digest(provided, ADMIN_KEY):
+        raise HTTPException(403, "Invalid admin key")
+
+    from .storage import count_sessions
+    return count_sessions()
+
+
 # ── Emergency kill-switch (HTTP) ────────────────────────────
 # Callable by a Cloudflare Worker or operator script when Telegram is
 # unavailable. Disables every enabled trading session in one call.

--- a/backend/okx/storage.py
+++ b/backend/okx/storage.py
@@ -154,6 +154,7 @@ def save_session(session_id: str, tokens: dict) -> None:
             "(session_id, user_data, created_at, updated_at) VALUES (?, ?, ?, ?)",
             (session_id, encrypted, now, now),
         )
+    logger.info("OKX session saved: %s", session_id[:8])
 
 
 def get_session(session_id: str) -> dict | None:
@@ -183,6 +184,15 @@ def update_session(session_id: str, tokens: dict) -> None:
 def delete_session(session_id: str) -> None:
     with _get_conn() as conn:
         conn.execute("DELETE FROM okx_sessions WHERE session_id = ?", (session_id,))
+
+
+def count_sessions() -> dict:
+    """Return total connected user count and most recent connect time."""
+    with _get_conn() as conn:
+        row = conn.execute(
+            "SELECT COUNT(*), MAX(created_at) FROM okx_sessions"
+        ).fetchone()
+    return {"total": row[0], "last_connected_at": row[1]}
 
 
 # ── CSRF States ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- GET /admin/sessions (x-admin-key 필요) — OAuth 완료 사용자 수 + 최근 연결 시각
- storage.count_sessions() DB 집계 함수
- save_session() 성공 시 logger.info 로 세션 ID 앞 8자 기록

## 확인 방법 (머지 후)
curl -s -H "x-admin-key: $ADMIN_API_KEY" https://api.pruviq.com/admin/sessions
journalctl -u pruviq-api | grep "OKX session saved"