### PR TITLE
fix(sprint-4.1): reveal 블랙아웃 제거 — 200px 선행 트리거 + 250ms 단축

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1054,7 +1054,7 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
               observer.unobserve(entry.target);
             }
           });
-        }, { threshold: 0.1, rootMargin: '0px 0px -40px 0px' });
+        }, { threshold: 0, rootMargin: '0px 0px 200px 0px' });
         els.forEach(function(el) { observer.observe(el); });
       })();
     </script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -842,9 +842,9 @@ a:not(.btn):not(.btn-primary):not(.btn-ghost):not(.btn-outline):not(.card-hover)
 /* ─── Scroll reveal ─── */
 .reveal {
   opacity: 0;
-  transform: translateY(20px);
-  transition: opacity var(--duration-slow) var(--ease-default),
-              transform var(--duration-slow) var(--ease-default);
+  transform: translateY(16px);
+  transition: opacity 250ms var(--ease-default),
+              transform 250ms var(--ease-default);
 }
 .reveal.visible {
   opacity: 1;


### PR DESCRIPTION
## 실제 화면 기준 발견된 문제

pruviq.com 실제 스크롤 테스트 결과: `.reveal` 섹션들이 빠른 스크롤 시 **최대 350ms 동안 완전히 검은 화면**으로 보임.

### 근본 원인

```
rootMargin: '0px 0px -40px 0px'  // 뷰포트 안 40px 들어와야 트리거
threshold: 0.1                     // 10% 보여야 트리거
transition: 350ms                  // 페이드인 시간
```

스크롤이 빠르면: 요소가 뷰포트 들어옴 → 40px 후 observer 트리거 → 350ms 페이드인 시작 → 이미 보이는 상태에서 투명 → 검은 섹션 경험.

### 수정

| | Before | After |
|---|---|---|
| rootMargin (bottom) | `-40px` (늦게 트리거) | `+200px` (200px 전에 미리 트리거) ✅ |
| threshold | `0.1` | `0` (즉시 트리거) ✅ |
| reveal transition | `350ms` | `250ms` ✅ |
| translateY | `20px` | `16px` ✅ |

뷰포트 진입 200px 전에 이미 `.visible` 추가 → 사용자 눈에 닿기 전 fade-in 완료.

`prefers-reduced-motion: reduce`는 기존 규칙으로 `opacity:1; transition:none` 유지.

## Build

1196 pages, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)