### PR TITLE
design(sprint-3.5): 라이트모드 정밀 — 하드코딩 다크값 CSS 변수화

### DIFF
--- a/src/components/SimulatorPreview.tsx
+++ b/src/components/SimulatorPreview.tsx
@@ -232,9 +232,9 @@ export default function SimulatorPreview() {
               left: `${(TRADES[hoveredTrade].x / 400) * 100}%`,
               top: `${(TRADES[hoveredTrade].y / 60) * 100 - 15}%`,
               transform: "translateX(-50%) translateY(-100%)",
-              background: "rgba(20,20,24,0.95)",
+              background: "var(--color-bg-tooltip)",
               backdropFilter: "blur(8px)",
-              boxShadow: "0 4px 12px rgba(0,0,0,0.4)",
+              boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
             }}
           >
             <span class="text-(--color-accent) font-bold">

--- a/src/components/ui/StepCard.astro
+++ b/src/components/ui/StepCard.astro
@@ -6,7 +6,7 @@ interface Props {
 }
 const { step, title, description } = Astro.props;
 ---
-<div class="relative rounded-2xl border border-(--color-border) bg-(--color-bg-card) p-8 text-center group hover:border-(--color-accent)/30 hover:-translate-y-1 motion-reduce:hover:translate-y-0 transition-all motion-reduce:transition-none duration-300" style="box-shadow: inset 0 1px 0 rgba(255,255,255,0.04), 0 4px 20px rgba(0,0,0,0.25);">
+<div class="relative rounded-2xl border border-(--color-border) bg-(--color-bg-card) p-8 text-center group hover:border-(--color-accent)/30 hover:-translate-y-1 motion-reduce:hover:translate-y-0 transition-all motion-reduce:transition-none duration-300" style="box-shadow: var(--shadow-card);">
   <!-- Step number with glow ring -->
   <div class="relative w-14 h-14 mx-auto mb-5">
     <div class="absolute inset-0 rounded-full bg-(--color-accent)/8 group-hover:bg-(--color-accent)/15 transition-colors duration-300"></div>


### PR DESCRIPTION
## 변경 내용

Sprint 3.5 — 라이트모드 정밀 (PR#1478 baseline 기준)

| 파일 | 문제 | 수정 |
|------|------|------|
| `StepCard.astro:9` | `rgba(255,255,255,0.04)` inset — 라이트 모드 흰 배경에서 사라짐 | `var(--shadow-card)` (CSS var가 dark/light 자동 전환) |
| `SimulatorPreview.tsx:235` | `rgba(20,20,24,0.95)` 툴팁 bg — 라이트 모드에서 어두운 박스로 표시 | `var(--color-bg-tooltip)` (dark: `rgba(24,24,27,0.95)` / light: `rgba(255,255,255,0.96)`) |
| `SimulatorPreview.tsx:237` | `rgba(0,0,0,0.4)` 박스섀도우 — 라이트 모드에서 과도하게 어두움 | `rgba(0,0,0,0.15)` |

## 근거 (Evidence)

- `--shadow-card` light: `0 0 0 1px rgba(0,0,0,0.06), 0 2px 8px rgba(0,0,0,0.06), 0 8px 24px rgba(0,0,0,0.04)` (global.css:298-302)
- `--color-bg-tooltip` light: `rgba(255,255,255,0.96)` (global.css:209)
- 두 CSS 변수 모두 `:root[data-theme="light"]` 에서 정의됨

## 검증

- `npm run build`: 1196 pages, 0 errors
- 두 파일 외 변경 없음 (다른 컴포넌트 하드코딩값은 시뮬레이터 내부로 홈/랭킹/전략 페이지에 미노출)