### PR TITLE
fix(ci): expand data-deploy gate to cover all public/ changes

### DIFF
--- a/.github/workflows/data-deploy.yml
+++ b/.github/workflows/data-deploy.yml
@@ -51,7 +51,7 @@ jobs:
         if: github.event_name == 'push'
         run: |
           set -euo pipefail
-          changed=$(git diff --name-only HEAD~1 HEAD | grep -E '^(public/data/|public/_worker\.js|src/|astro\.config\.mjs|wrangler\.toml|package(-lock)?\.json)' || true)
+          changed=$(git diff --name-only HEAD~1 HEAD | grep -E '^(public/|src/|astro\.config\.mjs|wrangler\.toml|package(-lock)?\.json)' || true)
           if [ -z "$changed" ]; then
             echo "no deploy-relevant files changed; skipping deploy"
             echo "skip=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem
`data-deploy.yml` gate filter only matched `public/data/` — silently skipping any change under `public/fonts/`, `public/icons/`, or other public/ subdirectories.

**Root cause evidence**: Sprint 3.1 Pretendard font subset (PR #1682) merged at 06:23 UTC. Run 25245725796 logged `"no deploy-relevant files changed; skipping deploy"` despite `public/fonts/pretendard-variable.woff2` changing from 2.0MB → 1.1MB. Production CDN still serving old 2.0MB font (etag unchanged).

## Fix
Pattern `^(public/data/|public/_worker\.js|src/|...)` → `^(public/|src/|...)`

This covers all `public/` subdirectories including fonts, icons, and any future static assets.

## Immediate remediation
Triggered `workflow_dispatch` on main (run 25245958447) to force-deploy the 1.1MB font without waiting for this PR.