### PR TITLE
perf(sprint-3.1b): remove unused hero image preload — 55KB wasted high-priority preload

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -26,7 +26,7 @@ const tradingDays = (stats.trading_days ?? 0).toLocaleString('en-US');
 const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1) + 'M';
 ---
 
-<Layout title={t('meta.home_title')} description={t('meta.index_desc')} ogImage="/og/home.png" heroImagePreload="/images/simulator-preview.webp">
+<Layout title={t('meta.home_title')} description={t('meta.index_desc')} ogImage="/og/home.png">
 
   <!-- HERO — 50/50 layout: text left, live demo right -->
   <section id="hero-section" class="relative overflow-hidden hero-bg-depth section-glow-green">

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -26,7 +26,7 @@ const tradingDays = (stats.trading_days ?? 0).toLocaleString('ko-KR');
 const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1) + 'M';
 ---
 
-<Layout title={t('meta.home_title')} description={t('meta.index_desc')} ogImage="/og/home.png" heroImagePreload="/images/simulator-preview.webp">
+<Layout title={t('meta.home_title')} description={t('meta.index_desc')} ogImage="/og/home.png">
 
   <!-- HERO — 50/50 layout: text left, live demo right -->
   <section id="hero-section" class="relative overflow-hidden hero-bg-depth section-glow-green">


### PR DESCRIPTION
## What

Remove `heroImagePreload="/images/simulator-preview.webp"` from EN and KO home pages.

## Why

`BrowserFrame.astro` uses `<slot>` — when `<SimulatorPreview client:visible />` is provided as slot content, the default `<picture><img fetchpriority="high">` is **never rendered**. The `heroImagePreload` prop was preloading `simulator-preview.webp` (55KB) with `fetchpriority="high"` via a `<link rel="preload">` in `<head>`, but JS-enabled browsers (including LHCI) never use this image — it only appears in the `<noscript>` fallback.

This wastes the high-priority network budget slot and delays the actual LCP candidate (the animated equity curve in SimulatorPreview).

## Root cause trace

- `Layout.astro` emits `<link rel="preload" href={heroImagePreload} fetchpriority="high">` when prop is set
- `BrowserFrame.astro` slot default: `<picture><img loading="eager" fetchpriority="high">` — but only rendered if NO slot content is provided
- `index.astro` passes `<SimulatorPreview>` as slot → default picture never rendered
- `simulator-preview.webp` is referenced only in the `<noscript>` block

## Impact

- Eliminates 55KB wasted high-priority preload from KO and EN home pages
- Frees high-priority connection for real LCP resource
- KO home Lighthouse perf was 71-84 (volatile) — this change + Sprint 3.1 CSS fixes should stabilize it above threshold

## Build

1196 pages, 0 errors, 0 TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)