### PR TITLE
fix(ci): dispatch CI after update-branch (GITHUB_TOKEN push = no re-trigger)

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -3,6 +3,7 @@ name: Accessibility
 on:
   pull_request:
     branches: [main]
+  workflow_dispatch: {}
 
 jobs:
   accessibility:

--- a/.github/workflows/automerge-on-label.yml
+++ b/.github/workflows/automerge-on-label.yml
@@ -199,9 +199,38 @@ jobs:
                   repo: context.repo.repo,
                   pull_number: prNumber,
                 });
-                core.info(`update-branch dispatched for PR #${prNumber}; checks will rerun, next cron tick will retry merge.`);
+                core.info(`update-branch dispatched for PR #${prNumber}.`);
               } catch (err) {
                 core.warning(`update-branch failed for PR #${prNumber}: ${err.message}`);
+                return;
+              }
+              // GITHUB_TOKEN push (update-branch) does NOT re-trigger CI workflows
+              // (GitHub recursive-workflow prevention). Explicitly dispatch each CI
+              // workflow for the PR branch so checks run on the new merge commit.
+              // workflow_dispatch is exempt from the recursive restriction.
+              const prBranch = prDetail.data.head.ref;
+              const ciWorkflows = [
+                'unit-tests.yml',
+                'e2e.yml',
+                'accessibility.yml',
+                'visual-regression.yml',
+                'gitleaks.yml',
+                'codeql.yml',
+                'validate-startup-files.yml',
+                'docs-lint.yml',
+              ];
+              for (const wf of ciWorkflows) {
+                try {
+                  await github.rest.actions.createWorkflowDispatch({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    workflow_id: wf,
+                    ref: prBranch,
+                  });
+                  core.info(`Dispatched ${wf} on ${prBranch}`);
+                } catch (err) {
+                  core.warning(`Could not dispatch ${wf}: ${err.message}`);
+                }
               }
               return;
             }

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch: {}
   schedule:
     # Weekly scan catches CVEs in deps that landed mid-week.
     - cron: '0 3 * * 0'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,7 @@ name: E2E Tests
 on:
   pull_request:
     branches: [main]
+  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -10,7 +10,6 @@ on:
     # Weekly baseline scan — catches anything that slipped through PRs
     # (e.g., if an automerge PR was force-pushed between CI runs).
     - cron: "0 3 * * 1"  # Monday 03:00 UTC
-  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   push:
     branches: [main]
+  workflow_dispatch: {}
   schedule:
     # Weekly baseline scan — catches anything that slipped through PRs
     # (e.g., if an automerge PR was force-pushed between CI runs).

--- a/.github/workflows/validate-startup-files.yml
+++ b/.github/workflows/validate-startup-files.yml
@@ -3,6 +3,7 @@ name: validate-startup-files
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
+  workflow_dispatch: {}
 
 jobs:
   validate:


### PR DESCRIPTION
## 근본 원인

automerge가 \`updateBranch()\` 호출 시 GITHUB_TOKEN 사용 → GITHUB_TOKEN push는 GitHub recursive-workflow 방지 정책으로 \`pull_request/push\` 이벤트 트리거 안 됨 → CI 워크플로우 미실행 → automerge cron이 \`total < 2\` checks 루프 → PR 영구 대기.

**실측 근거**: PR #1704 — \`8e572519\` (원래 head) 0 checks, \`c9925179\` (update-branch 후) 0 checks. 수동 empty commit 2회 필요.

## 수정 내용

**1. CI 워크플로우 5개에 \`workflow_dispatch: {}\` 추가**
- `accessibility.yml`, `e2e.yml`, `validate-startup-files.yml`, `gitleaks.yml`, `codeql.yml`
- (unit-tests.yml, visual-regression.yml은 이미 보유)

**2. automerge-on-label.yml: updateBranch 후 CI 명시 dispatch**
```
updateBranch 성공 → createWorkflowDispatch × 8 CI workflows (PR branch ref)
```
`workflow_dispatch`는 recursive-workflow 방지 정책 **적용 안 됨** (data-deploy.yml 머지 후 dispatch와 동일 패턴, 이미 GITHUB_TOKEN으로 동작 확인됨).

## Before / After

| 상황 | Before | After |
|------|--------|-------|
| updateBranch 후 CI | 미실행 (GITHUB_TOKEN push) | dispatch로 명시 트리거 |
| automerge 결과 | 무한 대기 | 다음 cron tick에 머지 |
| 수동 rekick 필요 | 30분+ 대기 후 필요 | 불필요 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)