### PR TITLE
fix(components): Tailwind v4 bracket→parentheses/inline for trading indicator colors

### DIFF
--- a/src/components/CoinChart.tsx
+++ b/src/components/CoinChart.tsx
@@ -529,7 +529,8 @@ export default function CoinChart({
             ${formatChartPrice(lastBar.c)}
           </span>
           <span
-            class={`font-mono text-[0.8125rem] font-semibold px-2 py-0.5 rounded ${change >= 0 ? "text-[--color-up] bg-[var(--color-up-fill)]" : "text-[--color-red] bg-[var(--color-down-fill)]"}`}
+            class={`font-mono text-[0.8125rem] font-semibold px-2 py-0.5 rounded ${change >= 0 ? "bg-[var(--color-up-fill)]" : "bg-[var(--color-down-fill)]"}`}
+            style={{ color: change >= 0 ? "var(--color-up)" : "var(--color-red)" }}
           >
             {change > 0 ? "+" : ""}
             {change.toFixed(2)}%
@@ -538,11 +539,11 @@ export default function CoinChart({
         <div class="flex gap-6 flex-wrap font-mono text-[0.6875rem] text-[--color-text-muted]">
           <span>
             {t.h24high}:{" "}
-            <span class="text-[--color-up]">${formatChartPrice(high24)}</span>
+            <span class="text-(--color-up)">${formatChartPrice(high24)}</span>
           </span>
           <span>
             {t.h24low}:{" "}
-            <span class="text-[--color-red]">${formatChartPrice(low24)}</span>
+            <span class="text-(--color-red)">${formatChartPrice(low24)}</span>
           </span>
           <span>
             {t.h24vol}:{" "}
@@ -566,13 +567,13 @@ export default function CoinChart({
           </span>
           <span class="text-[--color-text-muted]">
             {t.high}{" "}
-            <span class="text-[--color-up]">
+            <span class="text-(--color-up)">
               {formatChartPrice(displayBar.h)}
             </span>
           </span>
           <span class="text-[--color-text-muted]">
             {t.low}{" "}
-            <span class="text-[--color-red]">
+            <span class="text-(--color-red)">
               {formatChartPrice(displayBar.l)}
             </span>
           </span>
@@ -596,7 +597,8 @@ export default function CoinChart({
             </span>
           </span>
           <span
-            class={`font-semibold hidden sm:inline ${displayChange >= 0 ? "text-[--color-up]" : "text-[--color-red]"}`}
+            class="font-semibold hidden sm:inline"
+            style={{ color: displayChange >= 0 ? "var(--color-up)" : "var(--color-red)" }}
           >
             {displayChange > 0 ? "+" : ""}
             {displayChange.toFixed(2)}%

--- a/src/components/MarketDashboard.tsx
+++ b/src/components/MarketDashboard.tsx
@@ -459,7 +459,8 @@ export default function MarketDashboard({
               class={`mb-4 px-4 py-2.5 rounded-lg border text-center ${isDataVeryStale ? "border-[--color-down]/30 bg-[--color-down]/10" : "border-[--color-warning]/30 bg-[--color-warning]/10"}`}
             >
               <span
-                class={`text-xs font-mono ${isDataVeryStale ? "text-[--color-down]" : "text-[--color-warning]"}`}
+                class="text-xs font-mono"
+                style={{ color: isDataVeryStale ? "var(--color-down)" : "var(--color-warning)" }}
               >
                 ⚠ {isDataVeryStale ? l.staleWarningSevere : l.staleWarning} (
                 {refreshAgo})
@@ -617,9 +618,7 @@ export default function MarketDashboard({
                     (ind.previous != null ? ind.value - ind.previous : null);
                   const deltaColor =
                     delta != null
-                      ? delta >= 0
-                        ? "text-[--color-up]"
-                        : "text-[--color-down]"
+                      ? (delta >= 0 ? "var(--color-up)" : "var(--color-down)")
                       : "";
                   const arrow =
                     delta != null ? (delta >= 0 ? "\u25B2" : "\u25BC") : "";
@@ -673,7 +672,8 @@ export default function MarketDashboard({
                         </span>
                         {delta != null && (
                           <span
-                            class={`text-[0.625rem] font-mono ${deltaColor}`}
+                            class="text-[0.625rem] font-mono"
+                            style={{ color: deltaColor || undefined }}
                           >
                             <span aria-hidden="true">{arrow}</span>{" "}
                             {Math.abs(delta).toFixed(2)}

--- a/src/components/RankingCard.tsx
+++ b/src/components/RankingCard.tsx
@@ -113,8 +113,8 @@ function directionTag(direction: string) {
   const colorClass = isBoth
     ? "text-[--color-yellow] border-[--color-yellow]/40"
     : isLong
-      ? "text-[--color-up] border-[--color-up]/40"
-      : "text-[--color-red] border-[--color-red]/40";
+      ? "text-(--color-up) border-[--color-up]/40"
+      : "text-(--color-red) border-[--color-red]/40";
   return (
     <span class={`font-mono text-xs px-2 py-0.5 rounded border ${colorClass}`}>
       {label}
@@ -123,15 +123,15 @@ function directionTag(direction: string) {
 }
 
 function winRateColor(wr: number): string {
-  if (wr >= 55) return "text-[--color-up]";
+  if (wr >= 55) return "text-(--color-up)";
   if (wr >= 50) return "text-[--color-yellow]";
-  return "text-[--color-red]";
+  return "text-(--color-red)";
 }
 
 function pfColor(pf: number): string {
-  if (pf >= 1.5) return "text-[--color-up]";
+  if (pf >= 1.5) return "text-(--color-up)";
   if (pf >= 1.0) return "text-[--color-yellow]";
-  return "text-[--color-red]";
+  return "text-(--color-red)";
 }
 
 export function RankingCard({

--- a/src/components/ResultsCard.tsx
+++ b/src/components/ResultsCard.tsx
@@ -398,9 +398,9 @@ export default function ResultsCard({
           <span
             class={`inline-block px-2 py-0.5 rounded text-[10px] font-mono font-bold border ${
               data.direction === "short"
-                ? "text-[--color-red] border-[--color-red]/30 bg-[--color-red]/10"
+                ? "text-(--color-red) border-[--color-red]/30 bg-[--color-red]/10"
                 : data.direction === "long"
-                  ? "text-[--color-green] border-[--color-green]/30 bg-[--color-green]/10"
+                  ? "text-(--color-green) border-[--color-green]/30 bg-[--color-green]/10"
                   : "border-[--color-accent]/30 bg-[--color-accent]/10"
             }`}
             style={
@@ -437,12 +437,12 @@ export default function ResultsCard({
           <span
             class={`inline-flex items-center justify-center w-10 h-10 rounded-xl font-mono text-xl font-black border-2 shadow-sm shrink-0 ${
               data.strategy_grade === "A"
-                ? "text-[--color-green] border-[--color-green]/40 bg-[--color-green]/10"
+                ? "text-(--color-green) border-[--color-green]/40 bg-[--color-green]/10"
                 : data.strategy_grade === "B"
                   ? "text-[--color-accent] border-[--color-accent]/40 bg-[--color-accent]/10"
                   : data.strategy_grade === "C"
                     ? "text-[--color-yellow] border-[--color-yellow]/40 bg-[--color-yellow]/10"
-                    : "text-[--color-red] border-[--color-red]/40 bg-[--color-red]/10"
+                    : "text-(--color-red) border-[--color-red]/40 bg-[--color-red]/10"
             }`}
           >
             {data.strategy_grade}
@@ -451,12 +451,12 @@ export default function ResultsCard({
             <span
               class={`font-mono text-xs font-bold ${
                 data.strategy_grade === "A"
-                  ? "text-[--color-green]"
+                  ? "text-(--color-green)"
                   : data.strategy_grade === "B"
                     ? "text-[--color-accent]"
                     : data.strategy_grade === "C"
                       ? "text-[--color-yellow]"
-                      : "text-[--color-red]"
+                      : "text-(--color-red)"
               }`}
             >
               {`${t.gradePrefix} ${data.strategy_grade}`}
@@ -500,10 +500,10 @@ export default function ResultsCard({
               <span
                 class={`inline-block px-1.5 py-0.5 rounded text-[10px] font-mono font-bold ${
                   data.walk_forward_consistency >= 0.85
-                    ? "text-[--color-green] bg-[--color-green]/10"
+                    ? "text-(--color-green) bg-[--color-green]/10"
                     : data.walk_forward_consistency >= 0.7
                       ? "text-[--color-accent] bg-[--color-accent]/10"
-                      : "text-[--color-red] bg-[--color-red]/10"
+                      : "text-(--color-red) bg-[--color-red]/10"
                 }`}
               >
                 {data.walk_forward_consistency.toFixed(2)}
@@ -697,7 +697,7 @@ export default function ResultsCard({
         <span class="text-[--color-accent]">
           <Term abbr="TP" lang={lang} /> {tpPct.toFixed(0)}%
         </span>
-        <span class="text-[--color-red]">
+        <span class="text-(--color-red)">
           <Term abbr="SL" lang={lang} /> {slPct.toFixed(0)}%
         </span>
         <span class="text-[--color-text-muted]">TO {toPct.toFixed(0)}%</span>
@@ -792,21 +792,21 @@ export default function ResultsCard({
                 <div class="flex gap-4 font-mono text-xs">
                   <span class="text-[--color-text-muted]">
                     {t.tradingFee}:{" "}
-                    <span class="text-[--color-red]">
+                    <span class="text-(--color-red)">
                       {tradingFee.toFixed(1)}%
                     </span>
                   </span>
                   {fundingFee > 0 && (
                     <span class="text-[--color-text-muted]">
                       {t.fundingFee}:{" "}
-                      <span class="text-[--color-red]">
+                      <span class="text-(--color-red)">
                         {fundingFee.toFixed(1)}%
                       </span>
                     </span>
                   )}
                   <span class="text-[--color-text-muted]">
                     {t.totalCost}:{" "}
-                    <span class="text-[--color-red] font-bold">
+                    <span class="text-(--color-red) font-bold">
                       {totalCost.toFixed(1)}%
                     </span>
                   </span>

--- a/src/components/ResultsPanel.tsx
+++ b/src/components/ResultsPanel.tsx
@@ -378,7 +378,7 @@ export default function ResultsPanel({
           role="alert"
           aria-live="assertive"
         >
-          <span class="font-mono text-sm text-[--color-red]">
+          <span class="font-mono text-sm text-(--color-red)">
             {t.error}: {error}
           </span>
         </div>
@@ -691,7 +691,7 @@ export default function ResultsPanel({
                 </span>
                 <button
                   onClick={onClearHistory}
-                  class="text-[10px] font-mono text-[--color-text-muted] hover:text-[--color-red] transition-colors"
+                  class="text-[10px] font-mono text-[--color-text-muted] hover:text-(--color-red) transition-colors"
                 >
                   {t.clearHistory || "Clear"}
                 </button>
@@ -1261,9 +1261,9 @@ export default function ResultsPanel({
                                 <span
                                   class={`px-1.5 py-0.5 rounded text-[10px] ${
                                     tr.exit_reason === "TP"
-                                      ? "bg-[--color-green]/10 text-[--color-green]"
+                                      ? "bg-[--color-green]/10 text-(--color-green)"
                                       : tr.exit_reason === "SL"
-                                        ? "bg-[--color-red]/10 text-[--color-red]"
+                                        ? "bg-[--color-red]/10 text-(--color-red)"
                                         : "bg-[--color-yellow]/10 text-[--color-yellow]"
                                   }`}
                                 >
@@ -1286,7 +1286,7 @@ export default function ResultsPanel({
                                         {t.tradeDirection || "Direction"}
                                       </span>
                                       <div
-                                        class={`font-bold ${tr.direction === "SHORT" ? "text-[--color-red]" : "text-[--color-green]"}`}
+                                        class={`font-bold ${tr.direction === "SHORT" ? "text-(--color-red)" : "text-(--color-green)"}`}
                                       >
                                         {tr.direction}
                                       </div>

--- a/src/components/SimulatorPreview.tsx
+++ b/src/components/SimulatorPreview.tsx
@@ -257,7 +257,7 @@ export default function SimulatorPreview() {
               {TRADES[hoveredTrade].coin}
             </span>
             <span class="text-[--color-text-muted] mx-1">SHORT</span>
-            <span class="text-[--color-up] font-bold">
+            <span class="text-(--color-up) font-bold">
               {TRADES[hoveredTrade].pnl}
             </span>
           </div>


### PR DESCRIPTION
## Root Cause

In Tailwind v4.2.4, `text-[--color-up]` compiles to invalid CSS:
```css
.text-\[--color-up\]{color:--color-up}  /* ❌ no var() — browser ignores it */
```

This made green/red trading indicator colors invisible across 6 components — elements inherited parent text color instead of showing green for gains or red for losses.

## Fixed Components

| Component | Usage | Fix |
|-----------|-------|-----|
| `CoinChart.tsx` | Price badge, H/L labels, OHLCV delta | Inline `style={{ color: ... }}` |
| `MarketDashboard.tsx` | Stale warning, macro indicator delta | Inline `style={{ color: ... }}` |
| `RankingCard.tsx` | Return/WR/PF color helper functions | `text-(--color-up/red)` |
| `ResultsCard.tsx` | Loss/gain metric badges | `text-(--color-up/red)` |
| `ResultsPanel.tsx` | Trade table direction/loss/close colors | `text-(--color-up/red)` |
| `SimulatorPreview.tsx` | PnL label | `text-(--color-up)` |

## Evidence

Compiled CSS (before PR#1686):
```css
.text-\[--color-up\]{color:--color-up}   /* INVALID — no var() */
.text-\(--color-up\){color:var(--color-up)}  /* VALID — parentheses form */
```

## Build

Build: 1196 pages, 0 errors.