### PR TITLE
perf(lhci): raise performance budget 70→80 (Sprint 3.1 done)

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -27,7 +27,7 @@
     },
     "assert": {
       "assertions": {
-        "categories:performance": ["error", { "minScore": 0.70 }],
+        "categories:performance": ["error", { "minScore": 0.80 }],
         "categories:accessibility": ["error", { "minScore": 0.96 }],
         "categories:best-practices": ["error", { "minScore": 0.90 }],
         "categories:seo": ["error", { "minScore": 0.98 }],


### PR DESCRIPTION
## Summary
Sprint 3.1 Pretendard font 2.0MB → 1.1MB subset is deployed. Evidence from lhci run 25245997539 (2026-05-02):

| Page | Perf | A11y | LCP |
|------|------|------|-----|
| pruviq.com/ | 97 | 99 | 1220ms |
| **pruviq.com/ko/** | **82** | 99 | **2108ms** |
| pruviq.com/simulate/ | 99 | 96 | 931ms |
| pruviq.com/market/ | 98 | 96 | 979ms |
| pruviq.com/coins/ | 98 | 96 | 977ms |

KO page (worst): Perf +11 (71→82), LCP -2175ms (4283→2108ms).

Budget raised 0.70 → 0.80. Floor = KO 82, 2pt variance headroom.