### PR TITLE
fix(backend): indicator-builder working dir + PRUVIQ_DATA_DIR

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -215,6 +215,7 @@ jobs:
               /opt/pruviq/current/backend/deploy/systemd/pruviq-*.service \
               /opt/pruviq/current/backend/deploy/systemd/pruviq-*.timer \
               /etc/systemd/system/
+            mkdir -p /opt/pruviq/cache && chown pruviq:pruviq /opt/pruviq/cache
             systemctl daemon-reload
             systemctl enable --now pruviq-indicator-builder.timer 2>/dev/null || true
             echo 'wrapper + unit sync + daemon-reload done'

--- a/backend/deploy/systemd/bin/indicator-builder.sh
+++ b/backend/deploy/systemd/bin/indicator-builder.sh
@@ -4,4 +4,6 @@ set -euo pipefail
 VENV_PYTHON="/opt/pruviq/app/.venv/bin/python3"
 REPO="/opt/pruviq/current"
 
+cd "$REPO/backend"
+export PRUVIQ_DATA_DIR="/opt/pruviq/data/futures"
 exec "$VENV_PYTHON" -m api.offline_indicator_build


### PR DESCRIPTION
## 🚨 긴급 — 11시간째 반복 실패 수정

### 근본 원인

`pruviq-indicator-builder.service` 가 2026-05-02 03:21 UTC부터 매 1시간마다 실패:

```
ModuleNotFoundError: No module named 'api'
```

**원인 1**: `WorkingDirectory=/opt/pruviq/current` 에서 `python3 -m api.offline_indicator_build` 실행 → `api` 패키지는 `current/backend/api/` 에 있으나 Python이 `current/` 에서 탐색

**원인 2**: `PRUVIQ_DATA_DIR` 기본값 = `PROJECT_ROOT/backend/data/futures` = releases symlink 경로 → 빈 디렉토리 → "Loaded 0 coins"

### 수정

`backend/deploy/systemd/bin/indicator-builder.sh`:
```bash
cd "$REPO/backend"                           # api 모듈 찾을 수 있게
export PRUVIQ_DATA_DIR="/opt/pruviq/data/futures"  # 실제 CSV 240개 위치
```

### 서버 즉시 적용 + 검증 완료

```
2026-05-02 15:08:24 INFO Loaded 238 coins in 8.9s
2026-05-02 15:08:34 INFO Building 17 strategies × 50 coins
```

서비스 `activating (start)` 상태 확인 — 정상 실행 중