### PR TITLE
design(sprint-4.3): unify SVG stroke widths — icon 1.5 + action icon 2

### DIFF
--- a/src/components/OKXConnectButton.tsx
+++ b/src/components/OKXConnectButton.tsx
@@ -147,7 +147,7 @@ export default function OKXConnectButton({
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke="currentColor"
-                  stroke-width="2.5"
+                  stroke-width="2"
                 >
                   <path
                     stroke-linecap="round"
@@ -223,7 +223,7 @@ export default function OKXConnectButton({
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"
-                stroke-width="2.5"
+                stroke-width="2"
               >
                 <path
                   stroke-linecap="round"

--- a/src/components/OKXExecuteButton.tsx
+++ b/src/components/OKXExecuteButton.tsx
@@ -218,7 +218,7 @@ export default function OKXExecuteButton({
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"
-                stroke-width="2.5"
+                stroke-width="2"
               >
                 <path
                   stroke-linecap="round"

--- a/src/components/simulator/v1/EntryVisualizer.tsx
+++ b/src/components/simulator/v1/EntryVisualizer.tsx
@@ -330,7 +330,7 @@ function BBSqueeze({
         d={price}
         fill="none"
         stroke="var(--color-text)"
-        stroke-width="1.4"
+        stroke-width="1.5"
         stroke-linejoin="round"
       />
       <EntryMarker
@@ -385,7 +385,7 @@ function RSIReversal({
         d={price}
         fill="none"
         stroke="var(--color-text)"
-        stroke-width="1.4"
+        stroke-width="1.5"
         stroke-linejoin="round"
       />
       {/* RSI oversold band (below 30) */}
@@ -415,7 +415,7 @@ function RSIReversal({
         d={rsi}
         fill="none"
         stroke="var(--color-warning)"
-        stroke-width="1.2"
+        stroke-width="1.5"
         stroke-linejoin="round"
       />
       <EntryMarker
@@ -469,7 +469,7 @@ function MACDMomentum({
         d={price}
         fill="none"
         stroke="var(--color-text)"
-        stroke-width="1.4"
+        stroke-width="1.5"
         stroke-linejoin="round"
       />
       {/* MACD histogram zone */}
@@ -546,8 +546,8 @@ function StochasticOverbought({
       <text x={4} y={108} fill="var(--color-down)" font-size="7" font-family="monospace">
         STOCH 80
       </text>
-      <path d={price} fill="none" stroke="var(--color-text)" stroke-width="1.4" />
-      <path d={stoch} fill="none" stroke="var(--color-purple)" stroke-width="1.2" />
+      <path d={price} fill="none" stroke="var(--color-text)" stroke-width="1.5" />
+      <path d={stoch} fill="none" stroke="var(--color-purple)" stroke-width="1.5" />
       <EntryMarker
         x={150}
         y={55}
@@ -592,7 +592,7 @@ function EMACrossover({
         opacity="0.7"
       />
       <path d={emaFast} fill="none" stroke="var(--color-warning)" stroke-width="1.1" />
-      <path d={price} fill="none" stroke="var(--color-text)" stroke-width="1.4" />
+      <path d={price} fill="none" stroke="var(--color-text)" stroke-width="1.5" />
       <EntryMarker
         x={entryX}
         y={entryY}
@@ -664,7 +664,7 @@ function TurtleBreakout({
       >
         20-day HIGH
       </text>
-      <path d={price} fill="none" stroke="var(--color-text)" stroke-width="1.4" />
+      <path d={price} fill="none" stroke="var(--color-text)" stroke-width="1.5" />
       <EntryMarker
         x={entryX}
         y={entryY}
@@ -711,12 +711,12 @@ function ADXTrend({ dir, lang }: { dir: "long" | "short"; lang: "en" | "ko" }) {
       >
         ADX 25
       </text>
-      <path d={price} fill="none" stroke="var(--color-text)" stroke-width="1.4" />
+      <path d={price} fill="none" stroke="var(--color-text)" stroke-width="1.5" />
       <path
         d={adx}
         fill="none"
         stroke="var(--color-purple)"
-        stroke-width="1.2"
+        stroke-width="1.5"
         stroke-dasharray="2,2"
       />
       <EntryMarker
@@ -768,7 +768,7 @@ function Ichimoku({ dir, lang }: { dir: "long" | "short"; lang: "en" | "ko" }) {
         stroke-width="0.6"
         opacity="0.6"
       />
-      <path d={price} fill="none" stroke="var(--color-text)" stroke-width="1.4" />
+      <path d={price} fill="none" stroke="var(--color-text)" stroke-width="1.5" />
       <EntryMarker
         x={entryX}
         y={entryY}
@@ -829,7 +829,7 @@ function PsarReversal({
   return (
     <g>
       <AxisBase />
-      <path d={price} fill="none" stroke="var(--color-text)" stroke-width="1.4" />
+      <path d={price} fill="none" stroke="var(--color-text)" stroke-width="1.5" />
       {psarPoints.map(([x, y]) => (
         <circle
           key={`${x},${y}`}
@@ -896,8 +896,8 @@ function WilliamsR({
       >
         %R {dir === "long" ? "−80" : "−20"}
       </text>
-      <path d={price} fill="none" stroke="var(--color-text)" stroke-width="1.4" />
-      <path d={willr} fill="none" stroke="var(--color-warning)" stroke-width="1.2" />
+      <path d={price} fill="none" stroke="var(--color-text)" stroke-width="1.5" />
+      <path d={willr} fill="none" stroke="var(--color-warning)" stroke-width="1.5" />
       <EntryMarker
         x={entryX}
         y={entryY}
@@ -945,7 +945,7 @@ function RSIBB({ dir, lang }: { dir: "long" | "short"; lang: "en" | "ko" }) {
         stroke-dasharray="3,2"
         opacity="0.5"
       />
-      <path d={price} fill="none" stroke="var(--color-text)" stroke-width="1.4" />
+      <path d={price} fill="none" stroke="var(--color-text)" stroke-width="1.5" />
       <EntryMarker
         x={entryX}
         y={entryY}
@@ -1005,7 +1005,7 @@ function BBBounce({ dir, lang }: { dir: "long" | "short"; lang: "en" | "ko" }) {
         stroke-dasharray="1,2"
         opacity="0.4"
       />
-      <path d={price} fill="none" stroke="var(--color-text)" stroke-width="1.4" />
+      <path d={price} fill="none" stroke="var(--color-text)" stroke-width="1.5" />
       <EntryMarker
         x={entryX}
         y={entryY}
@@ -1050,17 +1050,17 @@ function Supertrend({
         d={supertrendBefore}
         fill="none"
         stroke={dir === "long" ? "var(--color-down)" : "var(--color-up)"}
-        stroke-width="1.2"
+        stroke-width="1.5"
         opacity="0.6"
       />
       <path
         d={supertrendAfter}
         fill="none"
         stroke={dir === "long" ? "var(--color-up)" : "var(--color-down)"}
-        stroke-width="1.2"
+        stroke-width="1.5"
         opacity="0.9"
       />
-      <path d={price} fill="none" stroke="var(--color-text)" stroke-width="1.4" />
+      <path d={price} fill="none" stroke="var(--color-text)" stroke-width="1.5" />
       <EntryMarker
         x={entryX}
         y={entryY}
@@ -1093,7 +1093,7 @@ function GenericViz({
         d="M0,80 L60,75 L120,70 L180,55 L240,45"
         fill="none"
         stroke="var(--color-text)"
-        stroke-width="1.4"
+        stroke-width="1.5"
       />
       <circle cx={180} cy={55} r="5" fill={hex} />
       <text x={10} y={14} fill="var(--color-text-muted)" font-size="9" font-family="monospace">


### PR DESCRIPTION
## Sprint 4.3 — Illustration / data-vis alignment

### Problem
Two inconsistent stroke weight clusters in data-vis components:

**EntryVisualizer (20 paths)**: Primary indicator paths used `1.4` (price lines)
and `1.2` (secondary oscillator lines: stoch, willr, envelope, Donchian bands).
All other chart components use `1.5` (SimulatorPreview, ResultsPanel, LiveTrade,
CoinChart). The `1.4`/`1.2` values produce visibly thinner lines in the
visualizer, breaking cross-component visual consistency.

**OKX action buttons (3 icons)**: `stroke-width="2.5"` on check/spinner icons
inside OKXExecuteButton and OKXConnectButton. All other UI action icons use `2`
(MarketDashboard expand chevron, CommandPalette). The heavier `2.5` made OKX
icons visually heavier than the rest of the icon system.

### Fix
- `EntryVisualizer.tsx`: `1.4` → `1.5` (price paths), `1.2` → `1.5` (secondary)
- `OKXExecuteButton.tsx`, `OKXConnectButton.tsx`: `2.5` → `2`

### Token system after fix
| Role | stroke-width |
|------|-------------|
| Indicator icon (sprite) | 1.5 |
| Chart signal line | 1.5 |
| UI action icon | 2 |
| Chart grid / axis | 0.5 – 0.8 |

No functional changes. Pure visual weight unification.
build: 1196 pages, 0 errors