### PR TITLE
fix(fees): FeeCalculator client:visible → client:idle (Sprint 3.5)

### DIFF
--- a/src/pages/fees.astro
+++ b/src/pages/fees.astro
@@ -77,7 +77,7 @@ const t = useTranslations('en');
   <section class="reveal pb-12 pt-12 section-elevated">
     <div class="max-w-5xl mx-auto px-4">
       <div class="shadow-[var(--shadow-lg)] rounded-2xl bg-[--color-bg-card] p-6 md:p-8">
-        <FeeCalculator client:visible lang="en" />
+        <FeeCalculator client:idle lang="en" />
       </div>
       <noscript><p class="text-[--color-text-muted] text-sm py-4">Enable JavaScript to use the fee calculator.</p></noscript>
       <p class="text-[--color-text-muted] text-xs mt-6">

--- a/src/pages/ko/fees.astro
+++ b/src/pages/ko/fees.astro
@@ -65,7 +65,7 @@ const t = useTranslations('ko');
   <!-- 인터랙티브 수수료 계산기 -->
   <section class="reveal pb-12 pt-12">
     <div class="max-w-5xl mx-auto px-4">
-      <FeeCalculator client:visible lang="ko" />
+      <FeeCalculator client:idle lang="ko" />
       <noscript><p class="text-[--color-text-muted] text-sm py-4">JavaScript를 활성화하면 수수료 계산기를 사용할 수 있습니다.</p></noscript>
       <p class="text-[--color-text-muted] text-xs mt-6">
         {t('fees.disclosure')}


### PR DESCRIPTION
## Summary
- FeeCalculator on `/fees` and `/ko/fees` changed from `client:visible` to `client:idle`
- `client:visible` only hydrates when the element enters the viewport → visible blank gap on scroll
- `client:idle` pre-hydrates during browser idle after page load → calculator ready before user scrolls

## Root Cause
`client:visible` is appropriate for deeply below-fold content, but the fee calculator is the primary interactive element of the page. Users scrolling to it saw a brief blank white area before the Preact island hydrated.

## Verification
- Build: 1196 pages ✓
- qa-redirects: PASS ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)