### PR TITLE
fix: activate _worker.js via wrangler main field (BP=95 fix)

### DIFF
--- a/.github/workflows/data-deploy.yml
+++ b/.github/workflows/data-deploy.yml
@@ -51,7 +51,7 @@ jobs:
         if: github.event_name == 'push'
         run: |
           set -euo pipefail
-          changed=$(git diff --name-only HEAD~1 HEAD | grep -E '^(public/data/|src/|astro\.config\.mjs|wrangler\.toml|package(-lock)?\.json)' || true)
+          changed=$(git diff --name-only HEAD~1 HEAD | grep -E '^(public/data/|public/_worker\.js|src/|astro\.config\.mjs|wrangler\.toml|package(-lock)?\.json)' || true)
           if [ -z "$changed" ]; then
             echo "no deploy-relevant files changed; skipping deploy"
             echo "skip=true" >> "$GITHUB_OUTPUT"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,7 @@
 #:schema node_modules/wrangler/config-schema.json
 name = "pruviq-website"
 compatibility_date = "2026-02-14"
+main = "dist/_worker.js"
 
 [assets]
 directory = "./dist"


### PR DESCRIPTION
## Root cause

`wrangler.toml` had only `[assets]` — no `main` field. Without `main`, `wrangler deploy` deploys assets-only mode: the static asset handler intercepts ALL requests, including `/events`. Result:
- `GET /events` → 404 (asset not found)  
- `POST /events` → 405 (method not allowed by asset handler)

Console errors from these 4xx responses cause the Best Practices audit to fail (BP=95 instead of 100).

## Fix

1. **`wrangler.toml`**: add `main = "dist/_worker.js"` — wrangler now deploys the worker script alongside static assets. The worker handles `/events` (GET→204, POST→200) before the asset handler sees the request.

2. **`data-deploy.yml` gate**: extend regex to include `public/_worker.js` so future worker-only edits trigger deployment without needing to touch `src/`.

## Evidence

```
curl -o /dev/null -w "%{http_code}" https://pruviq.com/events  # 404 (pre-fix)
curl -X POST -o /dev/null -w "%{http_code}" https://pruviq.com/events  # 405 (pre-fix)
```

Expected post-deploy: GET→204, POST→200.

## Test
- build: 1196 pages, 0 errors
- `dist/_worker.js` confirmed present after build