### PR TITLE
polish(ko): Sprint 4.4-C — fees 추천 링크→코드 용어 통일 (3건)

### DIFF
--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -343,9 +343,9 @@ export const ko: Record<TranslationKey, string> = {
   "fees.title1": "수수료 비교.",
   "fees.title2": "매 거래마다 절약.",
   "fees.desc":
-    "현물 & 선물 수수료 한눈에. PRUVIQ 추천 링크로 바이낸스 가입 시 최대 19% 할인.",
+    "현물 & 선물 수수료 한눈에. PRUVIQ 추천 코드로 바이낸스 가입 시 최대 19% 할인.",
   "fees.disclosure":
-    "제휴 공개: PRUVIQ는 추천 링크로 가입 시 거래소로부터 수수료를 받습니다. 회원의 수수료 할인에는 영향이 없습니다.",
+    "제휴 공개: PRUVIQ는 추천 코드로 가입 시 거래소로부터 수수료를 받습니다. 회원의 수수료 할인에는 영향이 없습니다.",
   "fees.ctaSimulate": "무료 시뮬레이션 시작",
   "fees.compare_title": "거래소 비교",
   "fees.compare_desc":
@@ -520,7 +520,7 @@ export const ko: Record<TranslationKey, string> = {
     "업계 표준: 프로모터 20% | 당신 0% | 당신은 알지 못함",
 
   "fees.affiliate_disclosure":
-    "제휴 공개: PRUVIQ는 바이낸스 추천 링크로 가입 시 1% 커미션을 받습니다. 회원의 수수료 할인(현물 19%, 선물 9%)에는 영향이 없습니다. 투자 조언이 아닙니다. 암호화폐 거래는 상당한 손실 위험을 수반합니다.",
+    "제휴 공개: PRUVIQ는 바이낸스 추천 코드로 가입 시 1% 커미션을 받습니다. 회원의 수수료 할인(현물 19%, 선물 9%)에는 영향이 없습니다. 투자 조언이 아닙니다. 암호화폐 거래는 상당한 손실 위험을 수반합니다.",
 
   // Changelog
   "changelog.tag": "변경 이력",


### PR DESCRIPTION
## Sprint 4.4-C — KO fees 용어 통일

수수료 페이지에서 "추천 코드"를 일관되게 사용하나 3곳에 "추천 링크" 잔존:

| 키 | 이전 | 이후 |
|---|---|---|
| `fees.desc` | `PRUVIQ 추천 링크로 바이낸스 가입 시` | `PRUVIQ 추천 코드로 바이낸스 가입 시` |
| `fees.disclosure` | `PRUVIQ는 추천 링크로 가입 시` | `PRUVIQ는 추천 코드로 가입 시` |
| `fees.affiliate_disclosure` | `바이낸스 추천 링크로 가입 시` | `바이낸스 추천 코드로 가입 시` |

**Evidence**: `grep ko.ts "추천 링크"` → 이 3줄 + `features.card3_desc`(PR #1625 처리 중).  
fees 섹션 나머지 10+ 곳에서 "추천 코드" 사용 중 — 이 3곳만 불일치.

## Test plan
- [ ] `/ko/fees/` 페이지 — "추천 코드" 표현 확인
- [ ] 빌드 1196 pages, qa-redirects PASS ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)