### PR TITLE
fix: SOON badge contrast + Auto-trading wrap (Sprint 4.4)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -539,7 +539,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
               </div>
             </div>
           ) : (
-            <a href={item.href} aria-current={isActive(item.match) ? "page" : undefined} class="transition-colors nav-slide-underline inline-flex items-center gap-1.5 min-h-11" style={isActive(item.match) ? 'color:var(--color-accent);font-weight:500' : 'color:var(--color-text-muted)'}>{item.label}{item.badge && <span class="text-[9px] font-bold px-1 py-0.5 rounded bg-[--color-accent] text-white leading-none tracking-wide">{item.badge}</span>}</a>
+            <a href={item.href} aria-current={isActive(item.match) ? "page" : undefined} class="transition-colors nav-slide-underline inline-flex items-center gap-1.5 min-h-11" style={isActive(item.match) ? 'color:var(--color-accent);font-weight:500' : 'color:var(--color-text-muted)'}>{item.label}{item.badge && <span class="text-[9px] font-bold px-1 py-0.5 rounded bg-[--color-accent] text-[--color-accent-text] leading-none tracking-wide">{item.badge}</span>}</a>
           ))}
         </div>
         <!-- 3열: Theme toggle + Lang + Mobile hamburger (우측) -->
@@ -658,7 +658,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
                    class="min-h-[48px] flex items-center px-3 rounded-lg text-[15px] font-medium transition-colors hover:bg-[--color-bg-hover]"
                    style={isActive(item.match) ? 'color:var(--color-accent);font-weight:500' : 'color:var(--color-text-muted)'}>
                   {item.label}
-                  {item.badge && <span class="ml-1.5 text-[9px] font-bold px-1 py-0.5 rounded bg-[--color-accent] text-white leading-none tracking-wide">{item.badge}</span>}
+                  {item.badge && <span class="ml-1.5 text-[9px] font-bold px-1 py-0.5 rounded bg-[--color-accent] text-[--color-accent-text] leading-none tracking-wide">{item.badge}</span>}
                 </a>
               )}
             </Fragment>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -142,7 +142,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
         <p class="text-base font-semibold group-hover:text-[--color-accent] transition-colors">Explore Strategies →</p>
       </a>
       <a href="/autotrading" class="card-premium card-hover p-6 text-center group border border-[--color-accent]/20">
-        <p class="text-sm text-[--color-accent] mb-2 font-mono inline-flex items-center gap-1.5">
+        <p class="text-sm text-[--color-accent] mb-2 font-mono inline-flex items-center gap-1.5 whitespace-nowrap">
           Auto-trading
           <span class="px-1.5 py-0.5 text-[9px] font-mono font-bold uppercase tracking-wider rounded bg-[--color-accent]/10 text-[--color-accent-bright] border border-[--color-accent]/30">Coming Soon</span>
         </p>


### PR DESCRIPTION
## What

Two visual issues found during light-mode inspection:

1. **SOON nav badge contrast** — `text-white` hardcoded on `bg-[--color-accent]` = 2.32:1 contrast (FAIL) in light mode. Badge invisible. Fix: `text-[--color-accent-text]` (dark in light mode, light in dark mode). Applied to both desktop (line 542) and mobile hamburger (line 661) in Layout.astro.

2. **"Auto-trading" card label wraps** — hyphen acts as break point, splitting "Auto-" / "trading" across 2 lines on the EN homepage card. Fix: `whitespace-nowrap` on the `<p>` wrapper.

## Files
- `src/layouts/Layout.astro` — SOON badge ×2 (desktop + mobile nav)
- `src/pages/index.astro` — Auto-trading card label whitespace-nowrap

## Test
- build: 1196 pages, 0 errors