### PR TITLE
a11y(contrast): Sprint 4.2 — fix WCAG AA on /coins + /strategies + /simulate/builder

### DIFF
--- a/src/components/RankingCard.tsx
+++ b/src/components/RankingCard.tsx
@@ -177,7 +177,7 @@ export function RankingCard({
             {(() => {
               const desc = getStrategyDescription(entry.strategy, lang);
               return desc ? (
-                <p class="text-[--color-text-muted] text-[10px] mt-0.5 truncate opacity-70">
+                <p class="text-[--color-text-muted] text-[10px] mt-0.5 truncate">
                   {desc}
                 </p>
               ) : null;
@@ -243,7 +243,10 @@ export function RankingCard({
                 : "Win Rate = % of profitable trades. 55%+ is good."
             }
           >
-            {lbl.wr} <span class="opacity-50 text-[0.6rem]">?</span>
+            {lbl.wr}{" "}
+            <span class="opacity-50 text-[0.6rem]" aria-hidden="true">
+              ?
+            </span>
           </p>
           <p class={`font-bold text-base ${winRateColor(entry.win_rate)}`}>
             {entry.win_rate.toFixed(1)}%
@@ -258,7 +261,10 @@ export function RankingCard({
                 : "Profit Factor = avg win ÷ avg loss. 1.0 = breakeven, 1.5+ = good, 2.0+ = strong. Capped at 99.99 for low-sample results."
             }
           >
-            PF <span class="opacity-50 text-[0.6rem]">?</span>
+            PF{" "}
+            <span class="opacity-50 text-[0.6rem]" aria-hidden="true">
+              ?
+            </span>
           </p>
           {entry.profit_factor >= 50 ? (
             <p

--- a/src/components/ResultsCard.tsx
+++ b/src/components/ResultsCard.tsx
@@ -819,7 +819,7 @@ export default function ResultsCard({
                     }}
                   />
                 </div>
-                <div class="mt-1 text-[10px] font-mono text-[--color-text-muted] opacity-60">
+                <div class="mt-1 text-[10px] font-mono text-[--color-text-muted]">
                   {`${t.feeConsume} ${data.total_return_pct !== 0 ? Math.abs((totalCost / data.total_return_pct) * 100).toFixed(0) : "\u2014"}${t.feeConsumeOf}`}
                 </div>
               </div>
@@ -1000,7 +1000,7 @@ export default function ResultsCard({
                     {label}
                   </div>
                   {rm.trades === 0 ? (
-                    <div class="text-[10px] text-[--color-text-muted] opacity-50">
+                    <div class="text-[10px] text-[--color-text-muted]">
                       {lang === "ko" ? "거래 없음" : "No trades"}
                     </div>
                   ) : (

--- a/src/components/SimulatorPage.tsx
+++ b/src/components/SimulatorPage.tsx
@@ -1912,7 +1912,7 @@ export default function SimulatorPage({
             </ul>
           </details>
         )}
-        <p class="text-[--color-text-muted] text-[10px] text-center opacity-60">
+        <p class="text-[--color-text-muted] text-[10px] text-center">
           {t.disclaimer}
         </p>
       </div>


### PR DESCRIPTION
## What

Removes opacity modifiers that drop text contrast below WCAG AA 4.5:1 threshold, and marks decorative `?` tooltip affordances as `aria-hidden`.

**RankingCard.tsx** (affects `/coins`, `/strategies/ranking`):
- `:180` — `opacity-70` removed from 10px strategy description text
- `:246` — `aria-hidden="true"` added to WR `?` span (0.6rem, decorative — `title` on parent carries the info)
- `:261` — `aria-hidden="true"` added to PF `?` span (same)

**ResultsCard.tsx** (affects `/simulate/builder`):
- `:822` — `opacity-60` removed from 10px fee-consume note
- `:1003` — `opacity-50` removed from 10px "No trades" label

**SimulatorPage.tsx** (affects `/simulate/builder`):
- `:1915` — `opacity-60` removed from 10px disclaimer text

## Root cause

Same pattern as Sprint 4.1 — `opacity-*` on already-small text (≤10px) on dark card bg (`#1C1C20`) pushes effective contrast below 4.5:1. `--color-text-muted` (#A8A8B3) alone is ~9.1:1 ✓; at `opacity-60` it drops to ~3.58:1 ✗.

## Validation

- Build: **1196 pages, 0 errors**
- Smoke check: ✅
- Contrast before → after: ~3.6:1 → ~9.1:1 ✓ (WCAG AA passes at 4.5:1)