### PR TITLE
fix(okx): use server-side /start redirect — fixes PKCE missing from authorize URL

### DIFF
--- a/src/components/OKXConnectButton.tsx
+++ b/src/components/OKXConnectButton.tsx
@@ -1,7 +1,6 @@
 /**
  * OKX Connect/Disconnect button.
- * OAuth flow: fetch /auth/okx/init → build URL → window.location.assign()
- * Mirrors OKX JS SDK behavior (domain + /account/oauth + queryString) without loading SDK.
+ * OAuth flow: /auth/okx/start → backend redirect → OKX consent → callback → session cookie.
  */
 import { useState, useEffect } from "preact/hooks";
 import { API_BASE_URL as API_BASE } from "../config/api";
@@ -12,10 +11,6 @@ interface Props {
   size?: "sm" | "md" | "lg";
   showCard?: boolean;
 }
-
-// OKX moved OAuth endpoint from /api/v5/oauth/* to /account/oauth/* in 2026.
-// Old path now returns 404.
-const OKX_OAUTH_BASE = "https://www.okx.com/account/oauth/authorize";
 
 // 2026-04-23: Autotrading is on hold while the OKX-side integration is being
 // hardened. All CTAs that previously initiated OAuth / auto-execute now show
@@ -109,34 +104,11 @@ export default function OKXConnectButton({
       .catch(() => setLoading(false));
   }, []);
 
-  const handleConnect = async () => {
+  const handleConnect = () => {
     setConnecting(true);
-    try {
-      // Get CSRF state + OAuth params from backend
-      const resp = await fetch(`${API_BASE}/auth/okx/init?lang=${lang}`);
-      if (!resp.ok) throw new Error(`init failed: ${resp.status}`);
-      const p = await resp.json();
-
-      // Build OKX authorize URL (same as OKEXOAuthSDK.authorize() internally).
-      // channelId is the broker program identifier — without it, OKX silently
-      // drops the authorize request after login and sends the user to
-      // /account/users instead of the consent page (seen 2026-04-17).
-      const authParams: Record<string, string> = {
-        client_id: p.client_id,
-        response_type: p.response_type,
-        access_type: p.access_type,
-        scope: p.scope,
-        redirect_uri: p.redirect_uri,
-        state: p.state,
-      };
-      if (p.channelId) authParams.channelId = p.channelId;
-      const qs = new URLSearchParams(authParams).toString();
-
-      window.location.assign(`${OKX_OAUTH_BASE}?${qs}`);
-    } catch (e) {
-      console.error("OKX OAuth init failed:", e);
-      setConnecting(false);
-    }
+    // Server-side redirect: backend generates full authorize URL with PKCE +
+    // CSRF state + correct scope. Avoids frontend URL-building drift.
+    window.location.assign(`${API_BASE}/auth/okx/start?lang=${lang}`);
   };
 
   const handleDisconnect = async () => {


### PR DESCRIPTION
## 원인
프론트엔드 `handleConnect`가 `/auth/okx/init`으로 파라미터를 받아 직접 URL을 조립했는데,
`code_challenge` / `code_challenge_method` (PKCE)를 누락했음.
OKX가 PKCE 없는 Fast API 요청을 `/account/users`로 silent redirect한 것으로 추정.

## 수정
`handleConnect`를 백엔드 `/auth/okx/start`로 서버사이드 리디렉트로 교체.
백엔드가 PKCE + CSRF state + 정확한 scope를 모두 포함한 URL을 생성함.

## 검증
빌드 통과 (1196 pages). `AUTOTRADE_COMING_SOON=true`인 동안 유저에게 노출 안 됨.
`PUBLIC_AUTOTRADE_LIVE=true` 빌드로 오너 직접 테스트 후 오픈 예정.