### PR TITLE
fix(ci): use PRUVIQ_GH_TOKEN in data-refresh-cron to trigger CI

### DIFF
--- a/.github/workflows/data-refresh-cron.yml
+++ b/.github/workflows/data-refresh-cron.yml
@@ -109,19 +109,18 @@ jobs:
       # GitHub의 documented 한계: GITHUB_TOKEN으로 만든 PR은 다른 workflow trigger
       # 못 함. Vitest/Playwright 등 PR-trigger workflow가 안 돌아 → check runs 0 →
       # ruleset의 7 required checks 충족 못함 → automerge 영원히 stuck.
-      # 해결: PRUVIQ_BOT_TOKEN (PAT 또는 GitHub App token) 사용.
-      # secret 없으면 fallback으로 GITHUB_TOKEN + workflow_dispatch 추가 발화로 우회.
+      # 해결: PRUVIQ_GH_TOKEN (PAT) 사용 — contents:write + pull-requests:write +
+      # workflows:write 권한. repo Settings → Secrets → Actions에 PRUVIQ_GH_TOKEN으로
+      # 저장돼 있어야 함 (2026-02-21 설정 확인).
+      # 미설정 시 fallback (GITHUB_TOKEN) — PR은 만들어지지만 CI 안 돌아 manual
+      # rekick 필요.
       - name: Create or update PR (with PAT for CI re-trigger)
         if: steps.changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
-          # PRUVIQ_BOT_TOKEN: contents:write + pull-requests:write + workflows:write
-          # 권한의 PAT 또는 fine-grained token. 사용자가 GitHub Settings → Developer
-          # settings → Personal access tokens → Fine-grained tokens 에서 발급 후
-          # repo Settings → Secrets → Actions에 PRUVIQ_BOT_TOKEN으로 저장.
-          # 미설정 시 fallback (GITHUB_TOKEN) — PR은 만들어지지만 CI 안 돌아 manual
-          # rekick 필요. 즉 마이그 효과 절반.
-          token: ${{ secrets.PRUVIQ_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          # PRUVIQ_GH_TOKEN: PAT with contents:write + pull-requests:write + workflows:write
+          # Previously referenced as PRUVIQ_BOT_TOKEN (wrong name — secret is PRUVIQ_GH_TOKEN)
+          token: ${{ secrets.PRUVIQ_GH_TOKEN || secrets.GITHUB_TOKEN }}
           branch: auto/data-refresh
           delete-branch: false
           base: main
@@ -133,7 +132,7 @@ jobs:
 
             **Replaces**: local Mac Mini `*/20 refresh_static.sh` cron (silent-failing since 2026-04-20 ruleset activation).
 
-            **CI trigger**: PRUVIQ_BOT_TOKEN (PAT) 사용 시 정상 trigger. GITHUB_TOKEN fallback 시 CI 안 돌아 manual rekick 필요.
+            **CI trigger**: PRUVIQ_GH_TOKEN (PAT) 사용 시 정상 trigger. GITHUB_TOKEN fallback 시 CI 안 돌아 manual rekick 필요.
           commit-message: |
             chore(data): cron refresh
           author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"


### PR DESCRIPTION
## Root cause

`data-refresh-cron.yml` used `PRUVIQ_BOT_TOKEN` which doesn't exist → fell back to `GITHUB_TOKEN` → GitHub security restriction blocks CI trigger on PRs created with `GITHUB_TOKEN` → `auto/data-refresh` PR gets **0 check runs** → automerge stuck forever (`MIN_CHECK_RUNS=2` never satisfied).

## Fix

Changed `secrets.PRUVIQ_BOT_TOKEN` → `secrets.PRUVIQ_GH_TOKEN` (the actual secret, set 2026-02-21).

## Evidence

```
gh secret list | grep PRUVIQ
PRUVIQ_GH_TOKEN     2026-02-21T18:01:53Z   # ← exists
PRUVIQ_BOT_TOKEN    (not found)            # ← was referenced, doesn't exist
```

## Impact

- Future `auto/data-refresh` PRs will have CI run properly and automerge
- PR #1718 (current stuck PR) needs to be closed and recreated after this merges