### PR TITLE
fix(api): offline indicator pre-build — eliminate GIL starvation at startup

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -216,6 +216,7 @@ jobs:
               /opt/pruviq/current/backend/deploy/systemd/pruviq-*.timer \
               /etc/systemd/system/
             systemctl daemon-reload
+            systemctl enable --now pruviq-indicator-builder.timer 2>/dev/null || true
             echo 'wrapper + unit sync + daemon-reload done'
           "
 

--- a/backend/api/indicator_cache.py
+++ b/backend/api/indicator_cache.py
@@ -10,7 +10,9 @@ Now stores only indicator columns per strategy (~2.5GB, 77% reduction).
 """
 
 import logging
+import pickle
 import time
+from pathlib import Path
 from typing import Dict, List, Tuple, Optional
 
 import pandas as pd
@@ -61,6 +63,49 @@ class IndicatorCache:
         self._data_manager: Optional[DataManager] = None
         self._build_time = 0.0
         self._primary_strategy = "bb-squeeze-short"
+
+    def load_from_file(self, cache_path, data_manager: DataManager, max_age_sec: int = 14400) -> bool:
+        """Load pre-built indicator cache from disk.
+
+        Returns True if loaded successfully and file is fresh enough.
+        Caller falls back to in-process build if this returns False.
+        """
+        path = Path(cache_path)
+        if not path.exists():
+            logger.info(f"[indicator_cache] No pre-built cache at {path}")
+            return False
+
+        file_age = time.time() - path.stat().st_mtime
+        if file_age > max_age_sec:
+            logger.warning(
+                f"[indicator_cache] Pre-built cache is {file_age / 3600:.1f}h old "
+                f"(limit {max_age_sec / 3600:.1f}h) — will rebuild in-process"
+            )
+            return False
+
+        try:
+            with open(path, "rb") as f:
+                data = pickle.load(f)
+
+            multi_cache = data.get("multi_cache", {})
+            if not multi_cache:
+                logger.warning("[indicator_cache] Pre-built cache is empty — will rebuild in-process")
+                return False
+
+            self._multi_cache = multi_cache
+            self._cache = multi_cache.get(self._primary_strategy, {})
+            self._data_manager = data_manager
+
+            coin_counts = {sid: len(c) for sid, c in multi_cache.items()}
+            logger.info(
+                f"[indicator_cache] Loaded from {path} "
+                f"(age {file_age / 60:.1f}min built_at={data.get('built_at', 0):.0f}): "
+                f"{coin_counts}"
+            )
+            return True
+        except Exception as e:
+            logger.warning(f"[indicator_cache] Failed to load pre-built cache: {e}")
+            return False
 
     def build(self, data_manager: DataManager, strategy):
         """Pre-compute indicators for single strategy (backwards compat)."""

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -417,15 +417,19 @@ async def lifespan(app: FastAPI):
     # startup. build_multi is now capped at max_coins=50 (was 572), so build
     # time is ~2-3 min on DO rather than 10+ min — watchdog tolerates it.
     async def _deferred_indicator_build():
-        """Build indicator cache after server is already accepting requests."""
+        """Load pre-built indicator cache from disk, or compute in-process as fallback.
+
+        True root-cause fix for GIL starvation:
+        - pruviq-indicator-builder.timer (systemd) runs offline_indicator_build.py
+          in a separate process with its own GIL, writing indicators to
+          PRUVIQ_INDICATOR_CACHE_PATH.
+        - This function simply loads the pre-built file — zero computation,
+          zero GIL impact on the asyncio event loop, /health always responsive.
+        - Fallback: if the cache file is missing or stale, builds in-process
+          with time.sleep(0.001) GIL yields per coin (workaround, not root fix).
+        """
         skip_delay = int(os.environ.get("SKIP_INDICATOR_PREBUILD_DELAY", "0"))
         if os.environ.get("SKIP_INDICATOR_PREBUILD", "").lower() in ("1", "true", "yes"):
-            # Delay (not skip) the build — server passes health checks first,
-            # then build runs with GIL yields in build_multi() so /health stays
-            # responsive throughout. Default 90s delay lets watchdog confirm
-            # startup before the CPU-intensive phase begins.
-            # Previously this was an early return which left coin_stats_cache=None
-            # permanently → /coins/stats always 503 while SKIP was set.
             delay = skip_delay if skip_delay > 0 else 90
             print(f"SKIP_INDICATOR_PREBUILD set — delaying indicator build {delay}s for health-check stability")
             await asyncio.sleep(delay)
@@ -434,23 +438,34 @@ async def lifespan(app: FastAPI):
         global _indicator_build_ready
         _indicator_build_ready = True  # Mark ready before build so /health stays fast
         if data_manager.coin_count > 0:
-            def _build():
-                print("Pre-computing indicators for all strategies...")
-                all_strategies = get_all_strategies()
-                indicator_cache.build_multi(data_manager, all_strategies)
-                for sid in all_strategies:
-                    cnt = indicator_cache.strategy_count(sid)
-                    print(f"  {sid}: {cnt} coins cached")
-                print(f"Total build time: {indicator_cache._build_time:.1f}s")
+            cache_path = Path(os.environ.get(
+                "PRUVIQ_INDICATOR_CACHE_PATH",
+                "/opt/pruviq/cache/indicators.pkl",
+            ))
+            max_cache_age = int(os.environ.get("PRUVIQ_INDICATOR_CACHE_MAX_AGE", str(4 * 3600)))
 
-                print("Pre-computing coin stats...")
-                strategy = BBSqueezeStrategy(avoid_hours=AVOID_HOURS)
-                global coin_stats_cache
-                coin_stats_cache = _build_coin_stats(strategy)
-                print(f"Coin stats cached for {len(coin_stats_cache['coins'])} coins")
-                global _indicator_build_ready
-                _indicator_build_ready = True
-            await asyncio.to_thread(_build)
+            if indicator_cache.load_from_file(cache_path, data_manager, max_age_sec=max_cache_age):
+                print(f"Indicator cache loaded from {cache_path} ({indicator_cache.count} primary-strategy coins)")
+            else:
+                # Fallback: compute in-process with GIL yields between coins.
+                # pruviq-indicator-builder.timer will populate the cache file
+                # so future restarts use the fast path.
+                print(f"No fresh indicator cache at {cache_path} — building in-process (GIL-yield fallback)...")
+                def _build():
+                    print("Pre-computing indicators for all strategies...")
+                    all_strategies = get_all_strategies()
+                    indicator_cache.build_multi(data_manager, all_strategies)
+                    for sid in all_strategies:
+                        cnt = indicator_cache.strategy_count(sid)
+                        print(f"  {sid}: {cnt} coins cached")
+                    print(f"Total build time: {indicator_cache._build_time:.1f}s")
+                await asyncio.to_thread(_build)
+
+            print("Pre-computing coin stats...")
+            strategy = BBSqueezeStrategy(avoid_hours=AVOID_HOURS)
+            global coin_stats_cache
+            coin_stats_cache = await asyncio.to_thread(_build_coin_stats, strategy)
+            print(f"Coin stats cached for {len(coin_stats_cache['coins'])} coins")
 
     indicator_task = asyncio.create_task(_deferred_indicator_build())
 

--- a/backend/api/offline_indicator_build.py
+++ b/backend/api/offline_indicator_build.py
@@ -1,0 +1,133 @@
+"""
+PRUVIQ Indicator Pre-Builder — runs as a standalone script (systemd timer).
+
+Computes indicators for all strategies × top MAX_COINS coins and writes a
+pre-built cache to disk. The API loads this file at startup instead of
+computing in-process, eliminating GIL starvation during the asyncio event loop.
+
+Root cause fixed: asyncio.to_thread(_build) ran numpy/pandas in a thread that
+shared the GIL with the event loop → /health probes timed out → watchdog
+restarted. Running computation here (separate process, own GIL) removes that
+contention entirely.
+
+Usage:
+    python3 -m api.offline_indicator_build
+    (or via systemd pruviq-indicator-builder.timer)
+"""
+import json
+import logging
+import os
+import pickle
+import sys
+import time
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+logger = logging.getLogger("indicator-builder")
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from api.data_manager import DataManager
+from api.indicator_cache import _strip_ohlcv
+from src.strategies.registry import get_all_strategies
+
+DATA_DIR = Path(os.environ.get(
+    "PRUVIQ_DATA_DIR",
+    str(PROJECT_ROOT / "backend" / "data" / "futures"),
+))
+CACHE_PATH = Path(os.environ.get(
+    "PRUVIQ_INDICATOR_CACHE_PATH",
+    "/opt/pruviq/cache/indicators.pkl",
+))
+MAX_COINS = int(os.environ.get("INDICATOR_BUILDER_MAX_COINS", "50"))
+
+
+def _load_market_cap_ranks() -> dict:
+    """Read market cap ranks from coins-stats.json (same source as API)."""
+    cg_path = PROJECT_ROOT / "public" / "data" / "coins-stats.json"
+    if not cg_path.exists():
+        return {}
+    try:
+        with open(cg_path) as f:
+            raw = json.load(f)
+        return {
+            coin["symbol"].upper(): coin["market_cap_rank"]
+            for coin in raw.get("coins", [])
+            if coin.get("symbol") and coin.get("market_cap_rank")
+        }
+    except Exception as e:
+        logger.warning(f"Market cap ranks unavailable: {e}")
+        return {}
+
+
+def main() -> None:
+    logger.info(f"DATA_DIR={DATA_DIR}  CACHE_PATH={CACHE_PATH}  MAX_COINS={MAX_COINS}")
+
+    CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+    t0 = time.time()
+    dm = DataManager()
+    dm.load(DATA_DIR)
+    logger.info(f"Loaded {dm.coin_count} coins in {time.time() - t0:.1f}s")
+
+    if dm.coin_count == 0:
+        logger.error(f"No coins loaded from {DATA_DIR} — aborting")
+        sys.exit(1)
+
+    mc_ranks = _load_market_cap_ranks()
+    if mc_ranks:
+        dm.sort_by_market_cap(mc_ranks)
+        top3 = [c["symbol"] for c in dm.coins[:3]]
+        logger.info(f"Sorted by market cap. Top 3: {top3}")
+    else:
+        logger.warning("Market cap ranks unavailable — falling back to data-size order")
+
+    strategies = get_all_strategies()
+    coins_to_cache = dm.coins[:MAX_COINS]
+    logger.info(f"Building {len(strategies)} strategies × {len(coins_to_cache)} coins")
+
+    multi_cache: dict = {}
+    t_build = time.time()
+    for sid, strategy in strategies.items():
+        cache: dict = {}
+        for coin_info in coins_to_cache:
+            sym = coin_info["symbol"]
+            df = dm.get_df(sym)
+            if df is None:
+                continue
+            try:
+                full_df = strategy.calculate_indicators(df.copy())
+                cache[sym] = _strip_ohlcv(full_df)
+            except Exception as e:
+                logger.warning(f"  {sid}/{sym}: {type(e).__name__}: {e}")
+                continue
+        multi_cache[sid] = cache
+        logger.info(f"  {sid}: {len(cache)} coins")
+
+    build_sec = time.time() - t_build
+    logger.info(f"Build complete in {build_sec:.1f}s")
+
+    payload = {
+        "multi_cache": multi_cache,
+        "built_at": time.time(),
+        "coin_count": dm.coin_count,
+        "strategy_count": len(strategies),
+        "max_coins": MAX_COINS,
+    }
+
+    tmp = CACHE_PATH.with_suffix(".pkl.tmp")
+    with open(tmp, "wb") as f:
+        pickle.dump(payload, f, protocol=4)
+    tmp.rename(CACHE_PATH)
+
+    size_mb = CACHE_PATH.stat().st_size / 1e6
+    logger.info(f"Cache written: {CACHE_PATH} ({size_mb:.1f}MB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/deploy/systemd/bin/indicator-builder.sh
+++ b/backend/deploy/systemd/bin/indicator-builder.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+VENV_PYTHON="/opt/pruviq/app/.venv/bin/python3"
+REPO="/opt/pruviq/current"
+
+exec "$VENV_PYTHON" -m api.offline_indicator_build

--- a/backend/deploy/systemd/pruviq-indicator-builder.service
+++ b/backend/deploy/systemd/pruviq-indicator-builder.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=PRUVIQ Indicator Pre-Builder (GIL-isolated offline computation)
+After=network.target
+OnFailure=pruviq-alert@%n.service
+
+[Service]
+Type=oneshot
+User=pruviq
+Group=pruviq
+WorkingDirectory=/opt/pruviq/current
+EnvironmentFile=/opt/pruviq/shared/.env
+ExecStart=/opt/pruviq/bin/indicator-builder.sh
+TimeoutStartSec=900
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=pruviq-indicator-builder

--- a/backend/deploy/systemd/pruviq-indicator-builder.timer
+++ b/backend/deploy/systemd/pruviq-indicator-builder.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=PRUVIQ Indicator Pre-Builder Timer (hourly)
+Requires=pruviq-indicator-builder.service
+
+[Timer]
+OnBootSec=3min
+OnUnitActiveSec=1h
+RandomizedDelaySec=30
+Persistent=true
+Unit=pruviq-indicator-builder.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Root cause

`asyncio.to_thread(_build)` ran numpy/pandas in a thread that **shared the GIL** with the asyncio event loop. Each coin's indicator computation held the GIL for 50-200ms → `/health` probes timed out → watchdog restarted the API. `time.sleep(0.001)` per coin in PR #1672 was a workaround, not the root fix.

## True fix: offline pre-build (architecturally separated)

`pruviq-indicator-builder.timer` (systemd, every 1h) runs `offline_indicator_build.py` in a **completely separate process with its own GIL**. The API loads the pre-built pickle at startup — zero computation, zero GIL impact on the event loop, `/health` always responsive.

```
Before: asyncio event loop → asyncio.to_thread → thread (shares GIL) → numpy/pandas
         → GIL held 50-200ms/coin → /health probe timeout → watchdog restart

After:  systemd timer → separate process (own GIL) → numpy/pandas → writes .pkl
        API startup → load .pkl (~1s, no computation) → /health always fast
```

## Fallback (first deploy)

If no fresh cache file exists, API falls back to in-process build with GIL yields (`time.sleep(0.001)` workaround). The timer runs 3min after boot, so the file is available before any subsequent restart.

## Changes

| File | Change |
|------|--------|
| `backend/api/offline_indicator_build.py` | New standalone builder script |
| `backend/api/indicator_cache.py` | Add `load_from_file()` method |
| `backend/api/main.py` | `_deferred_indicator_build()` loads file first, falls back to in-process |
| `backend/deploy/systemd/pruviq-indicator-builder.service` | New systemd service |
| `backend/deploy/systemd/pruviq-indicator-builder.timer` | Hourly timer (3min after boot) |
| `backend/deploy/systemd/bin/indicator-builder.sh` | Shell wrapper |
| `.github/workflows/deploy-backend.yml` | `systemctl enable --now` new timer |

## Tests

187 passed, 0 failures (same suite as CI gate)