### PR TITLE
content(strategies): 코인 수 Binance→OKX 기준 업데이트 (577/535→235)

### DIFF
--- a/src/content/strategies/atr-breakout.md
+++ b/src/content/strategies/atr-breakout.md
@@ -8,7 +8,7 @@ difficulty: "intermediate"
 winRate: 48.7
 profitFactor: 0.91
 timeframe: "1H"
-coins: 577
+coins: 235
 dateAdded: "2026-01-18"
 dateUpdated: "2026-04-10"
 tags: ["atr", "breakout", "shelved"]

--- a/src/content/strategies/bb-squeeze-long.md
+++ b/src/content/strategies/bb-squeeze-long.md
@@ -9,7 +9,7 @@ winRate: 51.0
 profitFactor: 0.98
 totalPnl: "-$26"
 timeframe: "1H"
-coins: 577
+coins: 235
 dateAdded: "2026-01-10"
 dateUpdated: "2026-04-10"
 dateKilled: "2026-02-05"

--- a/src/content/strategies/bb-squeeze-short.md
+++ b/src/content/strategies/bb-squeeze-short.md
@@ -11,7 +11,7 @@ maxDrawdown: 26.7
 totalPnl: "+$794"
 timeframe: "1H"
 dataPoints: 2898
-coins: 535
+coins: 235
 dateAdded: "2026-01-10"
 dateUpdated: "2026-04-10"
 tags: ["bollinger-bands", "squeeze", "volatility", "verified"]

--- a/src/content/strategies/hv-squeeze.md
+++ b/src/content/strategies/hv-squeeze.md
@@ -8,7 +8,7 @@ difficulty: "advanced"
 winRate: 58.1
 profitFactor: 1.42
 timeframe: "1H"
-coins: 577
+coins: 235
 dateAdded: "2026-01-15"
 dateUpdated: "2026-04-10"
 tags: ["historical-volatility", "squeeze", "shelved"]

--- a/src/content/strategies/momentum-long.md
+++ b/src/content/strategies/momentum-long.md
@@ -10,7 +10,7 @@ profitFactor: 0.42
 totalPnl: "Negative"
 timeframe: "1H"
 dataPoints: 8420
-coins: 577
+coins: 235
 dateAdded: "2026-01-31"
 dateUpdated: "2026-04-10"
 dateKilled: "2026-02-05"


### PR DESCRIPTION
## 원인
Vision QA [strategies-desktop] FAIL — `[STALE_DATA] 화면에 구버전 코인 수 표시됨`

/strategies/ 인덱스 카드가 `strategy.data.coins` 값을 노출:
- 구 Binance 시대 값: 577 (atr-breakout, bb-squeeze-long, bb-squeeze-short, hv-squeeze, momentum-long)
- 현재 OKX USDT-SWAP 스캐너: 235 (coins-stats.json.total_coins)

## 변경
5개 전략 .md 파일 `coins: 577 / 535` → `coins: 235`

| 파일 | 변경 전 | 변경 후 |
|------|---------|---------|
| atr-breakout.md | 577 | 235 |
| bb-squeeze-long.md | 577 | 235 |
| bb-squeeze-short.md | 535 | 235 |
| hv-squeeze.md | 577 | 235 |
| momentum-long.md | 577 | 235 |

이미 정확한 파일(ichimoku, ma-cross, keltner-squeeze): 변경 없음

## 검증
- `npm run build` 1196 pages 완료
- SSoT: `public/data/coins-stats.json.total_coins = 235`

🤖 Generated with [Claude Code](https://claude.com/claude-code)