### PR TITLE
fix(data-vis): icon stroke + chart grid alignment (Sprint 4.3)

### DIFF
--- a/src/components/CoinChart.tsx
+++ b/src/components/CoinChart.tsx
@@ -243,11 +243,11 @@ export default function CoinChart({
             horzLines: { color: getCssVar("--color-chart-grid") },
           },
           rightPriceScale: {
-            borderColor: getCssVar("--color-bg-hover"),
+            borderColor: getCssVar("--color-border"),
             scaleMargins: { top: 0.05, bottom: 0.25 },
           },
           timeScale: {
-            borderColor: getCssVar("--color-bg-hover"),
+            borderColor: getCssVar("--color-border"),
             timeVisible: true,
             secondsVisible: false,
             rightOffset: 5,

--- a/src/components/ResultsPanel.tsx
+++ b/src/components/ResultsPanel.tsx
@@ -191,8 +191,8 @@ export default function ResultsPanel({
             fontSize: 11,
           },
           grid: {
-            vertLines: { color: getCssVar("--color-bg-hover") },
-            horzLines: { color: getCssVar("--color-bg-hover") },
+            vertLines: { color: getCssVar("--color-chart-grid") },
+            horzLines: { color: getCssVar("--color-chart-grid") },
           },
         });
 
@@ -311,8 +311,8 @@ export default function ResultsPanel({
           fontSize: 10,
         },
         grid: {
-          vertLines: { color: getCssVar("--color-bg-hover") },
-          horzLines: { color: getCssVar("--color-bg-hover") },
+          vertLines: { color: getCssVar("--color-chart-grid") },
+          horzLines: { color: getCssVar("--color-chart-grid") },
         },
         rightPriceScale: { borderColor: getCssVar("--color-border") },
         timeScale: { visible: false },

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -47,7 +47,7 @@ import { AUTOTRADE_COMING_SOON } from '../config/feature-flags';
             <div class="flex items-center justify-between mb-4 flex-wrap gap-4">
               <div class="flex items-center gap-3">
                 <div class="w-12 h-12 rounded-xl bg-[--color-accent]/10 flex items-center justify-center">
-                  <svg class="w-7 h-7 text-[--color-accent]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <svg class="w-7 h-7 text-[--color-accent]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
                   </svg>
                 </div>

--- a/src/pages/ko/dashboard.astro
+++ b/src/pages/ko/dashboard.astro
@@ -46,7 +46,7 @@ const AUTOTRADE_COMING_SOON = true;
             <div class="flex items-center justify-between mb-4 flex-wrap gap-4">
               <div class="flex items-center gap-3">
                 <div class="w-12 h-12 rounded-xl bg-[--color-accent]/10 flex items-center justify-center">
-                  <svg class="w-7 h-7 text-[--color-accent]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <svg class="w-7 h-7 text-[--color-accent]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
                   </svg>
                 </div>


### PR DESCRIPTION
## Summary
Three data-vis alignment fixes identified via baseline screenshot review:

1. **Dashboard icon stroke** (EN + KO): `w-7 h-7` bolt icon `stroke-width="2"` → `"1.5"`. Large icons at 28px should use 1.5 per HeroIcons standard. The home page `w-7` icons all use 1.5 — this was the only outlier.

2. **ResultsPanel chart grid** (equity curve + drawdown): `--color-bg-hover` → `--color-chart-grid`. In light mode `--color-bg-hover = #F4F4F5` (3.6% contrast vs white = invisible grid). `--color-chart-grid = #E4E4E7` is the correct semantic token for chart grids (visible at 6.8% contrast).

3. **CoinChart axis border** (price scale + time scale): `--color-bg-hover` → `--color-border`. Axis separator lines were invisible in light mode.

## Verification
- Build: 1196 pages ✓
- qa-redirects: PASS ✓
- Simulator smoke check: PASS ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)