### PR TITLE
a11y: fix color-contrast + label-content-name-mismatch (A11y 96→99)

### DIFF
--- a/src/components/MarketDashboard.tsx
+++ b/src/components/MarketDashboard.tsx
@@ -248,29 +248,36 @@ const CRYPTO_SOURCES = [
 ];
 const MACRO_SOURCES = ["Bloomberg", "CNBC Economy", "MarketWatch"];
 
-// Fear & Greed gauge scale labels (i18n)
+// Fear & Greed gauge scale labels (i18n).
+// Colors use CSS variables so light/dark mode both pass WCAG AA contrast.
 const FG_SCALE = [
   {
     min: 0,
     max: 25,
     label: "Extreme Fear",
     labelKo: "극단적 공포",
-    color: "rgb(234,57,67)",
+    color: "var(--color-fg-extreme-fear)",
   },
-  { min: 25, max: 50, label: "Fear", labelKo: "공포", color: "rgb(255,140,0)" },
+  {
+    min: 25,
+    max: 50,
+    label: "Fear",
+    labelKo: "공포",
+    color: "var(--color-fg-fear)",
+  },
   {
     min: 50,
     max: 75,
     label: "Greed",
     labelKo: "탐욕",
-    color: "rgb(144,238,144)",
+    color: "var(--color-fg-greed)",
   },
   {
     min: 75,
     max: 100,
     label: "Extreme Greed",
     labelKo: "극단적 탐욕",
-    color: "rgb(22,163,74)",
+    color: "var(--color-fg-extreme-greed)",
   },
 ];
 

--- a/src/config/simulator-tokens.ts
+++ b/src/config/simulator-tokens.ts
@@ -37,7 +37,7 @@ export const RISK_TOKENS: Record<PresetRisk, RiskToken> = {
     label: { en: "Low risk", ko: "저위험" },
     hex: "#10b981",
     badge:
-      "bg-emerald-500/10 text-[--badge-risk-low] border border-emerald-500/30",
+      "bg-emerald-500/10 text-(--badge-risk-low) border border-emerald-500/30",
     ring: "ring-1 ring-emerald-500/40",
     dot: "bg-emerald-500",
   },
@@ -45,7 +45,7 @@ export const RISK_TOKENS: Record<PresetRisk, RiskToken> = {
     label: { en: "Medium risk", ko: "중위험" },
     hex: "#f59e0b",
     badge:
-      "bg-amber-500/10 text-[--badge-risk-medium] border border-amber-500/30",
+      "bg-amber-500/10 text-(--badge-risk-medium) border border-amber-500/30",
     ring: "ring-1 ring-amber-500/40",
     dot: "bg-amber-500",
   },
@@ -55,7 +55,7 @@ export const RISK_TOKENS: Record<PresetRisk, RiskToken> = {
     label: { en: "High risk", ko: "고위험" },
     hex: "#d946ef",
     badge:
-      "bg-fuchsia-500/10 text-[--badge-risk-high] border border-fuchsia-500/30",
+      "bg-fuchsia-500/10 text-(--badge-risk-high) border border-fuchsia-500/30",
     ring: "ring-1 ring-fuchsia-500/40",
     dot: "bg-fuchsia-500",
   },

--- a/src/config/simulator-tokens.ts
+++ b/src/config/simulator-tokens.ts
@@ -36,14 +36,16 @@ export const RISK_TOKENS: Record<PresetRisk, RiskToken> = {
   low: {
     label: { en: "Low risk", ko: "저위험" },
     hex: "#10b981",
-    badge: "bg-emerald-500/10 text-emerald-400 border border-emerald-500/30",
+    badge:
+      "bg-emerald-500/10 text-[--badge-risk-low] border border-emerald-500/30",
     ring: "ring-1 ring-emerald-500/40",
     dot: "bg-emerald-500",
   },
   medium: {
     label: { en: "Medium risk", ko: "중위험" },
     hex: "#f59e0b",
-    badge: "bg-amber-500/10 text-amber-400 border border-amber-500/30",
+    badge:
+      "bg-amber-500/10 text-[--badge-risk-medium] border border-amber-500/30",
     ring: "ring-1 ring-amber-500/40",
     dot: "bg-amber-500",
   },
@@ -52,7 +54,8 @@ export const RISK_TOKENS: Record<PresetRisk, RiskToken> = {
     // don't collide visually with risk badges.
     label: { en: "High risk", ko: "고위험" },
     hex: "#d946ef",
-    badge: "bg-fuchsia-500/10 text-fuchsia-400 border border-fuchsia-500/30",
+    badge:
+      "bg-fuchsia-500/10 text-[--badge-risk-high] border border-fuchsia-500/30",
     ring: "ring-1 ring-fuchsia-500/40",
     dot: "bg-fuchsia-500",
   },

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -16,7 +16,7 @@ export const en = {
   "nav.blog": "Blog",
   "nav.performance": "Performance",
   "nav.ranking": "Daily Strategy Ranking",
-  "nav.lang": "KO",
+  "nav.lang": "한국어",
 
   // Hero
   "hero.tag": "FREE BACKTESTING TOOL",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -16,7 +16,7 @@ export const ko: Record<TranslationKey, string> = {
   "nav.blog": "블로그",
   "nav.performance": "성과",
   "nav.ranking": "오늘의 전략 랭킹",
-  "nav.lang": "EN",
+  "nav.lang": "English",
 
   // Hero
   "hero.tag": "무료 백테스트 도구",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -245,11 +245,11 @@
   --color-yellow:        #B45309;
 
   /* Fear/Greed */
-  --color-fg-extreme-fear:  #DC2626;
-  --color-fg-fear:          #D97706;
-  --color-fg-neutral:       #71717A;
-  --color-fg-greed:         #15803D;
-  --color-fg-extreme-greed: #16A34A;
+  --color-fg-extreme-fear:  #DC2626;   /* red-600   — 4.83:1 vs white ✓ */
+  --color-fg-fear:          #B45309;   /* amber-700 — 5.02:1 vs white ✓ (was #D97706=3.18 FAIL) */
+  --color-fg-neutral:       #71717A;   /* zinc-500  — 4.83:1 vs white ✓ */
+  --color-fg-greed:         #15803D;   /* green-700 — 5.02:1 vs white ✓ */
+  --color-fg-extreme-greed: #166534;   /* green-800 — 7.13:1 vs white ✓ (was #16A34A=3.30 FAIL) */
 
   /* Risk badge text — light-mode overrides (AA vs white bg) */
   --badge-risk-low:    #047857;   /* emerald-700 — 5.7:1 vs white */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -100,6 +100,11 @@
   --color-fg-greed:         #34C759;
   --color-fg-extreme-greed: #22C55E;
 
+  /* ─── RISK BADGE TEXT — dark-mode defaults (AA vs dark bg) ─── */
+  --badge-risk-low:    #34D399;   /* emerald-400 — 5.3:1 vs zinc-950 */
+  --badge-risk-medium: #FBBF24;   /* amber-400 — 9.8:1 vs zinc-950 */
+  --badge-risk-high:   #E879F9;   /* fuchsia-400 — 6.2:1 vs zinc-950 */
+
   /* ─── BORDERS ─── */
   --color-border:        rgba(255,255,255,0.07);
   --color-border-hover:  rgba(255,255,255,0.22);
@@ -245,6 +250,11 @@
   --color-fg-neutral:       #71717A;
   --color-fg-greed:         #15803D;
   --color-fg-extreme-greed: #16A34A;
+
+  /* Risk badge text — light-mode overrides (AA vs white bg) */
+  --badge-risk-low:    #047857;   /* emerald-700 — 5.7:1 vs white */
+  --badge-risk-medium: #92400E;   /* amber-800 — 7.2:1 vs white */
+  --badge-risk-high:   #86198F;   /* fuchsia-800 — 4.9:1 vs white */
 
   /* Borders — dark on light */
   --color-border:        rgba(0,0,0,0.10);


### PR DESCRIPTION
## Root Cause
3 WCAG failures causing A11y 96 on simulate/market/coins pages (lhci run 25245997539).

## Fix 1 — color-contrast: risk badge (simulate)
- `text-amber-400` (#ffb900) on light-mode bg (#fff5e6) = **1.59:1** (need ≥4.5)
- Add CSS vars `--badge-risk-{low,medium,high}` with dark defaults + light overrides
- `--badge-risk-medium` dark: amber-400 (9.8:1 ✓) | light: amber-800 #92400E (7.2:1 ✓)

## Fix 2 — color-contrast: FG_SCALE hardcoded RGB (market)
- `rgb(255,140,0)` on white = **2.21:1** (need ≥3 for large 24px bold text)
- `rgb(144,238,144)` on white = **1.53:1**
- Replace all 4 FG_SCALE colors with `var(--color-fg-*)` CSS vars (already themed)
- Light-mode `--color-fg-fear` = amber-600 #D97706 = **3.18:1 ✓**
- Light-mode `--color-fg-greed` = green-700 #15803D = **4.7:1 ✓**

## Fix 3 — label-content-name-mismatch: nav lang switcher (simulate/market/coins)
- Visible "KO" ≠ aria-label "한국어로 전환" → WCAG 2.5.3 fail
- `nav.lang`: "KO" → "한국어" (EN page), "EN" → "English" (KO page)
- Now visible text IS contained in aria-label ✓

## Expected result: A11y 96 → 99 on simulate/market/coins