### PR TITLE
fix(ko): 불필요 → 없음 copy 일관성 (Sprint 4.4)

### DIFF
--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -41,7 +41,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
             대부분의 백테스트는 거짓말입니다.<br/><span class="gradient-text-shimmer">우리는 증거를 공개합니다.</span>
           </h1>
           <p class="mt-10 text-xl md:text-2xl text-[--color-text-secondary] leading-relaxed max-w-xl">
-            <strong class="text-[--color-text]">{coinsAnalyzed}개 이상의 코인</strong>에서 실제 수수료를 포함한 전략 검증. 실패를 확인하고, 살아남은 전략만 남기세요. 코딩 불필요. 가입 불필요.
+            <strong class="text-[--color-text]">{coinsAnalyzed}개 이상의 코인</strong>에서 실제 수수료를 포함한 전략 검증. 실패를 확인하고, 살아남은 전략만 남기세요. 코딩 없음. 가입 없음.
           </p>
           <!-- Differentiator — front and center -->
           <div class="mt-6 flex items-start gap-3 px-5 py-4 rounded-xl border border-[--color-verified-border] bg-[--color-verified-subtle] shadow-[0_2px_8px_rgba(245,158,11,0.08)]">
@@ -61,7 +61,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
             </a>
           </div>
           <!-- Trust strip -->
-          <p class="text-xs font-mono text-[--color-text-muted] mt-3">$0 — 구독 없음 · 가입 불필요 · 코딩 불필요</p>
+          <p class="text-xs font-mono text-[--color-text-muted] mt-3">$0 — 구독 없음 · 가입 없음 · 코딩 없음</p>
           <p class="text-[10px] text-[--color-text-muted]/50 mt-2">시뮬레이션 전용. 과거 성과가 미래 수익을 보장하지 않습니다. 투자 조언이 아닙니다.</p>
         </div>
         <!-- Right: Live simulator demo -->


### PR DESCRIPTION
## What
KO 히어로 description(line 44)과 trust strip(line 64)에서
`가입 불필요 · 코딩 불필요` → `가입 없음 · 코딩 없음` 통일.

`구독 없음`은 이미 올바른 형태였으나 나머지 두 구절이 `불필요` 혼용.

## Why
프루빅 브랜드 보이스: 간결·단정한 표현 일관성. `없음` 형태가
`불필요`보다 짧고 KO copy tone에 적합.

## Verified
- build: 1196 pages, 0 errors
- grep 불필요: 0건 (line 44, 64 모두 없음으로 교체됨)