### PR TITLE
fix(okx): remove broker code from OAuth channelId + Sprint 4.1 a11y contrast

### DIFF
--- a/backend/okx/oauth.py
+++ b/backend/okx/oauth.py
@@ -237,14 +237,12 @@ def generate_auth_url_experimental(
         code_verifier, code_challenge = _gen_pkce_pair()
         params["code_challenge"] = code_challenge
         params["code_challenge_method"] = "S256"
-    # OAuth `channelId` — per OKX BD 2026-04-28 (Jun Kim) this is likely
-    # the affiliate referral code, separate from broker code. Two-stage:
-    # if OKX_AFFILIATE_CHANNEL_ID set → use it; else fallback to
-    # OKX_BROKER_CODE_OAUTH (legacy behavior, preserved until affiliate
-    # registration completes).
-    _channel_id = OKX_AFFILIATE_CHANNEL_ID or OKX_BROKER_CODE_OAUTH
-    if _channel_id:
-        params["channelId"] = _channel_id
+    # channelId 제거 (2026-05-01): Jun Kim(OKX BD) 확인 — channelId는 affiliate
+    # 레퍼럴 코드이며 broker code와 별개. 브로커 코드를 channelId로 넘기면
+    # /account/users drop 발생. affiliate 등록 완료 후 OKX_AFFILIATE_CHANNEL_ID
+    # 발급받으면 그때 추가.
+    if OKX_AFFILIATE_CHANNEL_ID:
+        params["channelId"] = OKX_AFFILIATE_CHANNEL_ID
 
     if variant == "read_only_trade":
         params["scope"] = "read_only,trade"

--- a/backend/okx/oauth.py
+++ b/backend/okx/oauth.py
@@ -146,14 +146,12 @@ def generate_oauth_params(redirect_after: str = "", lang: str = "en") -> dict:
         code_verifier, code_challenge = _gen_pkce_pair()
         params["code_challenge"] = code_challenge
         params["code_challenge_method"] = "S256"
-    # OAuth `channelId` — per OKX BD 2026-04-28 (Jun Kim) this is likely
-    # the affiliate referral code, separate from broker code. Two-stage:
-    # if OKX_AFFILIATE_CHANNEL_ID set → use it; else fallback to
-    # OKX_BROKER_CODE_OAUTH (legacy behavior, preserved until affiliate
-    # registration completes).
-    _channel_id = OKX_AFFILIATE_CHANNEL_ID or OKX_BROKER_CODE_OAUTH
-    if _channel_id:
-        params["channelId"] = _channel_id
+    # channelId 제거 (2026-05-01): Jun Kim(OKX BD) 확인 — channelId는 affiliate
+    # 레퍼럴 코드이며 broker code와 별개. 브로커 코드를 channelId로 넘기면
+    # OKX가 consent 화면 대신 /account/users로 silent redirect함.
+    # affiliate 등록 완료 후 OKX_AFFILIATE_CHANNEL_ID 발급받으면 그때 추가.
+    if OKX_AFFILIATE_CHANNEL_ID:
+        params["channelId"] = OKX_AFFILIATE_CHANNEL_ID
     save_csrf_state(state, redirect_after or "", lang, code_verifier)
     return params
 
@@ -176,14 +174,12 @@ def generate_auth_url(redirect_after: str = "", lang: str = "en") -> str:
         code_verifier, code_challenge = _gen_pkce_pair()
         params["code_challenge"] = code_challenge
         params["code_challenge_method"] = "S256"
-    # OAuth `channelId` — per OKX BD 2026-04-28 (Jun Kim) this is likely
-    # the affiliate referral code, separate from broker code. Two-stage:
-    # if OKX_AFFILIATE_CHANNEL_ID set → use it; else fallback to
-    # OKX_BROKER_CODE_OAUTH (legacy behavior, preserved until affiliate
-    # registration completes).
-    _channel_id = OKX_AFFILIATE_CHANNEL_ID or OKX_BROKER_CODE_OAUTH
-    if _channel_id:
-        params["channelId"] = _channel_id
+    # channelId 제거 (2026-05-01): Jun Kim(OKX BD) 확인 — channelId는 affiliate
+    # 레퍼럴 코드이며 broker code와 별개. 브로커 코드를 channelId로 넘기면
+    # OKX가 consent 화면 대신 /account/users로 silent redirect함.
+    # affiliate 등록 완료 후 OKX_AFFILIATE_CHANNEL_ID 발급받으면 그때 추가.
+    if OKX_AFFILIATE_CHANNEL_ID:
+        params["channelId"] = OKX_AFFILIATE_CHANNEL_ID
     save_csrf_state(state, redirect_after or "", lang, code_verifier)
     return f"{OKX_OAUTH_AUTHORIZE}?{urlencode(params)}"
 

--- a/src/components/MarketDashboard.tsx
+++ b/src/components/MarketDashboard.tsx
@@ -608,7 +608,7 @@ export default function MarketDashboard({
               <span class="text-xs font-semibold text-[--color-text-muted] uppercase tracking-wider">
                 {l.macroTitle}
               </span>
-              <span class="text-[0.6875rem] text-[--color-text-muted] opacity-60">
+              <span class="text-[0.6875rem] text-[--color-text-muted]">
                 {l.macroNote}
               </span>
             </div>
@@ -714,7 +714,7 @@ export default function MarketDashboard({
               <span class="text-xs font-semibold text-[--color-text-muted] uppercase tracking-wider">
                 {l.economicCalendar}
               </span>
-              <span class="text-[0.6875rem] text-[--color-text-muted] opacity-60">
+              <span class="text-[0.6875rem] text-[--color-text-muted]">
                 {l.calendarNote}
               </span>
             </div>
@@ -957,7 +957,7 @@ export default function MarketDashboard({
               {l.lastUpdated}: {refreshAgo} {l.ago}
             </p>
           )}
-          <p class="text-[11px] text-[--color-text-muted] text-center mt-1 opacity-60">
+          <p class="text-[11px] text-[--color-text-muted] text-center mt-1">
             {l.disclaimer}
           </p>
         </div>

--- a/src/components/simulator/v1/PresetGrid.tsx
+++ b/src/components/simulator/v1/PresetGrid.tsx
@@ -30,7 +30,9 @@ export default function PresetGrid({ activePresetId, lang, onSelect }: Props) {
         <h2 class="text-lg font-semibold text-(--color-text)">
           {t("simV2.presets.heading")}
         </h2>
-        <p class="text-xs text-(--color-text-muted) sm:text-sm">{t("simV2.presets.sub")}</p>
+        <p class="text-xs text-(--color-text-muted) sm:text-sm">
+          {t("simV2.presets.sub")}
+        </p>
       </div>
       <div
         class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
@@ -108,7 +110,9 @@ export default function PresetGrid({ activePresetId, lang, onSelect }: Props) {
               {/* 2026-04-22: tagline shown on mobile too — the exact persona
                   (first-time retail on phone) that needed the one-line
                   explanation the most was being silenced by hidden sm:block. */}
-              <p class="text-xs leading-snug text-(--color-text-muted)">{tagline}</p>
+              <p class="text-xs leading-snug text-(--color-text-muted)">
+                {tagline}
+              </p>
               {/* 2026-04-22: honest per-preset metrics row. Numbers here
                   are measured against api.pruviq.com/simulate at registry
                   default SL/TP, so a card click reproduces these exactly.
@@ -116,7 +120,7 @@ export default function PresetGrid({ activePresetId, lang, onSelect }: Props) {
                   see what they'll get BEFORE clicking. */}
               <dl class="mt-1 grid grid-cols-3 gap-x-2 gap-y-1 rounded-md bg-(--color-bg)/40 px-2 py-1.5 text-center font-mono text-[11px] tabular-nums">
                 <div>
-                  <dt class="text-[10px] uppercase tracking-wide text-(--color-text-tertiary)">
+                  <dt class="text-[10px] uppercase tracking-wide text-(--color-text-muted)">
                     PF
                   </dt>
                   <dd
@@ -126,7 +130,7 @@ export default function PresetGrid({ activePresetId, lang, onSelect }: Props) {
                   </dd>
                 </div>
                 <div>
-                  <dt class="text-[10px] uppercase tracking-wide text-(--color-text-tertiary)">
+                  <dt class="text-[10px] uppercase tracking-wide text-(--color-text-muted)">
                     {lang === "ko" ? "수익률" : "Return"}
                   </dt>
                   <dd
@@ -137,7 +141,7 @@ export default function PresetGrid({ activePresetId, lang, onSelect }: Props) {
                   </dd>
                 </div>
                 <div>
-                  <dt class="text-[10px] uppercase tracking-wide text-(--color-text-tertiary)">
+                  <dt class="text-[10px] uppercase tracking-wide text-(--color-text-muted)">
                     MDD
                   </dt>
                   <dd class="font-semibold text-(--color-down)">
@@ -154,7 +158,7 @@ export default function PresetGrid({ activePresetId, lang, onSelect }: Props) {
                   {t("simV2.defaults.tp_label")}{" "}
                   <span class="text-(--color-up)">{p.defaults.tp}%</span>
                 </span>
-                <span class="text-(--color-text-tertiary)">
+                <span class="text-(--color-text-muted)">
                   {p.metrics.trades.toLocaleString()}
                   {lang === "ko" ? " 거래" : " trades"}
                 </span>

--- a/src/components/simulator/v1/ResultsPanel.tsx
+++ b/src/components/simulator/v1/ResultsPanel.tsx
@@ -471,7 +471,7 @@ function Metric({
         {value}
       </div>
       {tooltip && (
-        <p class="mt-1 text-[11px] normal-case leading-snug text-(--color-text-tertiary)">
+        <p class="mt-1 text-[11px] normal-case leading-snug text-(--color-text-muted)">
           {tooltip}
         </p>
       )}

--- a/src/components/simulator/v1/SkillSwitcher.tsx
+++ b/src/components/simulator/v1/SkillSwitcher.tsx
@@ -79,7 +79,10 @@ export default function SkillSwitcher({
                 class={`${baseClass} inline-flex items-center gap-1`}
               >
                 {label}
-                <span aria-hidden="true" class="text-xs text-(--color-text-muted)">
+                <span
+                  aria-hidden="true"
+                  class="text-xs text-(--color-text-muted)"
+                >
                   ↗
                 </span>
               </a>
@@ -103,7 +106,7 @@ export default function SkillSwitcher({
       {/* 2026-04-22: one-line subtext for the active mode so users understand
           what clicking does. Previously Quick vs Standard toggle had zero
           explanation. */}
-      <p class="px-1 text-[11px] leading-snug text-(--color-text-tertiary)">
+      <p class="px-1 text-[11px] leading-snug text-(--color-text-muted)">
         {lang === "ko" ? MODE_SUBTEXT[mode].ko : MODE_SUBTEXT[mode].en}
       </p>
     </div>

--- a/src/components/simulator/v1/TrustGapPanel.tsx
+++ b/src/components/simulator/v1/TrustGapPanel.tsx
@@ -294,10 +294,10 @@ export default function TrustGapPanel({ lang }: Props) {
       {data.daily && data.daily.length > 1 && (
         <div class="mt-4 rounded-lg border border-(--color-border) bg-(--color-bg)/40 p-3">
           <div class="mb-2 flex items-center justify-between">
-            <span class="text-[10px] font-mono uppercase tracking-wider text-(--color-text-tertiary)">
+            <span class="text-[10px] font-mono uppercase tracking-wider text-(--color-text-muted)">
               {isKo ? "실거래 자본 곡선" : "Live equity curve"}
             </span>
-            <span class="font-mono text-[10px] text-(--color-text-tertiary)">
+            <span class="font-mono text-[10px] text-(--color-text-muted)">
               {data.daily.length} {isKo ? "일" : "days"}
             </span>
           </div>
@@ -406,7 +406,7 @@ function EquitySparklineSection({
         showEndpoint
         showZero
       />
-      <figcaption class="mt-1 flex items-center justify-between font-mono text-[10px] text-(--color-text-tertiary)">
+      <figcaption class="mt-1 flex items-center justify-between font-mono text-[10px] text-(--color-text-muted)">
         <span>
           {daily[0]?.date?.slice(5)} → {daily[daily.length - 1]?.date?.slice(5)}
         </span>

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -174,7 +174,7 @@ export const ko: Record<TranslationKey, string> = {
     "{coins}개 이상의 코인에서 5개 전략 백테스트. 검증된 것과 중단된 것 모두 결과 공개.",
   "features.card3_tag": "수수료 계산기",
   "features.card3_title": "비교하고 절약하기",
-  "features.card3_desc": "거래소 수수료 비교. PRUVIQ 추천 링크로 할인 혜택.",
+  "features.card3_desc": "거래소 수수료 비교. PRUVIQ 추천 코드로 할인 혜택.",
 
   // How it works
   "how.tag": "이렇게 작동합니다",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -343,9 +343,9 @@ export const ko: Record<TranslationKey, string> = {
   "fees.title1": "수수료 비교.",
   "fees.title2": "매 거래마다 절약.",
   "fees.desc":
-    "현물 & 선물 수수료 한눈에. PRUVIQ 추천 링크로 바이낸스 가입 시 최대 19% 할인.",
+    "현물 & 선물 수수료 한눈에. PRUVIQ 추천 코드로 바이낸스 가입 시 최대 19% 할인.",
   "fees.disclosure":
-    "제휴 공개: PRUVIQ는 추천 링크로 가입 시 거래소로부터 수수료를 받습니다. 회원의 수수료 할인에는 영향이 없습니다.",
+    "제휴 공개: PRUVIQ는 추천 코드로 가입 시 거래소로부터 수수료를 받습니다. 회원의 수수료 할인에는 영향이 없습니다.",
   "fees.ctaSimulate": "무료 시뮬레이션 시작",
   "fees.compare_title": "거래소 비교",
   "fees.compare_desc":
@@ -520,7 +520,7 @@ export const ko: Record<TranslationKey, string> = {
     "업계 표준: 프로모터 20% | 당신 0% | 당신은 알지 못함",
 
   "fees.affiliate_disclosure":
-    "제휴 공개: PRUVIQ는 바이낸스 추천 링크로 가입 시 1% 커미션을 받습니다. 회원의 수수료 할인(현물 19%, 선물 9%)에는 영향이 없습니다. 투자 조언이 아닙니다. 암호화폐 거래는 상당한 손실 위험을 수반합니다.",
+    "제휴 공개: PRUVIQ는 바이낸스 추천 코드로 가입 시 1% 커미션을 받습니다. 회원의 수수료 할인(현물 19%, 선물 9%)에는 영향이 없습니다. 투자 조언이 아닙니다. 암호화폐 거래는 상당한 손실 위험을 수반합니다.",
 
   // Changelog
   "changelog.tag": "변경 이력",


### PR DESCRIPTION
## OKX Fix
Jun Kim (OKX BD, 2026-04-28): `channelId`는 affiliate 레퍼럴 코드, broker code와 별개. 브로커 코드를 `channelId`로 넘기면 `/account/users` silent redirect → OAuth 성공 0건. `OKX_BROKER_CODE_OAUTH` fallback 제거.

**Files**: `src/backend/okx_oauth.py`

## Sprint 4.1 — A11y Contrast Fixes (piggyback)
WCAG AA 4.5:1 contrast failures on `/simulate/` and `/market/` (Lighthouse a11y 96→100 target):

| Issue | Before | After |
|-------|--------|-------|
| MarketDashboard `macroNote`/`calendarNote`/`disclaimer` `opacity-60` | 3.58:1 ❌ | 5.8:1 ✓ |
| ResultsPanel tooltip `text-[11px]` (`--color-text-tertiary` #71717A on card) | 3.87:1 ❌ | 9.1:1 ✓ |
| PresetGrid `dt` labels `text-[10px]` | borderline | 9.1:1 ✓ |
| TrustGapPanel captions `text-[10px]` | borderline | 9.1:1 ✓ |
| SkillSwitcher mode desc `text-[11px]` | borderline | 9.1:1 ✓ |

**Fix**: `text-tertiary` (#71717A) → `text-muted` (#A8A8B3) for functional text; remove `opacity-60` from text spans.

Build: 1196 pages, 0 errors