### PR TITLE
fix(ci): deploy drift check — deploy when do_sha outside shallow clone

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -147,13 +147,21 @@ jobs:
             echo "DO is current — no drift, skipping deploy"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
-            changed=$(git diff --name-only "$do_sha" "$main_sha" -- backend/ 2>/dev/null | head -1)
-            if [ -z "$changed" ]; then
-              echo "DO is behind but no backend changes — skipping deploy"
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "Backend drift detected ($do_sha → $main_sha): $changed"
+            # If do_sha is outside the shallow clone, git diff silently returns
+            # empty — causing a false "no backend changes" skip. Deploy whenever
+            # we can't confirm the diff (safe default: extra restart > silent skip).
+            if ! git cat-file -e "$do_sha" 2>/dev/null; then
+              echo "DO commit $do_sha not in runner history (shallow clone) — deploying to be safe"
               echo "skip=false" >> "$GITHUB_OUTPUT"
+            else
+              changed=$(git diff --name-only "$do_sha" "$main_sha" -- backend/ 2>/dev/null | head -1)
+              if [ -z "$changed" ]; then
+                echo "DO is behind but no backend changes — skipping deploy"
+                echo "skip=true" >> "$GITHUB_OUTPUT"
+              else
+                echo "Backend drift detected ($do_sha → $main_sha): $changed"
+                echo "skip=false" >> "$GITHUB_OUTPUT"
+              fi
             fi
           fi
 


### PR DESCRIPTION
## 문제

`deploy-backend.yml` drift check가 `fetch-depth: 2` shallow clone 환경에서 서버 커밋(`do_sha`)이 runner 히스토리 밖에 있을 때 `git diff` 가 조용히 빈 결과를 반환 → "backend 변경 없음"으로 오판 → deploy skip.

실측: `d9b5824c` (서버) vs `c83e7029` (main) 비교 시 `git diff` 결과 없음 → 3회 연속 스킵.

## 수정

`git diff` 전에 `git cat-file -e $do_sha` 로 커밋이 히스토리에 있는지 확인:
- **있으면**: 기존대로 backend/ diff로 판단
- **없으면**: "알 수 없으므로 배포" (extra restart > silent skip)

## 원칙

false negative(silent skip) > false positive(unnecessary restart) — 서비스 재시작은 5초 downtime이지만 미배포는 버그가 프로덕션에 잔류.

🤖 Generated with [Claude Code](https://claude.com/claude-code)