### PR TITLE
a11y(sprint-4.1v2): prefers-reduced-motion SVG fix + focus-visible upgrade

### DIFF
--- a/src/components/DiscreteSlider.tsx
+++ b/src/components/DiscreteSlider.tsx
@@ -1,4 +1,4 @@
-import { useRef, useCallback } from 'preact/hooks';
+import { useRef, useCallback } from "preact/hooks";
 
 interface DiscreteSliderProps {
   label: string;
@@ -14,7 +14,7 @@ export default function DiscreteSlider({
   values,
   value,
   defaultValue,
-  unit = '%',
+  unit = "%",
   onChange,
 }: DiscreteSliderProps) {
   const trackRef = useRef<HTMLDivElement>(null);
@@ -30,7 +30,7 @@ export default function DiscreteSlider({
       const idx = Math.round(pct * (values.length - 1));
       onChange(values[idx]);
     },
-    [values, onChange]
+    [values, onChange],
   );
 
   const handlePointerDown = useCallback(
@@ -38,29 +38,29 @@ export default function DiscreteSlider({
       e.preventDefault();
       const move = (ev: PointerEvent) => resolveIndex(ev.clientX);
       const up = () => {
-        document.removeEventListener('pointermove', move);
-        document.removeEventListener('pointerup', up);
+        document.removeEventListener("pointermove", move);
+        document.removeEventListener("pointerup", up);
       };
-      document.addEventListener('pointermove', move);
-      document.addEventListener('pointerup', up);
+      document.addEventListener("pointermove", move);
+      document.addEventListener("pointerup", up);
       resolveIndex(e.clientX);
     },
-    [resolveIndex]
+    [resolveIndex],
   );
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
       let idx = currentIndex;
-      if (e.key === 'ArrowRight' || e.key === 'ArrowUp') {
+      if (e.key === "ArrowRight" || e.key === "ArrowUp") {
         idx = Math.min(values.length - 1, currentIndex + 1);
         e.preventDefault();
-      } else if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') {
+      } else if (e.key === "ArrowLeft" || e.key === "ArrowDown") {
         idx = Math.max(0, currentIndex - 1);
         e.preventDefault();
-      } else if (e.key === 'Home') {
+      } else if (e.key === "Home") {
         idx = 0;
         e.preventDefault();
-      } else if (e.key === 'End') {
+      } else if (e.key === "End") {
         idx = values.length - 1;
         e.preventDefault();
       } else {
@@ -68,14 +68,17 @@ export default function DiscreteSlider({
       }
       onChange(values[idx]);
     },
-    [values, currentIndex, onChange]
+    [values, currentIndex, onChange],
   );
 
   return (
     <div class="mb-5">
       <div class="flex justify-between items-center mb-2">
         <span class="font-mono text-xs text-(--color-text-muted)">{label}</span>
-        <span class="font-mono text-lg font-bold text-(--color-accent)">{value}{unit}</span>
+        <span class="font-mono text-lg font-bold text-(--color-accent)">
+          {value}
+          {unit}
+        </span>
       </div>
 
       {/* Track */}
@@ -90,7 +93,7 @@ export default function DiscreteSlider({
         aria-valuetext={`${value}${unit}`}
         onPointerDown={handlePointerDown}
         onKeyDown={handleKeyDown}
-        class="relative h-10 cursor-pointer flex items-center touch-none outline-none focus:ring-1 focus:ring-(--color-accent) rounded"
+        class="relative h-10 cursor-pointer flex items-center touch-none outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent) focus-visible:ring-offset-2 focus-visible:ring-offset-(--color-bg) rounded"
       >
         {/* Background */}
         <div class="absolute inset-x-0 h-1 bg-(--color-border) rounded-sm" />
@@ -106,7 +109,9 @@ export default function DiscreteSlider({
           const left = (i / (values.length - 1)) * 100;
           const isDefault = v === defaultValue;
           const isActive = i <= currentIndex;
-          const dotSize = isDefault ? 'w-2.5 h-2.5 border-2 border-(--color-accent)' : 'w-2 h-2';
+          const dotSize = isDefault
+            ? "w-2.5 h-2.5 border-2 border-(--color-accent)"
+            : "w-2 h-2";
           return (
             <div
               key={v}
@@ -114,10 +119,13 @@ export default function DiscreteSlider({
               style={{ left: `${left}%` }}
             >
               <div
-                class={`rounded-full transition-colors duration-100 ${dotSize} ${isActive ? 'bg-(--color-accent)' : 'bg-(--color-border)'}`}
+                class={`rounded-full transition-colors duration-100 ${dotSize} ${isActive ? "bg-(--color-accent)" : "bg-(--color-border)"}`}
               />
-              <span class={`font-mono text-[0.6875rem] mt-0.5 whitespace-nowrap ${isDefault ? 'text-(--color-accent)' : 'text-(--color-text-muted)'}`}>
-                {v}{isDefault ? '*' : ''}
+              <span
+                class={`font-mono text-[0.6875rem] mt-0.5 whitespace-nowrap ${isDefault ? "text-(--color-accent)" : "text-(--color-text-muted)"}`}
+              >
+                {v}
+                {isDefault ? "*" : ""}
               </span>
             </div>
           );

--- a/src/components/SimulatorPreview.tsx
+++ b/src/components/SimulatorPreview.tsx
@@ -87,10 +87,13 @@ function buildPath(pts: number[], width: number): string {
     .join(" ");
 }
 
+// SVG <animate> uses dur attr (not CSS animation-duration), so it bypasses the
+// global prefers-reduced-motion CSS rule. Evaluate once at module load (client only).
+const reducedMotion =
+  typeof window !== "undefined" &&
+  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
 export default function SimulatorPreview() {
-  // SSR-visible: true so the big-number hero is the LCP candidate in initial HTML.
-  // AnimatedNumber animates from 0 client-side via requestAnimationFrame.
-  const [visible, setVisible] = useState(true);
   const [hoveredTrade, setHoveredTrade] = useState<number | null>(null);
   const svgRef = useRef<SVGSVGElement>(null);
 
@@ -132,22 +135,13 @@ export default function SimulatorPreview() {
           class="text-4xl md:text-5xl font-extrabold"
           style={{ color: "var(--color-up)" }}
         >
-          {visible ? (
-            <AnimatedNumber target={157.7} prefix="+" duration={2000} />
-          ) : (
-            "0.0"
-          )}
-          %
+          <AnimatedNumber target={157.7} prefix="+" duration={2000} />%
         </div>
         <div class="text-(--color-text-muted) text-sm mt-1.5">
           $1,000 →{" "}
-          {visible ? (
-            <span style={{ color: "var(--color-up)" }}>
-              $<AnimatedNumber target={2577} decimals={0} duration={2000} />
-            </span>
-          ) : (
-            "$1,000"
-          )}
+          <span style={{ color: "var(--color-up)" }}>
+            $<AnimatedNumber target={2577} decimals={0} duration={2000} />
+          </span>
         </div>
       </div>
 
@@ -180,7 +174,7 @@ export default function SimulatorPreview() {
             fill="url(#eq-grad)"
             stroke="none"
           >
-            {visible && (
+            {!reducedMotion && (
               <animate
                 attributeName="d"
                 from={`${flatPath} L400,60 L0,60 Z`}
@@ -198,7 +192,7 @@ export default function SimulatorPreview() {
             stroke-width="2"
             stroke-linecap="round"
           >
-            {visible && (
+            {!reducedMotion && (
               <animate
                 attributeName="d"
                 from={flatPath}
@@ -209,29 +203,26 @@ export default function SimulatorPreview() {
             )}
           </path>
           {/* Trade markers */}
-          {visible &&
-            TRADES.map((t, i) => (
-              <g
-                key={i}
-                onMouseEnter={() => setHoveredTrade(i)}
-                style={{ cursor: "pointer" }}
-              >
-                <circle cx={t.x} cy={t.y} r="6" fill="transparent" />
-                <circle
-                  cx={t.x}
-                  cy={t.y}
-                  r={hoveredTrade === i ? 4 : 2.5}
-                  fill={
-                    t.type === "short"
-                      ? "var(--color-accent)"
-                      : "var(--color-up)"
-                  }
-                  stroke="var(--color-bg)"
-                  stroke-width="1"
-                  style={{ transition: "r 0.2s" }}
-                />
-              </g>
-            ))}
+          {TRADES.map((t, i) => (
+            <g
+              key={i}
+              onMouseEnter={() => setHoveredTrade(i)}
+              style={{ cursor: "pointer" }}
+            >
+              <circle cx={t.x} cy={t.y} r="6" fill="transparent" />
+              <circle
+                cx={t.x}
+                cy={t.y}
+                r={hoveredTrade === i ? 4 : 2.5}
+                fill={
+                  t.type === "short" ? "var(--color-accent)" : "var(--color-up)"
+                }
+                stroke="var(--color-bg)"
+                stroke-width="1"
+                style={{ transition: "r 0.2s" }}
+              />
+            </g>
+          ))}
         </svg>
         {/* Trade tooltip */}
         {hoveredTrade !== null && (
@@ -268,16 +259,12 @@ export default function SimulatorPreview() {
               {s.label}
             </div>
             <div class="text-sm font-bold mt-0.5" style={{ color: s.color }}>
-              {visible ? (
-                <AnimatedNumber
-                  target={s.value}
-                  decimals={s.value % 1 === 0 ? 0 : s.suffix === "%" ? 1 : 2}
-                  prefix={s.prefix || ""}
-                  duration={1800}
-                />
-              ) : (
-                "0"
-              )}
+              <AnimatedNumber
+                target={s.value}
+                decimals={s.value % 1 === 0 ? 0 : s.suffix === "%" ? 1 : 2}
+                prefix={s.prefix || ""}
+                duration={1800}
+              />
               {s.suffix}
             </div>
           </div>

--- a/src/components/ui/StepCard.astro
+++ b/src/components/ui/StepCard.astro
@@ -6,7 +6,7 @@ interface Props {
 }
 const { step, title, description } = Astro.props;
 ---
-<div class="relative rounded-2xl border border-(--color-border) bg-(--color-bg-card) p-8 text-center group hover:border-(--color-accent)/30 hover:-translate-y-1 transition-all duration-300" style="box-shadow: inset 0 1px 0 rgba(255,255,255,0.04), 0 4px 20px rgba(0,0,0,0.25);">
+<div class="relative rounded-2xl border border-(--color-border) bg-(--color-bg-card) p-8 text-center group hover:border-(--color-accent)/30 hover:-translate-y-1 motion-reduce:hover:translate-y-0 transition-all motion-reduce:transition-none duration-300" style="box-shadow: inset 0 1px 0 rgba(255,255,255,0.04), 0 4px 20px rgba(0,0,0,0.25);">
   <!-- Step number with glow ring -->
   <div class="relative w-14 h-14 mx-auto mb-5">
     <div class="absolute inset-0 rounded-full bg-(--color-accent)/8 group-hover:bg-(--color-accent)/15 transition-colors duration-300"></div>


### PR DESCRIPTION
## Sprint 4.1 (v2) — Micro-interactions: motion + focus corrections

### Root causes addressed

**1. SVG `<animate>` bypasses global prefers-reduced-motion CSS**
The existing `@media (prefers-reduced-motion: reduce)` rule in `global.css` sets
`animation-duration: 0.001ms !important` — but this only affects CSS animations.
SVG `<animate>` uses the `dur` attribute (SVG timing model), which CSS cannot override.
The equity curve animation (`dur="1.8s"`) was playing for all users regardless.

Fix: module-level `reducedMotion` check via `window.matchMedia` — skip `<animate>`
children entirely when true. Path renders at final `curvePath` state (no jump).

**2. Dead `visible` state in SimulatorPreview**
`const [visible, setVisible] = useState(true)` — `setVisible` was never called after
the Sprint 3.1 useEffect removal. State removed; ternaries inlined to direct values.

**3. `focus:ring` → `focus-visible:ring` on DiscreteSlider**
Mouse clicks were showing focus ring on the slider div. `focus-visible:` restricts
ring to keyboard navigation only (WCAG 2.4.7 compliant).

**4. StepCard hover translate — motion-reduce guard**
`hover:-translate-y-1` adds `motion-reduce:hover:translate-y-0 motion-reduce:transition-none`
to zero out the transform for reduced-motion users. (Global CSS cuts duration to
0.001ms but the transform still applies instantly — motion-reduce:translate-y-0
prevents it entirely.)

### Files
- `src/components/SimulatorPreview.tsx` — remove dead state, add reducedMotion guard
- `src/components/DiscreteSlider.tsx` — focus: → focus-visible: + ring-offset
- `src/components/ui/StepCard.astro` — motion-reduce:hover:translate-y-0

build: 1196 pages, 0 errors