### PR TITLE
fix(styles): Tailwind v4 bracket→parentheses for bg/border up/down/red colors (Sprint 3.5)

### DIFF
--- a/src/components/AutoTradingStatus.tsx
+++ b/src/components/AutoTradingStatus.tsx
@@ -66,7 +66,7 @@ const i18n = {
 
 function StatusLight({ status }: { status: BotStatus["status"] }) {
   const colors: Record<BotStatus["status"], string> = {
-    running: "bg-[--color-up]",
+    running: "bg-(--color-up)",
     stopped: "bg-[--color-text-muted]",
     paused: "bg-[--color-warning]",
   };
@@ -189,7 +189,7 @@ export default function AutoTradingStatus({ lang = "en" }: Props) {
       {/* Loss limit warning */}
       {botStatus.limit_reached && (
         <div
-          class="mb-4 px-3 py-2 rounded-lg bg-[--color-down]/10 border border-[--color-down]/20 text-xs text-[--color-down]"
+          class="mb-4 px-3 py-2 rounded-lg bg-(--color-down)/10 border border-(--color-down)/20 text-xs text-[--color-down]"
           role="alert"
           aria-live="assertive"
         >

--- a/src/components/BuilderPanel.tsx
+++ b/src/components/BuilderPanel.tsx
@@ -199,7 +199,7 @@ export default function BuilderPanel(props: Props) {
         />
         {props.presetError && (
           <div
-            class="mx-4 mt-1 mb-0 px-2.5 py-1 rounded bg-[--color-red]/10 border border-[--color-red]/20"
+            class="mx-4 mt-1 mb-0 px-2.5 py-1 rounded bg-(--color-red)/10 border border-(--color-red)/20"
             role="alert"
           >
             <span class="text-[10px] font-mono text-[--color-red]">
@@ -356,7 +356,7 @@ export default function BuilderPanel(props: Props) {
                   data-testid="dir-short"
                   aria-pressed={props.direction === "short"}
                   onClick={() => props.setDirection("short")}
-                  class={`flex-1 min-h-[44px] text-xs font-mono rounded transition-colors border ${props.direction === "short" ? "font-bold" : "bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-red]/30"}`}
+                  class={`flex-1 min-h-[44px] text-xs font-mono rounded transition-colors border ${props.direction === "short" ? "font-bold" : "bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-(--color-red)/30"}`}
                   style={
                     props.direction === "short" ? shortActiveStyle : undefined
                   }
@@ -828,7 +828,7 @@ export default function BuilderPanel(props: Props) {
                     ${
                       props.avoidHours.has(i)
                         ? ""
-                        : "bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-[--color-red]/20"
+                        : "bg-[--color-bg-tooltip] text-[--color-text-muted] border-[--color-border] hover:border-(--color-red)/20"
                     }`}
                   style={props.avoidHours.has(i) ? avoidActiveStyle : undefined}
                 >

--- a/src/components/CoinChart.tsx
+++ b/src/components/CoinChart.tsx
@@ -461,7 +461,7 @@ export default function CoinChart({
   if (error || !ohlcv) {
     return (
       <div class="py-12 text-center border border-[--color-border] rounded-xl bg-[--color-bg-card]">
-        <div class="w-12 h-12 mx-auto mb-4 rounded-full bg-[--color-red]/10 flex items-center justify-center">
+        <div class="w-12 h-12 mx-auto mb-4 rounded-full bg-(--color-red)/10 flex items-center justify-center">
           <svg
             width="24"
             height="24"

--- a/src/components/CoinListTable.tsx
+++ b/src/components/CoinListTable.tsx
@@ -656,7 +656,7 @@ export default function CoinListTable({ lang = "en" }: { lang?: "en" | "ko" }) {
                           ${formatPrice(coin.price)}
                         </span>
                         <span
-                          class={`text-[0.625rem] tabular-nums font-bold px-1.5 py-0.5 rounded ${(coin.change_24h ?? 0) >= 0 ? "text-[--color-up] bg-[--color-up]/10" : "text-[--color-down] bg-[--color-down]/10"}`}
+                          class={`text-[0.625rem] tabular-nums font-bold px-1.5 py-0.5 rounded ${(coin.change_24h ?? 0) >= 0 ? "text-[--color-up] bg-(--color-up)/10" : "text-[--color-down] bg-(--color-down)/10"}`}
                         >
                           {(coin.change_24h ?? 0) >= 0 ? "+" : ""}
                           {(coin.change_24h ?? 0).toFixed(1)}%

--- a/src/components/HotStrategies.tsx
+++ b/src/components/HotStrategies.tsx
@@ -89,7 +89,7 @@ export default function HotStrategies({ lang = "en" }: { lang?: string }) {
                   #{i + 1} {s.strategy_name}
                 </span>
                 {s.status === "verified" && (
-                  <span class="text-[10px] bg-[--color-up]/20 text-[--color-up] px-1.5 py-0.5 rounded">
+                  <span class="text-[10px] bg-(--color-up)/20 text-[--color-up] px-1.5 py-0.5 rounded">
                     verified
                   </span>
                 )}

--- a/src/components/LearnCard.tsx
+++ b/src/components/LearnCard.tsx
@@ -26,10 +26,10 @@ function isRead(id: string): boolean {
 }
 
 const levelColorMap: Record<string, string> = {
-  green: "bg-[--color-up]/10 text-[--color-up] border-[--color-up]/20",
+  green: "bg-(--color-up)/10 text-[--color-up] border-(--color-up)/20",
   yellow:
     "bg-[--color-warning]/10 text-[--color-warning] border-[--color-warning]/20",
-  red: "bg-[--color-down]/10 text-[--color-down] border-[--color-down]/20",
+  red: "bg-(--color-down)/10 text-[--color-down] border-(--color-down)/20",
 };
 
 export default function LearnCard({

--- a/src/components/LivePositions.tsx
+++ b/src/components/LivePositions.tsx
@@ -148,7 +148,7 @@ export default function LivePositions({ lang = "en" }: Props) {
       <div class="flex items-center justify-between mb-4">
         <div class="flex items-center gap-2">
           <span
-            class="w-2 h-2 rounded-full bg-[--color-up] animate-pulse"
+            class="w-2 h-2 rounded-full bg-(--color-up) animate-pulse"
             aria-hidden="true"
           />
           <h2 class="font-bold text-sm">{t.title}</h2>

--- a/src/components/MarketDashboard.tsx
+++ b/src/components/MarketDashboard.tsx
@@ -456,7 +456,7 @@ export default function MarketDashboard({
           {/* Staleness warning */}
           {isDataStale && (
             <div
-              class={`mb-4 px-4 py-2.5 rounded-lg border text-center ${isDataVeryStale ? "border-[--color-down]/30 bg-[--color-down]/10" : "border-[--color-warning]/30 bg-[--color-warning]/10"}`}
+              class={`mb-4 px-4 py-2.5 rounded-lg border text-center ${isDataVeryStale ? "border-(--color-down)/30 bg-(--color-down)/10" : "border-[--color-warning]/30 bg-[--color-warning]/10"}`}
             >
               <span
                 class={`text-xs font-mono ${isDataVeryStale ? "text-[--color-down]" : "text-[--color-warning]"}`}

--- a/src/components/OKXConnectButton.tsx
+++ b/src/components/OKXConnectButton.tsx
@@ -196,7 +196,7 @@ export default function OKXConnectButton({
     return (
       <div class="flex items-center gap-3">
         <span class="flex items-center gap-2 text-sm text-[--color-up] font-medium">
-          <span class="w-2 h-2 rounded-full bg-[--color-up] animate-pulse" />
+          <span class="w-2 h-2 rounded-full bg-(--color-up) animate-pulse" />
           {t.connected}
         </span>
         <button

--- a/src/components/OKXExecuteButton.tsx
+++ b/src/components/OKXExecuteButton.tsx
@@ -333,7 +333,7 @@ export default function OKXExecuteButton({
                 {t.cancel}
               </button>
               <button
-                class={`btn btn-md flex-1 ${status === "success" ? "bg-[--color-up] text-white" : status === "failed" ? "bg-[--color-down] text-white" : "btn-primary"}`}
+                class={`btn btn-md flex-1 ${status === "success" ? "bg-(--color-up) text-white" : status === "failed" ? "bg-(--color-down) text-white" : "btn-primary"}`}
                 onClick={handleExecute}
                 disabled={status === "executing" || status === "success"}
               >

--- a/src/components/PerformanceDashboard.tsx
+++ b/src/components/PerformanceDashboard.tsx
@@ -584,7 +584,7 @@ export default function PerformanceDashboard({
               </div>
               <div class="h-1.5 rounded-full bg-[--color-border] overflow-hidden">
                 <div
-                  class="h-full bg-[--color-red] rounded-full transition-[width] duration-500"
+                  class="h-full bg-(--color-red) rounded-full transition-[width] duration-500"
                   style={{ width: `${slPct}%` }}
                 />
               </div>
@@ -629,7 +629,7 @@ export default function PerformanceDashboard({
           {/* Combined bar */}
           <div class="flex flex-wrap h-1 rounded-sm overflow-hidden mt-3">
             <div class="bg-[--color-accent]" style={{ width: `${tpPct}%` }} />
-            <div class="bg-[--color-red]" style={{ width: `${slPct}%` }} />
+            <div class="bg-(--color-red)" style={{ width: `${slPct}%` }} />
             <div
               class="bg-[--color-text-muted]"
               style={{ width: `${toPct}%` }}

--- a/src/components/RankingCard.tsx
+++ b/src/components/RankingCard.tsx
@@ -113,8 +113,8 @@ function directionTag(direction: string) {
   const colorClass = isBoth
     ? "text-[--color-yellow] border-[--color-yellow]/40"
     : isLong
-      ? "text-[--color-up] border-[--color-up]/40"
-      : "text-[--color-red] border-[--color-red]/40";
+      ? "text-[--color-up] border-(--color-up)/40"
+      : "text-[--color-red] border-(--color-red)/40";
   return (
     <span class={`font-mono text-xs px-2 py-0.5 rounded border ${colorClass}`}>
       {label}
@@ -153,7 +153,7 @@ export function RankingCard({
 
   return (
     <div
-      class={`rounded-lg p-4 bg-[--color-bg-card] card-hover ${lowSampleBest ? "border border-[--color-yellow]/50 hover:border-[--color-yellow]" : variant === "worst" ? "border border-[--color-down]/30 opacity-70" : "border border-[--color-up]/30"}`}
+      class={`rounded-lg p-4 bg-[--color-bg-card] card-hover ${lowSampleBest ? "border border-[--color-yellow]/50 hover:border-[--color-yellow]" : variant === "worst" ? "border border-(--color-down)/30 opacity-70" : "border border-(--color-up)/30"}`}
       style="box-shadow: var(--shadow-card);"
     >
       {/* Header row */}

--- a/src/components/ResultsCard.tsx
+++ b/src/components/ResultsCard.tsx
@@ -398,7 +398,7 @@ export default function ResultsCard({
           <span
             class={`inline-block px-2 py-0.5 rounded text-[10px] font-mono font-bold border ${
               data.direction === "short"
-                ? "text-[--color-red] border-[--color-red]/30 bg-[--color-red]/10"
+                ? "text-[--color-red] border-(--color-red)/30 bg-(--color-red)/10"
                 : data.direction === "long"
                   ? "text-[--color-green] border-[--color-green]/30 bg-[--color-green]/10"
                   : "border-[--color-accent]/30 bg-[--color-accent]/10"
@@ -431,7 +431,7 @@ export default function ResultsCard({
                 ? "border-[--color-accent]/30 bg-[--color-accent]/5"
                 : data.strategy_grade === "C"
                   ? "border-[--color-yellow]/30 bg-[--color-yellow]/5"
-                  : "border-[--color-red]/30 bg-[--color-red]/5"
+                  : "border-(--color-red)/30 bg-(--color-red)/5"
           }`}
         >
           <span
@@ -442,7 +442,7 @@ export default function ResultsCard({
                   ? "text-[--color-accent] border-[--color-accent]/40 bg-[--color-accent]/10"
                   : data.strategy_grade === "C"
                     ? "text-[--color-yellow] border-[--color-yellow]/40 bg-[--color-yellow]/10"
-                    : "text-[--color-red] border-[--color-red]/40 bg-[--color-red]/10"
+                    : "text-[--color-red] border-(--color-red)/40 bg-(--color-red)/10"
             }`}
           >
             {data.strategy_grade}
@@ -503,7 +503,7 @@ export default function ResultsCard({
                     ? "text-[--color-green] bg-[--color-green]/10"
                     : data.walk_forward_consistency >= 0.7
                       ? "text-[--color-accent] bg-[--color-accent]/10"
-                      : "text-[--color-red] bg-[--color-red]/10"
+                      : "text-[--color-red] bg-(--color-red)/10"
                 }`}
               >
                 {data.walk_forward_consistency.toFixed(2)}
@@ -683,7 +683,7 @@ export default function ResultsCard({
             style={{ width: `${tpPct}%` }}
           />
           <div
-            class="bg-[--color-red] transition-[width] duration-300"
+            class="bg-(--color-red) transition-[width] duration-300"
             style={{ width: `${slPct}%` }}
           />
           <div
@@ -813,7 +813,7 @@ export default function ResultsCard({
                 </div>
                 <div class="mt-1.5 h-1 rounded-full overflow-hidden bg-[--color-border]">
                   <div
-                    class="h-full bg-[--color-red]/60 transition-[width] duration-300"
+                    class="h-full bg-(--color-red)/60 transition-[width] duration-300"
                     style={{
                       width: `${Math.min((totalCost / Math.abs(data.total_return_pct || 1)) * 100, 100)}%`,
                     }}

--- a/src/components/ResultsPanel.tsx
+++ b/src/components/ResultsPanel.tsx
@@ -374,7 +374,7 @@ export default function ResultsPanel({
     <div>
       {error && (
         <div
-          class="border border-[--color-red]/30 rounded-lg p-4 bg-[--color-red]/5 mb-3"
+          class="border border-(--color-red)/30 rounded-lg p-4 bg-(--color-red)/5 mb-3"
           role="alert"
           aria-live="assertive"
         >
@@ -1263,7 +1263,7 @@ export default function ResultsPanel({
                                     tr.exit_reason === "TP"
                                       ? "bg-[--color-green]/10 text-[--color-green]"
                                       : tr.exit_reason === "SL"
-                                        ? "bg-[--color-red]/10 text-[--color-red]"
+                                        ? "bg-(--color-red)/10 text-[--color-red]"
                                         : "bg-[--color-yellow]/10 text-[--color-yellow]"
                                   }`}
                                 >
@@ -1622,7 +1622,7 @@ export default function ResultsPanel({
                 }
                 class="flex items-center gap-3 p-3 rounded-lg border border-[--color-border] hover:border-[--color-accent]/30 hover:bg-[--color-accent]/5 transition-colors"
               >
-                <span class="w-8 h-8 rounded-lg bg-[--color-up]/10 flex items-center justify-center shrink-0">
+                <span class="w-8 h-8 rounded-lg bg-(--color-up)/10 flex items-center justify-center shrink-0">
                   <svg
                     width="16"
                     height="16"

--- a/src/components/SignalsDashboard.tsx
+++ b/src/components/SignalsDashboard.tsx
@@ -251,8 +251,8 @@ export default function SignalsDashboard({ lang = "en" }: Props) {
           aria-pressed={filter === "verified"}
           class={`text-center p-3 rounded-lg border transition-all cursor-pointer ${
             filter === "verified"
-              ? "border-[--color-up] bg-[--color-up]/10 shadow-[0_0_12px_rgba(34,171,148,0.3)]"
-              : "border-[--color-border] bg-[--color-bg-card] hover:border-[--color-up]/50"
+              ? "border-(--color-up) bg-(--color-up)/10 shadow-[0_0_12px_rgba(34,171,148,0.3)]"
+              : "border-[--color-border] bg-[--color-bg-card] hover:border-(--color-up)/50"
           }`}
         >
           <p class="text-2xl font-bold font-mono text-[--color-up]">
@@ -265,8 +265,8 @@ export default function SignalsDashboard({ lang = "en" }: Props) {
           aria-pressed={filter === "short"}
           class={`text-center p-3 rounded-lg border transition-all cursor-pointer ${
             filter === "short"
-              ? "border-[--color-down] bg-[--color-down]/10 shadow-[0_0_12px_rgba(242,54,69,0.3)]"
-              : "border-[--color-border] bg-[--color-bg-card] hover:border-[--color-down]/50"
+              ? "border-(--color-down) bg-(--color-down)/10 shadow-[0_0_12px_rgba(242,54,69,0.3)]"
+              : "border-[--color-border] bg-[--color-bg-card] hover:border-(--color-down)/50"
           }`}
         >
           <p class="text-2xl font-bold font-mono text-[--color-down]">
@@ -302,7 +302,7 @@ export default function SignalsDashboard({ lang = "en" }: Props) {
                 {sigs.length} {sigs.length > 1 ? t.signals : t.signal}
               </span>
               {sigs[0]?.status === "verified" && (
-                <span class="text-[10px] bg-[--color-up]/20 text-[--color-up] px-1.5 py-0.5 rounded">
+                <span class="text-[10px] bg-(--color-up)/20 text-[--color-up] px-1.5 py-0.5 rounded">
                   {t.verified.toLowerCase()}
                 </span>
               )}
@@ -318,14 +318,14 @@ export default function SignalsDashboard({ lang = "en" }: Props) {
                   } ${
                     s.direction === "long"
                       ? "border-[--color-accent]/20 bg-[--color-accent]/5 hover:border-[--color-accent]/40"
-                      : "border-[--color-down]/20 bg-[--color-down]/5 hover:border-[--color-down]/40"
+                      : "border-(--color-down)/20 bg-(--color-down)/5 hover:border-(--color-down)/40"
                   }`}
                 >
                   <div class="flex items-center gap-4">
                     <span
                       class={`text-xs font-mono font-bold px-2 py-1 rounded ${
                         s.direction === "short"
-                          ? "bg-[--color-down]/20 text-[--color-down]"
+                          ? "bg-(--color-down)/20 text-[--color-down]"
                           : "bg-[--color-accent]/20 text-[--color-accent]"
                       }`}
                     >

--- a/src/components/SimulatorPreview.tsx
+++ b/src/components/SimulatorPreview.tsx
@@ -124,7 +124,7 @@ export default function SimulatorPreview() {
           </span>
         </div>
         <div class="flex items-center gap-1.5">
-          <span class="w-1.5 h-1.5 rounded-full bg-[--color-up] animate-pulse"></span>
+          <span class="w-1.5 h-1.5 rounded-full bg-(--color-up) animate-pulse"></span>
           <span class="text-[--color-text-muted] text-[10px]">
             1H · OKX USDT-SWAP
           </span>

--- a/src/components/StrategyComparison.tsx
+++ b/src/components/StrategyComparison.tsx
@@ -413,7 +413,7 @@ export default function StrategyComparison({ lang = "en" }: Props) {
       </div>
 
       {error && (
-        <div class="border border-[--color-red]/40 rounded-xl p-4 bg-[--color-red]/5">
+        <div class="border border-(--color-red)/40 rounded-xl p-4 bg-(--color-red)/5">
           <p class="font-mono text-sm text-[--color-red]">{error}</p>
         </div>
       )}
@@ -639,7 +639,7 @@ export default function StrategyComparison({ lang = "en" }: Props) {
                       style={{ width: `${tpPctVal}%` }}
                     />
                     <div
-                      class="bg-[--color-red]"
+                      class="bg-(--color-red)"
                       style={{ width: `${slPctVal}%` }}
                     />
                     <div

--- a/src/components/TopStrategyWidget.tsx
+++ b/src/components/TopStrategyWidget.tsx
@@ -142,7 +142,7 @@ export function TopStrategyWidget({ lang = "en" }: { lang?: Lang }) {
         </span>
         <span class="inline-flex items-center gap-1.5 font-mono text-[10px] text-[--color-up]">
           <span
-            class="w-1.5 h-1.5 rounded-full bg-[--color-up]"
+            class="w-1.5 h-1.5 rounded-full bg-(--color-up)"
             style="animation: live-pulse 2s ease-in-out infinite;"
           />
           {t.live}

--- a/src/components/TradingSettings.tsx
+++ b/src/components/TradingSettings.tsx
@@ -395,7 +395,7 @@ export default function TradingSettings({ lang = "en" }: Props) {
   return (
     <div class="space-y-6">
       {/* Warning banner */}
-      <div class="bg-[--color-down]/10 border border-[--color-down]/20 rounded-xl p-4 text-sm text-[--color-down]">
+      <div class="bg-(--color-down)/10 border border-(--color-down)/20 rounded-xl p-4 text-sm text-[--color-down]">
         {t.warning}
       </div>
 
@@ -503,7 +503,7 @@ export default function TradingSettings({ lang = "en" }: Props) {
             }
             class="sr-only peer"
           />
-          <div class="w-11 h-6 bg-[--color-border] peer-checked:bg-[--color-up] rounded-full peer-focus:ring-2 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+          <div class="w-11 h-6 bg-[--color-border] peer-checked:bg-(--color-up) rounded-full peer-focus:ring-2 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
         </label>
       </div>
 
@@ -557,7 +557,7 @@ export default function TradingSettings({ lang = "en" }: Props) {
                   class="accent-[--color-accent]"
                 />
                 <span class="text-sm">{s.name}</span>
-                <span class="text-[10px] font-mono text-[--color-up] bg-[--color-up]/10 px-1.5 rounded ml-auto">
+                <span class="text-[10px] font-mono text-[--color-up] bg-(--color-up)/10 px-1.5 rounded ml-auto">
                   {s.status}
                 </span>
               </label>
@@ -829,7 +829,7 @@ export default function TradingSettings({ lang = "en" }: Props) {
 
       {/* Save */}
       <button
-        class={`btn btn-lg w-full ${saving === "saved" ? "bg-[--color-up] text-white" : "btn-primary"}`}
+        class={`btn btn-lg w-full ${saving === "saved" ? "bg-(--color-up) text-white" : "btn-primary"}`}
         onClick={handleSave}
         disabled={saving === "saving"}
       >

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -55,9 +55,9 @@ const variantClasses: Record<BadgeVariant, string> = {
     "bg-transparent border border-[--color-border] text-[--color-text-muted]",
   accent:
     "bg-[--color-accent]/10 border border-[--color-accent]/30 text-[--color-accent-bright]",
-  success: "bg-[--color-up]/10 border border-[--color-up]/30 text-[--color-up]",
+  success: "bg-(--color-up)/10 border border-(--color-up)/30 text-[--color-up]",
   danger:
-    "bg-[--color-down]/10 border border-[--color-down]/30 text-[--color-down]",
+    "bg-(--color-down)/10 border border-(--color-down)/30 text-[--color-down]",
   warning:
     "bg-[--color-verified-subtle] border border-[--color-verified-border] text-[--color-verified]",
   info: "bg-[--color-accent]/5 border border-[--color-accent]/20 text-[--color-accent]",
@@ -78,8 +78,8 @@ const dotSize: Record<BadgeSize, string> = {
 const dotColor: Record<BadgeVariant, string> = {
   neutral: "bg-[--color-text-muted]",
   accent: "bg-[--color-accent]",
-  success: "bg-[--color-up]",
-  danger: "bg-[--color-down]",
+  success: "bg-(--color-up)",
+  danger: "bg-(--color-down)",
   warning: "bg-[--color-verified]",
   info: "bg-[--color-accent]",
 };

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -73,9 +73,9 @@ const variantClasses: Record<ButtonVariant, string> = {
   ghost:
     "bg-transparent border border-transparent text-[--color-text-muted] hover:text-[--color-text] hover:bg-[--color-bg-hover]",
   danger:
-    "bg-[--color-down]/10 border border-[--color-down]/30 text-[--color-down] hover:bg-[--color-down]/15 hover:border-[--color-down]/50",
+    "bg-(--color-down)/10 border border-(--color-down)/30 text-[--color-down] hover:bg-(--color-down)/15 hover:border-(--color-down)/50",
   success:
-    "bg-[--color-up]/10 border border-[--color-up]/30 text-[--color-up] hover:bg-[--color-up]/15 hover:border-[--color-up]/50",
+    "bg-(--color-up)/10 border border-(--color-up)/30 text-[--color-up] hover:bg-(--color-up)/15 hover:border-(--color-up)/50",
 };
 
 // Size — `md` meets 44px a11y minimum. `sm` (32px) for dense inline use only.

--- a/src/components/ui/Field.tsx
+++ b/src/components/ui/Field.tsx
@@ -138,7 +138,7 @@ export default function Field({
     "read-only:bg-[--color-bg-hover] read-only:cursor-default";
 
   const inputStateCls = hasError
-    ? "border-[--color-down] focus:border-[--color-down] focus:ring-[--color-down]"
+    ? "border-(--color-down) focus:border-(--color-down) focus:ring-[--color-down]"
     : "border-[--color-border] focus:border-[--color-accent] focus:ring-[--color-accent]";
 
   const inputCls =

--- a/src/components/ui/HeroBadge.astro
+++ b/src/components/ui/HeroBadge.astro
@@ -9,7 +9,7 @@ const { href = '/simulate', stat = '12,847', label = 'simulations run', cta = 'T
 ---
 <div class="flex mb-6">
   <a href={href} class="inline-flex items-center gap-2 rounded-full border border-[--color-border-hover] bg-[--color-bg-card]/50 px-4 py-1.5 text-sm text-[--color-text-secondary] hover:border-[--color-accent]/30 transition-colors no-underline">
-    <span class="inline-block w-1.5 h-1.5 rounded-full bg-[--color-up] animate-pulse"></span>
+    <span class="inline-block w-1.5 h-1.5 rounded-full bg-(--color-up) animate-pulse"></span>
     <span class="font-mono">{stat}</span> {label}
     <span class="text-[--color-accent]">{cta}</span>
   </a>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -526,8 +526,8 @@ for (let i = 0; i < breadcrumbSegments.length; i++) {
                     <span class="w-9 h-9 rounded-xl bg-[--color-accent]/12 flex items-center justify-center shrink-0 transition-colors group-hover/item:bg-[--color-accent]/20"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--color-accent)" stroke-width="2" aria-hidden="true"><path d="M12 20V10M18 20V4M6 20v-4"/></svg></span>
                     <div><div class="font-semibold text-[15px]">{t('nav.ranking')}</div><div class="text-[11px] text-[--color-text-muted] mt-0.5 leading-tight">{t('nav.ranking_desc')}</div></div>
                   </a>
-                  <a href={leaderboardPath} class="flex items-center gap-3.5 px-4 py-3.5 rounded-xl text-[15px] text-[--color-text] hover:bg-[--color-up]/8 transition-all group/item">
-                    <span class="w-9 h-9 rounded-xl bg-[--color-up]/12 flex items-center justify-center shrink-0 transition-colors group-hover/item:bg-[--color-up]/20"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--color-up)" stroke-width="2" aria-hidden="true"><path d="M8 21V11M16 21V3M12 21v-6"/></svg></span>
+                  <a href={leaderboardPath} class="flex items-center gap-3.5 px-4 py-3.5 rounded-xl text-[15px] text-[--color-text] hover:bg-(--color-up)/8 transition-all group/item">
+                    <span class="w-9 h-9 rounded-xl bg-(--color-up)/12 flex items-center justify-center shrink-0 transition-colors group-hover/item:bg-(--color-up)/20"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--color-up)" stroke-width="2" aria-hidden="true"><path d="M8 21V11M16 21V3M12 21v-6"/></svg></span>
                     <div><div class="font-semibold text-[15px]">{t('nav.leaderboard')}</div><div class="text-[11px] text-[--color-text-muted] mt-0.5 leading-tight">{t('nav.leaderboard_desc')}</div></div>
                   </a>
                   <div class="border-t border-(--color-border) my-1.5 mx-3"></div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -88,7 +88,7 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
               {t('about.solo_why')}
             </p>
             <div class="flex items-center gap-2 mb-4">
-              <span class="inline-block w-1.5 h-1.5 rounded-full bg-[--color-up] animate-pulse"></span>
+              <span class="inline-block w-1.5 h-1.5 rounded-full bg-(--color-up) animate-pulse"></span>
               <span class="text-[--color-text-muted] text-xs font-mono">Independent research platform</span>
             </div>
             <div class="flex flex-wrap gap-3 text-sm">
@@ -165,7 +165,7 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
           <p class="text-[--color-text-muted] text-xs leading-relaxed">{t('about.method1_desc')}</p>
         </div>
         <div class="card-enterprise p-6">
-          <div class="w-10 h-10 rounded-xl bg-[--color-up]/10 flex items-center justify-center mb-4">
+          <div class="w-10 h-10 rounded-xl bg-(--color-up)/10 flex items-center justify-center mb-4">
             <svg class="w-5 h-5 text-[--color-up]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"/></svg>
           </div>
           <h3 class="font-bold text-sm mb-2">{t('about.method2_title')}</h3>
@@ -222,7 +222,7 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
       <div class="reveal grid sm:grid-cols-2 gap-6">
         <div class="card-premium card-accent-up p-6">
           <p class="font-mono text-xs text-[--color-up] font-bold mb-4 flex items-center gap-2">
-            <span class="w-2 h-2 rounded-full bg-[--color-up]"></span>
+            <span class="w-2 h-2 rounded-full bg-(--color-up)"></span>
             {t('about.roadmap_label_done')}
           </p>
           <div class="timeline-line space-y-4">
@@ -310,7 +310,7 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
             {t('about.proof_github')}
           </span>
           <span class="inline-flex items-center gap-2 font-mono text-xs px-4 py-2.5 rounded-lg border border-[--color-border] text-[--color-text-muted]">
-            <span class="w-2 h-2 rounded-full bg-[--color-up] animate-pulse inline-block"></span>
+            <span class="w-2 h-2 rounded-full bg-(--color-up) animate-pulse inline-block"></span>
             {t('about.proof_commits')}
           </span>
           <span class="inline-flex items-center font-mono text-xs px-4 py-2.5 rounded-lg border border-[--color-border] text-[--color-text-muted]">

--- a/src/pages/autotrading/index.astro
+++ b/src/pages/autotrading/index.astro
@@ -105,11 +105,11 @@ import { COINS_ANALYZED } from '../../config/site-stats';
       <div class="grid md:grid-cols-3 gap-6">
 
         <!-- BB Squeeze Short -->
-        <div class="card-enterprise p-6 border border-[--color-border] hover:border-[--color-up]/40 transition-colors">
+        <div class="card-enterprise p-6 border border-[--color-border] hover:border-(--color-up)/40 transition-colors">
           <div class="flex items-center justify-between mb-4">
             <h3 class="font-bold text-lg">BB Squeeze Short</h3>
-            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-[--color-up]/30 bg-[--color-up]/10 text-[--color-up] font-mono text-xs font-bold" aria-label="Status: Verified">
-              <span class="w-1.5 h-1.5 rounded-full bg-[--color-up]" aria-hidden="true"></span>
+            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-(--color-up)/30 bg-(--color-up)/10 text-[--color-up] font-mono text-xs font-bold" aria-label="Status: Verified">
+              <span class="w-1.5 h-1.5 rounded-full bg-(--color-up)" aria-hidden="true"></span>
               VERIFIED
             </span>
           </div>
@@ -129,11 +129,11 @@ import { COINS_ANALYZED } from '../../config/site-stats';
         </div>
 
         <!-- ATR Breakout -->
-        <div class="card-enterprise p-6 border border-[--color-border] hover:border-[--color-up]/40 transition-colors">
+        <div class="card-enterprise p-6 border border-[--color-border] hover:border-(--color-up)/40 transition-colors">
           <div class="flex items-center justify-between mb-4">
             <h3 class="font-bold text-lg">ATR Breakout</h3>
-            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-[--color-up]/30 bg-[--color-up]/10 text-[--color-up] font-mono text-xs font-bold" aria-label="Status: Verified">
-              <span class="w-1.5 h-1.5 rounded-full bg-[--color-up]" aria-hidden="true"></span>
+            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-(--color-up)/30 bg-(--color-up)/10 text-[--color-up] font-mono text-xs font-bold" aria-label="Status: Verified">
+              <span class="w-1.5 h-1.5 rounded-full bg-(--color-up)" aria-hidden="true"></span>
               VERIFIED
             </span>
           </div>
@@ -153,11 +153,11 @@ import { COINS_ANALYZED } from '../../config/site-stats';
         </div>
 
         <!-- Donchian Breakout -->
-        <div class="card-enterprise p-6 border border-[--color-border] hover:border-[--color-up]/40 transition-colors">
+        <div class="card-enterprise p-6 border border-[--color-border] hover:border-(--color-up)/40 transition-colors">
           <div class="flex items-center justify-between mb-4">
             <h3 class="font-bold text-lg">Donchian Breakout</h3>
-            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-[--color-up]/30 bg-[--color-up]/10 text-[--color-up] font-mono text-xs font-bold" aria-label="Status: Verified">
-              <span class="w-1.5 h-1.5 rounded-full bg-[--color-up]" aria-hidden="true"></span>
+            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-(--color-up)/30 bg-(--color-up)/10 text-[--color-up] font-mono text-xs font-bold" aria-label="Status: Verified">
+              <span class="w-1.5 h-1.5 rounded-full bg-(--color-up)" aria-hidden="true"></span>
               VERIFIED
             </span>
           </div>
@@ -194,7 +194,7 @@ import { COINS_ANALYZED } from '../../config/site-stats';
       <div class="grid sm:grid-cols-2 gap-5">
 
         <div class="card-enterprise p-6 flex items-start gap-4">
-          <div class="w-10 h-10 rounded-xl bg-[--color-up]/15 flex items-center justify-center shrink-0" aria-hidden="true">
+          <div class="w-10 h-10 rounded-xl bg-(--color-up)/15 flex items-center justify-center shrink-0" aria-hidden="true">
             <svg class="w-5 h-5 text-[--color-up]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
             </svg>
@@ -206,7 +206,7 @@ import { COINS_ANALYZED } from '../../config/site-stats';
         </div>
 
         <div class="card-enterprise p-6 flex items-start gap-4">
-          <div class="w-10 h-10 rounded-xl bg-[--color-up]/15 flex items-center justify-center shrink-0" aria-hidden="true">
+          <div class="w-10 h-10 rounded-xl bg-(--color-up)/15 flex items-center justify-center shrink-0" aria-hidden="true">
             <svg class="w-5 h-5 text-[--color-up]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
             </svg>
@@ -218,7 +218,7 @@ import { COINS_ANALYZED } from '../../config/site-stats';
         </div>
 
         <div class="card-enterprise p-6 flex items-start gap-4">
-          <div class="w-10 h-10 rounded-xl bg-[--color-up]/15 flex items-center justify-center shrink-0" aria-hidden="true">
+          <div class="w-10 h-10 rounded-xl bg-(--color-up)/15 flex items-center justify-center shrink-0" aria-hidden="true">
             <svg class="w-5 h-5 text-[--color-up]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" d="M7.864 4.243A7.5 7.5 0 0119.5 10.5c0 2.92-.556 5.709-1.568 8.268M5.742 6.364A7.465 7.465 0 004.5 10.5a7.464 7.464 0 01-1.15 3.993m1.989 3.559A11.209 11.209 0 008.25 10.5a3.75 3.75 0 117.5 0c0 .527-.021 1.049-.064 1.565M12 10.5a14.94 14.94 0 01-3.6 9.75m6.633-4.596a18.666 18.666 0 01-2.485 5.33" />
             </svg>
@@ -230,7 +230,7 @@ import { COINS_ANALYZED } from '../../config/site-stats';
         </div>
 
         <div class="card-enterprise p-6 flex items-start gap-4">
-          <div class="w-10 h-10 rounded-xl bg-[--color-up]/15 flex items-center justify-center shrink-0" aria-hidden="true">
+          <div class="w-10 h-10 rounded-xl bg-(--color-up)/15 flex items-center justify-center shrink-0" aria-hidden="true">
             <svg class="w-5 h-5 text-[--color-up]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5M9 11.25v1.5M12 9v3.75m3-6v6" />
             </svg>
@@ -266,10 +266,10 @@ import { COINS_ANALYZED } from '../../config/site-stats';
       </p>
 
       <div class="flex flex-wrap gap-3 justify-center mb-10 font-mono text-xs">
-        <span class="px-4 py-2 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5">OKX Official Partner</span>
-        <span class="px-4 py-2 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5">OAuth Only</span>
-        <span class="px-4 py-2 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5">No Withdrawal Access</span>
-        <span class="px-4 py-2 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5">20% Fee Discount</span>
+        <span class="px-4 py-2 rounded-full border border-(--color-up)/20 text-[--color-up] bg-(--color-up)/5">OKX Official Partner</span>
+        <span class="px-4 py-2 rounded-full border border-(--color-up)/20 text-[--color-up] bg-(--color-up)/5">OAuth Only</span>
+        <span class="px-4 py-2 rounded-full border border-(--color-up)/20 text-[--color-up] bg-(--color-up)/5">No Withdrawal Access</span>
+        <span class="px-4 py-2 rounded-full border border-(--color-up)/20 text-[--color-up] bg-(--color-up)/5">20% Fee Discount</span>
       </div>
 
       <a href="/dashboard" class="btn btn-primary btn-lg">

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -46,8 +46,8 @@ const t = useTranslations('en');
         </div>
         <h3 class="font-bold mb-2">P0 Bug Fix: reduceOnly Parameter</h3>
         <ul class="text-[--color-text-muted] text-sm space-y-1">
-          <li><span class="inline-block px-1.5 py-0.5 rounded text-[10px] font-mono bg-[--color-up]/10 text-[--color-up] mr-1">feat</span>&bull; Added reduceOnly=True to market close orders to prevent ghost reverse positions</li>
-          <li><span class="inline-block px-1.5 py-0.5 rounded text-[10px] font-mono bg-[--color-red]/10 text-[--color-red] mr-1">fix</span>&bull; Fixed execute_market_order to accept reduce_only parameter (4 call sites updated)</li>
+          <li><span class="inline-block px-1.5 py-0.5 rounded text-[10px] font-mono bg-(--color-up)/10 text-[--color-up] mr-1">feat</span>&bull; Added reduceOnly=True to market close orders to prevent ghost reverse positions</li>
+          <li><span class="inline-block px-1.5 py-0.5 rounded text-[10px] font-mono bg-(--color-red)/10 text-[--color-red] mr-1">fix</span>&bull; Fixed execute_market_order to accept reduce_only parameter (4 call sites updated)</li>
           <li>&bull; RSI&lt;30 filter and TIMEOUT early exit evaluated and deferred (insufficient edge)</li>
         </ul>
         <p class="text-[--color-text-muted] text-xs mt-2 font-mono">Evidence: 2,898 trades backtested, 238 coins, 2+ years</p>
@@ -90,7 +90,7 @@ const t = useTranslations('en');
         <h3 class="font-bold mb-2">Partial Fill Aggregation Fix</h3>
         <ul class="text-[--color-text-muted] text-sm space-y-1">
           <li>&bull; Income API partial fills now aggregated (42% of exits were split)</li>
-          <li><span class="inline-block px-1.5 py-0.5 rounded text-[10px] font-mono bg-[--color-red]/10 text-[--color-red] mr-1">fix</span>&bull; Fixed PnL under-calculation bug (was using last fill only)</li>
+          <li><span class="inline-block px-1.5 py-0.5 rounded text-[10px] font-mono bg-(--color-red)/10 text-[--color-red] mr-1">fix</span>&bull; Fixed PnL under-calculation bug (was using last fill only)</li>
           <li>&bull; 16 new tests + 25 existing tests all pass</li>
         </ul>
       </div>

--- a/src/pages/compare/index.astro
+++ b/src/pages/compare/index.astro
@@ -29,7 +29,7 @@ const comparisons = [
 
       <!-- Why PRUVIQ: 3 strengths -->
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-10 mb-10 reveal">
-        <div class="border border-[--color-up]/30 rounded-lg p-6 bg-[--color-bg-card] shadow-[var(--shadow-md)]">
+        <div class="border border-(--color-up)/30 rounded-lg p-6 bg-[--color-bg-card] shadow-[var(--shadow-md)]">
           <p class="font-mono text-[--color-up] text-xs font-bold mb-2 tracking-wider">{t('compare_index.strength1_tag')}</p>
           <p class="font-bold text-lg mb-2">{t('compare_index.strength1_title')}</p>
           <p class="text-[--color-text-muted] text-sm leading-relaxed">{t('compare_index.strength1_desc')}</p>

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -103,15 +103,15 @@ import { AUTOTRADE_COMING_SOON } from '../config/feature-flags';
         <h3 class="font-bold mb-3">Security</h3>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-3 text-xs">
           <div class="flex items-center gap-2 text-[--color-text-muted]">
-            <span class="w-2 h-2 rounded-full bg-[--color-up]"></span>
+            <span class="w-2 h-2 rounded-full bg-(--color-up)"></span>
             OAuth — no API keys shared
           </div>
           <div class="flex items-center gap-2 text-[--color-text-muted]">
-            <span class="w-2 h-2 rounded-full bg-[--color-up]"></span>
+            <span class="w-2 h-2 rounded-full bg-(--color-up)"></span>
             No withdrawal permission
           </div>
           <div class="flex items-center gap-2 text-[--color-text-muted]">
-            <span class="w-2 h-2 rounded-full bg-[--color-up]"></span>
+            <span class="w-2 h-2 rounded-full bg-(--color-up)"></span>
             AES-256 encrypted tokens
           </div>
         </div>

--- a/src/pages/fees.astro
+++ b/src/pages/fees.astro
@@ -54,7 +54,7 @@ const t = useTranslations('en');
         {t('fees.desc')}
       </p>
       <!-- Savings example callout -->
-      <div class="inline-flex items-center gap-2 px-5 py-3 rounded-xl border border-[--color-up]/30 bg-[--color-up]/5 text-[--color-up] font-mono shadow-[var(--shadow-md)]">
+      <div class="inline-flex items-center gap-2 px-5 py-3 rounded-xl border border-(--color-up)/30 bg-(--color-up)/5 text-[--color-up] font-mono shadow-[var(--shadow-md)]">
         <span class="text-3xl font-extrabold">&#9650;</span>
         <span class="text-base font-bold">{t('fees.savings_callout')}</span>
       </div>
@@ -130,7 +130,7 @@ const t = useTranslations('en');
             </div>
 
             <div class="flex flex-wrap items-center gap-2 pt-2">
-              <span class="inline-flex items-center gap-1 text-xs font-mono px-2 py-1 rounded border border-[--color-up]/40 bg-[--color-up]/5 text-[--color-up] font-semibold">
+              <span class="inline-flex items-center gap-1 text-xs font-mono px-2 py-1 rounded border border-(--color-up)/40 bg-(--color-up)/5 text-[--color-up] font-semibold">
                 Spot 19% · Futures 9% rebate
               </span>
               <span class="inline-flex items-center gap-1 text-xs font-mono px-2 py-1 rounded border border-[--color-yellow]/40 bg-[--color-yellow]/5 text-[--color-yellow] font-semibold">
@@ -138,7 +138,7 @@ const t = useTranslations('en');
               </span>
             </div>
             {savingsBadge && (
-              <span class="inline-flex items-center gap-1 text-xs font-mono px-2 py-1 rounded border border-[--color-up]/40 bg-[--color-up]/5 text-[--color-up] font-semibold">
+              <span class="inline-flex items-center gap-1 text-xs font-mono px-2 py-1 rounded border border-(--color-up)/40 bg-(--color-up)/5 text-[--color-up] font-semibold">
                 &#9650; {savingsBadge}
                 <span class="font-normal text-[--color-text-muted]">at $10k/mo</span>
               </span>
@@ -155,11 +155,11 @@ const t = useTranslations('en');
         <div class="border border-[--color-border] rounded-xl p-6 md:p-8 flex flex-col relative overflow-hidden shadow-[var(--shadow-lg)]">
           <div class="flex items-center gap-3 mb-6">
             <h3 class="text-2xl font-bold">{okxDisplay.name}</h3>
-            <span class="font-mono text-[--color-up] text-xs font-bold px-2 py-0.5 rounded border border-[--color-up]/30 bg-[--color-up]/5">Official Partner</span>
+            <span class="font-mono text-[--color-up] text-xs font-bold px-2 py-0.5 rounded border border-(--color-up)/30 bg-(--color-up)/5">Official Partner</span>
           </div>
 
           <!-- Discount highlight -->
-          <div class="text-center mb-6 py-4 rounded-lg bg-[--color-up]/5 border border-[--color-up]/20">
+          <div class="text-center mb-6 py-4 rounded-lg bg-(--color-up)/5 border border-(--color-up)/20">
             <p class="text-3xl font-bold font-mono text-[--color-up]">{okxConfig.futuresDiscountPct}%</p>
             <p class="text-xs text-[--color-text-muted]">Fee discount (Spot + Futures)</p>
           </div>
@@ -185,7 +185,7 @@ const t = useTranslations('en');
             </div>
 
             {okxSavingsBadge && (
-              <span class="inline-flex items-center gap-1 text-xs font-mono px-2 py-1 rounded border border-[--color-up]/40 bg-[--color-up]/5 text-[--color-up] font-semibold mt-2">
+              <span class="inline-flex items-center gap-1 text-xs font-mono px-2 py-1 rounded border border-(--color-up)/40 bg-(--color-up)/5 text-[--color-up] font-semibold mt-2">
                 &#9650; {okxSavingsBadge}
                 <span class="font-normal text-[--color-text-muted]">at $10k/mo</span>
               </span>
@@ -193,7 +193,7 @@ const t = useTranslations('en');
           </div>
 
           <a href={`${okxDisplay.referralUrl}?utm_source=pruviq&utm_medium=referral&utm_campaign=fees`} target="_blank" rel="noopener noreferrer"
-             class="mt-6 block text-center border-2 border-[--color-up] text-[--color-up] px-4 py-3 min-h-[48px] rounded text-sm font-bold hover:bg-[--color-up]/10 transition-colors">
+             class="mt-6 block text-center border-2 border-(--color-up) text-[--color-up] px-4 py-3 min-h-[48px] rounded text-sm font-bold hover:bg-(--color-up)/10 transition-colors">
             Sign up on OKX &rarr;
           </a>
           <div class="mt-3">
@@ -219,7 +219,7 @@ const t = useTranslations('en');
       <p class="text-[--color-text-muted] text-sm mb-6 max-w-3xl">{t('fees.referral.problem.body')}</p>
 
       <!-- Fact callout -->
-      <div class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-[--color-down]/30 bg-[--color-down]/5 text-[--color-down] text-sm">
+      <div class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-(--color-down)/30 bg-(--color-down)/5 text-[--color-down] text-sm">
         <span>{t('fees.referral.callout.fact')}</span>
       </div>
     </div>
@@ -254,7 +254,7 @@ const t = useTranslations('en');
               <td class="py-2 px-3 text-center font-mono text-[--color-down]">{t('fees.referral.table.row.typical.actual')}</td>
               <td class="py-2 px-3 text-center font-mono text-[--color-down]">{t('fees.referral.table.row.typical.keeps')}</td>
             </tr>
-            <tr class="border-b border-[--color-border]/50 bg-[--color-down]/5">
+            <tr class="border-b border-[--color-border]/50 bg-(--color-down)/5">
               <td class="py-2 px-3 text-[--color-down]">{t('fees.referral.table.row.worst')}</td>
               <td class="py-2 px-3 text-center font-mono text-[--color-text-muted]">{t('fees.referral.table.row.worst.claim')}</td>
               <td class="py-2 px-3 text-center font-mono text-[--color-text-muted]">{t('fees.referral.table.row.worst.claimFutures')}</td>
@@ -273,7 +273,7 @@ const t = useTranslations('en');
       </div>
 
       <!-- Warning callout -->
-      <div class="border border-[--color-down]/30 bg-[--color-down]/5 rounded-lg p-4 max-w-4xl mb-4">
+      <div class="border border-(--color-down)/30 bg-(--color-down)/5 rounded-lg p-4 max-w-4xl mb-4">
         <p class="text-[--color-down] text-sm font-medium">{t('fees.referral.callout.warning')}</p>
       </div>
       <p class="text-[--color-text-muted] text-xs max-w-3xl">{t('fees.referral.how.check')}</p>
@@ -301,7 +301,7 @@ const t = useTranslations('en');
       <p class="text-[--color-text-muted] text-xs text-center mb-6 max-w-2xl mx-auto">{t('fees.referral.proof.timestamp')}</p>
 
       <!-- Why we show this -->
-      <div class="border border-[--color-up]/30 bg-[--color-up]/5 rounded-lg p-6 max-w-2xl mx-auto">
+      <div class="border border-(--color-up)/30 bg-(--color-up)/5 rounded-lg p-6 max-w-2xl mx-auto">
         <p class="text-sm mb-3 leading-relaxed">{t('fees.referral.proof.why')}</p>
         <p class="text-[--color-text-muted] text-sm leading-relaxed">{t('fees.referral.proof.transparent')}</p>
       </div>
@@ -336,7 +336,7 @@ const t = useTranslations('en');
       </div>
 
       <!-- Warning note -->
-      <div class="border border-[--color-down]/30 bg-[--color-down]/5 rounded-lg p-4 max-w-3xl mb-4">
+      <div class="border border-(--color-down)/30 bg-(--color-down)/5 rounded-lg p-4 max-w-3xl mb-4">
         <p class="text-[--color-down] text-sm font-medium">{t('fees.referral.verify.cta')}</p>
       </div>
       <p class="text-[--color-text-muted] text-xs max-w-3xl">{t('fees.referral.verify.note')}</p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -220,7 +220,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       <div class="grid md:grid-cols-3 gap-5 mb-14 reveal reveal-child">
         <div class="card-enterprise p-6 border-t-2 border-t-[--color-down]/30 card-hover shadow-[var(--shadow-md)]">
           <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
-            <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
+            <span class="inline-block w-2 h-2 rounded-full bg-(--color-down)"></span>
             {t('problem.case1_label')}
           </div>
           <h3 class="font-bold text-lg mb-2">{t('problem.card1_title')}</h3>
@@ -229,7 +229,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
         </div>
         <div class="card-enterprise p-6 border-t-2 border-t-[--color-down]/30 card-hover shadow-[var(--shadow-md)]">
           <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
-            <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
+            <span class="inline-block w-2 h-2 rounded-full bg-(--color-down)"></span>
             {t('problem.case2_label')}
           </div>
           <h3 class="font-bold text-lg mb-2">{t('problem.card2_title')}</h3>
@@ -238,7 +238,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
         </div>
         <div class="card-enterprise p-6 border-t-2 border-t-[--color-down]/30 card-hover shadow-[var(--shadow-md)]">
           <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
-            <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
+            <span class="inline-block w-2 h-2 rounded-full bg-(--color-down)"></span>
             {t('problem.case3_label')}
           </div>
           <h3 class="font-bold text-lg mb-2">{t('problem.card3_title')}</h3>
@@ -381,10 +381,10 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
       <!-- Risk reversal badges -->
       <div class="flex flex-wrap gap-3 justify-center mb-10 font-mono text-xs">
-        <span class="px-4 py-2 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5 shadow-[var(--shadow-sm)]">{t('cta.badge1')}</span>
-        <span class="px-4 py-2 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5 shadow-[var(--shadow-sm)]">{t('cta.badge2')}</span>
-        <span class="px-4 py-2 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5 shadow-[var(--shadow-sm)]">{t('cta.badge3')}</span>
-        <span class="px-4 py-2 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5 shadow-[var(--shadow-sm)]">{t('cta.badge4')}</span>
+        <span class="px-4 py-2 rounded-full border border-(--color-up)/20 text-[--color-up] bg-(--color-up)/5 shadow-[var(--shadow-sm)]">{t('cta.badge1')}</span>
+        <span class="px-4 py-2 rounded-full border border-(--color-up)/20 text-[--color-up] bg-(--color-up)/5 shadow-[var(--shadow-sm)]">{t('cta.badge2')}</span>
+        <span class="px-4 py-2 rounded-full border border-(--color-up)/20 text-[--color-up] bg-(--color-up)/5 shadow-[var(--shadow-sm)]">{t('cta.badge3')}</span>
+        <span class="px-4 py-2 rounded-full border border-(--color-up)/20 text-[--color-up] bg-(--color-up)/5 shadow-[var(--shadow-sm)]">{t('cta.badge4')}</span>
       </div>
 
       <div class="flex flex-col sm:flex-row gap-4 justify-center mb-6">

--- a/src/pages/ko/about.astro
+++ b/src/pages/ko/about.astro
@@ -87,7 +87,7 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
               {t('about.solo_why')}
             </p>
             <div class="flex items-center gap-2 mb-4">
-              <span class="inline-block w-1.5 h-1.5 rounded-full bg-[--color-up] animate-pulse"></span>
+              <span class="inline-block w-1.5 h-1.5 rounded-full bg-(--color-up) animate-pulse"></span>
               <span class="text-[--color-text-muted] text-xs font-mono">독립 리서치 플랫폼</span>
             </div>
             <div class="flex flex-wrap gap-3 text-sm">
@@ -154,7 +154,7 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
           <p class="text-[--color-text-muted] text-xs leading-relaxed">{t('about.method1_desc')}</p>
         </div>
         <div class="card-enterprise p-6">
-          <div class="w-10 h-10 rounded-xl bg-[--color-up]/10 flex items-center justify-center mb-4">
+          <div class="w-10 h-10 rounded-xl bg-(--color-up)/10 flex items-center justify-center mb-4">
             <svg class="w-5 h-5 text-[--color-up]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"/></svg>
           </div>
           <h3 class="font-bold text-sm mb-2">{t('about.method2_title')}</h3>
@@ -211,7 +211,7 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
       <div class="reveal grid sm:grid-cols-2 gap-6">
         <div class="card-premium card-accent-up p-6">
           <p class="font-mono text-xs text-[--color-up] font-bold mb-4 flex items-center gap-2">
-            <span class="w-2 h-2 rounded-full bg-[--color-up]"></span>
+            <span class="w-2 h-2 rounded-full bg-(--color-up)"></span>
             {t('about.roadmap_label_done')}
           </p>
           <div class="timeline-line space-y-4">
@@ -278,7 +278,7 @@ const simulationsRun = (siteStats as { simulations_run: number }).simulations_ru
             {t('about.proof_github')}
           </span>
           <span class="inline-flex items-center gap-2 font-mono text-xs px-4 py-2.5 rounded-lg border border-[--color-border] text-[--color-text-muted]">
-            <span class="w-2 h-2 rounded-full bg-[--color-up] animate-pulse inline-block"></span>
+            <span class="w-2 h-2 rounded-full bg-(--color-up) animate-pulse inline-block"></span>
             {t('about.proof_commits')}
           </span>
           <span class="inline-flex items-center font-mono text-xs px-4 py-2.5 rounded-lg border border-[--color-border] text-[--color-text-muted]">

--- a/src/pages/ko/autotrading/index.astro
+++ b/src/pages/ko/autotrading/index.astro
@@ -104,11 +104,11 @@ import Layout from '../../../layouts/Layout.astro';
       <div class="grid md:grid-cols-3 gap-6">
 
         <!-- BB Squeeze Short -->
-        <div class="card-enterprise p-6 border border-[--color-border] hover:border-[--color-up]/40 transition-colors">
+        <div class="card-enterprise p-6 border border-[--color-border] hover:border-(--color-up)/40 transition-colors">
           <div class="flex items-center justify-between mb-4">
             <h3 class="font-bold text-lg">BB 스퀴즈 숏</h3>
-            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-[--color-up]/30 bg-[--color-up]/10 text-[--color-up] font-mono text-xs font-bold" aria-label="상태: 검증됨">
-              <span class="w-1.5 h-1.5 rounded-full bg-[--color-up]" aria-hidden="true"></span>
+            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-(--color-up)/30 bg-(--color-up)/10 text-[--color-up] font-mono text-xs font-bold" aria-label="상태: 검증됨">
+              <span class="w-1.5 h-1.5 rounded-full bg-(--color-up)" aria-hidden="true"></span>
               검증됨
             </span>
           </div>
@@ -128,11 +128,11 @@ import Layout from '../../../layouts/Layout.astro';
         </div>
 
         <!-- ATR Breakout -->
-        <div class="card-enterprise p-6 border border-[--color-border] hover:border-[--color-up]/40 transition-colors">
+        <div class="card-enterprise p-6 border border-[--color-border] hover:border-(--color-up)/40 transition-colors">
           <div class="flex items-center justify-between mb-4">
             <h3 class="font-bold text-lg">ATR 브레이크아웃</h3>
-            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-[--color-up]/30 bg-[--color-up]/10 text-[--color-up] font-mono text-xs font-bold" aria-label="상태: 검증됨">
-              <span class="w-1.5 h-1.5 rounded-full bg-[--color-up]" aria-hidden="true"></span>
+            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-(--color-up)/30 bg-(--color-up)/10 text-[--color-up] font-mono text-xs font-bold" aria-label="상태: 검증됨">
+              <span class="w-1.5 h-1.5 rounded-full bg-(--color-up)" aria-hidden="true"></span>
               검증됨
             </span>
           </div>
@@ -152,11 +152,11 @@ import Layout from '../../../layouts/Layout.astro';
         </div>
 
         <!-- Donchian Breakout -->
-        <div class="card-enterprise p-6 border border-[--color-border] hover:border-[--color-up]/40 transition-colors">
+        <div class="card-enterprise p-6 border border-[--color-border] hover:border-(--color-up)/40 transition-colors">
           <div class="flex items-center justify-between mb-4">
             <h3 class="font-bold text-lg">돈치안 브레이크아웃</h3>
-            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-[--color-up]/30 bg-[--color-up]/10 text-[--color-up] font-mono text-xs font-bold" aria-label="상태: 검증됨">
-              <span class="w-1.5 h-1.5 rounded-full bg-[--color-up]" aria-hidden="true"></span>
+            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-(--color-up)/30 bg-(--color-up)/10 text-[--color-up] font-mono text-xs font-bold" aria-label="상태: 검증됨">
+              <span class="w-1.5 h-1.5 rounded-full bg-(--color-up)" aria-hidden="true"></span>
               검증됨
             </span>
           </div>
@@ -193,7 +193,7 @@ import Layout from '../../../layouts/Layout.astro';
       <div class="grid sm:grid-cols-2 gap-5">
 
         <div class="card-enterprise p-6 flex items-start gap-4">
-          <div class="w-10 h-10 rounded-xl bg-[--color-up]/15 flex items-center justify-center shrink-0" aria-hidden="true">
+          <div class="w-10 h-10 rounded-xl bg-(--color-up)/15 flex items-center justify-center shrink-0" aria-hidden="true">
             <svg class="w-5 h-5 text-[--color-up]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
             </svg>
@@ -205,7 +205,7 @@ import Layout from '../../../layouts/Layout.astro';
         </div>
 
         <div class="card-enterprise p-6 flex items-start gap-4">
-          <div class="w-10 h-10 rounded-xl bg-[--color-up]/15 flex items-center justify-center shrink-0" aria-hidden="true">
+          <div class="w-10 h-10 rounded-xl bg-(--color-up)/15 flex items-center justify-center shrink-0" aria-hidden="true">
             <svg class="w-5 h-5 text-[--color-up]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
             </svg>
@@ -217,7 +217,7 @@ import Layout from '../../../layouts/Layout.astro';
         </div>
 
         <div class="card-enterprise p-6 flex items-start gap-4">
-          <div class="w-10 h-10 rounded-xl bg-[--color-up]/15 flex items-center justify-center shrink-0" aria-hidden="true">
+          <div class="w-10 h-10 rounded-xl bg-(--color-up)/15 flex items-center justify-center shrink-0" aria-hidden="true">
             <svg class="w-5 h-5 text-[--color-up]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" d="M7.864 4.243A7.5 7.5 0 0119.5 10.5c0 2.92-.556 5.709-1.568 8.268M5.742 6.364A7.465 7.465 0 004.5 10.5a7.464 7.464 0 01-1.15 3.993m1.989 3.559A11.209 11.209 0 008.25 10.5a3.75 3.75 0 117.5 0c0 .527-.021 1.049-.064 1.565M12 10.5a14.94 14.94 0 01-3.6 9.75m6.633-4.596a18.666 18.666 0 01-2.485 5.33" />
             </svg>
@@ -229,7 +229,7 @@ import Layout from '../../../layouts/Layout.astro';
         </div>
 
         <div class="card-enterprise p-6 flex items-start gap-4">
-          <div class="w-10 h-10 rounded-xl bg-[--color-up]/15 flex items-center justify-center shrink-0" aria-hidden="true">
+          <div class="w-10 h-10 rounded-xl bg-(--color-up)/15 flex items-center justify-center shrink-0" aria-hidden="true">
             <svg class="w-5 h-5 text-[--color-up]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5M9 11.25v1.5M12 9v3.75m3-6v6" />
             </svg>
@@ -265,10 +265,10 @@ import Layout from '../../../layouts/Layout.astro';
       </p>
 
       <div class="flex flex-wrap gap-3 justify-center mb-10 font-mono text-xs">
-        <span class="px-4 py-2 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5">OKX 공식 파트너</span>
-        <span class="px-4 py-2 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5">OAuth만 사용</span>
-        <span class="px-4 py-2 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5">출금 권한 없음</span>
-        <span class="px-4 py-2 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5">수수료 20% 할인</span>
+        <span class="px-4 py-2 rounded-full border border-(--color-up)/20 text-[--color-up] bg-(--color-up)/5">OKX 공식 파트너</span>
+        <span class="px-4 py-2 rounded-full border border-(--color-up)/20 text-[--color-up] bg-(--color-up)/5">OAuth만 사용</span>
+        <span class="px-4 py-2 rounded-full border border-(--color-up)/20 text-[--color-up] bg-(--color-up)/5">출금 권한 없음</span>
+        <span class="px-4 py-2 rounded-full border border-(--color-up)/20 text-[--color-up] bg-(--color-up)/5">수수료 20% 할인</span>
       </div>
 
       <a href="/ko/dashboard" class="btn btn-primary btn-lg">

--- a/src/pages/ko/compare/index.astro
+++ b/src/pages/ko/compare/index.astro
@@ -29,7 +29,7 @@ const comparisons = [
 
       <!-- Why PRUVIQ: 3 strengths -->
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-10 mb-10 reveal">
-        <div class="border border-[--color-up]/30 rounded-lg p-6 bg-[--color-bg-card]">
+        <div class="border border-(--color-up)/30 rounded-lg p-6 bg-[--color-bg-card]">
           <p class="font-mono text-[--color-up] text-xs font-bold mb-2 tracking-wider">{t('compare_index.strength1_tag')}</p>
           <p class="font-bold text-lg mb-2">{t('compare_index.strength1_title')}</p>
           <p class="text-[--color-text-muted] text-sm leading-relaxed">{t('compare_index.strength1_desc')}</p>

--- a/src/pages/ko/dashboard.astro
+++ b/src/pages/ko/dashboard.astro
@@ -103,15 +103,15 @@ const AUTOTRADE_COMING_SOON = true;
         <h3 class="font-bold mb-3">보안</h3>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-3 text-xs">
           <div class="flex items-center gap-2 text-[--color-text-muted]">
-            <span class="w-2 h-2 rounded-full bg-[--color-up]"></span>
+            <span class="w-2 h-2 rounded-full bg-(--color-up)"></span>
             OAuth — API 키 미공유
           </div>
           <div class="flex items-center gap-2 text-[--color-text-muted]">
-            <span class="w-2 h-2 rounded-full bg-[--color-up]"></span>
+            <span class="w-2 h-2 rounded-full bg-(--color-up)"></span>
             출금 권한 없음
           </div>
           <div class="flex items-center gap-2 text-[--color-text-muted]">
-            <span class="w-2 h-2 rounded-full bg-[--color-up]"></span>
+            <span class="w-2 h-2 rounded-full bg-(--color-up)"></span>
             AES-256 암호화 토큰
           </div>
         </div>

--- a/src/pages/ko/fees.astro
+++ b/src/pages/ko/fees.astro
@@ -53,7 +53,7 @@ const t = useTranslations('ko');
         {t('fees.desc')}
       </p>
       <!-- Savings example callout -->
-      <div class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-[--color-up]/30 bg-[--color-up]/5 text-[--color-up] font-mono text-sm">
+      <div class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-(--color-up)/30 bg-(--color-up)/5 text-[--color-up] font-mono text-sm">
         <span class="font-bold">&#9650;</span>
         <span>{t('fees.savings_callout')}</span>
       </div>
@@ -117,7 +117,7 @@ const t = useTranslations('ko');
             </div>
 
             <div class="flex flex-wrap items-center gap-2 pt-2">
-              <span class="inline-flex items-center gap-1 text-xs font-mono px-2 py-1 rounded border border-[--color-up]/40 bg-[--color-up]/5 text-[--color-up] font-semibold">
+              <span class="inline-flex items-center gap-1 text-xs font-mono px-2 py-1 rounded border border-(--color-up)/40 bg-(--color-up)/5 text-[--color-up] font-semibold">
                 현물 19% · 선물 9% 리베이트
               </span>
               <span class="inline-flex items-center gap-1 text-xs font-mono px-2 py-1 rounded border border-[--color-yellow]/40 bg-[--color-yellow]/5 text-[--color-yellow] font-semibold">
@@ -125,7 +125,7 @@ const t = useTranslations('ko');
               </span>
             </div>
             {savingsBadge && (
-              <span class="inline-flex items-center gap-1 text-xs font-mono px-2 py-1 rounded border border-[--color-up]/40 bg-[--color-up]/5 text-[--color-up] font-semibold">
+              <span class="inline-flex items-center gap-1 text-xs font-mono px-2 py-1 rounded border border-(--color-up)/40 bg-(--color-up)/5 text-[--color-up] font-semibold">
                 &#9650; {savingsBadge}
                 <span class="font-normal text-[--color-text-muted]">($10k/월 기준)</span>
               </span>
@@ -142,11 +142,11 @@ const t = useTranslations('ko');
         <div class="border border-[--color-border] rounded-xl p-6 md:p-8 flex flex-col relative overflow-hidden">
           <div class="flex items-center gap-3 mb-6">
             <h3 class="text-2xl font-bold">{okxDisplay.name}</h3>
-            <span class="font-mono text-[--color-up] text-xs font-bold px-2 py-0.5 rounded border border-[--color-up]/30 bg-[--color-up]/5">공식 파트너</span>
+            <span class="font-mono text-[--color-up] text-xs font-bold px-2 py-0.5 rounded border border-(--color-up)/30 bg-(--color-up)/5">공식 파트너</span>
           </div>
 
           <!-- 할인율 강조 -->
-          <div class="text-center mb-6 py-4 rounded-lg bg-[--color-up]/5 border border-[--color-up]/20">
+          <div class="text-center mb-6 py-4 rounded-lg bg-(--color-up)/5 border border-(--color-up)/20">
             <p class="text-3xl font-bold font-mono text-[--color-up]">{okxConfig.futuresDiscountPct}%</p>
             <p class="text-xs text-[--color-text-muted]">수수료 할인 (현물 + 선물)</p>
           </div>
@@ -172,7 +172,7 @@ const t = useTranslations('ko');
             </div>
 
             {okxSavingsBadge && (
-              <span class="inline-flex items-center gap-1 text-xs font-mono px-2 py-1 rounded border border-[--color-up]/40 bg-[--color-up]/5 text-[--color-up] font-semibold mt-2">
+              <span class="inline-flex items-center gap-1 text-xs font-mono px-2 py-1 rounded border border-(--color-up)/40 bg-(--color-up)/5 text-[--color-up] font-semibold mt-2">
                 &#9650; {okxSavingsBadge}
                 <span class="font-normal text-[--color-text-muted]">($10k/월 기준)</span>
               </span>
@@ -180,7 +180,7 @@ const t = useTranslations('ko');
           </div>
 
           <a href={`${okxDisplay.referralUrl}?utm_source=pruviq&utm_medium=referral&utm_campaign=fees`} target="_blank" rel="noopener noreferrer"
-             class="mt-6 block text-center border-2 border-[--color-up] text-[--color-up] px-4 py-3 min-h-[48px] rounded text-sm font-bold hover:bg-[--color-up]/10 transition-colors">
+             class="mt-6 block text-center border-2 border-(--color-up) text-[--color-up] px-4 py-3 min-h-[48px] rounded text-sm font-bold hover:bg-(--color-up)/10 transition-colors">
             OKX 가입하기 &rarr;
           </a>
         </div>
@@ -203,7 +203,7 @@ const t = useTranslations('ko');
       <p class="text-[--color-text-muted] text-sm mb-6 max-w-3xl">{t('fees.referral.problem.body')}</p>
 
       <!-- Fact callout -->
-      <div class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-[--color-down]/30 bg-[--color-down]/5 text-[--color-down] text-sm">
+      <div class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-(--color-down)/30 bg-(--color-down)/5 text-[--color-down] text-sm">
         <span>{t('fees.referral.callout.fact')}</span>
       </div>
     </div>
@@ -238,7 +238,7 @@ const t = useTranslations('ko');
               <td class="py-2 px-3 text-center font-mono text-[--color-down]">{t('fees.referral.table.row.typical.actual')}</td>
               <td class="py-2 px-3 text-center font-mono text-[--color-down]">{t('fees.referral.table.row.typical.keeps')}</td>
             </tr>
-            <tr class="border-b border-[--color-border]/50 bg-[--color-down]/5">
+            <tr class="border-b border-[--color-border]/50 bg-(--color-down)/5">
               <td class="py-2 px-3 text-[--color-down]">{t('fees.referral.table.row.worst')}</td>
               <td class="py-2 px-3 text-center font-mono text-[--color-text-muted]">{t('fees.referral.table.row.worst.claim')}</td>
               <td class="py-2 px-3 text-center font-mono text-[--color-text-muted]">{t('fees.referral.table.row.worst.claimFutures')}</td>
@@ -257,7 +257,7 @@ const t = useTranslations('ko');
       </div>
 
       <!-- Warning callout -->
-      <div class="border border-[--color-down]/30 bg-[--color-down]/5 rounded-lg p-4 max-w-4xl mb-4">
+      <div class="border border-(--color-down)/30 bg-(--color-down)/5 rounded-lg p-4 max-w-4xl mb-4">
         <p class="text-[--color-down] text-sm font-medium">{t('fees.referral.callout.warning')}</p>
       </div>
       <p class="text-[--color-text-muted] text-xs max-w-3xl">{t('fees.referral.how.check')}</p>
@@ -285,7 +285,7 @@ const t = useTranslations('ko');
       <p class="text-[--color-text-muted] text-xs text-center mb-6 max-w-2xl mx-auto">{t('fees.referral.proof.timestamp')}</p>
 
       <!-- Why we show this -->
-      <div class="border border-[--color-up]/30 bg-[--color-up]/5 rounded-lg p-6 max-w-2xl mx-auto">
+      <div class="border border-(--color-up)/30 bg-(--color-up)/5 rounded-lg p-6 max-w-2xl mx-auto">
         <p class="text-sm mb-3 leading-relaxed">{t('fees.referral.proof.why')}</p>
         <p class="text-[--color-text-muted] text-sm leading-relaxed">{t('fees.referral.proof.transparent')}</p>
       </div>
@@ -320,7 +320,7 @@ const t = useTranslations('ko');
       </div>
 
       <!-- Warning note -->
-      <div class="border border-[--color-down]/30 bg-[--color-down]/5 rounded-lg p-4 max-w-3xl mb-4">
+      <div class="border border-(--color-down)/30 bg-(--color-down)/5 rounded-lg p-4 max-w-3xl mb-4">
         <p class="text-[--color-down] text-sm font-medium">{t('fees.referral.verify.cta')}</p>
       </div>
       <p class="text-[--color-text-muted] text-xs max-w-3xl">{t('fees.referral.verify.note')}</p>

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -217,7 +217,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
       <div class="grid md:grid-cols-3 gap-4 mb-12 reveal">
         <div class="card-enterprise p-6 border-t-2 border-t-[--color-down]/30 card-hover shadow-[var(--shadow-md)]">
           <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
-            <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
+            <span class="inline-block w-2 h-2 rounded-full bg-(--color-down)"></span>
             {t('problem.case1_label')}
           </div>
           <h3 class="font-bold text-lg mb-2">{t('problem.card1_title')}</h3>
@@ -226,7 +226,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
         </div>
         <div class="card-enterprise p-6 border-t-2 border-t-[--color-down]/30 card-hover shadow-[var(--shadow-md)]">
           <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
-            <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
+            <span class="inline-block w-2 h-2 rounded-full bg-(--color-down)"></span>
             {t('problem.case2_label')}
           </div>
           <h3 class="font-bold text-lg mb-2">{t('problem.card2_title')}</h3>
@@ -235,7 +235,7 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
         </div>
         <div class="card-enterprise p-6 border-t-2 border-t-[--color-down]/30 card-hover shadow-[var(--shadow-md)]">
           <div class="text-[--color-down] font-mono text-xs font-bold mb-3 flex items-center gap-2">
-            <span class="inline-block w-2 h-2 rounded-full bg-[--color-down]"></span>
+            <span class="inline-block w-2 h-2 rounded-full bg-(--color-down)"></span>
             {t('problem.case3_label')}
           </div>
           <h3 class="font-bold text-lg mb-2">{t('problem.card3_title')}</h3>
@@ -379,10 +379,10 @@ const candlesProcessed = ((stats.candles_processed ?? 0) / 1_000_000).toFixed(1)
 
       <!-- Risk reversal badges -->
       <div class="flex flex-wrap gap-3 justify-center mb-8 font-mono text-xs">
-        <span class="px-3 py-1.5 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5 shadow-[var(--shadow-sm)]">{t('cta.badge1')}</span>
-        <span class="px-3 py-1.5 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5 shadow-[var(--shadow-sm)]">{t('cta.badge2')}</span>
-        <span class="px-3 py-1.5 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5 shadow-[var(--shadow-sm)]">{t('cta.badge3')}</span>
-        <span class="px-3 py-1.5 rounded-full border border-[--color-up]/20 text-[--color-up] bg-[--color-up]/5 shadow-[var(--shadow-sm)]">{t('cta.badge4')}</span>
+        <span class="px-3 py-1.5 rounded-full border border-(--color-up)/20 text-[--color-up] bg-(--color-up)/5 shadow-[var(--shadow-sm)]">{t('cta.badge1')}</span>
+        <span class="px-3 py-1.5 rounded-full border border-(--color-up)/20 text-[--color-up] bg-(--color-up)/5 shadow-[var(--shadow-sm)]">{t('cta.badge2')}</span>
+        <span class="px-3 py-1.5 rounded-full border border-(--color-up)/20 text-[--color-up] bg-(--color-up)/5 shadow-[var(--shadow-sm)]">{t('cta.badge3')}</span>
+        <span class="px-3 py-1.5 rounded-full border border-(--color-up)/20 text-[--color-up] bg-(--color-up)/5 shadow-[var(--shadow-sm)]">{t('cta.badge4')}</span>
       </div>
 
       <div class="flex flex-col sm:flex-row gap-4 justify-center mb-4">

--- a/src/pages/ko/leaderboard.astro
+++ b/src/pages/ko/leaderboard.astro
@@ -54,7 +54,7 @@ function formatDate(iso: string) {
               const isLong = entry.direction === 'long';
               const isBoth = entry.direction === 'both';
               const dirLabel = isBoth ? 'BOTH↕' : isLong ? 'LONG↑' : 'SHORT↓';
-              const dirColor = isBoth ? 'text-[--color-yellow] border-[--color-yellow]/40' : isLong ? 'text-[--color-up] border-[--color-up]/40' : 'text-[--color-red] border-[--color-red]/40';
+              const dirColor = isBoth ? 'text-[--color-yellow] border-[--color-yellow]/40' : isLong ? 'text-[--color-up] border-(--color-up)/40' : 'text-[--color-red] border-(--color-red)/40';
               const wrColor = entry.win_rate >= 55 ? 'text-[--color-up]' : entry.win_rate >= 50 ? 'text-[--color-yellow]' : 'text-[--color-red]';
               const pfColor = entry.profit_factor >= 1.5 ? 'text-[--color-up]' : entry.profit_factor >= 1.0 ? 'text-[--color-yellow]' : 'text-[--color-red]';
               return (

--- a/src/pages/ko/learn/index.astro
+++ b/src/pages/ko/learn/index.astro
@@ -75,9 +75,9 @@ const tagMap: Record<string, string> = {
 };
 
 const levelColorMap: Record<string, string> = {
-  green: 'bg-[--color-up]/10 text-[--color-up] border-[--color-up]/20',
+  green: 'bg-(--color-up)/10 text-[--color-up] border-(--color-up)/20',
   yellow: 'bg-[--color-warning]/10 text-[--color-warning] border-[--color-warning]/20',
-  red: 'bg-[--color-down]/10 text-[--color-down] border-[--color-down]/20',
+  red: 'bg-(--color-down)/10 text-[--color-down] border-(--color-down)/20',
 };
 
 const levelConfig = [

--- a/src/pages/ko/methodology.astro
+++ b/src/pages/ko/methodology.astro
@@ -38,7 +38,7 @@ const t = useTranslations('ko');
         <span class="text-[--color-text-disabled]">&rarr;</span>
         <span class="px-3 py-1.5 rounded-full bg-[--color-warning]/10 text-[--color-warning] border border-[--color-warning]/20">− 슬리피지</span>
         <span class="text-[--color-text-disabled]">&rarr;</span>
-        <span class="px-3 py-1.5 rounded-full bg-[--color-up]/10 text-[--color-up] border border-[--color-up]/20 font-bold">결과</span>
+        <span class="px-3 py-1.5 rounded-full bg-(--color-up)/10 text-[--color-up] border border-(--color-up)/20 font-bold">결과</span>
       </div>
 
       <div class="space-y-6 max-w-3xl">

--- a/src/pages/ko/performance/index.astro
+++ b/src/pages/ko/performance/index.astro
@@ -244,7 +244,7 @@ const liveTrades = perf.summary.total_trades.toLocaleString();
 
       <!-- 비교 카드 -->
       <div class="grid md:grid-cols-2 gap-6 mb-8">
-        <div class="border border-[--color-up]/30 rounded-lg p-6 bg-[--color-up]/5">
+        <div class="border border-(--color-up)/30 rounded-lg p-6 bg-(--color-up)/5">
           <p class="font-mono text-[--color-up] text-xs font-bold mb-4">{t('perf.gap_backtest')}</p>
           <div class="space-y-3">
             <div class="flex justify-between text-sm">
@@ -261,7 +261,7 @@ const liveTrades = perf.summary.total_trades.toLocaleString();
             </div>
           </div>
         </div>
-        <div class="border border-[--color-down]/30 rounded-lg p-6 bg-[--color-down]/5">
+        <div class="border border-(--color-down)/30 rounded-lg p-6 bg-(--color-down)/5">
           <p class="font-mono text-[--color-down] text-xs font-bold mb-4">{t('perf.gap_live')}</p>
           <div class="space-y-3">
             <div class="flex justify-between text-sm">
@@ -315,9 +315,9 @@ const liveTrades = perf.summary.total_trades.toLocaleString();
       </p>
 
       <div class="grid md:grid-cols-2 gap-4">
-        <div class="border border-[--color-red]/30 rounded-lg p-5 bg-[--color-red]/5 opacity-70">
+        <div class="border border-(--color-red)/30 rounded-lg p-5 bg-(--color-red)/5 opacity-70">
           <div class="flex items-center gap-2 mb-3">
-            <span class="text-xs font-mono px-2 py-0.5 rounded bg-[--color-red]/10 text-[--color-text] border border-[--color-red]/20">{t('strategy.killed')}</span>
+            <span class="text-xs font-mono px-2 py-0.5 rounded bg-(--color-red)/10 text-[--color-text] border border-(--color-red)/20">{t('strategy.killed')}</span>
           </div>
           <h3 class="font-bold mb-2">BB Squeeze LONG</h3>
           <p class="text-[--color-text-muted] text-xs mb-3">{t('perf.killed_bb_long')}</p>
@@ -332,14 +332,14 @@ const liveTrades = perf.summary.total_trades.toLocaleString();
             </div>
             <div>
               <span class="text-[--color-text-muted] text-xs block">PnL</span>
-              <span class="font-mono px-1 py-0.5 rounded bg-[--color-red]/10 text-[--color-text]">-$26</span>
+              <span class="font-mono px-1 py-0.5 rounded bg-(--color-red)/10 text-[--color-text]">-$26</span>
             </div>
           </div>
         </div>
 
-        <div class="border border-[--color-red]/30 rounded-lg p-5 bg-[--color-red]/5 opacity-70">
+        <div class="border border-(--color-red)/30 rounded-lg p-5 bg-(--color-red)/5 opacity-70">
           <div class="flex items-center gap-2 mb-3">
-            <span class="text-xs font-mono px-2 py-0.5 rounded bg-[--color-red]/10 text-[--color-text] border border-[--color-red]/20">{t('strategy.killed')}</span>
+            <span class="text-xs font-mono px-2 py-0.5 rounded bg-(--color-red)/10 text-[--color-text] border border-(--color-red)/20">{t('strategy.killed')}</span>
           </div>
           <h3 class="font-bold mb-2">Momentum Breakout LONG</h3>
           <p class="text-[--color-text-muted] text-xs mb-3">{t('perf.killed_momentum')}</p>
@@ -354,12 +354,12 @@ const liveTrades = perf.summary.total_trades.toLocaleString();
             </div>
             <div>
               <span class="text-[--color-text-muted] text-xs block">PnL</span>
-              <span class="font-mono px-1 py-0.5 rounded bg-[--color-red]/10 text-[--color-text]">중단</span>
+              <span class="font-mono px-1 py-0.5 rounded bg-(--color-red)/10 text-[--color-text]">중단</span>
             </div>
           </div>
         </div>
 
-        <div class="border border-[--color-red]/30 rounded-lg p-5 bg-[--color-red]/5 opacity-70">
+        <div class="border border-(--color-red)/30 rounded-lg p-5 bg-(--color-red)/5 opacity-70">
           <div class="flex items-center gap-2 mb-3">
             <span class="text-xs font-mono px-2 py-0.5 rounded bg-[--color-yellow]/10 text-[--color-yellow] border border-[--color-yellow]/20">88+ 변형</span>
           </div>
@@ -381,7 +381,7 @@ const liveTrades = perf.summary.total_trades.toLocaleString();
           </div>
         </div>
 
-        <div class="border border-[--color-red]/30 rounded-lg p-5 bg-[--color-red]/5 opacity-70">
+        <div class="border border-(--color-red)/30 rounded-lg p-5 bg-(--color-red)/5 opacity-70">
           <div class="flex items-center gap-2 mb-3">
             <span class="text-xs font-mono px-2 py-0.5 rounded bg-[--color-yellow]/10 text-[--color-yellow] border border-[--color-yellow]/20">기각된 필터</span>
           </div>

--- a/src/pages/ko/signals/index.astro
+++ b/src/pages/ko/signals/index.astro
@@ -15,7 +15,7 @@ const t = useTranslations('ko');
       <div class="flex items-center gap-3 mb-5">
         <span class="relative flex h-3 w-3">
           <span class="animate-ping absolute inline-flex h-full w-full rounded-full live-dot-ping opacity-75"></span>
-          <span class="relative inline-flex rounded-full h-3 w-3 bg-[--color-up]"></span>
+          <span class="relative inline-flex rounded-full h-3 w-3 bg-(--color-up)"></span>
         </span>
         <h1 class="text-3xl md:text-5xl lg:text-6xl font-extrabold">{t('signals.title')}</h1>
       </div>

--- a/src/pages/ko/simulate/index.astro
+++ b/src/pages/ko/simulate/index.astro
@@ -107,7 +107,7 @@ const simulateJsonLd = {
             <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
           </div>
         </div>
-        <div class="flex items-start gap-3 border border-[--color-up]/20 rounded-lg px-4 py-4 bg-[--color-up]/5 card-hover">
+        <div class="flex items-start gap-3 border border-(--color-up)/20 rounded-lg px-4 py-4 bg-(--color-up)/5 card-hover">
           <div class="step-badge step-badge-green shrink-0 mt-0.5">3</div>
           <div>
             <p class="text-sm font-semibold">{t('simulate.step3_title')}</p>

--- a/src/pages/ko/strategies/index.astro
+++ b/src/pages/ko/strategies/index.astro
@@ -333,7 +333,7 @@ const presetDirColors: Record<string, string> = { long: '--color-accent', short:
           {presetDirOrder.map((dir, idx) => (
             <div class={idx > 0 ? 'mt-8' : ''}>
               <div class="flex items-center gap-2 mb-4">
-                <span class={`font-mono text-sm font-bold tracking-wider py-1 px-3 rounded-md ${dir === 'long' ? 'bg-[--color-accent]/10' : dir === 'short' ? 'bg-[--color-red]/10' : 'bg-[--color-yellow]/10'}`} style={`color: var(${presetDirColors[dir]})`}>{presetDirLabels[dir]}</span>
+                <span class={`font-mono text-sm font-bold tracking-wider py-1 px-3 rounded-md ${dir === 'long' ? 'bg-[--color-accent]/10' : dir === 'short' ? 'bg-(--color-red)/10' : 'bg-[--color-yellow]/10'}`} style={`color: var(${presetDirColors[dir]})`}>{presetDirLabels[dir]}</span>
                 <div class="flex-1 border-t border-[--color-border]"></div>
                 <span class="font-mono text-xs text-[--color-text-disabled]">{presetsByDirection[dir].length}</span>
               </div>
@@ -370,7 +370,7 @@ const presetDirColors: Record<string, string> = { long: '--color-accent', short:
                       </div>
                       <div class="flex items-center gap-2 shrink-0 ml-3">
                         {preset.direction && (
-                          <span class={`font-mono text-xs px-1.5 py-0.5 rounded border ${preset.direction === 'long' ? 'text-[--color-accent] border-[--color-accent]/30 bg-[--color-accent]/5' : preset.direction === 'short' ? 'text-[--color-red] border-[--color-red]/30 bg-[--color-red]/5' : 'text-[--color-yellow] border-[--color-yellow]/30 bg-[--color-yellow]/5'}`}>
+                          <span class={`font-mono text-xs px-1.5 py-0.5 rounded border ${preset.direction === 'long' ? 'text-[--color-accent] border-[--color-accent]/30 bg-[--color-accent]/5' : preset.direction === 'short' ? 'text-[--color-red] border-(--color-red)/30 bg-(--color-red)/5' : 'text-[--color-yellow] border-[--color-yellow]/30 bg-[--color-yellow]/5'}`}>
                             {preset.direction.toUpperCase()}
                           </span>
                         )}

--- a/src/pages/ko/strategies/ranking.astro
+++ b/src/pages/ko/strategies/ranking.astro
@@ -134,7 +134,7 @@ if (!ssrRanking) {
               const medals = ['🥇','🥈','🥉'];
               const medal = medals[entry.rank - 1] ?? `#${entry.rank}`;
               const dirLabel = isBoth ? 'BOTH↕' : isLong ? 'LONG↑' : 'SHORT↓';
-              const dirColor = isBoth ? 'text-[--color-yellow] border-[--color-yellow]/40' : isLong ? 'text-[--color-up] border-[--color-up]/40' : 'text-[--color-red] border-[--color-red]/40';
+              const dirColor = isBoth ? 'text-[--color-yellow] border-[--color-yellow]/40' : isLong ? 'text-[--color-up] border-(--color-up)/40' : 'text-[--color-red] border-(--color-red)/40';
               const wrColor = entry.win_rate >= 55 ? 'text-[--color-up]' : entry.win_rate >= 50 ? 'text-[--color-yellow]' : 'text-[--color-red]';
               const pfColor = entry.profit_factor >= 1.5 ? 'text-[--color-up]' : entry.profit_factor >= 1.0 ? 'text-[--color-yellow]' : 'text-[--color-red]';
               return (

--- a/src/pages/leaderboard.astro
+++ b/src/pages/leaderboard.astro
@@ -56,7 +56,7 @@ function formatDate(iso: string) {
               const isLong = entry.direction === 'long';
               const isBoth = entry.direction === 'both';
               const dirLabel = isBoth ? 'BOTH↕' : isLong ? 'LONG↑' : 'SHORT↓';
-              const dirColor = isBoth ? 'text-[--color-yellow] border-[--color-yellow]/40' : isLong ? 'text-[--color-up] border-[--color-up]/40' : 'text-[--color-red] border-[--color-red]/40';
+              const dirColor = isBoth ? 'text-[--color-yellow] border-[--color-yellow]/40' : isLong ? 'text-[--color-up] border-(--color-up)/40' : 'text-[--color-red] border-(--color-red)/40';
               const wrColor = entry.win_rate >= 55 ? 'text-[--color-up]' : entry.win_rate >= 50 ? 'text-[--color-yellow]' : 'text-[--color-red]';
               const pfColor = entry.profit_factor >= 1.5 ? 'text-[--color-up]' : entry.profit_factor >= 1.0 ? 'text-[--color-yellow]' : 'text-[--color-red]';
               return (

--- a/src/pages/learn/index.astro
+++ b/src/pages/learn/index.astro
@@ -68,9 +68,9 @@ const tagMap: Record<string, string> = {
 };
 
 const levelColorMap: Record<string, string> = {
-  green: 'bg-[--color-up]/10 text-[--color-up] border-[--color-up]/20',
+  green: 'bg-(--color-up)/10 text-[--color-up] border-(--color-up)/20',
   yellow: 'bg-[--color-warning]/10 text-[--color-warning] border-[--color-warning]/20',
-  red: 'bg-[--color-down]/10 text-[--color-down] border-[--color-down]/20',
+  red: 'bg-(--color-down)/10 text-[--color-down] border-(--color-down)/20',
 };
 
 const levelConfig = [

--- a/src/pages/methodology.astro
+++ b/src/pages/methodology.astro
@@ -38,7 +38,7 @@ const t = useTranslations('en');
         <span class="text-[--color-text-disabled]">&rarr;</span>
         <span class="px-3 py-1.5 rounded-full bg-[--color-warning]/10 text-[--color-warning] border border-[--color-warning]/20">− Slippage</span>
         <span class="text-[--color-text-disabled]">&rarr;</span>
-        <span class="px-3 py-1.5 rounded-full bg-[--color-up]/10 text-[--color-up] border border-[--color-up]/20 font-bold">Result</span>
+        <span class="px-3 py-1.5 rounded-full bg-(--color-up)/10 text-[--color-up] border border-(--color-up)/20 font-bold">Result</span>
       </div>
 
       <div class="space-y-6 max-w-3xl">

--- a/src/pages/performance/index.astro
+++ b/src/pages/performance/index.astro
@@ -309,7 +309,7 @@ const liveTrades = perf.summary.total_trades.toLocaleString();
 
       <!-- Side-by-side comparison -->
       <div class="grid md:grid-cols-2 gap-6 mb-8">
-        <div class="border border-[--color-up]/30 rounded-lg p-6 bg-[--color-up]/5">
+        <div class="border border-(--color-up)/30 rounded-lg p-6 bg-(--color-up)/5">
           <p class="font-mono text-[--color-up] text-xs font-bold mb-4">{t('perf.gap_backtest')}</p>
           <div class="space-y-3">
             <div class="flex justify-between text-sm">
@@ -326,7 +326,7 @@ const liveTrades = perf.summary.total_trades.toLocaleString();
             </div>
           </div>
         </div>
-        <div class="border border-[--color-down]/30 rounded-lg p-6 bg-[--color-down]/5">
+        <div class="border border-(--color-down)/30 rounded-lg p-6 bg-(--color-down)/5">
           <p class="font-mono text-[--color-down] text-xs font-bold mb-4">{t('perf.gap_live')}</p>
           <div class="space-y-3">
             <div class="flex justify-between text-sm">
@@ -380,9 +380,9 @@ const liveTrades = perf.summary.total_trades.toLocaleString();
       </p>
 
       <div class="grid md:grid-cols-2 gap-4">
-        <div class="border border-[--color-red]/30 rounded-lg p-5 bg-[--color-red]/5 opacity-70">
+        <div class="border border-(--color-red)/30 rounded-lg p-5 bg-(--color-red)/5 opacity-70">
           <div class="flex items-center gap-2 mb-3">
-            <span class="text-xs font-mono px-2 py-0.5 rounded bg-[--color-red]/10 text-[--color-text] border border-[--color-red]/20">{t('strategy.killed')}</span>
+            <span class="text-xs font-mono px-2 py-0.5 rounded bg-(--color-red)/10 text-[--color-text] border border-(--color-red)/20">{t('strategy.killed')}</span>
           </div>
           <h3 class="font-bold mb-2">BB Squeeze LONG</h3>
           <p class="text-[--color-text-muted] text-xs mb-3">{t('perf.killed_bb_long')}</p>
@@ -397,14 +397,14 @@ const liveTrades = perf.summary.total_trades.toLocaleString();
             </div>
             <div>
               <span class="text-[--color-text-muted] text-xs block">PnL</span>
-              <span class="font-mono px-1 py-0.5 rounded bg-[--color-red]/10 text-[--color-text]">-$26</span>
+              <span class="font-mono px-1 py-0.5 rounded bg-(--color-red)/10 text-[--color-text]">-$26</span>
             </div>
           </div>
         </div>
 
-        <div class="border border-[--color-red]/30 rounded-lg p-5 bg-[--color-red]/5 opacity-70">
+        <div class="border border-(--color-red)/30 rounded-lg p-5 bg-(--color-red)/5 opacity-70">
           <div class="flex items-center gap-2 mb-3">
-            <span class="text-xs font-mono px-2 py-0.5 rounded bg-[--color-red]/10 text-[--color-text] border border-[--color-red]/20">{t('strategy.killed')}</span>
+            <span class="text-xs font-mono px-2 py-0.5 rounded bg-(--color-red)/10 text-[--color-text] border border-(--color-red)/20">{t('strategy.killed')}</span>
           </div>
           <h3 class="font-bold mb-2">Momentum Breakout LONG</h3>
           <p class="text-[--color-text-muted] text-xs mb-3">{t('perf.killed_momentum')}</p>
@@ -419,12 +419,12 @@ const liveTrades = perf.summary.total_trades.toLocaleString();
             </div>
             <div>
               <span class="text-[--color-text-muted] text-xs block">PnL</span>
-              <span class="font-mono px-1 py-0.5 rounded bg-[--color-red]/10 text-[--color-text]">Killed</span>
+              <span class="font-mono px-1 py-0.5 rounded bg-(--color-red)/10 text-[--color-text]">Killed</span>
             </div>
           </div>
         </div>
 
-        <div class="border border-[--color-red]/30 rounded-lg p-5 bg-[--color-red]/5 opacity-70">
+        <div class="border border-(--color-red)/30 rounded-lg p-5 bg-(--color-red)/5 opacity-70">
           <div class="flex items-center gap-2 mb-3">
             <span class="text-xs font-mono px-2 py-0.5 rounded bg-[--color-yellow]/10 text-[--color-yellow] border border-[--color-yellow]/20">88+ Variations</span>
           </div>
@@ -441,12 +441,12 @@ const liveTrades = perf.summary.total_trades.toLocaleString();
             </div>
             <div>
               <span class="text-[--color-text-muted] text-xs block">Verdict</span>
-              <span class="font-mono px-1 py-0.5 rounded bg-[--color-red]/10 text-[--color-text]">All Failed</span>
+              <span class="font-mono px-1 py-0.5 rounded bg-(--color-red)/10 text-[--color-text]">All Failed</span>
             </div>
           </div>
         </div>
 
-        <div class="border border-[--color-red]/30 rounded-lg p-5 bg-[--color-red]/5 opacity-70">
+        <div class="border border-(--color-red)/30 rounded-lg p-5 bg-(--color-red)/5 opacity-70">
           <div class="flex items-center gap-2 mb-3">
             <span class="text-xs font-mono px-2 py-0.5 rounded bg-[--color-yellow]/10 text-[--color-yellow] border border-[--color-yellow]/20">Rejected Filter</span>
           </div>

--- a/src/pages/signals/index.astro
+++ b/src/pages/signals/index.astro
@@ -15,7 +15,7 @@ const t = useTranslations('en');
       <div class="flex items-center gap-3 mb-5">
         <span class="relative flex h-3 w-3">
           <span class="animate-ping absolute inline-flex h-full w-full rounded-full live-dot-ping opacity-75"></span>
-          <span class="relative inline-flex rounded-full h-3 w-3 bg-[--color-up]"></span>
+          <span class="relative inline-flex rounded-full h-3 w-3 bg-(--color-up)"></span>
         </span>
         <h1 class="text-3xl md:text-5xl lg:text-6xl font-extrabold">{t('signals.title')}</h1>
       </div>

--- a/src/pages/simulate/index.astro
+++ b/src/pages/simulate/index.astro
@@ -114,7 +114,7 @@ const simulateJsonLd = {
             <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
           </div>
         </div>
-        <div class="flex items-start gap-3 border border-[--color-up]/20 rounded-lg px-4 py-4 bg-[--color-up]/5 card-hover">
+        <div class="flex items-start gap-3 border border-(--color-up)/20 rounded-lg px-4 py-4 bg-(--color-up)/5 card-hover">
           <div class="step-badge step-badge-green shrink-0 mt-0.5">3</div>
           <div>
             <p class="text-sm font-semibold">{t('simulate.step3_title')}</p>

--- a/src/pages/strategies/index.astro
+++ b/src/pages/strategies/index.astro
@@ -357,7 +357,7 @@ const presetDirColors: Record<string, string> = { long: '--color-accent', short:
           {presetDirOrder.map((dir, idx) => (
             <div class={idx > 0 ? 'mt-8' : ''}>
               <div class="flex items-center gap-2 mb-4">
-                <span class={`font-mono text-sm font-bold tracking-wider py-1 px-3 rounded-md ${dir === 'long' ? 'bg-[--color-accent]/10' : dir === 'short' ? 'bg-[--color-red]/10' : 'bg-[--color-yellow]/10'}`} style={`color: var(${presetDirColors[dir]})`}>{presetDirLabels[dir]}</span>
+                <span class={`font-mono text-sm font-bold tracking-wider py-1 px-3 rounded-md ${dir === 'long' ? 'bg-[--color-accent]/10' : dir === 'short' ? 'bg-(--color-red)/10' : 'bg-[--color-yellow]/10'}`} style={`color: var(${presetDirColors[dir]})`}>{presetDirLabels[dir]}</span>
                 <div class="flex-1 border-t border-[--color-border]"></div>
                 <span class="font-mono text-xs text-[--color-text-disabled]">{presetsByDirection[dir].length}</span>
               </div>
@@ -394,7 +394,7 @@ const presetDirColors: Record<string, string> = { long: '--color-accent', short:
                       </div>
                       <div class="flex items-center gap-2 shrink-0 ml-3">
                         {preset.direction && (
-                          <span class={`font-mono text-xs px-1.5 py-0.5 rounded border ${preset.direction === 'long' ? 'text-[--color-accent] border-[--color-accent]/30 bg-[--color-accent]/5' : preset.direction === 'short' ? 'text-[--color-red] border-[--color-red]/30 bg-[--color-red]/5' : 'text-[--color-yellow] border-[--color-yellow]/30 bg-[--color-yellow]/5'}`}>
+                          <span class={`font-mono text-xs px-1.5 py-0.5 rounded border ${preset.direction === 'long' ? 'text-[--color-accent] border-[--color-accent]/30 bg-[--color-accent]/5' : preset.direction === 'short' ? 'text-[--color-red] border-(--color-red)/30 bg-(--color-red)/5' : 'text-[--color-yellow] border-[--color-yellow]/30 bg-[--color-yellow]/5'}`}>
                             {preset.direction.toUpperCase()}
                           </span>
                         )}

--- a/src/pages/strategies/ranking.astro
+++ b/src/pages/strategies/ranking.astro
@@ -146,11 +146,11 @@ if (!ssrRanking) {
               const medals = ['🥇','🥈','🥉'];
               const medal = medals[entry.rank - 1] ?? `#${entry.rank}`;
               const dirLabel = isBoth ? 'BOTH↕' : isLong ? 'LONG↑' : 'SHORT↓';
-              const dirColor = isBoth ? 'text-[--color-yellow] border-[--color-yellow]/40' : isLong ? 'text-[--color-up] border-[--color-up]/40' : 'text-[--color-red] border-[--color-red]/40';
+              const dirColor = isBoth ? 'text-[--color-yellow] border-[--color-yellow]/40' : isLong ? 'text-[--color-up] border-(--color-up)/40' : 'text-[--color-red] border-(--color-red)/40';
               const wrColor = entry.win_rate >= 55 ? 'text-[--color-up]' : entry.win_rate >= 50 ? 'text-[--color-yellow]' : 'text-[--color-red]';
               const pfColor = entry.profit_factor >= 1.5 ? 'text-[--color-up]' : entry.profit_factor >= 1.0 ? 'text-[--color-yellow]' : 'text-[--color-red]';
               return (
-                <div class="border border-[--color-up]/30 rounded-lg p-4 bg-[--color-bg-card]">
+                <div class="border border-(--color-up)/30 rounded-lg p-4 bg-[--color-bg-card]">
                   <div class="flex items-start justify-between gap-2 mb-3">
                     <div class="flex items-center gap-2 min-w-0">
                       <span class="text-xl shrink-0">{medal}</span>
@@ -212,7 +212,7 @@ if (!ssrRanking) {
               const wrColor = entry.win_rate >= 55 ? 'text-[--color-up]' : entry.win_rate >= 50 ? 'text-[--color-yellow]' : 'text-[--color-red]';
               const pfColor = entry.profit_factor >= 1.5 ? 'text-[--color-up]' : entry.profit_factor >= 1.0 ? 'text-[--color-yellow]' : 'text-[--color-red]';
               return (
-                <div class="border border-[--color-down]/30 rounded-lg p-4 bg-[--color-bg-card] opacity-70">
+                <div class="border border-(--color-down)/30 rounded-lg p-4 bg-[--color-bg-card] opacity-70">
                   <div class="flex items-center gap-2 mb-3">
                     <span class="text-xl shrink-0">{medal}</span>
                     <div class="min-w-0">


### PR DESCRIPTION
## Root Cause

In Tailwind v4.2.4, `bg-[--color-up]/10` compiles to invalid CSS:
```css
.bg-\[--color-up\]\/10{background-color:color-mix(in oklab,--color-up 10%,transparent)}
/* ❌ --color-up has no var() — browser ignores it → background invisible */
```

The correct parentheses syntax `bg-(--color-up)/10` compiles to:
```css
.bg-\(--color-up\)\/10{background-color:color-mix(in oklab,var(--color-up) 10%,transparent)}
/* ✓ valid */
```

## Scope

**271 instances** fixed across 45 source files:
- `bg-[--color-up/down/red]` → `bg-(--color-up/down/red)` — 161 instances
- `border-[--color-up/down/red]` → `border-(--color-up/down/red)` — 110 instances

Affected: trading indicator badge backgrounds, performance metric borders, strategy comparison cards, result panels, CoinChart, MarketDashboard, RankingCard, and 40+ pages.

## Build

Build: 1196 pages, 0 errors.