### PR TITLE
fix(light-mode): Sprint 3.5 — accent-text contrast FAIL 3.6:1→5.8:1

### DIFF
--- a/src/pages/compare/index.astro
+++ b/src/pages/compare/index.astro
@@ -151,7 +151,7 @@ const comparisons = [
             {/* Subtle accent line top */}
             <div class="absolute top-0 left-0 right-0 h-[2px] opacity-40" style={`background: ${c.accent};`} aria-hidden="true"></div>
             {c.badge && (
-              <span class="absolute top-4 right-4 text-xs font-mono bg-[--color-accent] text-black px-2 py-0.5 rounded">
+              <span class="absolute top-4 right-4 text-xs font-mono bg-[--color-accent] text-[--color-accent-text] px-2 py-0.5 rounded">
                 {c.badge}
               </span>
             )}

--- a/src/pages/ko/compare/index.astro
+++ b/src/pages/ko/compare/index.astro
@@ -150,7 +150,7 @@ const comparisons = [
           >
             <div class="absolute top-0 left-0 right-0 h-[2px] opacity-40" style={`background: ${c.accent};`} aria-hidden="true"></div>
             {c.badge && (
-              <span class="absolute top-4 right-4 text-xs font-mono bg-[--color-accent] text-black px-2 py-0.5 rounded">
+              <span class="absolute top-4 right-4 text-xs font-mono bg-[--color-accent] text-[--color-accent-text] px-2 py-0.5 rounded">
                 {c.badge}
               </span>
             )}

--- a/src/pages/ko/strategies/index.astro
+++ b/src/pages/ko/strategies/index.astro
@@ -193,7 +193,7 @@ const presetDirColors: Record<string, string> = { long: '--color-accent', short:
         <div class="flex items-center gap-1.5 flex-wrap">
           <span class="font-mono text-xs text-[--color-text-muted] mr-1">상태:</span>
           <button data-filter-group="status" data-filter-value="all" aria-label="모든 전략 표시"
-            class="font-mono text-xs border rounded px-3 py-2.5 transition-colors bg-[--color-accent] text-black border-[--color-accent]">전체</button>
+            class="font-mono text-xs border rounded px-3 py-2.5 transition-colors bg-[--color-accent] text-[--color-accent-text] border-[--color-accent]">전체</button>
           <button data-filter-group="status" data-filter-value="verified" aria-label="검증된 전략만 표시"
             class="font-mono text-xs border border-[--color-border] rounded px-3 py-2.5 text-[--color-text-muted] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">검증됨</button>
           <button data-filter-group="status" data-filter-value="killed" aria-label="종료된 전략만 표시"
@@ -202,7 +202,7 @@ const presetDirColors: Record<string, string> = { long: '--color-accent', short:
         <div class="flex items-center gap-1.5 flex-wrap">
           <span class="font-mono text-xs text-[--color-text-muted] mr-1">정렬:</span>
           <button data-sort-value="default" aria-label="기본 정렬"
-            class="font-mono text-xs border rounded px-3 py-2.5 transition-colors bg-[--color-accent] text-black border-[--color-accent]">기본</button>
+            class="font-mono text-xs border rounded px-3 py-2.5 transition-colors bg-[--color-accent] text-[--color-accent-text] border-[--color-accent]">기본</button>
           <button data-sort-value="winrate" aria-label="승률 내림차순 정렬"
             class="font-mono text-xs border border-[--color-border] rounded px-3 py-2.5 text-[--color-text-muted] hover:border-[--color-accent] hover:text-[--color-accent] transition-colors">승률 ↓</button>
           <button data-sort-value="pf" aria-label="수익팩터 내림차순 정렬"
@@ -352,7 +352,7 @@ const presetDirColors: Record<string, string> = { long: '--color-accent', short:
                     class={`relative flex flex-col group preset-card-enhanced ${glowClass}`}
                   >
                     {isTodaysPick && (
-                      <span class="absolute -top-2.5 left-3 font-mono text-[10px] tracking-wider px-2 py-0.5 rounded-full bg-[--color-accent] text-black font-bold z-10">
+                      <span class="absolute -top-2.5 left-3 font-mono text-[10px] tracking-wider px-2 py-0.5 rounded-full bg-[--color-accent] text-[--color-accent-text] font-bold z-10">
                         {t('strategies.todays_pick')}
                       </span>
                     )}

--- a/src/pages/strategies/index.astro
+++ b/src/pages/strategies/index.astro
@@ -180,7 +180,7 @@ const presetDirColors: Record<string, string> = { long: '--color-accent', short:
         <div class="flex items-center gap-1.5 flex-wrap">
           <span class="font-mono text-xs text-[--color-text-muted] mr-1">Status:</span>
           <button data-filter-group="status" data-filter-value="all" aria-label="Show all strategies"
-            class="font-mono text-xs border rounded px-3 py-2.5 transition-colors bg-[--color-accent] text-black border-[--color-accent]">
+            class="font-mono text-xs border rounded px-3 py-2.5 transition-colors bg-[--color-accent] text-[--color-accent-text] border-[--color-accent]">
             All
           </button>
           <button data-filter-group="status" data-filter-value="verified" aria-label="Show verified strategies only"
@@ -195,7 +195,7 @@ const presetDirColors: Record<string, string> = { long: '--color-accent', short:
         <div class="flex items-center gap-1.5 flex-wrap">
           <span class="font-mono text-xs text-[--color-text-muted] mr-1">Direction:</span>
           <button data-filter-group="direction" data-filter-value="all" aria-label="Show all directions"
-            class="font-mono text-xs border rounded px-3 py-2.5 transition-colors bg-[--color-accent] text-black border-[--color-accent]">
+            class="font-mono text-xs border rounded px-3 py-2.5 transition-colors bg-[--color-accent] text-[--color-accent-text] border-[--color-accent]">
             All
           </button>
           <button data-filter-group="direction" data-filter-value="long" aria-label="Show long strategies only"
@@ -214,7 +214,7 @@ const presetDirColors: Record<string, string> = { long: '--color-accent', short:
         <div class="flex items-center gap-1.5 flex-wrap">
           <span class="font-mono text-xs text-[--color-text-muted] mr-1">Sort:</span>
           <button data-sort-value="default" aria-label="Sort by default order"
-            class="font-mono text-xs border rounded px-3 py-2.5 transition-colors bg-[--color-accent] text-black border-[--color-accent]" id="sort-default">
+            class="font-mono text-xs border rounded px-3 py-2.5 transition-colors bg-[--color-accent] text-[--color-accent-text] border-[--color-accent]" id="sort-default">
             Default
           </button>
           <button data-sort-value="winrate" aria-label="Sort by win rate descending"
@@ -376,7 +376,7 @@ const presetDirColors: Record<string, string> = { long: '--color-accent', short:
                     class={`relative flex flex-col group preset-card-enhanced ${glowClass}`}
                   >
                     {isTodaysPick && (
-                      <span class="absolute -top-2.5 left-3 font-mono text-[10px] tracking-wider px-2 py-0.5 rounded-full bg-[--color-accent] text-black font-bold z-10">
+                      <span class="absolute -top-2.5 left-3 font-mono text-[10px] tracking-wider px-2 py-0.5 rounded-full bg-[--color-accent] text-[--color-accent-text] font-bold z-10">
                         {t('strategies.todays_pick')}
                       </span>
                     )}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -67,6 +67,8 @@
   --color-accent-bright: #5CC8ED;   /* highlight, selected */
   --color-accent-subtle: rgba(44,181,232,0.10);
   --color-accent-glow:   rgba(44,181,232,0.22);
+  /* Text ON accent bg — #000 in dark (light cyan bg), overridden to #fff in light mode (dark teal bg) */
+  --color-accent-text:   #000000;
 
   /* ─── VERIFICATION ACCENT — used for trust signals, verified badges, proven results ─── */
   --color-verified:        #f59e0b;          /* amber-500 */
@@ -211,6 +213,8 @@
   --color-accent-bright: #0891B2;   /* cyan-600 highlight (was --color-accent) */
   --color-accent-subtle: rgba(14,116,144,0.10);
   --color-accent-glow:   rgba(14,116,144,0.18);
+  /* Dark teal bg in light mode → white text for AA compliance (black = 3.6:1 FAIL) */
+  --color-accent-text:   #FFFFFF;
 
   /* Verification (amber) tuned darker */
   --color-verified:        #B45309;   /* amber-700 */


### PR DESCRIPTION
## Sprint 3.5 — Light mode contrast fix

### Root cause
`text-black` hardcoded on `bg-[--color-accent]` elements.

| Mode | --color-accent | text-black contrast | Result |
|------|---------------|---------------------|--------|
| Dark | #2CB5E8 (light cyan) | 10.4:1 | ✓ AAA |
| Light | #0E7490 (dark teal) | **3.6:1** | ✗ **FAIL** (AA needs 4.5:1) |

### Fix
Added `--color-accent-text` CSS variable to `global.css`:
- Dark mode: `#000000` (black on light cyan)
- Light mode: `#FFFFFF` (white on dark teal — 5.83:1 ✓ AA)

Replaced `text-black` → `text-[--color-accent-text]` in 9 elements across:
- `/strategies` — sort/filter buttons (3) + verified badge (1)
- `/compare/*` — "PRUVIQ" badge (1)
- `/ko/strategies` — sort/filter buttons (2) + verified badge (1)  
- `/ko/compare` — badge (1)

### Evidence
`#0E7490` luminance ≈ 0.13 → contrast with black: `(0.13+0.05)/(0+0.05) = 3.6:1`
After fix (white): `(1.05)/(0.18) = 5.83:1` ✓ AA

### QA
- Build: 1196 pages, 0 errors
- No JS changes — CSS variable + class swap only