### PR TITLE
perf(ko): preload Pretendard Variable font on /ko/* pages

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -196,6 +196,9 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
     <meta name="application-name" content="PRUVIQ" />
     <link rel="preload" href="/fonts/geist.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="/fonts/geist-mono.woff2" as="font" type="font/woff2" crossorigin />
+    {lang === 'ko' && (
+      <link rel="preload" href="/fonts/pretendard-variable.woff2" as="font" type="font/woff2" crossorigin />
+    )}
     {heroImagePreload && (
       <link rel="preload" href={heroImagePreload} as="image" fetchpriority="high" />
     )}


### PR DESCRIPTION
## Sprint 3.1 — /ko/ LCP fix

**Root cause**: `/ko/` LCP was 2853ms vs `/en/` 1172ms.  
Korean h1 (`font-extrabold`, `text-7xl`) requires Pretendard-Variable (2MB).  
Pretendard was *not* preloaded → browser discovered it via CSS font-face during layout → 2MB download blocked text render.  
Geist (28KB) was already preloaded for EN pages.

**Fix**: Conditional `<link rel="preload">` in `Layout.astro:199` gated on `lang === 'ko'`. EN pages unaffected — 0 extra bytes for non-Korean visitors.

**Evidence**:
- `global.css` → `pretendard-variable.woff2` declared with `unicode-range: U+AC00-D7AF` (Korean Hangul)
- `Layout.astro:30` → `lang = getLangFromUrl(Astro.url)` (available at preload injection point)
- Build: 1196 pages, qa-redirects: PASS

## Test plan
- [ ] Lighthouse run on `https://pruviq.com/ko/` — LCP should drop toward 1200ms range
- [ ] `/en/` Lighthouse unchanged (no Pretendard preload on EN path)
- [ ] LHCI `categories:performance` ≥ 0.70 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)